### PR TITLE
feat(egress): the policy a capsule's network is held to

### DIFF
--- a/docs/adrs/2026-08-11-network-sandbox-proxy.md
+++ b/docs/adrs/2026-08-11-network-sandbox-proxy.md
@@ -1,0 +1,122 @@
+# Plain L3 routing over a Docker internal network is rejected
+
+**Status:** accepted; implemented by [the egress relay](2026-08-13-egress-relay.md)
+**Date:** 2026-08-11
+**Scope:** rejects one topology — direct L3 routing across an `internal`
+bridge — not transparent sandboxing as such. Finding 3 below is the
+shape the implementation eventually took.
+
+> Independently re-measured on 2026-08-13. The routed topology produced the
+> same findings:
+> zero packets in the gateway's `FORWARD` chain, the drop counted by
+> `DOCKER-ISOLATION-STAGE-1`, and the daemon refusing `isolated` without
+> `internal`.
+
+## Context
+
+The evaluated topology used a per-capsule network sandbox: an internal bridge in
+Engine 28's `isolated` gateway mode so it carries no host address, a
+per-capsule egress gateway attached to both that bridge and a
+Runpool-owned uplink, and a short-lived route initializer that points
+the capsule's default route at the gateway. Traffic would then be
+forwarded by the gateway, which applies a default-deny policy.
+
+A live measurement on Docker Engine 28.5 shows that topology cannot work.
+
+## Findings
+
+**1. `internal` blocks forwarding at the host, not at the bridge.**
+Docker implements an internal network with host-level rules:
+
+```text
+-A DOCKER-ISOLATION-STAGE-1 ! -d 172.23.0.0/16 -i br-<id> -j DROP
+```
+
+Any packet entering the host from that bridge whose destination lies
+outside the bridge's own subnet is dropped by the host. With
+`br_netfilter` enabled — the norm on Docker hosts — this applies even to
+frames bridged toward another container on the same network. A capsule
+that sets its default route to a gateway container therefore emits
+packets addressed to `1.1.1.1`, and the host drops them before the
+gateway ever sees them. Measured: the gateway's `FORWARD` chain counted
+zero packets, while a ping to the gateway's own address (a destination
+inside the subnet) succeeded.
+
+**2. `isolated` gateway mode requires `internal`.** Docker refuses the
+combination the design implies as an alternative:
+
+```text
+gateway mode 'isolated' can only be used for an internal network
+```
+
+So "no host gateway address on the bridge" cannot be obtained without
+also accepting the destination-based drop rules.
+
+**3. The drop rule keys on destination, which leaves one path open.**
+Traffic addressed *to the gateway's own internal address* is inside the
+subnet and is delivered normally. The gateway can then originate its own
+connections from its uplink interface, which are not subject to the
+rule. A gateway that terminates connections — a proxy — works where a
+gateway that forwards packets cannot.
+
+## Evidence
+
+A capsule running the real runner image on an internal, isolated bridge,
+with a proxy on the gateway's internal address (Engine 28.5, forge):
+
+| Probe | Result |
+|---|---|
+| Direct HTTPS to api.github.com, no proxy | blocked |
+| HTTPS to api.github.com through the proxy | reachable |
+| Host address `:22` through the proxy | blocked |
+| `docker0` gateway `:80` through the proxy | blocked |
+| Host address, RFC1918, metadata, loopback (routing probe) | blocked |
+
+## What this rejects, and what it does not
+
+Rejected: **direct L3 routing** from the capsule to a gateway across an
+`internal` bridge — the capsule emitting packets addressed to public
+destinations and expecting a neighbour container to forward them.
+
+Not rejected: transparent sandboxing in general. Finding 3 says the host
+rule keys on the *destination of the packet that leaves the bridge*. Two
+shapes satisfy it: a proxy, which terminates connections at the
+gateway's address; and **encapsulation**, where the capsule's inner
+traffic is wrapped in an outer packet addressed to the gateway's
+internal address, decapsulated there, filtered, and NATed out a
+Runpool-owned uplink. Encapsulation keeps transparency — arbitrary
+protocols, no proxy variables — while still satisfying the rule.
+
+Encapsulation was evaluated separately and rejected for V1 on portability and
+privilege grounds. The accepted per-capsule gateway is a **relay**, not a
+router:
+
+- the capsule network stays `internal` with `gateway_mode=isolated`, so
+  the host itself enforces default-deny egress;
+- the gateway attaches to that network and to the Runpool uplink, runs
+  a DNS relay and an HTTP `CONNECT` proxy with an address-and-port policy,
+  and holds no socket, secret or volume;
+- the runner, job, and inner daemon inherit
+  `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY`; and
+- the route initializer disappears. The gateway receives `NET_ADMIN` only for
+  its own fail-closed ruleset; the capsule receives no network capability.
+
+This is stronger than the routed topology in one respect and weaker in
+another, and both must be stated plainly:
+
+- **Stronger:** egress is denied by the host kernel, not by rules
+  Runpool installs. A gateway that crashes, a policy that fails to load,
+  a workflow that manipulates routes inside privileged dind — none of
+  them produce egress. Fail-closed is structural.
+- **Weaker:** it is not transparent. Only protocols that traverse an
+  HTTP proxy work; a workflow that ignores the proxy variables has no
+  egress at all rather than unfiltered egress. Arbitrary TCP is unsupported.
+  DNS is served by the gateway, while relay connections resolve and enforce
+  policy against the exact address they dial.
+
+## Superseding decision
+
+V1 adopts the policy-enforcing relay described in
+[the egress relay ADR](2026-08-13-egress-relay.md). It preserves the
+kernel-enforced no-route property and makes the compatibility cost explicit.
+Transparent L3 egress is not part of the V1 restricted profile.

