### PR TITLE
feat(config): the deployment contract

### DIFF
--- a/docs/adrs/2026-08-17-target-hosts-and-scopes.md
+++ b/docs/adrs/2026-08-17-target-hosts-and-scopes.md
@@ -1,0 +1,78 @@
+# A target is any host the protocol serves, at any scope it defines
+
+**Status:** accepted
+**Date:** 2026-08-17
+
+`ParseTargetURL` refuses any host that is not `github.com`, with the
+message "V1 supports github.com targets only". One rule closes three
+different doors, and they are not equally justified.
+
+## What the provider library serves
+
+The library derives its API URL with **enterprise as the default case**:
+the same host, under `/api/v3`. It switches to `api.<host>` only for
+hosts it recognises as hosted, which are `github.com`, `www.github.com`,
+`github.localhost` and any `*.ghe.com`. It also carries a distinct
+enterprise scope, whose runner registration goes to
+`/enterprises/<name>/actions/runners/registration-token`.
+
+Measured against that, the single rule refuses:
+
+- **`*.ghe.com`** — GitHub's own hosted service under a data-residency
+  hostname. Identical endpoints, identical code path, different host
+  string.
+- **A self-hosted Enterprise Server** — the same endpoints under
+  `/api/v3`.
+- **Enterprise scope** — a different registration endpoint that no test
+  in this repository exercises.
+
+## The misclassification underneath
+
+The host rule is also masking a defect that exists with the rule in
+place. `https://github.com/enterprises/acme` passes the host check, has
+two path segments, and both segments satisfy the owner and repository
+patterns. It is therefore accepted as **repository `acme` owned by
+`enterprises`**, and the canonical URL is rebuilt from a hardcoded
+`https://github.com/` prefix.
+
+An enterprise URL is not refused today. It is silently understood as
+something else.
+
+## Decision
+
+**The host is not the unit of refusal.** Any `https` host is accepted;
+the canonical URL is built from the host that was given rather than from
+a literal. A host that does not serve the protocol fails at the live
+credential check in `runpool doctor`, which already makes a real call,
+with an error about the host rather than a rule about a name.
+
+**Enterprise is a scope**, parsed from `/enterprises/<name>` and carried
+through as a third value beside organization and repository. The
+lifecycle core keys on opaque provider identity and is unaffected. The
+rules that branch on scope are: runner groups, which enterprises have,
+so the organization rule extends to them; and cache lanes, which stay
+repository-only, because the identity that justifies a persistent lane
+is unchanged by this.
+
+**Verification is stated per path, because it differs.** A hermetic test
+pins the derivation for each shape — a hosted host resolves to
+`api.<host>`, an enterprise host to `<host>/api/v3`, and each URL shape
+to its scope. That proves this side of the boundary entirely. What it
+does not prove is that a given remote answers, and the support matrix
+says which hosts and scopes the gates actually observed: `github.com`,
+at organization and repository scope.
+
+## Consequences
+
+- An enterprise URL stops being misread as a repository. That is a
+  correctness fix, independent of everything else here.
+- A deployment on Enterprise Cloud with data residency, or on Enterprise
+  Server, can be configured. Neither has been observed by the gates, and
+  the support matrix says so.
+- Enterprise scope reaches an endpoint no suite in this repository
+  reaches. It is the least exercised path of the three and is documented
+  as such, rather than grouped with paths that share the endpoints the
+  suites do exercise.
+- A typo in a host no longer fails at configuration validation. It fails
+  at `runpool doctor`, one step later, against the real service — which
+  is where a wrong-but-well-formed host was always going to fail.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/rhobuild/runpool
 
 go 1.26.6
 
