### PR TITLE
feat(credential): secrets resolved at the moment of use

### DIFF
--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -1,0 +1,150 @@
+// Package credential resolves configured credential references into
+// secret values at the moment of use. Values never enter configuration,
+// state or logs; this package is the only place a token value passes
+// through, and it hands it to the caller without retaining it.
+package credential
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// Token resolves a credential's token from its environment-variable or
+// file reference. Config validation already guarantees exactly one
+// reference is set; this re-checks defensively because a secret path
+// must not depend on every caller having validated first. Errors name
+// the reference, never the value.
+func Token(environ func(string) string, c config.Credential) (string, error) {
+	switch {
+	case c.TokenEnv != "" && c.TokenFile != "":
+		return "", fmt.Errorf("credential %q: tokenEnv and tokenFile are mutually exclusive", c.ID)
+	case c.TokenEnv != "":
+		v := environ(c.TokenEnv)
+		if v == "" {
+			return "", fmt.Errorf("credential %q: environment variable %s is empty or unset", c.ID, c.TokenEnv)
+		}
+		return v, nil
+	case c.TokenFile != "":
+		if err := checkSecretFileMode(c.TokenFile); err != nil {
+			return "", fmt.Errorf("credential %q: %w", c.ID, err)
+		}
+		data, err := os.ReadFile(c.TokenFile)
+		if err != nil {
+			return "", fmt.Errorf("credential %q: %w", c.ID, err)
+		}
+		// Mounted secret files conventionally end with a newline; tokens
+		// never contain whitespace, so trimming is safe and expected.
+		v := strings.TrimSpace(string(data))
+		if v == "" {
+			return "", fmt.Errorf("credential %q: file %s is empty", c.ID, c.TokenFile)
+		}
+		return v, nil
+	default:
+		return "", fmt.Errorf("credential %q: no token reference configured", c.ID)
+	}
+}
+
+// checkSecretFileMode refuses a secret file other local users can read.
+// `shared-daemon` is a supported topology, so "another uid on this host"
+// is a real party, not a hypothetical one — and a GitHub token is the
+// credential that mints runners. This is the one function whose whole
+// purpose is to be careful with a secret, so the check belongs here
+// rather than in each caller.
+//
+// A symlink is resolved before the check: the mode that matters is the
+// file's own, not the link's, and Lstat on a link reports 0777.
+func checkSecretFileMode(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("secret file %s is a directory", path)
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		return fmt.Errorf("secret file %s is readable by group or other (mode %#o); "+
+			"restrict it to the controller's own user with chmod 600", path, perm)
+	}
+	return nil
+}
+
+// Secret is the material one credential names, resolved. Exactly one of
+// its members is set, which is the same thing the credential's type says
+// — carried as a value so a caller branches on what it holds rather than
+// on a string it has to interpret.
+type Secret struct {
+	// Token authenticates as the person who minted it.
+	Token string
+	// App authenticates as an installation of a GitHub App. Nil unless
+	// the credential is one.
+	App *AppKey
+}
+
+// AppKey is a GitHub App installation's identity and its private key. The
+// ids are not secret and the key is; they travel together because the
+// provider client cannot mint an installation token without all three.
+type AppKey struct {
+	ClientID       string
+	InstallationID int64
+	PrivateKey     string
+}
+
+// Resolve turns a credential reference into the secret it names, at the
+// moment of use. It is the one door: every kind of credential passes
+// through here, so the file-mode rule and the "never log the value" rule
+// have one place to hold rather than one per kind.
+func Resolve(environ func(string) string, c config.Credential) (Secret, error) {
+	switch c.Type {
+	case config.CredentialTypeGitHubApp:
+		key, err := appKey(environ, c)
+		if err != nil {
+			return Secret{}, err
+		}
+		return Secret{App: key}, nil
+	default:
+		// An unset type is a token: the field defaults to it, and
+		// validation refuses anything else this does not name.
+		token, err := Token(environ, c)
+		if err != nil {
+			return Secret{}, err
+		}
+		return Secret{Token: token}, nil
+	}
+}
+
+func appKey(environ func(string) string, c config.Credential) (*AppKey, error) {
+	var pem string
+	switch {
+	case c.PrivateKeyEnv != "" && c.PrivateKeyFile != "":
+		return nil, fmt.Errorf("credential %q: privateKeyEnv and privateKeyFile are mutually exclusive", c.ID)
+	case c.PrivateKeyEnv != "":
+		// Only the surrounding whitespace, on both paths: a PEM is
+		// multi-line and the lines between the markers are the key.
+		pem = strings.TrimSpace(environ(c.PrivateKeyEnv))
+		if pem == "" {
+			return nil, fmt.Errorf("credential %q: environment variable %s is empty or unset",
+				c.ID, c.PrivateKeyEnv)
+		}
+	case c.PrivateKeyFile != "":
+		if err := checkSecretFileMode(c.PrivateKeyFile); err != nil {
+			return nil, fmt.Errorf("credential %q: %w", c.ID, err)
+		}
+		data, err := os.ReadFile(c.PrivateKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("credential %q: %w", c.ID, err)
+		}
+		pem = strings.TrimSpace(string(data))
+		if pem == "" {
+			return nil, fmt.Errorf("credential %q: file %s is empty", c.ID, c.PrivateKeyFile)
+		}
+	default:
+		return nil, fmt.Errorf("credential %q: no private key reference configured", c.ID)
+	}
+	if c.ClientID == "" || c.InstallationID <= 0 {
+		return nil, fmt.Errorf("credential %q: a GitHub App credential needs a client id and an installation id", c.ID)
+	}
+	return &AppKey{ClientID: c.ClientID, InstallationID: c.InstallationID, PrivateKey: pem}, nil
+}

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -1,0 +1,174 @@
+package credential
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+func TestToken(t *testing.T) {
+	secret := "tok-abc123-secret"
+	dir := t.TempDir()
+	file := filepath.Join(dir, "token")
+	if err := os.WriteFile(file, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	empty := filepath.Join(dir, "empty")
+	if err := os.WriteFile(empty, []byte("\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	environ := func(name string) string {
+		if name == "MY_TOKEN" {
+			return secret
+		}
+		return ""
+	}
+
+	cases := map[string]struct {
+		cred config.Credential
+		want string
+	}{
+		"from env":            {config.Credential{ID: "c", TokenEnv: "MY_TOKEN"}, secret},
+		"from file trims eol": {config.Credential{ID: "c", TokenFile: file}, secret},
+		"unset env":           {config.Credential{ID: "c", TokenEnv: "OTHER"}, ""},
+		"missing file":        {config.Credential{ID: "c", TokenFile: file + ".missing"}, ""},
+		"empty file":          {config.Credential{ID: "c", TokenFile: empty}, ""},
+		"both references":     {config.Credential{ID: "c", TokenEnv: "MY_TOKEN", TokenFile: file}, ""},
+		"no reference":        {config.Credential{ID: "c"}, ""},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := Token(environ, tc.cred)
+			if tc.want == "" {
+				if err == nil {
+					t.Fatal("want error")
+				}
+				// A resolution error must never leak the secret value.
+				if strings.Contains(err.Error(), secret) {
+					t.Fatalf("error leaks the secret: %v", err)
+				}
+				return
+			}
+			if err != nil || got != tc.want {
+				t.Fatalf("Token = %q, %v; want %q", got, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestTokenFileRefusesPermissiveModes: shared-daemon is a supported
+// topology, so another uid on the host is a real party. A token file it
+// can read is a GitHub credential it can use to mint runners, and reading
+// one without comment is not what a package that exists to be careful with
+// secrets should do.
+func TestTokenFileRefusesPermissiveModes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("ghs_secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := config.Credential{ID: "gh", Type: config.CredentialTypeToken, TokenFile: path}
+
+	got, err := Token(nil, c)
+	if err != nil {
+		t.Fatalf("0600 token file rejected: %v", err)
+	}
+	if got != "ghs_secret" {
+		t.Errorf("token = %q; want the trimmed file contents", got)
+	}
+
+	for _, mode := range []os.FileMode{0o640, 0o604, 0o644, 0o666} {
+		if err := os.Chmod(path, mode); err != nil {
+			t.Fatal(err)
+		}
+		_, err := Token(nil, c)
+		if err == nil {
+			t.Errorf("mode %#o was accepted; group or other can read the token", mode)
+			continue
+		}
+		if strings.Contains(err.Error(), "ghs_secret") {
+			t.Error("the error leaked the token value")
+		}
+	}
+}
+
+// TestResolveAGitHubAppCredential: the key is the longest-lived secret a
+// deployment holds, so it takes the same references and the same
+// owner-only file rule a token does, and the ids travel with it because
+// the provider cannot mint an installation token without all three.
+func TestResolveAGitHubAppCredential(t *testing.T) {
+	const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIB\nkey\n-----END RSA PRIVATE KEY-----"
+	base := config.Credential{
+		ID: "app", Type: config.CredentialTypeGitHubApp,
+		ClientID: "Iv1.abc", InstallationID: 42,
+	}
+
+	t.Run("from the environment", func(t *testing.T) {
+		c := base
+		c.PrivateKeyEnv = "APP_KEY"
+		got, err := Resolve(func(k string) string {
+			if k == "APP_KEY" {
+				return pem + "\n"
+			}
+			return ""
+		}, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Token != "" {
+			t.Error("an app credential resolved a token")
+		}
+		if got.App == nil || got.App.PrivateKey != pem {
+			t.Fatalf("app = %+v; want the key with its surrounding whitespace trimmed", got.App)
+		}
+		if got.App.ClientID != "Iv1.abc" || got.App.InstallationID != 42 {
+			t.Errorf("app identity = %+v", got.App)
+		}
+	})
+
+	t.Run("from a file the owner alone can read", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "app.pem")
+		if err := os.WriteFile(path, []byte(pem+"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		c := base
+		c.PrivateKeyFile = path
+		got, err := Resolve(func(string) string { return "" }, c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.App == nil || got.App.PrivateKey != pem {
+			t.Fatalf("app = %+v; want the multi-line key intact", got.App)
+		}
+	})
+
+	t.Run("a key others can read is refused", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "app.pem")
+		if err := os.WriteFile(path, []byte(pem), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		c := base
+		c.PrivateKeyFile = path
+		_, err := Resolve(func(string) string { return "" }, c)
+		if err == nil {
+			t.Fatal("a world-readable private key was accepted")
+		}
+		if !strings.Contains(err.Error(), "readable by group or other") {
+			t.Errorf("error = %q", err)
+		}
+		if strings.Contains(err.Error(), "BEGIN") {
+			t.Error("the error carries the key")
+		}
+	})
+
+	t.Run("an empty reference is refused", func(t *testing.T) {
+		c := base
+		c.PrivateKeyEnv = "APP_KEY"
+		if _, err := Resolve(func(string) string { return "" }, c); err == nil {
+			t.Fatal("an unset key variable was accepted")
+		}
+	})
+}


### PR DESCRIPTION
## What changes

`internal/credential` arrives: it turns a configured credential reference
into the secret it names, at the moment of use. Callers receive a value
and the package keeps nothing.

Resolution covers both forms a deployment can use — an environment
variable or a mounted file — and refuses a file whose mode lets another
local user read it.

## What was found

Three failure modes here surface far from their cause, so each is caught
at resolution instead.

An unset or empty reference would otherwise resolve to an empty token and
reach the provider as anonymous access. The failure then arrives as an
authorization error against the provider, which sends an operator to
their token's scopes when the actual fault is a variable that was never
set. Both the empty variable and the empty file are errors here, naming
the reference.

A secret file readable by group or other is refused rather than warned
about. This is not hypothetical: `shared-daemon` is a supported host
topology, so another uid on the host is a real party, and the material in
that file mints runners. The check stats through a symlink deliberately —
`Lstat` reports `0777` for a link, so checking the link's own mode would
pass every time.

Mounted secret files conventionally end with a newline and tokens contain
no whitespace, so the file form trims before checking for emptiness. A
token that arrived with its trailing newline intact would otherwise fail
at the provider with an opaque error.

Validation already guarantees exactly one reference is set, and this
re-checks anyway: a secret path should not depend on every caller having
validated first.

## Evidence

Hermetic only — the environment is injected as a function and the file
cases run against a temporary directory whose modes the test sets.

```text
hermetic only — injected environment, temporary files with explicit modes
```

## What would notice this regressing

`internal/credential`'s suite. It fails if an empty variable or an empty
file yields a token instead of an error, if a group-readable or
world-readable secret file is accepted, if the symlink case starts
checking the link rather than its target, or if an error message ever
contains the resolved value.

## Risk, compatibility and operations

Trust boundary: this is the only place secret material passes through, so
the mode check and the "never retain, never log" property are the whole
point of the package rather than incidental to it.

Credentials: handled by definition. Values are returned to the caller and
not stored; no error message interpolates a value; nothing is written to
state or to a log from here.

Ownership, cleanup, networking, resource limits: N/A — no state, no
socket, nothing created.

CLI, configuration, status API, schema, migration, deployment, rollback:
N/A — the configuration schema this reads already exists; nothing imports
this package yet.

Runbook: the mode refusal produces an operator-facing message naming the
file and the remedy, so an operator hitting it needs no runbook entry to
act on it.

## Changelog

```text
NONE
```