--- a/docs/adrs/2026-08-13-egress-relay.md
+++ b/docs/adrs/2026-08-13-egress-relay.md
@@ -1,0 +1,104 @@
+# Capsule egress is a relay, not a route
+
+**Status:** accepted and implemented; release qualification pending
+**Date:** 2026-08-13
+**Supersedes:** the routed-gateway topology
+
+The restricted profile provides no route out and a policy-enforcing relay
+for permitted destinations. The implementation has passed its live contract
+suite, but remains unqualified until the complete release workflow succeeds
+on the locked platform.
+
+> This record is the implementation decision. The constraint it rests on
+> was already measured and written down two days earlier in
+> [Plain L3 routing over a Docker internal network is rejected](2026-08-11-network-sandbox-proxy.md),
+> including the conclusion that a gateway which *terminates* connections
+> works where one that forwards cannot. The findings below independently
+> confirm that earlier measurement.
+
+## The design that could not be built
+
+The design specified a per-capsule internal bridge in Engine 28's
+`isolated` gateway mode, plus a per-capsule gateway container attached
+to both that bridge and a Runpool uplink, with the capsule's default
+route pointed at the gateway. The gateway would forward what its policy
+allowed and NAT it out the uplink.
+
+Built exactly that way, no packet ever reached the gateway. The
+measurements, on the original measurement host (Engine 28.5.0, cgroup v2/systemd,
+`br_netfilter` loaded, `bridge-nf-call-iptables=1`):
+
+- the capsule's routes, the gateway's two legs, `ip_forward`, the
+  installed ruleset and the NAT rule were all exactly as intended;
+- the gateway's own `FORWARD` chain counted **zero packets**, including
+  its default DROP;
+- the host's `DOCKER-ISOLATION-STAGE-1` chain counted the missing
+  packets against
+  `-i br-<capsule> ! -d <capsule subnet> -j DROP`.
+
+That rule is how Docker implements `--internal`. With bridge netfilter
+enabled — Docker's own default — it applies to frames bridged *within*
+the network too, so a packet the capsule addresses to `1.1.1.1` is
+dropped by the host as it crosses the bridge toward the gateway, before
+any container-side rule is consulted. The daemon also refuses
+`gateway_mode=isolated` on a non-internal network ("gateway mode
+'isolated' can only be used for an internal network"), so the two
+options cannot be separated: an internal bridge cannot host a router.
+
+## What the constraint actually gives us
+
+The same rule that broke the topology is a stronger deny than the
+gateway could have enforced. The host drops **every** packet the capsule
+addresses outside its own bridge subnet, in the host's namespace, where
+a privileged capsule has no reach. Rewriting its routes, flushing its
+firewall, or running anything at all inside dind does not lift it. The
+default-deny is therefore kernel-enforced and unconditional, rather than
+enforced by a container that must stay correct.
+
+What remains reachable from the capsule is its bridge neighbours, which
+is exactly one container: the gateway.
+
+## Decision
+
+Egress is a relay. The gateway keeps both legs and the policy, and it
+serves the capsule two things on the internal leg:
+
+- **DNS**, relayed to the daemon's embedded resolver;
+- **an HTTP proxy** (CONNECT and absolute-URI), which resolves the
+  destination itself, checks every resolved address against the policy,
+  and connects only to an allowed one.
+
+The capsule is created with its resolver and `HTTP(S)_PROXY` pinned to
+the gateway, inherited by the runner, the job and the inner daemon, so
+checkouts, package installs and image pulls all take that path.
+
+Resolve-then-dial in the gateway is also the DNS rebinding defense: the
+address that is checked is the address that is dialed, and a name is
+never the unit of policy.
+
+The gateway's own ruleset is filter-only. It accepts DNS and proxy
+connections from the capsule's subnet, forwards nothing, and refuses the
+deny set on OUTPUT as a second layer under the proxy's check. It does
+not touch the nat table: flushing nat destroys the daemon-installed
+rules for the embedded resolver the gateway itself resolves through —
+found the same way, by measurement.
+
+## Consequences
+
+- **Kernel-enforced deny.** No route out exists at all; the bypass suite
+  asserts unproxied TCP to public addresses fails just as private ones
+  do.
+- **Only proxy-aware traffic leaves.** HTTPS, HTTP and anything
+  tunnelled over CONNECT work. Protocols that ignore proxy environment
+  variables — `git+ssh`, arbitrary TCP to a service on the internet — do
+  not. They fail closed, which is the safe direction, but it is a real
+  functional limit of the restricted profile and is documented as one.
+  Service containers are unaffected: they run inside the capsule, on the
+  inner daemon's own network.
+- **`unsafe-open-egress` keeps its meaning.** It builds no sandbox: a
+  plain bridge with host egress, for deployments that accept it.
+- Restoring full L3 egress later means giving up either the host's
+  `--internal` rule (a host firewall change through `DOCKER-USER`) or
+  the shared bridge (a veth pair plumbed between namespaces). Both are
+  more privileged than this; neither is needed for the qualified
+  profile.

--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -1,0 +1,257 @@
+// Package egress is the capsule egress policy: what the controller
+// computes, what travels to the gateway, and what the gateway enforces.
+// It is pure — the deny set, the decision for one address, and the
+// gateway's own ruleset are functions of their inputs — so the policy a
+// capsule runs under is reproducible and testable without a kernel.
+//
+// The topology this serves (see docs/adrs/2026-08-13-egress-relay.md):
+// the capsule's only network is an internal bridge in Engine 28's
+// isolated gateway mode, which makes the host kernel drop every packet
+// the capsule sends to any address outside that bridge's own subnet.
+// That deny is absolute — a privileged capsule rewriting its own
+// routes and firewall cannot lift a rule that lives in the host's
+// namespace. What the capsule can still reach is its bridge
+// neighbours, which is exactly one container: the gateway.
+//
+// Egress therefore is not routing but relaying. The gateway resolves
+// names for the capsule and opens connections on its behalf through
+// its second leg, applying this policy to every address it is about to
+// connect to. Because the gateway resolves and then connects to the
+// address it validated, a resolver that answers with a private address
+// — DNS rebinding — changes nothing.
+package egress
+
+import (
+	"fmt"
+	"net/netip"
+	"strings"
+)
+
+// ProxyPort is where the relay listens on the internal leg. It is the
+// capsule's only outbound surface, published to it as HTTP(S)_PROXY.
+//
+// It lives here rather than in the gateway because both sides of the
+// relationship need it: the gateway to listen, and the capsule to point
+// its proxy variables at. This package is the policy vocabulary they
+// already share, so naming the port here is what lets the capsule stop
+// importing the whole gateway for one integer.
+const ProxyPort = 3128
+
+// Policy is what the gateway needs: the subnets that identify its two
+// legs, and the allow/deny sets it applies to every destination. Allow
+// is consulted before Deny, so an operator's allowPrivateCIDRs punch a
+// named hole through the private-range denies without weakening
+// anything else.
+type Policy struct {
+	InternalSubnet string   `json:"internal_subnet"`
+	UplinkSubnet   string   `json:"uplink_subnet"`
+	Allow          []string `json:"allow,omitempty"`
+	Deny           []string `json:"deny"`
+}
+
+// Validate parses every prefix so a malformed policy fails before the
+// gateway reports ready — half a policy is an open gateway.
+func (p Policy) Validate() error {
+	if _, err := netip.ParsePrefix(p.InternalSubnet); err != nil {
+		return fmt.Errorf("internal subnet: %w", err)
+	}
+	if _, err := netip.ParsePrefix(p.UplinkSubnet); err != nil {
+		return fmt.Errorf("uplink subnet: %w", err)
+	}
+	if len(p.Deny) == 0 {
+		return fmt.Errorf("deny set is empty; a policy that denies nothing is not a policy")
+	}
+	for _, c := range append(append([]string{}, p.Allow...), p.Deny...) {
+		if _, err := netip.ParsePrefix(c); err != nil {
+			return fmt.Errorf("cidr %q: %w", c, err)
+		}
+	}
+	return nil
+}
+
+// Decider is a compiled policy: parsed once, consulted per connection.
+type Decider struct {
+	allow []netip.Prefix
+	deny  []netip.Prefix
+}
+
+// Compile parses the policy's prefixes. It fails on the first bad one,
+// so a Decider always represents a complete policy.
+func (p Policy) Compile() (*Decider, error) {
+	if err := p.Validate(); err != nil {
+		return nil, err
+	}
+	d := &Decider{}
+	for _, c := range p.Allow {
+		prefix, err := netip.ParsePrefix(c)
+		if err != nil {
+			return nil, err
+		}
+		d.allow = append(d.allow, prefix)
+	}
+	for _, c := range p.Deny {
+		prefix, err := netip.ParsePrefix(c)
+		if err != nil {
+			return nil, err
+		}
+		d.deny = append(d.deny, prefix)
+	}
+	return d, nil
+}
+
+// Allowed reports whether the gateway may connect to an address.
+// Anything that is not an ordinary global unicast IPv4 address is
+// refused outright: IPv6 has no path here, and the special-purpose
+// forms (loopback, link-local, multicast, unspecified) are the ones an
+// attacker reaches for. An explicit allow prefix wins over a deny;
+// otherwise a deny match refuses; otherwise the address is public and
+// permitted.
+func (d *Decider) Allowed(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	if !addr.Is4() || !addr.IsGlobalUnicast() || addr.IsLoopback() ||
+		addr.IsLinkLocalUnicast() || addr.IsMulticast() || addr.IsUnspecified() {
+		return false
+	}
+	for _, p := range d.allow {
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	for _, p := range d.deny {
+		if p.Contains(addr) {
+			return false
+		}
+	}
+	return true
+}
+
+// baselineDeny is every IPv4 range that is never a legitimate public
+// destination for a CI job: the private ranges, loopback, link-local
+// (cloud metadata lives there), CGNAT, benchmarking, multicast,
+// reserved, and broadcast. Operator allowPrivateCIDRs punch holes
+// through it at decision time; nothing widens the list away.
+var baselineDeny = []string{
+	"0.0.0.0/8",
+	"10.0.0.0/8",
+	"100.64.0.0/10",
+	"127.0.0.0/8",
+	"169.254.0.0/16",
+	"172.16.0.0/12",
+	"192.0.0.0/24",
+	"192.168.0.0/16",
+	"198.18.0.0/15",
+	"224.0.0.0/4",
+	"240.0.0.0/4",
+	"255.255.255.255/32",
+}
+
+// BuildDeny composes the deny set: the baseline, the host's own
+// interface networks, every Docker network subnet the daemon knows,
+// and the uplink subnet. Duplicates are dropped, order is stable.
+func BuildDeny(uplinkSubnet string, hostCIDRs, dockerSubnets []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(c string) {
+		if c != "" && !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	for _, c := range baselineDeny {
+		add(c)
+	}
+	add(uplinkSubnet)
+	for _, c := range hostCIDRs {
+		add(c)
+	}
+	for _, c := range dockerSubnets {
+		add(c)
+	}
+	return out
+}
+
+// WidensBaselineDeny reports whether prefix would reopen a whole range the
+// baseline refuses, as a side effect of being broader than it.
+//
+// Allow is consulted before deny, so `0.0.0.0/0` in allowPrivateCIDRs
+// readmits every private range while the profile still reads
+// `public-internet-only` — the hazard this exists to refuse. What it must
+// not refuse is the two legitimate shapes: a prefix wholly inside a denied
+// range (a targeted reopening, which is the field's whole purpose), and a
+// prefix in public space, which is a no-op because the profile already
+// permits the public internet — and which is how an operator reaches a
+// service on the host's own public address, since BuildDeny adds the host's
+// interface CIDRs at runtime.
+//
+// So the rule is containment in one direction only: an allow that strictly
+// contains a denied range takes that whole range with it.
+func WidensBaselineDeny(prefix netip.Prefix) bool {
+	for _, raw := range baselineDeny {
+		denied, err := netip.ParsePrefix(raw)
+		if err != nil {
+			continue
+		}
+		if prefix.Bits() < denied.Bits() && prefix.Contains(denied.Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+// RenderIPTables is the gateway's own ruleset, applied to the filter
+// table only. The nat table is deliberately untouched: the gateway
+// routes nothing, and flushing nat would destroy the daemon-installed
+// rules that make its own embedded resolver work.
+//
+// The shape:
+//   - INPUT drops everything except loopback, established replies, and
+//     DNS and proxy connections from the capsule's subnet. Other
+//     gateways share the uplink, so restricting by source subnet is
+//     what keeps one capsule's gateway from serving another's.
+//   - FORWARD drops everything: the gateway is a relay, never a
+//     router, and a rule that would forward is a rule that would
+//     defeat the address policy applied in userspace.
+//   - OUTPUT allows loopback and established, refuses the deny set as
+//     a second layer under the proxy's own check, and permits the
+//     rest so the relay can reach public destinations.
+func (p Policy) RenderIPTables(internalIf string, proxyPort int) string {
+	var b strings.Builder
+	w := func(format string, args ...any) { fmt.Fprintf(&b, format+"\n", args...) }
+
+	w("*filter")
+	w(":INPUT DROP [0:0]")
+	w(":FORWARD DROP [0:0]")
+	w(":OUTPUT DROP [0:0]")
+	w("-A INPUT -i lo -j ACCEPT")
+	w("-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+	w("-A INPUT -i %s -s %s -p udp --dport 53 -j ACCEPT", internalIf, p.InternalSubnet)
+	w("-A INPUT -i %s -s %s -p tcp --dport 53 -j ACCEPT", internalIf, p.InternalSubnet)
+	w("-A INPUT -i %s -s %s -p tcp --dport %d -j ACCEPT", internalIf, p.InternalSubnet, proxyPort)
+	w("-A OUTPUT -o lo -j ACCEPT")
+	w("-A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+	for _, c := range p.Allow {
+		w("-A OUTPUT -d %s -j ACCEPT", c)
+	}
+	for _, c := range p.Deny {
+		w("-A OUTPUT -d %s -j REJECT --reject-with icmp-admin-prohibited", c)
+	}
+	w("-A OUTPUT -j ACCEPT")
+	w("COMMIT")
+	return b.String()
+}
+
+// RenderIP6Tables denies IPv6 outright: the capsule's network does not
+// enable it, and a default-deny ruleset makes "not enabled" into
+// "denied even if something enables it".
+func RenderIP6Tables() string {
+	return strings.Join([]string{
+		"*filter",
+		":INPUT DROP [0:0]",
+		":FORWARD DROP [0:0]",
+		":OUTPUT DROP [0:0]",
+		"-A INPUT -i lo -j ACCEPT",
+		"-A OUTPUT -o lo -j ACCEPT",
+		"COMMIT",
+		"",
+	}, "\n")
+}

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -1,0 +1,150 @@
+package egress
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+func policy() Policy {
+	return Policy{
+		InternalSubnet: "172.20.0.0/24",
+		UplinkSubnet:   "172.21.0.0/24",
+		Allow:          []string{"10.9.8.0/24"},
+		Deny:           BuildDeny("172.21.0.0/24", []string{"203.0.113.0/24"}, []string{"172.17.0.0/16"}),
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := policy().Validate(); err != nil {
+		t.Fatal(err)
+	}
+	bad := policy()
+	bad.Deny = append(bad.Deny, "not-a-cidr")
+	if err := bad.Validate(); err == nil {
+		t.Fatal("malformed deny cidr validated; half a policy is an open gateway")
+	}
+	if err := (Policy{}).Validate(); err == nil {
+		t.Fatal("empty policy validated")
+	}
+	noDeny := policy()
+	noDeny.Deny = nil
+	if err := noDeny.Validate(); err == nil {
+		t.Fatal("a policy with an empty deny set validated")
+	}
+}
+
+// TestBuildDeny: the deny set always carries the baseline — private
+// ranges, loopback, link-local metadata, CGNAT, multicast — plus the
+// uplink, host and Docker subnets, without duplicates.
+func TestBuildDeny(t *testing.T) {
+	deny := BuildDeny("172.21.0.0/24", []string{"203.0.113.0/24", "10.0.0.0/8"}, []string{"172.17.0.0/16"})
+
+	for _, must := range []string{
+		"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", // RFC1918
+		"169.254.0.0/16", // link-local / cloud metadata
+		"127.0.0.0/8", "100.64.0.0/10", "224.0.0.0/4",
+		"172.21.0.0/24", // the uplink itself
+		"203.0.113.0/24",
+		"172.17.0.0/16",
+	} {
+		if !contains(deny, must) {
+			t.Errorf("deny set lacks %s", must)
+		}
+	}
+	seen := map[string]bool{}
+	for _, c := range deny {
+		if seen[c] {
+			t.Errorf("duplicate deny entry %s", c)
+		}
+		seen[c] = true
+	}
+}
+
+// TestDecide is the check every relayed connection passes through: it
+// is what makes DNS rebinding irrelevant, because the gateway applies
+// it to the address it has already resolved and is about to dial.
+func TestDecide(t *testing.T) {
+	d, err := policy().Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]bool{
+		"1.1.1.1":         true,  // ordinary public
+		"140.82.121.4":    true,  // github
+		"169.254.169.254": false, // cloud metadata
+		"127.0.0.1":       false, // loopback
+		"10.1.2.3":        false, // RFC1918
+		"192.168.1.1":     false,
+		"172.17.0.5":      false, // another Docker network
+		"172.21.0.1":      false, // the uplink itself
+		"203.0.113.9":     false, // a host interface network
+		"224.0.0.1":       false, // multicast
+		"0.0.0.0":         false,
+		"255.255.255.255": false,
+		"10.9.8.7":        true, // the operator's explicit allow, inside a denied range
+		"::1":             false,
+		"2606:4700::1111": false, // IPv6 has no path here at all
+	}
+	for text, want := range cases {
+		addr := netip.MustParseAddr(text)
+		if got := d.Allowed(addr); got != want {
+			t.Errorf("Allowed(%s) = %v; want %v", text, got, want)
+		}
+	}
+}
+
+// TestRenderRules pins the gateway's own ruleset: it accepts DNS and
+// proxy connections only from the capsule's subnet, forwards nothing
+// at all, and never touches the nat table — flushing nat would destroy
+// the daemon rules its own resolver depends on.
+func TestRenderRules(t *testing.T) {
+	out := policy().RenderIPTables("eth0", 3128)
+
+	for _, must := range []string{
+		":INPUT DROP", ":FORWARD DROP", ":OUTPUT DROP",
+		"-A INPUT -i eth0 -s 172.20.0.0/24 -p udp --dport 53 -j ACCEPT",
+		"-A INPUT -i eth0 -s 172.20.0.0/24 -p tcp --dport 3128 -j ACCEPT",
+		"-A OUTPUT -d 169.254.0.0/16 -j REJECT",
+		"-A OUTPUT -d 10.9.8.0/24 -j ACCEPT",
+	} {
+		if !strings.Contains(out, must) {
+			t.Errorf("ruleset lacks %q\n%s", must, out)
+		}
+	}
+	if strings.Contains(out, "*nat") || strings.Contains(out, "MASQUERADE") {
+		t.Error("the gateway must not touch the nat table: flushing it destroys the daemon's embedded-resolver rules")
+	}
+	if strings.Contains(out, "-A FORWARD -") {
+		t.Error("the gateway is a relay, not a router; no FORWARD rule may exist")
+	}
+
+	// The operator's allow renders before the denies, so a hole inside
+	// a denied range works while the range itself stays denied.
+	allowAt := strings.Index(out, "-A OUTPUT -d 10.9.8.0/24 -j ACCEPT")
+	denyAt := strings.Index(out, "-A OUTPUT -d 10.0.0.0/8 -j REJECT")
+	if allowAt == -1 || denyAt == -1 || allowAt > denyAt {
+		t.Errorf("allow must render before deny: allow@%d deny@%d", allowAt, denyAt)
+	}
+}
+
+func TestRenderIP6DeniesEverything(t *testing.T) {
+	out := RenderIP6Tables()
+	for _, must := range []string{":INPUT DROP", ":FORWARD DROP", ":OUTPUT DROP"} {
+		if !strings.Contains(out, must) {
+			t.Errorf("ip6 ruleset lacks %q", must)
+		}
+	}
+	if strings.Contains(out, "ACCEPT") && !strings.Contains(out, "-o lo") {
+		t.Error("ip6 accepts something beyond loopback")
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What changes

`internal/egress` arrives: the egress policy for a job capsule, expressed
as pure functions over their inputs. It computes the deny set from the
uplink subnet and the host's own ranges, decides whether a single
destination is permitted, and renders the gateway's IPv6 ruleset. Nothing
in it touches a socket or a kernel.

## What was found

The capsule's network is an internal bridge, so the host kernel already
drops everything the capsule sends beyond that bridge's subnet — a deny
the capsule cannot lift, because the rule is not in its namespace. That
leaves exactly one reachable peer, the gateway, and it makes egress a
relaying problem rather than a routing one.

Two consequences shaped the code. The gateway resolves a name and then
connects to the address it validated, so a resolver answering with a
private address changes nothing. And `Allow` is consulted before `Deny`,
because an operator opening one private range should not have to weaken
the baseline that protects the rest.

`ProxyPort` is declared here rather than in the gateway: the gateway
listens on it and the capsule points `HTTP(S)_PROXY` at it, so it belongs
to the vocabulary they share instead of to either side.

## Evidence

Hermetic only — the package is pure, and its behaviour is fully covered
by the unit suite that arrives with it.

```text
hermetic only — no kernel, socket or daemon is involved
```

## What would notice this regressing

`internal/egress`'s own suite: it fixes a two-leg topology and asserts
the deny set, the allow-before-deny ordering, the baseline-widening
guard and the rendered ruleset. A policy that stopped denying a private
range, or an `Allow` that stopped overriding, fails there.

## Risk, compatibility and operations

Trust boundary: this is the declarative half of the capsule's network
boundary. It grants nothing by itself — no code in this change opens a
socket, and the enforcing gateway does not exist yet.

Credentials, ownership, cleanup, networking, resource limits: N/A — the
package holds no state and performs no I/O.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports the package yet.

Constrains what the code may do later, so it arrives with its records:
[why plain L3 routing is rejected](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-11-network-sandbox-proxy.md)
and [egress is a relay, not a route](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-13-egress-relay.md).

## Changelog

```text
NONE
```