+require gopkg.in/yaml.v3 v3.0.1
+
 require (
 	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,5 +44,9 @@ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTF
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
 golang.org/x/vuln v1.6.0 h1:FeMO9Rm/HwyduOztbvKcOw+zvDEPr4I4aQNSfevFcKY=
 golang.org/x/vuln v1.6.0/go.mod h1:bWlG2493/sjR7ksvicBgMrznH3eYQEyK8ifUYBrqUbg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
 honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,0 +1,217 @@
+package config
+
+// Enumerated values the schema accepts. V1 qualifies exactly one restricted
+// network profile and one DNS mode; widening either is a design change.
+const (
+	HostTopologySharedDaemon    = "shared-daemon"
+	HostTopologyDedicatedDaemon = "dedicated-daemon"
+
+	// NetworkProfilePublicInternetOnly is the restricted profile: the
+	// capsule has no route out, and its gateway relays what the policy
+	// allows. It is implemented and tested live; release qualification on
+	// the reference platform has not run.
+	NetworkProfilePublicInternetOnly = "public-internet-only"
+	// NetworkProfileUnsafeOpen builds no sandbox: the capsule reaches
+	// whatever the host reaches. It is named so that no deployment can
+	// claim containment it does not have.
+	NetworkProfileUnsafeOpen = "unsafe-open-egress"
+	IPv6Disabled             = "disabled"
+	DNSModeGateway           = "gateway"
+	CacheStorageModeVolume   = "volume"
+	CredentialTypeToken      = "token"
+	// CredentialTypeGitHubApp authenticates as an installation of a GitHub
+	// App rather than as a person. The provider client mints and refreshes
+	// the installation token itself from the App's own key.
+	CredentialTypeGitHubApp = "github_app"
+
+	LogFormatJSON = "json"
+	LogFormatText = "text"
+
+	DefaultInstanceName    = "primary"
+	DefaultTierID          = "standard"
+	DefaultCacheGeneration = "default"
+	DefaultLogLevel        = "info"
+	// MaxParallelism bounds allocator and preflight work for an untrusted
+	// configuration while remaining far above a practical single-host limit.
+	MaxParallelism = 10_000
+
+	// DefaultJobTimeout is how long Runpool waits for a capsule that has
+	// stopped reporting. A backstop below the provider's own 360-minute
+	// maximum for a job ends work the provider still permits, and one
+	// equal to it races the provider: the timeout that resolves a healthy
+	// lease is the provider's, which then has to reach the runner, exit
+	// it, and be observed here. Two hours of margin buys that sequence.
+	DefaultJobTimeout = Duration(8 * 60 * 60 * 1e9) // 8h
+	// MinJobTimeout and MaxJobTimeout bound the wait a tier may configure.
+	//
+	// The floor is low because preparation is bounded separately: a
+	// ceiling governs the wait for a job the provider owns, and a tier
+	// that knows its work is short gets its capacity back sooner. The cap
+	// exists for the same reason the retry budget has one — a wedged
+	// capsule holds a lane, an admission credit and a cache lane for the
+	// whole ceiling, and a value with no upper bound is how that becomes
+	// permanent by configuration.
+	MinJobTimeout = Duration(60 * 1e9)           // 1m
+	MaxJobTimeout = Duration(7 * 24 * 60 * 60e9) // 168h
+	// MinRetryBudget and MaxRetryBudget bound what a deployment may set
+	// for scheduling.retryBudget. The range is narrow because the budget
+	// breaks a loop rather than tunes a rate: raising it far is how a
+	// systematic failure gets paid for instead of found.
+	MinRetryBudget = 1
+	MaxRetryBudget = 10
+	// DefaultLeaseHistory keeps a finished lease's record for 90 days.
+	// Long enough to explain an incident from last quarter, short enough
+	// that the books stay bounded by recent work on a host that runs for
+	// years.
+	DefaultLeaseHistory = Duration(90 * 24 * 60 * 60 * 1e9) // 2160h
+
+	// MinLeaseHistory is the shortest configurable window. A retention of
+	// minutes would delete the record of work an operator is still
+	// looking at, which is a support problem rather than a saving.
+	MinLeaseHistory = Duration(24 * 60 * 60 * 1e9) // 24h
+
+	// DefaultScaleSetPrefix + tier id is the runs-on label workflows use
+	// when a binding does not name its scale set explicitly.
+	DefaultScaleSetPrefix = "runpool-"
+)
+
+var logLevels = []string{"debug", "info", "warn", "error"}
+
+// ApplyDefaults fills unset optional fields in place. Mandatory fields
+// (apiVersion, kind, targets, credentials, tiers) are never invented here;
+// Validate reports them instead.
+func ApplyDefaults(c *Config) {
+	if c.Instance.Name == "" {
+		c.Instance.Name = DefaultInstanceName
+	}
+
+	// On a dedicated daemon these are product defaults. A shared daemon
+	// must state its reserve explicitly: Runpool cannot infer what the
+	// colocated platform and production services need to remain healthy.
+	if c.Host.Topology == HostTopologyDedicatedDaemon {
+		r := &c.Host.Reserve
+		if r.CPU == 0 {
+			r.CPU = 1 * nanoPerCPU
+		}
+		if r.Memory == 0 {
+			r.Memory = 2 << 30 // 2GiB
+		}
+		if r.FreeDisk == 0 {
+			r.FreeDisk = 20 << 30 // 20GiB
+		}
+	}
+
+	for i := range c.Targets {
+		t := &c.Targets[i]
+		if t.Cache.Enabled && t.Cache.Generation == "" {
+			t.Cache.Generation = DefaultCacheGeneration
+		}
+		for j := range t.Tiers {
+			b := &t.Tiers[j]
+			if b.ScaleSetName == "" {
+				b.ScaleSetName = DefaultScaleSetPrefix + b.TierID
+			}
+		}
+	}
+
+	for i := range c.Credentials {
+		if c.Credentials[i].Type == "" {
+			c.Credentials[i].Type = CredentialTypeToken
+		}
+	}
+
+	for i := range c.Tiers {
+		t := &c.Tiers[i]
+		if t.Parallelism == 0 {
+			t.Parallelism = 1
+		}
+		if t.Resources.CPU == 0 {
+			t.Resources.CPU = 2 * nanoPerCPU
+		}
+		if t.Resources.Memory == 0 {
+			t.Resources.Memory = 4 << 30 // 4GiB
+		}
+		if t.Resources.PIDs == 0 {
+			t.Resources.PIDs = 1024
+		}
+	}
+
+	if c.Cache.Storage.Mode == "" {
+		c.Cache.Storage.Mode = CacheStorageModeVolume
+	}
+	g := &c.Cache.Global
+	if g.MaxManagedBytes == 0 {
+		g.MaxManagedBytes = 150 << 30 // 150GiB
+	}
+	if g.HighWatermarkPercent == 0 {
+		g.HighWatermarkPercent = 80
+	}
+	if g.LowWatermarkPercent == 0 {
+		g.LowWatermarkPercent = 65
+	}
+	if g.SoftEmergencyFreeBytes == 0 {
+		g.SoftEmergencyFreeBytes = 20 << 30 // 20GiB
+	}
+	if g.HardEmergencyFreeBytes == 0 {
+		g.HardEmergencyFreeBytes = 10 << 30 // 10GiB
+	}
+	d := &c.Cache.Defaults
+	if d.RepositoryMaxBytes == 0 {
+		d.RepositoryMaxBytes = 15 << 30 // 15GiB
+	}
+	if d.UnusedTTL == 0 {
+		d.UnusedTTL = Duration(720 * 60 * 60 * 1e9) // 720h
+	}
+
+	// Materialised rather than left nil, because nothing downstream would
+	// do it: an unset pointer would read as "keep forever", which is the
+	// opposite of the default. Once set it always renders in `config
+	// effective`, which is right — a deletion policy should not be
+	// invisible.
+	if c.Retention.LeaseHistory == nil {
+		d := DefaultLeaseHistory
+		c.Retention.LeaseHistory = &d
+	}
+
+	if c.Observability.Log.Format == "" {
+		c.Observability.Log.Format = LogFormatJSON
+	}
+	if c.Observability.Log.Level == "" {
+		c.Observability.Log.Level = DefaultLogLevel
+	}
+
+	n := &c.Network
+	if n.Profile == "" {
+		n.Profile = NetworkProfilePublicInternetOnly
+	}
+	if n.IPv6 == "" {
+		n.IPv6 = IPv6Disabled
+	}
+	if n.DNS.Mode == "" {
+		n.DNS.Mode = DNSModeGateway
+	}
+}
+
+// The gateway's share of a lease's tier envelope, and the floor the
+// capsule must be left with.
+//
+// A lease's budget covers everything a workload can cause to run. Under
+// the restricted profile that includes its egress gateway: every
+// connection the job opens is work the gateway performs. So the tier is
+// split rather than duplicated — the gateway takes this fixed reserve,
+// the capsule takes the rest, both sit under one parent cgroup, and the
+// sum is the tier by construction.
+//
+// These live here, next to the validation that enforces them, because
+// the rule is a property of a configured tier. The capsule package
+// applies them.
+const (
+	GatewayReserveMemory = 128 << 20 // 128 MiB
+	GatewayReserveCPUs   = 500_000_000
+	GatewayReservePIDs   = 128
+	// MinCapsuleMemory is what has to be left for a runner and a Docker
+	// daemon after the gateway takes its share. Below this the capsule
+	// cannot boot, so a tier that small is a configuration error rather
+	// than a small tier.
+	MinCapsuleMemory = 512 << 20
+)

--- a/internal/config/input_test.go
+++ b/internal/config/input_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// The configuration file is parsed before it is trusted, so these
+// bounds are checked at the parser, not at the fields. Each case is a
+// document that is cheap to write and expensive to build.
+
+func loadText(t *testing.T, content string) error {
+	t.Helper()
+	path := t.TempDir() + "/config.yaml"
+	if err := writeFile(path, content); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadFile(path)
+	return err
+}
+
+const configHeader = "apiVersion: runpool.rhobuild.com/v1\nkind: RunpoolConfig\n"
+
+// TestRejectsOversizedFile: the reader stops at the limit rather than
+// pulling an arbitrarily large file into memory.
+func TestRejectsOversizedFile(t *testing.T) {
+	padding := strings.Repeat("# padding to exceed the input limit\n", (MaxConfigBytes/36)+64)
+	err := loadText(t, configHeader+padding)
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("oversized configuration = %v; want a size error", err)
+	}
+}
+
+// TestRejectsAliases is the billion-laughs family: an alias graph is
+// small on disk and enormous in memory. Refusing aliases outright
+// removes the class instead of pricing it.
+func TestRejectsAliases(t *testing.T) {
+	bomb := configHeader + `
+a: &a ["x","x","x","x","x","x","x","x","x"]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+targets: [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+`
+	err := loadText(t, bomb)
+	if err == nil {
+		t.Fatal("an alias expansion document was accepted")
+	}
+	if !strings.Contains(err.Error(), "anchor") && !strings.Contains(err.Error(), "alias") {
+		t.Errorf("error = %v; want it to name anchors or aliases", err)
+	}
+}
+
+// TestRejectsDeepNesting: depth is what turns a recursive walk into a
+// stack problem, so it is bounded before the tree is walked for real.
+func TestRejectsDeepNesting(t *testing.T) {
+	err := loadText(t, configHeader+"targets: "+strings.Repeat("[", 200)+strings.Repeat("]", 200)+"\n")
+	if err == nil || !strings.Contains(err.Error(), "deeper") {
+		t.Errorf("deeply nested configuration = %v; want a depth error", err)
+	}
+}
+
+// TestRejectsDuplicateKeys: two values for one key means the file says
+// two different things, and silently taking the last is how a
+// configuration ends up meaning something nobody wrote.
+func TestRejectsDuplicateKeys(t *testing.T) {
+	err := loadText(t, configHeader+"instance:\n  name: first\n  name: second\n")
+	if err == nil {
+		t.Fatal("a document with a duplicate key was accepted")
+	}
+}
+
+// TestRejectsMultipleDocuments: a second document would be silently
+// ignored, and an operator who wrote one expects it to take effect.
+func TestRejectsMultipleDocuments(t *testing.T) {
+	err := loadText(t, configHeader+"---\n"+configHeader)
+	if err == nil || !strings.Contains(err.Error(), "single YAML document") {
+		t.Errorf("multi-document configuration = %v; want a single-document error", err)
+	}
+}
+
+// TestAcceptsARealConfiguration keeps the limits honest: they must not
+// reject the file the project ships as its own example.
+func TestAcceptsARealConfiguration(t *testing.T) {
+	if _, err := LoadFile("testdata/example.yaml"); err != nil {
+		t.Fatalf("the shipped example configuration was rejected: %v", err)
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,0 +1,135 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Load builds the effective configuration from the process environment:
+// file mode when RUNPOOL_CONFIG_FILE is set, Quick Start translation
+// otherwise. The result is defaulted and validated.
+func Load(environ func(string) string) (*Config, error) {
+	if path := environ(EnvConfigFile); path != "" {
+		for _, name := range quickStartTargetVars {
+			if environ(name) != "" {
+				return nil, fmt.Errorf("%s and %s are mutually exclusive: with a configuration file, target, tier and capacity settings come from the file", EnvConfigFile, name)
+			}
+		}
+		return LoadFile(path)
+	}
+	c, err := FromEnvironment(environ)
+	if err != nil {
+		return nil, err
+	}
+	return finish(c)
+}
+
+// Input limits for a configuration file. A configuration is written by
+// a person and read once at startup; none of these bounds constrains a
+// real one, and each bounds what a hostile or broken file can make the
+// parser do before any field is even looked at.
+const (
+	// MaxConfigBytes is generous for a file whose largest realistic
+	// form is a few dozen targets.
+	MaxConfigBytes = 1 << 20
+	// maxConfigDepth bounds nesting; the deepest legitimate path is
+	// about six levels (targets, then tiers, then their fields).
+	maxConfigDepth = 32
+	// maxConfigNodes bounds the total node count, which is the quantity
+	// an expansion attack inflates.
+	maxConfigNodes = 20000
+)
+
+// LoadFile reads, defaults and validates an advanced configuration
+// file. Unknown fields are errors: a typo must fail, not silently
+// configure nothing.
+//
+// The document is checked before it is decoded. YAML can describe
+// structures that cost far more to build than to write — aliases
+// expanding into each other, unbounded nesting — so size, depth, node
+// count and alias use are bounded first, and only a document within
+// those bounds is decoded into the configuration.
+func LoadFile(path string) (*Config, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// Reading one byte past the limit is what distinguishes a file at
+	// the limit from one truncated at it.
+	raw, err := io.ReadAll(io.LimitReader(f, MaxConfigBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if len(raw) > MaxConfigBytes {
+		return nil, fmt.Errorf("%s: configuration exceeds %d bytes", path, MaxConfigBytes)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if err := checkDocument(&doc); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	var c Config
+	if err := dec.Decode(&c); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	if err := dec.Decode(new(struct{})); !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("%s: expected a single YAML document", path)
+	}
+	return finish(&c)
+}
+
+// checkDocument walks the parsed tree and enforces the input limits.
+// Anchors and aliases are refused outright rather than bounded: a
+// configuration that reuses a node is harder to read than one that
+// repeats it, so refusing them removes expansion attacks entirely
+// instead of pricing them.
+func checkDocument(doc *yaml.Node) error {
+	nodes := 0
+	var walk func(n *yaml.Node, depth int) error
+	walk = func(n *yaml.Node, depth int) error {
+		if n == nil {
+			return nil
+		}
+		if depth > maxConfigDepth {
+			return fmt.Errorf("configuration nests deeper than %d levels", maxConfigDepth)
+		}
+		nodes++
+		if nodes > maxConfigNodes {
+			return fmt.Errorf("configuration has more than %d nodes", maxConfigNodes)
+		}
+		if n.Kind == yaml.AliasNode {
+			return fmt.Errorf("line %d: YAML aliases are not accepted; write the value out", n.Line)
+		}
+		if n.Anchor != "" {
+			return fmt.Errorf("line %d: YAML anchors are not accepted; write the value out", n.Line)
+		}
+		for _, child := range n.Content {
+			if err := walk(child, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return walk(doc, 0)
+}
+
+func finish(c *Config) (*Config, error) {
+	ApplyDefaults(c)
+	if err := Validate(c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/internal/config/quickstart.go
+++ b/internal/config/quickstart.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Quick Start environment variables. They compile into the same schema the
+// advanced YAML file uses; there is no second configuration model.
+const (
+	EnvGitHubURL           = "RUNPOOL_GITHUB_URL"
+	EnvGitHubToken         = "RUNPOOL_GITHUB_TOKEN"
+	EnvGitHubTokenFile     = "RUNPOOL_GITHUB_TOKEN_FILE"
+	EnvGitHubRunnerGroup   = "RUNPOOL_GITHUB_RUNNER_GROUP"
+	EnvHostTopology        = "RUNPOOL_HOST_TOPOLOGY"
+	EnvHostReserveCPU      = "RUNPOOL_HOST_RESERVE_CPU"
+	EnvHostReserveMemory   = "RUNPOOL_HOST_RESERVE_MEMORY"
+	EnvHostReserveSwap     = "RUNPOOL_HOST_RESERVE_SWAP"
+	EnvHostReserveFreeDisk = "RUNPOOL_HOST_RESERVE_FREE_DISK"
+	EnvTier                = "RUNPOOL_TIER"
+	EnvParallelism         = "RUNPOOL_PARALLELISM"
+	EnvLogLevel            = "RUNPOOL_LOG_LEVEL"
+	EnvNetworkProfile      = "RUNPOOL_NETWORK_PROFILE"
+	EnvConfigFile          = "RUNPOOL_CONFIG_FILE"
+)
+
+// quickStartTargetVars conflict with file mode: when RUNPOOL_CONFIG_FILE is
+// set, every setting a Quick Start variable carries comes from the file
+// alone.
+//
+// The list is every one of them, including those the file also has a
+// place for — logging and the network profile. A variable that is
+// neither applied nor refused is the worst of the three outcomes: an
+// operator who set RUNPOOL_LOG_LEVEL=debug beside a configuration file
+// gets no debug logging and no explanation, and looks for the reason
+// somewhere else.
+var quickStartTargetVars = []string{
+	EnvGitHubURL, EnvGitHubRunnerGroup, EnvHostTopology, EnvHostReserveCPU,
+	EnvHostReserveMemory, EnvHostReserveSwap, EnvHostReserveFreeDisk, EnvTier, EnvParallelism,
+	EnvLogLevel, EnvNetworkProfile,
+}
+
+// FromEnvironment translates the Quick Start variables into a Config.
+// The token value is never read here — the credential records only the
+// environment variable name or file path that references it.
+func FromEnvironment(environ func(string) string) (*Config, error) {
+	rawURL := environ(EnvGitHubURL)
+	if rawURL == "" {
+		return nil, fmt.Errorf("%s is required: set it to https://github.com/<owner> or https://github.com/<owner>/<repository>", EnvGitHubURL)
+	}
+	ref, err := ParseTargetURL(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", EnvGitHubURL, err)
+	}
+
+	token, tokenFile := environ(EnvGitHubToken), environ(EnvGitHubTokenFile)
+	switch {
+	case token == "" && tokenFile == "":
+		return nil, fmt.Errorf("either %s or %s is required", EnvGitHubToken, EnvGitHubTokenFile)
+	case token != "" && tokenFile != "":
+		return nil, fmt.Errorf("%s and %s are mutually exclusive", EnvGitHubToken, EnvGitHubTokenFile)
+	}
+	topology := environ(EnvHostTopology)
+	if topology == "" {
+		return nil, fmt.Errorf("%s is required: set %q when sharing a platform daemon or %q on an exclusive CI host",
+			EnvHostTopology, HostTopologySharedDaemon, HostTopologyDedicatedDaemon)
+	}
+	credential := Credential{ID: "github-default", Type: CredentialTypeToken}
+	if token != "" {
+		credential.TokenEnv = EnvGitHubToken
+	} else {
+		credential.TokenFile = tokenFile
+	}
+
+	tier := environ(EnvTier)
+	if tier == "" {
+		tier = DefaultTierID
+	}
+
+	parallelism := 1
+	if raw := environ(EnvParallelism); raw != "" {
+		parallelism, err = strconv.Atoi(raw)
+		if err != nil || parallelism < 1 {
+			return nil, fmt.Errorf("%s: expected an integer >= 1, got %q", EnvParallelism, raw)
+		}
+	}
+
+	c := &Config{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Host:       Host{Topology: topology},
+		Targets: []Target{{
+			ID:           "default",
+			URL:          ref.CanonicalURL,
+			CredentialID: credential.ID,
+			// Cache stays off in Quick Start until reuse across jobs is
+			// release-qualified on the reference deployment: a default must not
+			// promise what the runtime has not demonstrated. A repository
+			// target can still enable it explicitly in the advanced
+			// configuration; an organization target never can, because
+			// its runners are not bound to the repository whose cache
+			// they would mount.
+			Cache:       TargetCache{Enabled: false},
+			RunnerGroup: environ(EnvGitHubRunnerGroup),
+			Tiers:       []TierBinding{{TierID: tier}},
+		}},
+		Credentials: []Credential{credential},
+		Tiers:       []Tier{{ID: tier, Parallelism: parallelism}},
+	}
+	if raw := environ(EnvHostReserveCPU); raw != "" {
+		c.Host.Reserve.CPU, err = ParseCPUQuantity(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", EnvHostReserveCPU, err)
+		}
+	}
+	if raw := environ(EnvHostReserveMemory); raw != "" {
+		c.Host.Reserve.Memory, err = ParseByteSize(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", EnvHostReserveMemory, err)
+		}
+	}
+	if raw := environ(EnvHostReserveSwap); raw != "" {
+		c.Host.Reserve.Swap, err = ParseByteSize(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", EnvHostReserveSwap, err)
+		}
+	}
+	if raw := environ(EnvHostReserveFreeDisk); raw != "" {
+		c.Host.Reserve.FreeDisk, err = ParseByteSize(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", EnvHostReserveFreeDisk, err)
+		}
+	}
+	if level := environ(EnvLogLevel); level != "" {
+		c.Observability.Log.Level = level
+	}
+	if profile := environ(EnvNetworkProfile); profile != "" {
+		c.Network.Profile = profile
+	}
+	return c, nil
+}

--- a/internal/config/quickstart_test.go
+++ b/internal/config/quickstart_test.go
@@ -1,0 +1,173 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func env(m map[string]string) func(string) string {
+	return func(name string) string { return m[name] }
+}
+
+func TestQuickStartMinimal(t *testing.T) {
+	c, err := Load(env(map[string]string{
+		EnvGitHubURL:    "https://github.com/acme/app",
+		EnvGitHubToken:  "secret",
+		EnvHostTopology: HostTopologyDedicatedDaemon,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := c.Targets[0]
+	// Quick Start leaves the cache off until reuse across jobs is
+	// release-qualified: a default that enables an unqualified feature ships a
+	// promise the runtime has not kept.
+	if target.Cache.Enabled {
+		t.Error("Quick Start enabled the cache before its reuse was release-qualified")
+	}
+	if got := target.Tiers[0].ScaleSetName; got != "runpool-standard" {
+		t.Errorf("scaleSetName = %q; want runpool-standard", got)
+	}
+	if c.Tiers[0].Parallelism != 1 {
+		t.Errorf("parallelism = %d; want 1", c.Tiers[0].Parallelism)
+	}
+	if cr := c.Credentials[0]; cr.TokenEnv != EnvGitHubToken || cr.TokenFile != "" {
+		t.Errorf("credential should reference the env var by name, got %+v", cr)
+	}
+	if c.Network.Profile != NetworkProfilePublicInternetOnly {
+		t.Errorf("network profile = %q", c.Network.Profile)
+	}
+}
+
+func TestQuickStartOrganizationDisablesCache(t *testing.T) {
+	c, err := Load(env(map[string]string{
+		EnvGitHubURL:         "https://github.com/acme",
+		EnvGitHubToken:       "secret",
+		EnvGitHubRunnerGroup: "runpool",
+		EnvHostTopology:      HostTopologyDedicatedDaemon,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Targets[0].Cache.Enabled {
+		t.Error("organization target must not enable a repository cache")
+	}
+}
+
+func TestQuickStartErrors(t *testing.T) {
+	cases := map[string]map[string]string{
+		"missing topology": {EnvGitHubURL: "https://github.com/acme/app", EnvGitHubToken: "secret"},
+		"missing url":      {EnvGitHubToken: "secret", EnvHostTopology: HostTopologyDedicatedDaemon},
+		"missing token":    {EnvGitHubURL: "https://github.com/acme/app", EnvHostTopology: HostTopologyDedicatedDaemon},
+		"token and file": {
+			EnvGitHubURL:       "https://github.com/acme/app",
+			EnvGitHubToken:     "secret",
+			EnvGitHubTokenFile: "/run/secrets/token",
+			EnvHostTopology:    HostTopologyDedicatedDaemon,
+		},
+		"bad parallelism": {
+			EnvGitHubURL:    "https://github.com/acme/app",
+			EnvGitHubToken:  "secret",
+			EnvParallelism:  "zero",
+			EnvHostTopology: HostTopologyDedicatedDaemon,
+		},
+		"config file with target var": {
+			EnvConfigFile: "testdata/example.yaml",
+			EnvGitHubURL:  "https://github.com/acme/app",
+		},
+	}
+	for name, vars := range cases {
+		if _, err := Load(env(vars)); err == nil {
+			t.Errorf("%s: Load succeeded; want error", name)
+		}
+	}
+}
+
+func TestQuickStartTokenFile(t *testing.T) {
+	c, err := Load(env(map[string]string{
+		EnvGitHubURL:       "https://github.com/acme/app",
+		EnvGitHubTokenFile: "/run/secrets/github-token",
+		EnvHostTopology:    HostTopologyDedicatedDaemon,
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cr := c.Credentials[0]; cr.TokenFile != "/run/secrets/github-token" || cr.TokenEnv != "" {
+		t.Errorf("credential = %+v", cr)
+	}
+}
+
+func TestQuickStartSharedDaemonRequiresReserve(t *testing.T) {
+	base := map[string]string{
+		EnvGitHubURL:    "https://github.com/acme/app",
+		EnvGitHubToken:  "secret",
+		EnvHostTopology: HostTopologySharedDaemon,
+	}
+	if _, err := Load(env(base)); err == nil || !strings.Contains(err.Error(), "host.reserve") {
+		t.Fatalf("shared daemon without reserve: %v", err)
+	}
+	base[EnvHostReserveCPU] = "1"
+	base[EnvHostReserveMemory] = "2GiB"
+	base[EnvHostReserveFreeDisk] = "20GiB"
+	c, err := Load(env(base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Host.Topology != HostTopologySharedDaemon {
+		t.Fatalf("topology = %q", c.Host.Topology)
+	}
+}
+
+func TestLoadFileMode(t *testing.T) {
+	c, err := Load(env(map[string]string{EnvConfigFile: "testdata/example.yaml"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c.Targets) != 2 {
+		t.Fatalf("targets = %d; want 2", len(c.Targets))
+	}
+	// The same human-friendly scale-set name in different GitHub scopes
+	// names different resources and must be accepted.
+	if c.Targets[0].Tiers[0].ScaleSetName != c.Targets[1].Tiers[0].ScaleSetName {
+		t.Error("example should exercise cross-scope name reuse")
+	}
+}
+
+func TestLoadFileUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/bad.yaml"
+	content := "apiVersion: runpool.rhobuild.com/v1\nkind: RunpoolConfig\nfoo: 1\n"
+	if err := writeFile(path, content); err != nil {
+		t.Fatal(err)
+	}
+	_, err := LoadFile(path)
+	if err == nil || !strings.Contains(err.Error(), "foo") {
+		t.Errorf("unknown field error should name the field, got: %v", err)
+	}
+}
+
+// TestFileModeRefusesEveryQuickStartVariable: a variable that is neither
+// applied nor refused is the worst of the three outcomes. An operator who
+// sets RUNPOOL_LOG_LEVEL=debug beside a configuration file gets no debug
+// logging and no explanation, and looks for the reason somewhere else.
+func TestFileModeRefusesEveryQuickStartVariable(t *testing.T) {
+	for _, name := range []string{EnvLogLevel, EnvNetworkProfile} {
+		environ := func(k string) string {
+			switch k {
+			case EnvConfigFile:
+				return "/etc/runpool/config.yaml"
+			case name:
+				return "debug"
+			}
+			return ""
+		}
+		_, err := Load(environ)
+		if err == nil {
+			t.Errorf("%s beside a configuration file was accepted; it applies to neither", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error for %s = %q; want it to name the variable", name, err)
+		}
+	}
+}

--- a/internal/config/testdata/example.yaml
+++ b/internal/config/testdata/example.yaml
@@ -1,0 +1,82 @@
+apiVersion: runpool.rhobuild.com/v1
+kind: RunpoolConfig
+
+instance:
+  name: primary
+
+host:
+  topology: dedicated-daemon
+  reserve:
+    cpu: "1"
+    memory: 2GiB
+    swap: 0B
+    freeDisk: 20GiB
+
+scheduling:
+  parallelism: 2
+
+targets:
+  - id: app
+    url: https://github.com/acme/app
+    credential: github-default
+    cache:
+      enabled: true
+      generation: rust-v1
+    tiers:
+      - tier: standard
+        scaleSetName: runpool-standard
+
+  - id: acme-org
+    url: https://github.com/acme
+    credential: github-default
+    cache:
+      enabled: false
+    runnerGroup: default
+    tiers:
+      - tier: standard
+        scaleSetName: runpool-standard
+
+credentials:
+  - id: github-default
+    type: token
+    tokenEnv: RUNPOOL_GITHUB_TOKEN
+
+tiers:
+  - id: standard
+    parallelism: 2
+    resources:
+      cpu: "2"
+      memory: 4GiB
+      swap: 0B
+      pids: 1024
+
+cache:
+  storage:
+    mode: volume
+  global:
+    maxManagedBytes: 150GiB
+    highWatermarkPercent: 80
+    lowWatermarkPercent: 65
+    softEmergencyFreeBytes: 20GiB
+    hardEmergencyFreeBytes: 10GiB
+  defaults:
+    repositoryMaxBytes: 15GiB
+    unusedTTL: 720h
+
+retention:
+  leaseHistory: 2160h
+
+observability:
+  log:
+    format: json
+    level: info
+  metrics:
+    enabled: false
+
+network:
+  profile: public-internet-only
+  ipv6: disabled
+  dns:
+    mode: gateway
+  allowPrivateCIDRs: []
+  denyCIDRs: []

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,0 +1,499 @@
+// Package config defines the Runpool configuration schema shared by the
+// Quick Start environment translation and the advanced YAML file, applies
+// product defaults, and validates the result into the canonical in-memory
+// form every other subsystem consumes.
+package config
+
+import (
+	"fmt"
+	"math"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// APIVersion and Kind identify a configuration document. Unknown values are
+// rejected so schema evolution stays explicit.
+const (
+	APIVersion = "runpool.rhobuild.com/v1"
+	Kind       = "RunpoolConfig"
+)
+
+type Config struct {
+	APIVersion    string        `yaml:"apiVersion"`
+	Kind          string        `yaml:"kind"`
+	Instance      Instance      `yaml:"instance"`
+	Host          Host          `yaml:"host"`
+	Scheduling    Scheduling    `yaml:"scheduling,omitempty"`
+	Targets       []Target      `yaml:"targets"`
+	Credentials   []Credential  `yaml:"credentials"`
+	Tiers         []Tier        `yaml:"tiers"`
+	Cache         Cache         `yaml:"cache"`
+	Retention     Retention     `yaml:"retention"`
+	Observability Observability `yaml:"observability"`
+	Network       Network       `yaml:"network"`
+}
+
+// Retention is how long durable records outlive the work they describe.
+type Retention struct {
+	// LeaseHistory is how long the record of a finished lease is kept.
+	// Zero keeps it forever; nil means unset and takes the default.
+	//
+	// It is a pointer because zero is a decision here, not an absence,
+	// and defaulting keys on the zero value everywhere else in this
+	// package — without the pointer, "keep forever" and "not configured"
+	// would be the same value.
+	//
+	// This is the record of the host resources an attempt consumed, not
+	// the attempt itself: what the work did is the attempt's evidence and
+	// is never pruned.
+	LeaseHistory *Duration `yaml:"leaseHistory"`
+}
+
+// Window is the retention window in force: how long a finished lease's
+// record is kept, with zero meaning forever.
+//
+// It exists so the pointer is unwrapped in one place. A loaded
+// configuration never carries nil — ApplyDefaults materialises it — so
+// the fallback only serves a Retention built in memory, and callers that
+// spelled that fallback themselves were writing a branch they could not
+// reach and diverging from each other in the process.
+func (r Retention) Window() time.Duration {
+	if r.LeaseHistory == nil {
+		return time.Duration(DefaultLeaseHistory)
+	}
+	return time.Duration(*r.LeaseHistory)
+}
+
+type Instance struct {
+	Name string `yaml:"name"`
+}
+
+type Host struct {
+	// Topology states who else relies on the Docker daemon. Shared-daemon
+	// enables the coexistence contract used by platforms such as Dokploy;
+	// dedicated-daemon gives Runpool exclusive operational ownership.
+	Topology string  `yaml:"topology"`
+	Reserve  Reserve `yaml:"reserve"`
+}
+
+// Reserve is capacity withheld from tier scheduling so the host, the
+// controller and the platform keep breathing room.
+type Reserve struct {
+	CPU      CPUQuantity `yaml:"cpu"`
+	Memory   ByteSize    `yaml:"memory"`
+	Swap     ByteSize    `yaml:"swap"`
+	FreeDisk ByteSize    `yaml:"freeDisk"`
+}
+
+// Scheduling contains instance-wide admission policy. A nil Parallelism
+// leaves tiers independent; a value caps active leases and advertised
+// provider capacity across every target and tier in the instance.
+type Scheduling struct {
+	Parallelism *int `yaml:"parallelism,omitempty"`
+	// RetryBudget is how many times one attempt whose work provably never
+	// began may be served before it is held for review. It breaks a loop
+	// rather than tunes a rate, so its range is narrow: raising it far is
+	// how a systematic failure gets paid for instead of found. Zero takes
+	// the default.
+	RetryBudget int `yaml:"retryBudget,omitempty"`
+}
+
+type Target struct {
+	ID           string        `yaml:"id"`
+	URL          string        `yaml:"url"`
+	CredentialID string        `yaml:"credential"`
+	Cache        TargetCache   `yaml:"cache"`
+	RunnerGroup  string        `yaml:"runnerGroup"`
+	Tiers        []TierBinding `yaml:"tiers"`
+}
+
+type TargetCache struct {
+	Enabled    bool   `yaml:"enabled"`
+	Generation string `yaml:"generation"`
+}
+
+// TierBinding creates or adopts one GitHub scale set. The scale-set name
+// belongs to the target and tier pairing, never to the tier itself.
+type TierBinding struct {
+	TierID       string `yaml:"tier"`
+	ScaleSetName string `yaml:"scaleSetName"`
+}
+
+// Credential is how a deployment proves it may administer runners on a
+// target. A `token` credential is a person's: it carries their
+// permissions, appears in their account and stops working when they
+// leave. A `github_app` credential belongs to the organization instead.
+//
+// No secret value ever appears here. Every field is a reference to one.
+type Credential struct {
+	ID   string `yaml:"id"`
+	Type string `yaml:"type"`
+	// Exactly one of TokenEnv (an environment variable name) or TokenFile
+	// (a mounted secret path) references the token of a `token`
+	// credential; the value itself never appears in configuration.
+	TokenEnv  string `yaml:"tokenEnv"`
+	TokenFile string `yaml:"tokenFile"`
+	// ClientID and InstallationID identify a `github_app` credential.
+	// Neither is secret: the key is.
+	ClientID       string `yaml:"clientID"`
+	InstallationID int64  `yaml:"installationID"`
+	// Exactly one of PrivateKeyEnv or PrivateKeyFile references the App's
+	// private key, in PEM form. It is the longest-lived secret a
+	// deployment holds and the one whose leak a single revocation cannot
+	// contain, so a file is held to the same owner-only mode a token file
+	// is.
+	PrivateKeyEnv  string `yaml:"privateKeyEnv"`
+	PrivateKeyFile string `yaml:"privateKeyFile"`
+}
+
+// Tier is a reusable local resource envelope, not a GitHub scale set.
+type Tier struct {
+	ID          string    `yaml:"id"`
+	Parallelism int       `yaml:"parallelism"`
+	Resources   Resources `yaml:"resources"`
+	// JobTimeout bounds how long Runpool waits for one of this tier's
+	// capsules. It is a backstop against a capsule that stops reporting,
+	// not the job's own limit: the provider ends a job at its own timeout
+	// and the runner exits, which resolves the lease long before this.
+	// Empty takes DefaultJobTimeout.
+	JobTimeout *Duration `yaml:"jobTimeout"`
+	// CapsuleImage replaces the capsule this build ships for this tier's
+	// jobs. Empty keeps the shipped one. It must be digest-qualified: the
+	// controller launching an exact image it can name is the property the
+	// shipped pin provides, and it is the one an operator's image has to
+	// keep.
+	CapsuleImage string `yaml:"capsuleImage"`
+}
+
+type Resources struct {
+	CPU    CPUQuantity `yaml:"cpu"`
+	Memory ByteSize    `yaml:"memory"`
+	// Swap is additional swap above Memory. The Docker adapter translates
+	// it to the daemon's total memory-plus-swap limit; zero disables swap.
+	Swap ByteSize `yaml:"swap"`
+	PIDs int64    `yaml:"pids"`
+}
+
+type Cache struct {
+	Storage  CacheStorage  `yaml:"storage"`
+	Global   CacheGlobal   `yaml:"global"`
+	Defaults CacheDefaults `yaml:"defaults"`
+}
+
+type CacheStorage struct {
+	Mode string `yaml:"mode"`
+}
+
+type CacheGlobal struct {
+	MaxManagedBytes        ByteSize `yaml:"maxManagedBytes"`
+	HighWatermarkPercent   int      `yaml:"highWatermarkPercent"`
+	LowWatermarkPercent    int      `yaml:"lowWatermarkPercent"`
+	SoftEmergencyFreeBytes ByteSize `yaml:"softEmergencyFreeBytes"`
+	HardEmergencyFreeBytes ByteSize `yaml:"hardEmergencyFreeBytes"`
+}
+
+type CacheDefaults struct {
+	RepositoryMaxBytes ByteSize `yaml:"repositoryMaxBytes"`
+	UnusedTTL          Duration `yaml:"unusedTTL"`
+}
+
+type Observability struct {
+	Log     LogConfig     `yaml:"log"`
+	Metrics MetricsConfig `yaml:"metrics"`
+}
+
+type LogConfig struct {
+	Format string `yaml:"format"`
+	Level  string `yaml:"level"`
+}
+
+type MetricsConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+type Network struct {
+	Profile           string    `yaml:"profile"`
+	IPv6              string    `yaml:"ipv6"`
+	DNS               DNSConfig `yaml:"dns"`
+	AllowPrivateCIDRs []CIDR    `yaml:"allowPrivateCIDRs"`
+	DenyCIDRs         []CIDR    `yaml:"denyCIDRs"`
+}
+
+type DNSConfig struct {
+	Mode string `yaml:"mode"`
+}
+
+// ByteSize is a byte quantity written as a non-negative integer with a
+// binary (IEC) suffix: B, KiB, MiB, GiB or TiB. Decimal units and bare
+// numbers are rejected so a config never means two different sizes.
+type ByteSize int64
+
+var byteUnits = []struct {
+	suffix string
+	factor int64
+}{
+	{"TiB", 1 << 40},
+	{"GiB", 1 << 30},
+	{"MiB", 1 << 20},
+	{"KiB", 1 << 10},
+	{"B", 1},
+}
+
+func ParseByteSize(s string) (ByteSize, error) {
+	for _, u := range byteUnits {
+		digits, ok := strings.CutSuffix(s, u.suffix)
+		if !ok {
+			continue
+		}
+		if !allDigits(digits) {
+			break
+		}
+		n, err := strconv.ParseInt(digits, 10, 64)
+		if err != nil || n > math.MaxInt64/u.factor {
+			return 0, fmt.Errorf("byte quantity %q overflows", s)
+		}
+		return ByteSize(n * u.factor), nil
+	}
+	return 0, fmt.Errorf("invalid byte quantity %q: expected a non-negative integer with a B, KiB, MiB, GiB or TiB suffix", s)
+}
+
+func (b ByteSize) String() string {
+	if b == 0 {
+		return "0B"
+	}
+	for _, u := range byteUnits {
+		if int64(b)%u.factor == 0 {
+			return strconv.FormatInt(int64(b)/u.factor, 10) + u.suffix
+		}
+	}
+	return strconv.FormatInt(int64(b), 10) + "B"
+}
+
+func (b *ByteSize) UnmarshalYAML(node *yaml.Node) error {
+	v, err := ParseByteSize(node.Value)
+	if err != nil {
+		return err
+	}
+	*b = v
+	return nil
+}
+
+func (b ByteSize) MarshalYAML() (any, error) { return b.String(), nil }
+
+// CPUQuantity is a CPU count in nano-CPUs, written as a decimal such as
+// "2" or "0.5" with at most nine fractional digits (Docker's NanoCPUs
+// resolution). Parsing is exact; no floating point is involved.
+type CPUQuantity int64
+
+const nanoPerCPU = 1_000_000_000
+
+func ParseCPUQuantity(s string) (CPUQuantity, error) {
+	whole, frac, hasFrac := strings.Cut(s, ".")
+	if !allDigits(whole) || len(whole) > 6 || (hasFrac && (!allDigits(frac) || len(frac) > 9)) {
+		return 0, fmt.Errorf("invalid cpu quantity %q: expected a decimal count such as \"2\" or \"0.5\"", s)
+	}
+	n, _ := strconv.ParseInt(whole, 10, 64)
+	nano := n * nanoPerCPU
+	if hasFrac {
+		f, _ := strconv.ParseInt(frac+strings.Repeat("0", 9-len(frac)), 10, 64)
+		nano += f
+	}
+	return CPUQuantity(nano), nil
+}
+
+func (c CPUQuantity) String() string {
+	whole, frac := int64(c)/nanoPerCPU, int64(c)%nanoPerCPU
+	if frac == 0 {
+		return strconv.FormatInt(whole, 10)
+	}
+	return fmt.Sprintf("%d.%s", whole, strings.TrimRight(fmt.Sprintf("%09d", frac), "0"))
+}
+
+func (c *CPUQuantity) UnmarshalYAML(node *yaml.Node) error {
+	v, err := ParseCPUQuantity(node.Value)
+	if err != nil {
+		return err
+	}
+	*c = v
+	return nil
+}
+
+func (c CPUQuantity) MarshalYAML() (any, error) { return c.String(), nil }
+
+// Duration wraps time.Duration with strict Go duration syntax ("720h",
+// "30m"); negative values are rejected at parse time.
+type Duration time.Duration
+
+func ParseDuration(s string) (Duration, error) {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: expected Go duration syntax such as \"720h\"", s)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("invalid duration %q: must not be negative", s)
+	}
+	return Duration(d), nil
+}
+
+func (d Duration) String() string {
+	s := time.Duration(d).String()
+	if strings.HasSuffix(s, "m0s") {
+		s = strings.TrimSuffix(s, "0s")
+	}
+	if strings.HasSuffix(s, "h0m") {
+		s = strings.TrimSuffix(s, "0m")
+	}
+	return s
+}
+
+func (d *Duration) UnmarshalYAML(node *yaml.Node) error {
+	v, err := ParseDuration(node.Value)
+	if err != nil {
+		return err
+	}
+	*d = v
+	return nil
+}
+
+func (d Duration) MarshalYAML() (any, error) { return d.String(), nil }
+
+// CIDR is a network prefix; the address must be the network address, so a
+// policy entry never silently means a wider or narrower range than written.
+type CIDR struct {
+	netip.Prefix
+}
+
+func ParseCIDR(s string) (CIDR, error) {
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		return CIDR{}, fmt.Errorf("invalid cidr %q", s)
+	}
+	if p != p.Masked() {
+		return CIDR{}, fmt.Errorf("invalid cidr %q: address has host bits set; the network address is %s", s, p.Masked())
+	}
+	return CIDR{p}, nil
+}
+
+func (c *CIDR) UnmarshalYAML(node *yaml.Node) error {
+	v, err := ParseCIDR(node.Value)
+	if err != nil {
+		return err
+	}
+	*c = v
+	return nil
+}
+
+func (c CIDR) MarshalYAML() (any, error) { return c.Prefix.String(), nil }
+
+type TargetScope string
+
+const (
+	ScopeRepository   TargetScope = "repository"
+	ScopeOrganization TargetScope = "organization"
+	// ScopeEnterprise is a scale set registered against an enterprise
+	// rather than one of its organizations. The provider registers a
+	// runner for it through a different endpoint from the other two.
+	ScopeEnterprise TargetScope = "enterprise"
+)
+
+// TargetRef is a parsed target URL. V1 supports github.com only, so any
+// other host is rejected here rather than failing later against the API.
+type TargetRef struct {
+	Scope        TargetScope
+	Owner        string
+	Repository   string
+	CanonicalURL string
+}
+
+var (
+	slugRe    = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$`)
+	envNameRe = regexp.MustCompile(`^[A-Z_][A-Z0-9_]*$`)
+	ownerRe   = regexp.MustCompile(`^[A-Za-z0-9-]+$`)
+	repoRe    = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+func ParseTargetURL(raw string) (TargetRef, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return TargetRef{}, fmt.Errorf("invalid target url %q", raw)
+	}
+	switch {
+	case u.Scheme != "https":
+		return TargetRef{}, fmt.Errorf("invalid target url %q: scheme must be https", raw)
+	case u.Host == "":
+		return TargetRef{}, fmt.Errorf("invalid target url %q: no host", raw)
+	case u.User != nil || u.RawQuery != "" || u.Fragment != "":
+		return TargetRef{}, fmt.Errorf("invalid target url %q: credentials, query and fragment are not allowed", raw)
+	}
+	// The host is carried rather than checked. What serves the protocol is
+	// a question the provider answers, and `runpool doctor` asks it with a
+	// real call; a name refused here would refuse an Enterprise Server or
+	// a data-residency host that speaks exactly the endpoints github.com
+	// speaks. What is qualified is a separate statement, and the support
+	// matrix is where it is made.
+	host := strings.ToLower(u.Host)
+	base := "https://" + host + "/"
+	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	switch {
+	case len(segments) == 2 && strings.EqualFold(segments[0], "enterprises") && ownerRe.MatchString(segments[1]):
+		return TargetRef{
+			Scope:        ScopeEnterprise,
+			Owner:        segments[1],
+			CanonicalURL: base + "enterprises/" + segments[1],
+		}, nil
+	case len(segments) == 1 && ownerRe.MatchString(segments[0]):
+		return TargetRef{
+			Scope:        ScopeOrganization,
+			Owner:        segments[0],
+			CanonicalURL: base + segments[0],
+		}, nil
+	case len(segments) == 2 && ownerRe.MatchString(segments[0]) && repoRe.MatchString(segments[1]):
+		return TargetRef{
+			Scope:        ScopeRepository,
+			Owner:        segments[0],
+			Repository:   segments[1],
+			CanonicalURL: base + segments[0] + "/" + segments[1],
+		}, nil
+	}
+	return TargetRef{}, fmt.Errorf(
+		"invalid target url %q: expected https://<host>/<owner>, https://<host>/<owner>/<repository> or https://<host>/enterprises/<name>",
+		raw)
+}
+
+// digestQualifiedImage matches a reference pinned to a content digest,
+// which is the only form that cannot move underneath the controller.
+var digestQualifiedImage = regexp.MustCompile(`^.+@sha256:[a-f0-9]{64}$`)
+
+// IsDigestQualifiedImage reports whether a reference names an exact
+// image. It lives here because both the validator and the composition
+// root decide the same thing about the same strings, and two copies of
+// the rule is how one of them eventually accepts a tag.
+func IsDigestQualifiedImage(ref string) bool {
+	return digestQualifiedImage.MatchString(ref)
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// Ceiling is how long Runpool waits for one of this tier's capsules.
+func (t Tier) Ceiling() time.Duration {
+	if t.JobTimeout == nil {
+		return time.Duration(DefaultJobTimeout)
+	}
+	return time.Duration(*t.JobTimeout)
+}

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,0 +1,242 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"testing"
+	"time"
+)
+
+func TestParseByteSize(t *testing.T) {
+	valid := map[string]int64{
+		"0B":      0,
+		"512B":    512,
+		"4KiB":    4 << 10,
+		"1536MiB": 1536 << 20,
+		"150GiB":  150 << 30,
+		"2TiB":    2 << 40,
+	}
+	for in, want := range valid {
+		got, err := ParseByteSize(in)
+		if err != nil || int64(got) != want {
+			t.Errorf("ParseByteSize(%q) = %d, %v; want %d", in, got, err, want)
+		}
+		if s := got.String(); s != in {
+			t.Errorf("ByteSize(%q).String() = %q; want round-trip", in, s)
+		}
+	}
+	for _, in := range []string{"", "150", "4GB", "1.5GiB", "GiB", "-1B", "+4GiB", "4 GiB", "99999999999TiB"} {
+		if _, err := ParseByteSize(in); err == nil {
+			t.Errorf("ParseByteSize(%q) succeeded; want error", in)
+		}
+	}
+}
+
+func TestParseCPUQuantity(t *testing.T) {
+	valid := map[string]int64{
+		"0":    0,
+		"2":    2 * nanoPerCPU,
+		"0.5":  nanoPerCPU / 2,
+		"1.25": 1_250_000_000,
+	}
+	for in, want := range valid {
+		got, err := ParseCPUQuantity(in)
+		if err != nil || int64(got) != want {
+			t.Errorf("ParseCPUQuantity(%q) = %d, %v; want %d", in, got, err, want)
+		}
+		if s := got.String(); s != in {
+			t.Errorf("CPUQuantity(%q).String() = %q; want round-trip", in, s)
+		}
+	}
+	for _, in := range []string{"", ".5", "1.", "1.1234567890", "2,5", "-1", "1e3", "1234567"} {
+		if _, err := ParseCPUQuantity(in); err == nil {
+			t.Errorf("ParseCPUQuantity(%q) succeeded; want error", in)
+		}
+	}
+}
+
+func TestDuration(t *testing.T) {
+	d, err := ParseDuration("720h")
+	if err != nil || time.Duration(d) != 720*time.Hour {
+		t.Fatalf("ParseDuration(720h) = %v, %v", d, err)
+	}
+	if s := d.String(); s != "720h" {
+		t.Errorf("Duration(720h).String() = %q", s)
+	}
+	if s := Duration(90 * time.Minute).String(); s != "1h30m" {
+		t.Errorf("Duration(90m).String() = %q; want 1h30m", s)
+	}
+	for _, in := range []string{"", "3d", "-1h", "720"} {
+		if _, err := ParseDuration(in); err == nil {
+			t.Errorf("ParseDuration(%q) succeeded; want error", in)
+		}
+	}
+}
+
+func TestParseCIDR(t *testing.T) {
+	for _, in := range []string{"10.0.0.0/8", "192.168.1.0/24", "fd00::/8"} {
+		c, err := ParseCIDR(in)
+		if err != nil {
+			t.Errorf("ParseCIDR(%q): %v", in, err)
+		}
+		if c.Prefix.String() != in {
+			t.Errorf("ParseCIDR(%q).String() = %q", in, c.Prefix)
+		}
+	}
+	for _, in := range []string{"10.0.0.1/8", "10.0.0.0", "10.0.0.0/33", "example.com/8"} {
+		if _, err := ParseCIDR(in); err == nil {
+			t.Errorf("ParseCIDR(%q) succeeded; want error", in)
+		}
+	}
+}
+
+func TestParseTargetURL(t *testing.T) {
+	repo, err := ParseTargetURL("https://github.com/acme/app")
+	if err != nil || repo.Scope != ScopeRepository || repo.Owner != "acme" || repo.Repository != "app" {
+		t.Fatalf("repository parse = %+v, %v", repo, err)
+	}
+	org, err := ParseTargetURL("https://github.com/acme/")
+	if err != nil || org.Scope != ScopeOrganization || org.CanonicalURL != "https://github.com/acme" {
+		t.Fatalf("organization parse = %+v, %v", org, err)
+	}
+	invalid := []string{
+		"",
+		"http://github.com/acme",
+		"https://github.com/acme/app/tree/main",
+		"https://github.com/acme?tab=repositories",
+		"https://user@github.com/acme",
+		"https://github.com/",
+	}
+	for _, in := range invalid {
+		if _, err := ParseTargetURL(in); err == nil {
+			t.Errorf("ParseTargetURL(%q) succeeded; want error", in)
+		}
+	}
+}
+
+// TestParseTargetURLCarriesTheHost: what serves the protocol is a
+// question the provider answers, so the host is carried rather than
+// checked against a name. An Enterprise Server and a data-residency host
+// speak the endpoints github.com speaks; refusing them here would refuse
+// them for being unfamiliar rather than for not working.
+func TestParseTargetURLCarriesTheHost(t *testing.T) {
+	for _, tc := range []struct {
+		in    string
+		scope TargetScope
+		canon string
+	}{
+		{"https://ghe.example.com/acme", ScopeOrganization, "https://ghe.example.com/acme"},
+		{"https://ghe.example.com/acme/app", ScopeRepository, "https://ghe.example.com/acme/app"},
+		{"https://acme.ghe.com/team", ScopeOrganization, "https://acme.ghe.com/team"},
+		{"https://GitHub.com/Acme", ScopeOrganization, "https://github.com/Acme"},
+	} {
+		got, err := ParseTargetURL(tc.in)
+		if err != nil {
+			t.Errorf("ParseTargetURL(%q): %v", tc.in, err)
+			continue
+		}
+		if got.Scope != tc.scope || got.CanonicalURL != tc.canon {
+			t.Errorf("ParseTargetURL(%q) = %s %q; want %s %q",
+				tc.in, got.Scope, got.CanonicalURL, tc.scope, tc.canon)
+		}
+	}
+}
+
+// TestParseTargetURLReadsAnEnterprise: /enterprises/<name> has two path
+// segments that both satisfy the owner and repository patterns, so
+// without a case of its own it is not refused — it is silently understood
+// as a repository named after the enterprise, owned by "enterprises".
+func TestParseTargetURLReadsAnEnterprise(t *testing.T) {
+	got, err := ParseTargetURL("https://github.com/enterprises/acme")
+	if err != nil {
+		t.Fatalf("ParseTargetURL: %v", err)
+	}
+	if got.Scope != ScopeEnterprise {
+		t.Errorf("scope = %s, want %s", got.Scope, ScopeEnterprise)
+	}
+	if got.Owner != "acme" || got.Repository != "" {
+		t.Errorf("ref = %+v; want the enterprise named, and no repository", got)
+	}
+	if got.CanonicalURL != "https://github.com/enterprises/acme" {
+		t.Errorf("canonical = %q", got.CanonicalURL)
+	}
+}
+
+// TestCIDRYAMLRoundTrip: the CIDR type is the one config value that reaches
+// the egress ruleset, so both directions have to hold. Unmarshalling is
+// where a bad prefix must fail; marshalling is what `config effective`
+// prints, and a value that does not survive the round trip means the
+// effective document is not loadable.
+func TestCIDRYAMLRoundTrip(t *testing.T) {
+	type doc struct {
+		Nets []CIDR `yaml:"nets"`
+	}
+
+	var in doc
+	if err := yaml.Unmarshal([]byte("nets:\n  - 10.0.0.0/8\n  - 169.254.0.0/16\n"), &in); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(in.Nets) != 2 || in.Nets[0].String() != "10.0.0.0/8" {
+		t.Fatalf("parsed = %v", in.Nets)
+	}
+
+	out, err := yaml.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back doc
+	if err := yaml.Unmarshal(out, &back); err != nil {
+		t.Fatalf("re-unmarshal of the marshalled form: %v", err)
+	}
+	if len(back.Nets) != len(in.Nets) || back.Nets[0] != in.Nets[0] || back.Nets[1] != in.Nets[1] {
+		t.Errorf("round trip changed the value: %v -> %s -> %v", in.Nets, out, back.Nets)
+	}
+
+	// Host bits set is the error worth naming: it is the typo that would
+	// otherwise silently widen or narrow a rule.
+	for _, bad := range []string{"10.0.0.1/8", "not-a-cidr", "10.0.0.0/33"} {
+		if err := yaml.Unmarshal([]byte("nets:\n  - "+bad+"\n"), &doc{}); err == nil {
+			t.Errorf("unmarshal accepted %q", bad)
+		}
+	}
+
+	// A null list entry yields no entry at all rather than a zero CIDR, so
+	// there is no path by which an empty line becomes a prefix. Worth
+	// pinning: the zero Prefix is invalid, but 0.0.0.0/0 is what an empty
+	// value would have to mean if one ever leaked through.
+	var nul doc
+	if err := yaml.Unmarshal([]byte("nets:\n  -\n"), &nul); err != nil {
+		t.Fatalf("a null entry failed to unmarshal: %v", err)
+	}
+	if len(nul.Nets) != 0 {
+		t.Errorf("null entry produced %v; want no entry", nul.Nets)
+	}
+	// And an invalid prefix reaching the config by any other route is
+	// refused by validation, not silently rendered into the ruleset.
+	cfg := validConfig()
+	cfg.Network.AllowPrivateCIDRs = []CIDR{{}}
+	if err := Validate(cfg); err == nil {
+		t.Error("an invalid allowPrivateCIDRs entry passed validation")
+	}
+}
+
+// TestRetentionWindow: zero is a decision — keep every record — and it
+// has to survive the unwrapping. Folding it in with nil, the way a
+// `LeaseHistory == nil || *LeaseHistory == 0` reading would, turns an
+// operator's "keep forever" into the ninety-day default and starts
+// deleting records they asked to be kept.
+func TestRetentionWindow(t *testing.T) {
+	keep := Duration(0)
+	week := Duration(7 * 24 * time.Hour)
+	for name, tc := range map[string]struct {
+		in   Retention
+		want time.Duration
+	}{
+		"unset takes the default": {Retention{}, time.Duration(DefaultLeaseHistory)},
+		"zero keeps every record": {Retention{LeaseHistory: &keep}, 0},
+		"configured is honoured":  {Retention{LeaseHistory: &week}, 7 * 24 * time.Hour},
+	} {
+		if got := tc.in.Window(); got != tc.want {
+			t.Errorf("%s: Window() = %s; want %s", name, got, tc.want)
+		}
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,426 @@
+package config
+
+import (
+	"fmt"
+	"math"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/egress"
+)
+
+// FieldError locates one defect by its configuration path.
+type FieldError struct {
+	Path    string
+	Message string
+}
+
+// ValidationError aggregates every defect found so the operator fixes the
+// configuration in one round trip instead of one error per restart.
+type ValidationError struct {
+	Fields []FieldError
+}
+
+func (e *ValidationError) Error() string {
+	var b strings.Builder
+	b.WriteString("invalid configuration:")
+	for _, f := range e.Fields {
+		fmt.Fprintf(&b, "\n  %s: %s", f.Path, f.Message)
+	}
+	return b.String()
+}
+
+type validator struct {
+	fields []FieldError
+}
+
+func (v *validator) errf(path, format string, args ...any) {
+	v.fields = append(v.fields, FieldError{Path: path, Message: fmt.Sprintf(format, args...)})
+}
+
+// Validate checks the defaulted configuration against the V1 rules. Both
+// Quick Start and file mode pass through here; there is one source of
+// truth for what a valid configuration is.
+//
+// The host-reserve versus scheduling capacity rule needs live host facts
+// and therefore belongs to the doctor, not to static validation.
+func Validate(c *Config) error {
+	v := &validator{}
+
+	if c.APIVersion != APIVersion {
+		v.errf("apiVersion", "must be %q", APIVersion)
+	}
+	if c.Kind != Kind {
+		v.errf("kind", "must be %q", Kind)
+	}
+	if !slugRe.MatchString(c.Instance.Name) {
+		v.errf("instance.name", "must be a lowercase slug")
+	}
+	if c.Host.Topology != HostTopologySharedDaemon && c.Host.Topology != HostTopologyDedicatedDaemon {
+		v.errf("host.topology", "must be %q or %q", HostTopologySharedDaemon, HostTopologyDedicatedDaemon)
+	}
+
+	tiers := make(map[string]bool, len(c.Tiers))
+	tiersUsed := make(map[string]bool, len(c.Tiers))
+	totalParallelism := 0
+	if len(c.Tiers) == 0 {
+		v.errf("tiers", "at least one tier is required")
+	}
+	for i, t := range c.Tiers {
+		path := fmt.Sprintf("tiers[%d]", i)
+		if !slugRe.MatchString(t.ID) {
+			v.errf(path+".id", "must be a lowercase slug")
+		} else if tiers[t.ID] {
+			v.errf(path+".id", "duplicate tier id %q", t.ID)
+		}
+		tiers[t.ID] = true
+		if t.Parallelism < 1 {
+			v.errf(path+".parallelism", "must be >= 1")
+		} else if t.Parallelism > MaxParallelism {
+			v.errf(path+".parallelism", "must be <= %d", MaxParallelism)
+		} else {
+			totalParallelism += t.Parallelism
+		}
+		if t.JobTimeout != nil && (*t.JobTimeout < MinJobTimeout || *t.JobTimeout > MaxJobTimeout) {
+			v.errf(path+".jobTimeout", "must be between %s and %s; it is the wait for a capsule that stopped reporting, not the job's own limit",
+				time.Duration(MinJobTimeout), time.Duration(MaxJobTimeout))
+		}
+		if t.CapsuleImage != "" && !IsDigestQualifiedImage(t.CapsuleImage) {
+			v.errf(path+".capsuleImage",
+				"must be digest-qualified (name@sha256:...); a tag can move under a running controller")
+		}
+		if t.Resources.CPU <= 0 {
+			v.errf(path+".resources.cpu", "must be > 0")
+		}
+		if t.Resources.Memory <= 0 {
+			v.errf(path+".resources.memory", "must be > 0")
+		}
+		if t.Resources.Swap < 0 {
+			v.errf(path+".resources.swap", "must be >= 0B")
+		} else if int64(t.Resources.Memory) > math.MaxInt64-int64(t.Resources.Swap) {
+			v.errf(path+".resources.swap", "memory plus swap exceeds the runtime limit")
+		}
+		if t.Resources.PIDs < 1 {
+			v.errf(path+".resources.pids", "must be >= 1")
+		}
+		// Under the restricted profile a lease's envelope covers its
+		// capsule and its egress gateway together, so a tier must be
+		// large enough to hold both. Rejecting it here is what keeps
+		// the split from silently handing the capsule a negative or
+		// unusable share.
+		if c.Network.Profile != NetworkProfileUnsafeOpen {
+			if int64(t.Resources.Memory) < GatewayReserveMemory+MinCapsuleMemory {
+				v.errf(path+".resources.memory",
+					"must be at least %s: the egress gateway reserves %s of the lease envelope and the capsule needs the rest",
+					ByteSize(GatewayReserveMemory+MinCapsuleMemory), ByteSize(GatewayReserveMemory))
+			}
+			if int64(t.Resources.CPU) <= GatewayReserveCPUs {
+				v.errf(path+".resources.cpu",
+					"must exceed %.1f: the egress gateway reserves that much of the lease envelope",
+					float64(GatewayReserveCPUs)/1e9)
+			}
+			if t.Resources.PIDs <= GatewayReservePIDs {
+				v.errf(path+".resources.pids",
+					"must exceed %d: the egress gateway reserves that many of the lease envelope",
+					GatewayReservePIDs)
+			}
+		}
+	}
+	if c.Scheduling.Parallelism != nil {
+		switch {
+		case *c.Scheduling.Parallelism < 1:
+			v.errf("scheduling.parallelism", "must be >= 1 when set; omit the field to keep tiers independent")
+		case *c.Scheduling.Parallelism > MaxParallelism:
+			v.errf("scheduling.parallelism", "must be <= %d", MaxParallelism)
+		case *c.Scheduling.Parallelism > totalParallelism:
+			v.errf("scheduling.parallelism", "must not exceed aggregate tier parallelism %d", totalParallelism)
+		}
+	}
+
+	credentials := make(map[string]bool, len(c.Credentials))
+	credentialsUsed := make(map[string]bool, len(c.Credentials))
+	if len(c.Credentials) == 0 {
+		v.errf("credentials", "at least one credential is required")
+	}
+	for i, cr := range c.Credentials {
+		path := fmt.Sprintf("credentials[%d]", i)
+		if !slugRe.MatchString(cr.ID) {
+			v.errf(path+".id", "must be a lowercase slug")
+		} else if credentials[cr.ID] {
+			v.errf(path+".id", "duplicate credential id %q", cr.ID)
+		}
+		credentials[cr.ID] = true
+		switch cr.Type {
+		case CredentialTypeToken:
+			v.tokenCredential(path, cr)
+		case CredentialTypeGitHubApp:
+			v.appCredential(path, cr)
+		default:
+			v.errf(path+".type", "must be %q or %q", CredentialTypeToken, CredentialTypeGitHubApp)
+		}
+	}
+
+	if b := c.Scheduling.RetryBudget; b != 0 && (b < MinRetryBudget || b > MaxRetryBudget) {
+		v.errf("scheduling.retryBudget", "must be between %d and %d",
+			MinRetryBudget, MaxRetryBudget)
+	}
+
+	if len(c.Targets) == 0 {
+		v.errf("targets", "at least one target is required")
+	}
+	targetIDs := make(map[string]bool, len(c.Targets))
+	targetURLs := make(map[string]bool, len(c.Targets))
+	for i, t := range c.Targets {
+		path := fmt.Sprintf("targets[%d]", i)
+		if !slugRe.MatchString(t.ID) {
+			v.errf(path+".id", "must be a lowercase slug")
+		} else if targetIDs[t.ID] {
+			v.errf(path+".id", "duplicate target id %q", t.ID)
+		}
+		targetIDs[t.ID] = true
+
+		ref, err := ParseTargetURL(t.URL)
+		if err != nil {
+			v.errf(path+".url", "%v", err)
+		} else {
+			if targetURLs[ref.CanonicalURL] {
+				v.errf(path+".url", "duplicate target %s: bind additional tiers on the existing target instead", ref.CanonicalURL)
+			}
+			targetURLs[ref.CanonicalURL] = true
+			// A JIT runner is not bound to the job whose demand message
+			// triggered it — measured live, not assumed — so only a
+			// repository-scoped scale set may mount a repository cache.
+			if ref.Scope != ScopeRepository && t.Cache.Enabled {
+				v.errf(path+".cache.enabled", "persistent cache requires a repository-scoped target; a runner that is not bound to one repository could execute another's job against its cache")
+			}
+			// Enterprises have runner groups for the same reason
+			// organizations do: a scale set that is not in one shares a
+			// pool with runners this instance does not own.
+			grouped := ref.Scope == ScopeOrganization || ref.Scope == ScopeEnterprise
+			if !grouped && t.RunnerGroup != "" {
+				v.errf(path+".runnerGroup", "runner groups apply to organization and enterprise targets only")
+			}
+			if c.Host.Topology == HostTopologySharedDaemon && grouped && t.RunnerGroup == "" {
+				v.errf(path+".runnerGroup", "is required for %s targets on a shared daemon; isolate Runpool runners from unrelated self-hosted runners", ref.Scope)
+			}
+		}
+
+		if t.CredentialID == "" {
+			v.errf(path+".credential", "is required")
+		} else if !credentials[t.CredentialID] {
+			v.errf(path+".credential", "unknown credential %q", t.CredentialID)
+		}
+		credentialsUsed[t.CredentialID] = true
+
+		if t.Cache.Enabled && !slugRe.MatchString(t.Cache.Generation) {
+			v.errf(path+".cache.generation", "must be a lowercase slug")
+		}
+		if t.RunnerGroup != "" && !slugRe.MatchString(t.RunnerGroup) {
+			v.errf(path+".runnerGroup", "must be a lowercase slug")
+		}
+
+		if len(t.Tiers) == 0 {
+			v.errf(path+".tiers", "at least one tier binding is required")
+		}
+		names := make(map[string]bool, len(t.Tiers))
+		refs := make(map[string]bool, len(t.Tiers))
+		for j, b := range t.Tiers {
+			bpath := fmt.Sprintf("%s.tiers[%d]", path, j)
+			if !tiers[b.TierID] {
+				v.errf(bpath+".tier", "unknown tier %q", b.TierID)
+			} else if refs[b.TierID] {
+				v.errf(bpath+".tier", "duplicate binding for tier %q", b.TierID)
+			}
+			refs[b.TierID] = true
+			tiersUsed[b.TierID] = true
+			if !slugRe.MatchString(b.ScaleSetName) {
+				v.errf(bpath+".scaleSetName", "must be a lowercase slug")
+			} else if names[b.ScaleSetName] {
+				// Target URLs are unique, so a name collision within one
+				// GitHub scope can only happen between bindings of the
+				// same target.
+				v.errf(bpath+".scaleSetName", "duplicate scale-set name %q in the same target scope", b.ScaleSetName)
+			}
+			names[b.ScaleSetName] = true
+		}
+	}
+
+	// More bindings than tier parallelism is legal: the bindings share
+	// capacity credits, and a binding with nothing to run holds none. It
+	// stays visible through the tier's rotating discovery credit rather
+	// than through a reservation of its own.
+
+	for id := range tiers {
+		if !tiersUsed[id] {
+			v.errf("tiers", "tier %q is not referenced by any target", id)
+		}
+	}
+	for id := range credentials {
+		if !credentialsUsed[id] {
+			v.errf("credentials", "credential %q is not referenced by any target", id)
+		}
+	}
+
+	r := c.Host.Reserve
+	if r.CPU < 0 || r.Memory < 0 || r.Swap < 0 || r.FreeDisk < 0 {
+		v.errf("host.reserve", "cpu, memory, swap and freeDisk must not be negative")
+	}
+	if c.Host.Topology == HostTopologySharedDaemon && (r.CPU <= 0 || r.Memory <= 0 || r.FreeDisk <= 0) {
+		v.errf("host.reserve", "cpu, memory and freeDisk must all be explicit and greater than zero on a shared daemon")
+	}
+	if c.Host.Topology == HostTopologySharedDaemon && c.Network.Profile == NetworkProfileUnsafeOpen {
+		v.errf("network.profile", "%q is not supported on a shared daemon; use %q or move Runpool to a dedicated daemon",
+			NetworkProfileUnsafeOpen, NetworkProfilePublicInternetOnly)
+	}
+
+	if c.Cache.Storage.Mode != CacheStorageModeVolume {
+		v.errf("cache.storage.mode", "must be %q; the quota-backed bind mode arrives with the advanced storage feature", CacheStorageModeVolume)
+	}
+	g := c.Cache.Global
+	if g.LowWatermarkPercent < 1 || g.HighWatermarkPercent > 99 || g.LowWatermarkPercent >= g.HighWatermarkPercent {
+		v.errf("cache.global", "watermarks must satisfy 1 <= low < high <= 99")
+	}
+	if g.HardEmergencyFreeBytes >= g.SoftEmergencyFreeBytes {
+		v.errf("cache.global.hardEmergencyFreeBytes", "must be below softEmergencyFreeBytes")
+	}
+	if c.Cache.Defaults.RepositoryMaxBytes > g.MaxManagedBytes {
+		v.errf("cache.defaults.repositoryMaxBytes", "must not exceed cache.global.maxManagedBytes")
+	}
+	if c.Cache.Defaults.UnusedTTL <= 0 {
+		v.errf("cache.defaults.unusedTTL", "must be > 0")
+	}
+	// Zero is legal here and means keep forever, so the `> 0` rule the
+	// cache TTL uses does not apply. What is refused is a negative value
+	// and a window so short it would delete work an operator is still
+	// reading.
+	if h := c.Retention.LeaseHistory; h != nil {
+		switch {
+		case *h < 0:
+			v.errf("retention.leaseHistory", "must not be negative")
+		case *h > 0 && *h < MinLeaseHistory:
+			v.errf("retention.leaseHistory", "must be at least %s, or 0 to keep every lease record",
+				MinLeaseHistory)
+		}
+	}
+
+	// There is no metrics endpoint yet: budget, credits and pressure
+	// are reported through status and the structured log. Accepting
+	// `enabled: true` would have an operator wire an alert to a port
+	// nothing listens on.
+	if c.Observability.Metrics.Enabled {
+		v.errf("observability.metrics.enabled", "must be false; no metrics endpoint exists yet — capacity, credits and disk pressure are reported by `runpool status` and the structured log")
+	}
+
+	if f := c.Observability.Log.Format; f != LogFormatJSON && f != LogFormatText {
+		v.errf("observability.log.format", "must be %q or %q", LogFormatJSON, LogFormatText)
+	}
+	if !slices.Contains(logLevels, c.Observability.Log.Level) {
+		v.errf("observability.log.level", "must be one of %s", strings.Join(logLevels, ", "))
+	}
+
+	// The restricted profile sandboxes egress: no route out, and a
+	// policy-enforcing relay for what is allowed. The other name is the
+	// deployment that accepts open egress and must say so.
+	if c.Network.Profile != NetworkProfilePublicInternetOnly && c.Network.Profile != NetworkProfileUnsafeOpen {
+		v.errf("network.profile", "must be %q (restricted) or %q",
+			NetworkProfilePublicInternetOnly, NetworkProfileUnsafeOpen)
+	}
+	// A capsule's network carries no IPv6 and its gateway denies the
+	// protocol outright, so "disabled" is the only value that describes
+	// what runs. Accepting "enforced" would promise parity that does
+	// not exist.
+	// The egress policy is rendered into an IPv4 ruleset, and an allow
+	// prefix is a hole punched through the baseline deny. Both facts have
+	// to be checked here: an IPv6 prefix passes CIDR parsing and then fails
+	// at gateway boot pointing at iptables instead of at the config line,
+	// and a public or over-wide allow silently reopens what the restricted
+	// profile exists to close.
+	for i, p := range c.Network.AllowPrivateCIDRs {
+		path := fmt.Sprintf("network.allowPrivateCIDRs[%d]", i)
+		switch {
+		case !p.Addr().Unmap().Is4():
+			v.errf(path, "must be IPv4: the capsule egress ruleset is IPv4 only")
+		case egress.WidensBaselineDeny(p.Prefix):
+			v.errf(path, "%s is broader than a range the restricted profile withholds, "+
+				"so allowing it would reopen that whole range; name the specific addresses instead", p)
+		}
+	}
+	for i, p := range c.Network.DenyCIDRs {
+		if !p.Addr().Unmap().Is4() {
+			v.errf(fmt.Sprintf("network.denyCIDRs[%d]", i), "must be IPv4: the capsule egress ruleset is IPv4 only")
+		}
+	}
+	if c.Network.IPv6 != IPv6Disabled {
+		v.errf("network.ipv6", "must be %q; IPv6 parity for the capsule network is not implemented, and the sandbox denies the protocol", IPv6Disabled)
+	}
+	if c.Network.DNS.Mode != DNSModeGateway {
+		v.errf("network.dns.mode", "must be %q", DNSModeGateway)
+	}
+
+	if len(v.fields) > 0 {
+		return &ValidationError{Fields: v.fields}
+	}
+	return nil
+}
+
+// tokenCredential checks a credential that authenticates as a person. The
+// fields of the other kind must be absent rather than ignored: a
+// credential carrying both is a deployment that believes something about
+// which one is in use, and only one of those beliefs is right.
+func (v *validator) tokenCredential(path string, cr Credential) {
+	switch {
+	case cr.TokenEnv == "" && cr.TokenFile == "":
+		v.errf(path, "exactly one of tokenEnv or tokenFile is required")
+	case cr.TokenEnv != "" && cr.TokenFile != "":
+		v.errf(path, "tokenEnv and tokenFile are mutually exclusive")
+	case cr.TokenEnv != "" && !envNameRe.MatchString(cr.TokenEnv):
+		v.errf(path+".tokenEnv", "must be an environment variable name")
+	default:
+		v.secretPath(path+".tokenFile", cr.TokenFile)
+	}
+	if cr.ClientID != "" || cr.InstallationID != 0 ||
+		cr.PrivateKeyEnv != "" || cr.PrivateKeyFile != "" {
+		v.errf(path, "clientID, installationID and the private key belong to a %q credential",
+			CredentialTypeGitHubApp)
+	}
+}
+
+// appCredential checks a credential that authenticates as an installation
+// of a GitHub App. The client id and installation id are not secret; the
+// key is, and it is referenced the same two ways a token is.
+func (v *validator) appCredential(path string, cr Credential) {
+	if cr.ClientID == "" {
+		v.errf(path+".clientID", "is required for a %q credential", CredentialTypeGitHubApp)
+	}
+	if cr.InstallationID <= 0 {
+		v.errf(path+".installationID", "must be > 0; it identifies the installation this deployment acts as")
+	}
+	switch {
+	case cr.PrivateKeyEnv == "" && cr.PrivateKeyFile == "":
+		v.errf(path, "exactly one of privateKeyEnv or privateKeyFile is required")
+	case cr.PrivateKeyEnv != "" && cr.PrivateKeyFile != "":
+		v.errf(path, "privateKeyEnv and privateKeyFile are mutually exclusive")
+	case cr.PrivateKeyEnv != "" && !envNameRe.MatchString(cr.PrivateKeyEnv):
+		v.errf(path+".privateKeyEnv", "must be an environment variable name")
+	default:
+		v.secretPath(path+".privateKeyFile", cr.PrivateKeyFile)
+	}
+	if cr.TokenEnv != "" || cr.TokenFile != "" {
+		v.errf(path, "tokenEnv and tokenFile belong to a %q credential", CredentialTypeToken)
+	}
+}
+
+// secretPath refuses a reference that names a different file depending on
+// how the process was started. The controller's working directory is not
+// part of the contract.
+func (v *validator) secretPath(path, ref string) {
+	switch {
+	case ref == "":
+	case !filepath.IsAbs(ref):
+		v.errf(path, "must be an absolute path")
+	case filepath.Clean(ref) != ref:
+		v.errf(path, "must be a clean path; %q resolves to %q", ref, filepath.Clean(ref))
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,414 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// validConfig returns a minimal configuration that passes validation after
+// defaults; each test mutates one aspect and expects one class of failure.
+func validConfig() *Config {
+	c := &Config{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Host:       Host{Topology: HostTopologyDedicatedDaemon},
+		Targets: []Target{{
+			ID:           "app",
+			URL:          "https://github.com/acme/app",
+			CredentialID: "github-default",
+			Cache:        TargetCache{Enabled: true},
+			Tiers:        []TierBinding{{TierID: "standard"}},
+		}},
+		Credentials: []Credential{{ID: "github-default", TokenEnv: "RUNPOOL_GITHUB_TOKEN"}},
+		Tiers:       []Tier{{ID: "standard"}},
+	}
+	ApplyDefaults(c)
+	return c
+}
+
+func expectFieldError(t *testing.T, c *Config, wantPath string) {
+	t.Helper()
+	err := Validate(c)
+	if err == nil {
+		t.Fatalf("Validate succeeded; want error at %s", wantPath)
+	}
+	verr, ok := err.(*ValidationError)
+	if !ok {
+		t.Fatalf("error type %T; want *ValidationError", err)
+	}
+	for _, f := range verr.Fields {
+		if strings.HasPrefix(f.Path, wantPath) {
+			return
+		}
+	}
+	t.Errorf("no error at %s; got: %v", wantPath, err)
+}
+
+func TestValidateBase(t *testing.T) {
+	if err := Validate(validConfig()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidateRules(t *testing.T) {
+	cases := map[string]struct {
+		mutate func(*Config)
+		path   string
+	}{
+		"wrong apiVersion": {func(c *Config) { c.APIVersion = "v2" }, "apiVersion"},
+		"cache on an enterprise target": {func(c *Config) {
+			c.Targets[0].URL = "https://github.com/enterprises/acme"
+			c.Targets[0].RunnerGroup = "runpool"
+			c.Targets[0].Cache.Enabled = true
+		}, "targets[0].cache.enabled"},
+		"runner group on a repository target": {func(c *Config) {
+			c.Targets[0].RunnerGroup = "runpool"
+		}, "targets[0].runnerGroup"},
+		"retry budget above the range": {func(c *Config) {
+			c.Scheduling.RetryBudget = MaxRetryBudget + 1
+		}, "scheduling.retryBudget"},
+		"retry budget below the range": {func(c *Config) {
+			c.Scheduling.RetryBudget = -1
+		}, "scheduling.retryBudget"},
+		"job ceiling above the cap": {func(c *Config) {
+			d := MaxJobTimeout + Duration(time.Hour)
+			c.Tiers[0].JobTimeout = &d
+		}, "tiers[0].jobTimeout"},
+		"job ceiling below the floor": {func(c *Config) {
+			d := Duration(time.Second)
+			c.Tiers[0].JobTimeout = &d
+		}, "tiers[0].jobTimeout"},
+		"unknown credential type": {func(c *Config) {
+			c.Credentials[0].Type = "oauth"
+		}, "credentials[0].type"},
+		"app credential without a client id": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				InstallationID: 1, PrivateKeyEnv: "KEY"}
+		}, "credentials[0].clientID"},
+		"app credential without an installation": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", PrivateKeyEnv: "KEY"}
+		}, "credentials[0].installationID"},
+		"app credential with no key reference": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", InstallationID: 1}
+		}, "credentials[0]"},
+		"app credential with both key references": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", InstallationID: 1,
+				PrivateKeyEnv: "KEY", PrivateKeyFile: "/run/secrets/app.pem"}
+		}, "credentials[0]"},
+		"app credential with a relative key path": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", InstallationID: 1, PrivateKeyFile: "secrets/app.pem"}
+		}, "credentials[0].privateKeyFile"},
+		"app credential also carrying a token": {func(c *Config) {
+			c.Credentials[0] = Credential{ID: "app", Type: CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", InstallationID: 1, PrivateKeyEnv: "KEY",
+				TokenEnv: "TOKEN"}
+		}, "credentials[0]"},
+		"token credential carrying app fields": {func(c *Config) {
+			c.Credentials[0].ClientID = "Iv1.a"
+		}, "credentials[0]"},
+		"capsule image by tag": {func(c *Config) {
+			c.Tiers[0].CapsuleImage = "ghcr.io/acme/capsule:v1"
+		}, "tiers[0].capsuleImage"},
+		"capsule image by name alone": {func(c *Config) {
+			c.Tiers[0].CapsuleImage = "acme-capsule"
+		}, "tiers[0].capsuleImage"},
+		"capsule image with a short digest": {func(c *Config) {
+			c.Tiers[0].CapsuleImage = "ghcr.io/acme/capsule@sha256:abc123"
+		}, "tiers[0].capsuleImage"},
+		"missing host topology": {func(c *Config) { c.Host.Topology = "" }, "host.topology"},
+		"shared daemon without reserve": {func(c *Config) {
+			c.Host.Topology = HostTopologySharedDaemon
+			c.Host.Reserve = Reserve{}
+		}, "host.reserve"},
+		"shared daemon with unsafe egress": {func(c *Config) {
+			c.Host.Topology = HostTopologySharedDaemon
+			c.Network.Profile = NetworkProfileUnsafeOpen
+		}, "network.profile"},
+		"shared organization without runner group": {func(c *Config) {
+			c.Host.Topology = HostTopologySharedDaemon
+			c.Targets[0].URL = "https://github.com/acme"
+			c.Targets[0].Cache.Enabled = false
+		}, "targets[0].runnerGroup"},
+		"shared enterprise without runner group": {func(c *Config) {
+			c.Host.Topology = HostTopologySharedDaemon
+			c.Targets[0].URL = "https://github.com/enterprises/acme"
+			c.Targets[0].Cache.Enabled = false
+		}, "targets[0].runnerGroup"},
+		"org with cache": {func(c *Config) {
+			c.Targets[0].URL = "https://github.com/acme"
+		}, "targets[0].cache.enabled"},
+		"runner group on repository": {func(c *Config) {
+			c.Targets[0].RunnerGroup = "default"
+		}, "targets[0].runnerGroup"},
+		"unknown tier": {func(c *Config) {
+			c.Targets[0].Tiers[0].TierID = "huge"
+		}, "targets[0].tiers[0].tier"},
+		"unknown credential": {func(c *Config) {
+			c.Targets[0].CredentialID = "nope"
+		}, "targets[0].credential"},
+		"duplicate target url": {func(c *Config) {
+			dup := c.Targets[0]
+			dup.ID = "again"
+			c.Targets = append(c.Targets, dup)
+		}, "targets[1].url"},
+		"duplicate scale-set name in scope": {func(c *Config) {
+			c.Tiers = append(c.Tiers, Tier{ID: "heavy"})
+			ApplyDefaults(c)
+			c.Targets[0].Tiers = append(c.Targets[0].Tiers, TierBinding{TierID: "heavy", ScaleSetName: "runpool-standard"})
+		}, "targets[0].tiers[1].scaleSetName"},
+		"credential with both sources": {func(c *Config) {
+			c.Credentials[0].TokenFile = "/run/secrets/token"
+		}, "credentials[0]"},
+		"credential with no source": {func(c *Config) {
+			c.Credentials[0].TokenEnv = ""
+		}, "credentials[0]"},
+		"unused tier": {func(c *Config) {
+			c.Tiers = append(c.Tiers, Tier{ID: "idle"})
+			ApplyDefaults(c)
+		}, "tiers"},
+		"unused credential": {func(c *Config) {
+			c.Credentials = append(c.Credentials, Credential{ID: "spare", TokenEnv: "OTHER_TOKEN"})
+		}, "credentials"},
+		"negative swap": {func(c *Config) {
+			c.Tiers[0].Resources.Swap = -1
+		}, "tiers[0].resources.swap"},
+		"negative tier parallelism": {func(c *Config) { c.Tiers[0].Parallelism = -1 }, "tiers[0].parallelism"},
+		"tier parallelism above input bound": {func(c *Config) {
+			c.Tiers[0].Parallelism = MaxParallelism + 1
+		}, "tiers[0].parallelism"},
+		"zero global parallelism": {func(c *Config) {
+			zero := 0
+			c.Scheduling.Parallelism = &zero
+		}, "scheduling.parallelism"},
+		"global parallelism above tier total": {func(c *Config) {
+			two := 2
+			c.Scheduling.Parallelism = &two
+		}, "scheduling.parallelism"},
+		"inverted watermarks": {func(c *Config) {
+			c.Cache.Global.LowWatermarkPercent = 90
+		}, "cache.global"},
+		"hard emergency above soft": {func(c *Config) {
+			c.Cache.Global.HardEmergencyFreeBytes = c.Cache.Global.SoftEmergencyFreeBytes * 2
+		}, "cache.global.hardEmergencyFreeBytes"},
+		"unqualified network profile": {func(c *Config) {
+			c.Network.Profile = "standard"
+		}, "network.profile"},
+		"invalid ipv6 mode": {func(c *Config) { c.Network.IPv6 = "on" }, "network.ipv6"},
+		"bind storage not yet supported": {func(c *Config) {
+			c.Cache.Storage.Mode = "bind"
+		}, "cache.storage.mode"},
+		"bad log level": {func(c *Config) {
+			c.Observability.Log.Level = "trace"
+		}, "observability.log.level"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := validConfig()
+			tc.mutate(c)
+			expectFieldError(t, c, tc.path)
+		})
+	}
+}
+
+// A digest-qualified capsule image is accepted: the field exists so an
+// operator can add tools to their jobs, and refusing every value would be
+// the same as not having it.
+func TestADigestQualifiedCapsuleImageIsAccepted(t *testing.T) {
+	c := validConfig()
+	c.Tiers[0].CapsuleImage = "ghcr.io/acme/capsule@sha256:" +
+		"3333333333333333333333333333333333333333333333333333333333333333"
+	if err := Validate(c); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// A GitHub App credential is accepted whole: an organization running on
+// one is the case the type exists for, and refusing every shape would be
+// the same as not having it.
+func TestAGitHubAppCredentialIsAccepted(t *testing.T) {
+	c := validConfig()
+	c.Credentials[0] = Credential{
+		ID: "runners", Type: CredentialTypeGitHubApp,
+		ClientID: "Iv1.0123456789abcdef", InstallationID: 12345678,
+		PrivateKeyFile: "/run/secrets/runpool/app.pem",
+	}
+	c.Targets[0].CredentialID = "runners"
+	if err := Validate(c); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// An enterprise target is accepted whole. The runner-group rule it
+// carries on a shared daemon is in the table above, beside the
+// organization case it matches.
+func TestAnEnterpriseTargetIsAccepted(t *testing.T) {
+	c := validConfig()
+	c.Targets[0].URL = "https://github.com/enterprises/acme"
+	c.Targets[0].RunnerGroup = "runpool"
+	c.Targets[0].Cache.Enabled = false
+	if err := Validate(c); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+}
+
+func TestValidateAggregatesErrors(t *testing.T) {
+	c := validConfig()
+	c.APIVersion = "nope"
+	c.Network.IPv6 = "on"
+	err := Validate(c)
+	verr, ok := err.(*ValidationError)
+	if !ok || len(verr.Fields) < 2 {
+		t.Fatalf("expected aggregated errors, got: %v", err)
+	}
+}
+
+// TestNetworkCIDRValidation: allowPrivateCIDRs punches holes through the
+// baseline deny, and allow is consulted before deny at decision time. A
+// prefix wider than what the baseline withholds therefore reopens egress
+// the restricted profile exists to close — silently, with `network.profile`
+// still reading public-internet-only. IPv6 is rejected because the ruleset
+// it renders into is IPv4 only; accepting it moves the failure to gateway
+// boot, pointing at iptables instead of at the offending line.
+func TestNetworkCIDRValidation(t *testing.T) {
+	for name, tc := range map[string]struct {
+		allow, deny string
+		wantErr     bool
+	}{
+		"private range is the intended use": {allow: "10.0.0.0/8"},
+		"narrower than the baseline":        {allow: "192.168.5.0/24"},
+		"link-local may be reopened":        {allow: "169.254.169.254/32"},
+		// Public space is a no-op: the profile already permits the public
+		// internet. This is how an operator reaches a service on the host's
+		// own public address, which BuildDeny withholds at runtime from
+		// facts static validation cannot see.
+		"public space is a no-op":     {allow: "8.8.8.0/24"},
+		"host's own public address":   {allow: "203.0.113.7/32"},
+		"everything":                  {allow: "0.0.0.0/0", wantErr: true},
+		"swallows a whole deny range": {allow: "10.0.0.0/7", wantErr: true},
+		"swallows link-local":         {allow: "169.254.0.0/15", wantErr: true},
+		"ipv6 allow":                  {allow: "fd00::/8", wantErr: true},
+		"ipv4 deny is fine":           {deny: "203.0.113.0/24"},
+		"ipv6 deny":                   {deny: "fd00::/8", wantErr: true},
+	} {
+		cfg := validConfig()
+		if tc.allow != "" {
+			p, err := ParseCIDR(tc.allow)
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			cfg.Network.AllowPrivateCIDRs = []CIDR{p}
+		}
+		if tc.deny != "" {
+			p, err := ParseCIDR(tc.deny)
+			if err != nil {
+				t.Fatalf("%s: %v", name, err)
+			}
+			cfg.Network.DenyCIDRs = []CIDR{p}
+		}
+		err := Validate(cfg)
+		if tc.wantErr && err == nil {
+			t.Errorf("%s: accepted; want a validation error", name)
+		}
+		if !tc.wantErr && err != nil {
+			t.Errorf("%s: rejected: %v", name, err)
+		}
+	}
+}
+
+// TestLeaseHistoryRetention: zero is a decision here, not an absence, so
+// the `> 0` rule the cache TTL uses does not apply. The pointer is what
+// separates "keep every record" from "not configured" — without it,
+// defaulting would silently overwrite the operator's choice.
+func TestLeaseHistoryRetention(t *testing.T) {
+	// Omitted takes the default, materialised rather than left nil.
+	c := &Config{}
+	ApplyDefaults(c)
+	if c.Retention.LeaseHistory == nil {
+		t.Fatal("an omitted retention window was left nil; nothing downstream would default it")
+	}
+	if *c.Retention.LeaseHistory != DefaultLeaseHistory {
+		t.Errorf("default = %s; want %s", c.Retention.LeaseHistory, DefaultLeaseHistory)
+	}
+
+	// Zero survives defaulting and validation: it means keep forever.
+	keep := Duration(0)
+	c = validConfig()
+	c.Retention.LeaseHistory = &keep
+	ApplyDefaults(c)
+	if c.Retention.LeaseHistory == nil || *c.Retention.LeaseHistory != 0 {
+		t.Fatalf("zero was overwritten by defaulting: %v", c.Retention.LeaseHistory)
+	}
+	if err := Validate(c); err != nil {
+		t.Errorf("zero retention rejected: %v", err)
+	}
+
+	for name, d := range map[string]Duration{
+		"negative":      Duration(-time.Hour),
+		"below the min": MinLeaseHistory - 1,
+	} {
+		c := validConfig()
+		v := d
+		c.Retention.LeaseHistory = &v
+		err := Validate(c)
+		if err == nil {
+			t.Errorf("%s retention was accepted", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "retention.leaseHistory") {
+			t.Errorf("%s: error %q does not name the field", name, err)
+		}
+	}
+}
+
+// The effective document has to be loadable: a value that does not
+// survive marshal-then-parse means `config effective` prints something
+// the loader would reject.
+func TestLeaseHistoryRoundTripsThroughTheEffectiveDocument(t *testing.T) {
+	for _, d := range []Duration{DefaultLeaseHistory, 0, MinLeaseHistory} {
+		v := d
+		in := Retention{LeaseHistory: &v}
+		out, err := yaml.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var back Retention
+		if err := yaml.Unmarshal(out, &back); err != nil {
+			t.Fatalf("re-reading %q: %v", out, err)
+		}
+		if back.LeaseHistory == nil || *back.LeaseHistory != d {
+			t.Errorf("round trip changed %s: rendered %q, read back %v", d, out, back.LeaseHistory)
+		}
+	}
+}
+
+// TestJobCeiling: the ceiling is Runpool's wait for a capsule that
+// stopped reporting, not the job's own limit, so its default clears the
+// provider's maximum for a job — a backstop below that ends work the
+// provider still permits.
+func TestJobCeiling(t *testing.T) {
+	const providerJobMaximum = 360 * time.Minute
+	if d := time.Duration(DefaultJobTimeout); d <= providerJobMaximum {
+		t.Errorf("default ceiling is %s, which is not above the provider's own %s maximum",
+			d, providerJobMaximum)
+	}
+	if got := (Tier{}).Ceiling(); got != time.Duration(DefaultJobTimeout) {
+		t.Errorf("a tier naming no ceiling waits %s, want the default", got)
+	}
+	own := Duration(90 * time.Minute)
+	if got := (Tier{JobTimeout: &own}).Ceiling(); got != 90*time.Minute {
+		t.Errorf("a tier naming a ceiling waits %s, want its own", got)
+	}
+}


### PR DESCRIPTION
## What changes

`internal/config` arrives: the configuration schema, its defaults and its
validation. It parses both input forms — the Quick Start environment
variables and the advanced YAML file — into one canonical value, and
rejects a document whose `apiVersion` or `kind` it does not recognise so
schema evolution stays explicit.

Targets accept any `https` host at repository, organization or enterprise
scope. Resource units, byte sizes, durations and CIDRs become typed
values at the boundary rather than strings carried inward.

## What was found

`ParseTargetURL` refused every host that was not `github.com`. One rule
closed three different doors, and they are not equally justified: the
provider library treats enterprise as its *default* case, deriving
`<host>/api/v3`, and switches to `api.<host>` only for hosts it
recognises as hosted — `github.com`, `www.github.com`, `github.localhost`
and any `*.ghe.com`. The rule refused GitHub's own data-residency hosts
and any Enterprise Server, both of which use code paths already present.

Underneath it sat a misclassification the rule was masking rather than
preventing. `https://github.com/enterprises/acme` passes a `github.com`
host check, has two path segments, and both satisfy the owner and
repository patterns — so it was accepted as *repository `acme` owned by
`enterprises`*. An enterprise URL was not refused; it was silently
understood as something else.

The host is therefore not the unit of refusal. A host that does not serve
the protocol fails at the live credential check with an error about the
host, which is a better answer than a rule about a name. Enterprise
becomes a third scope beside organization and repository: runner groups
extend to it, and cache lanes stay repository-only, because the identity
that justifies a persistent lane is unchanged by this.

Limits are bounded where an unbounded value would be a denial of service
against the controller rather than a mistake: the configuration document
itself is capped before parsing.

## Evidence

Hermetic only — the package performs no I/O beyond reading the file it is
given. Each URL shape is pinned by a test: a hosted host, a data-residency
host, an Enterprise Server host, and each of the three scopes.

```text
hermetic only — parsing, defaulting and validation, no network
```

## What would notice this regressing

`internal/config`'s suite. `TestParseTargetURL` fails if an enterprise
path is again read as an owner and repository, or if the canonical URL is
rebuilt from a literal instead of the host given. The validation tests
fail if a field error stops naming its path, and the defaults tests fail
if a product default drifts from the documented value.

## Risk, compatibility and operations

Trust boundary: this is where operator input is validated. It parses
untrusted YAML, so the document size is bounded before parsing and every
numeric field is range-checked rather than accepted and clamped later.

Credentials: the schema declares credential *references* — environment
variable names and file paths — never secret material. Nothing in this
package reads a secret.

Ownership, cleanup, networking, resource limits: N/A — the package holds
no state, opens no socket and creates nothing.

CLI, status API, schema, migration, deployment, rollback, runbook: N/A —
nothing imports the package yet.

Constrains what the code may do later, so it arrives with its record:
[a target is any host the protocol serves, at any scope it defines](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-17-target-hosts-and-scopes.md).

## Changelog

```text
NONE
```
