### PR TITLE
feat(platform): the host a release is qualified against

### DIFF
--- a/build/platform.lock.json
+++ b/build/platform.lock.json
@@ -1,0 +1,26 @@
+{
+  "_comment": [
+    "Release qualification is blocked until the production-class Linux host",
+    "has installed Docker from the official stable Debian channel and its exact",
+    "facts have been reviewed and frozen here before a release-candidate tag.",
+    "",
+    "The qualification job must compare the observed host with those frozen",
+    "facts. It must never derive its expected values from the host under test.",
+    "Updating Docker after a freeze requires a new reviewed lock and a complete",
+    "no-skip qualification run; it does not invalidate historical records."
+  ],
+  "schema_version": 1,
+  "status": "pending",
+  "policy": {
+    "os": "debian",
+    "os_version": "13",
+    "os_codename": "trixie",
+    "arch": "amd64",
+    "docker_channel": "stable",
+    "docker_source": "https://download.docker.com/linux/debian",
+    "selection": "latest-stable-at-policy-review",
+    "target_engine": "29.7.2",
+    "reviewed": "2026-08-16",
+    "freeze_point": "before-release-candidate"
+  }
+}

--- a/internal/platform/cmd/verify/main.go
+++ b/internal/platform/cmd/verify/main.go
@@ -1,0 +1,51 @@
+// Command verify compares collected host facts with Runpool's release-
+// qualification reference. It fails closed when a fact is missing or differs.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/rhobuild/runpool/internal/platform"
+)
+
+func main() {
+	observedPath := flag.String("observed", "platform-facts.json", "path to collected platform facts")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "verify: unexpected positional arguments")
+		os.Exit(2)
+	}
+
+	b, err := os.ReadFile(*observedPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "verify:", err)
+		os.Exit(1)
+	}
+	var observed platform.Facts
+	if err := json.Unmarshal(b, &observed); err != nil {
+		fmt.Fprintln(os.Stderr, "verify: decode observed platform:", err)
+		os.Exit(1)
+	}
+
+	reference, err := platform.Load()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "verify:", err)
+		os.Exit(1)
+	}
+	if err := reference.RequireFrozen(); err != nil {
+		fmt.Fprintln(os.Stderr, "verify:", err)
+		os.Exit(1)
+	}
+	if mismatches := reference.Compare(observed); len(mismatches) != 0 {
+		fmt.Fprintln(os.Stderr, "observed host does not match the release-qualification reference:")
+		for _, mismatch := range mismatches {
+			fmt.Fprintln(os.Stderr, " -", mismatch)
+		}
+		os.Exit(1)
+	}
+	fmt.Printf("release-qualification reference matched: %s %s, Docker Engine %s\n",
+		reference.Platform.OS, reference.Platform.OSVersion, reference.Platform.Engine)
+}

--- a/internal/platform/generate.go
+++ b/internal/platform/generate.go
@@ -1,0 +1,8 @@
+package platform
+
+// The embedded manifest is a mechanical copy of the reviewed one under
+// build/. Copying it by hand is how the two drift, so it is generated
+// and a test asserts byte equality — the embedded copy is what runs, so
+// the review has to have applied to exactly those bytes.
+//
+//go:generate cp ../../build/platform.lock.json platform.lock.json

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,251 @@
+// Package platform owns the selection policy and exact host reference used for
+// release qualification. The reference is frozen in build/platform.lock.json
+// before a candidate and embedded here so every check reads the same reviewed
+// answer.
+//
+// Runtime compatibility is enforced separately by doctor; this package
+// records evidence and never constrains operators to the reference patch.
+package platform
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// MinimumEngineMajor is the compatibility floor for ordinary runtime
+// admission. Exact release evidence is compared separately against Reference.
+const MinimumEngineMajor = 28
+
+const (
+	ReferenceStatusPending = "pending"
+	ReferenceStatusFrozen  = "frozen"
+)
+
+//go:embed platform.lock.json
+var manifestJSON []byte
+
+// Reference is the reviewed release-qualification target. A pending reference
+// keeps release gates closed until the operator facts have been captured and
+// frozen in the repository before a candidate tag is created.
+type Reference struct {
+	SchemaVersion int    `json:"schema_version"`
+	Status        string `json:"status"`
+	Policy        Policy `json:"policy"`
+	Recorded      string `json:"recorded,omitempty"`
+	Platform      Facts  `json:"platform,omitempty"`
+}
+
+// Policy records how the exact target is selected. It is distinct from the
+// frozen facts: selection happens once, then the candidate is qualified
+// against reviewed bytes rather than expectations derived from the host under
+// test.
+type Policy struct {
+	OS            string `json:"os"`
+	OSVersion     string `json:"os_version"`
+	OSCodename    string `json:"os_codename"`
+	Arch          string `json:"arch"`
+	DockerChannel string `json:"docker_channel"`
+	DockerSource  string `json:"docker_source"`
+	Selection     string `json:"selection"`
+	TargetEngine  string `json:"target_engine"`
+	Reviewed      string `json:"reviewed"`
+	FreezePoint   string `json:"freeze_point"`
+}
+
+// Facts are the platform's properties. Every one of them can change a
+// container's behaviour, which is why they are recorded rather than
+// summarised: engine patches, cgroup drivers, storage drivers, and backing
+// filesystems can all change container behaviour materially.
+type Facts struct {
+	OS                string `json:"os"`
+	OSVersion         string `json:"os_version"`
+	OSCodename        string `json:"os_codename"`
+	Arch              string `json:"arch"`
+	Kernel            string `json:"kernel"`
+	Engine            string `json:"engine"`
+	API               string `json:"api"`
+	CgroupVersion     string `json:"cgroup_version"`
+	CgroupDriver      string `json:"cgroup_driver"`
+	StorageDriver     string `json:"storage_driver"`
+	BackingFilesystem string `json:"backing_filesystem"`
+	Rootless          *bool  `json:"rootless"`
+	Containerd        string `json:"containerd"`
+	Runc              string `json:"runc"`
+	Buildx            string `json:"buildx"`
+	Compose           string `json:"compose"`
+	IPTables          string `json:"iptables"`
+	NFTables          string `json:"nftables"`
+}
+
+// Load returns the embedded manifest.
+func Load() (Reference, error) {
+	var ref Reference
+	if err := json.Unmarshal(manifestJSON, &ref); err != nil {
+		return ref, fmt.Errorf("platform manifest: %w", err)
+	}
+	if err := ref.validate(); err != nil {
+		return ref, err
+	}
+	return ref, nil
+}
+
+// MustLoad is Load for callers that cannot proceed without it. The
+// manifest is embedded and reviewed, so a failure is a build defect.
+func MustLoad() Reference {
+	ref, err := Load()
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
+func (r Reference) validate() error {
+	if r.SchemaVersion != 1 {
+		return fmt.Errorf("platform manifest schema_version %d is unsupported", r.SchemaVersion)
+	}
+	if r.Policy.OS != "debian" || r.Policy.OSVersion != "13" ||
+		r.Policy.OSCodename != "trixie" || r.Policy.Arch != "amd64" ||
+		r.Policy.DockerChannel != "stable" || r.Policy.DockerSource == "" ||
+		r.Policy.Selection != "latest-stable-at-policy-review" || r.Policy.TargetEngine == "" ||
+		r.Policy.Reviewed == "" || r.Policy.FreezePoint != "before-release-candidate" {
+		return fmt.Errorf("platform manifest has an invalid selection policy")
+	}
+	switch r.Status {
+	case ReferenceStatusPending:
+		if r.Recorded != "" || r.Platform != (Facts{}) {
+			return fmt.Errorf("pending platform manifest must not contain frozen facts")
+		}
+		return nil
+	case ReferenceStatusFrozen:
+		// Continue below and require every exact fact.
+	default:
+		return fmt.Errorf("platform manifest status %q is unsupported", r.Status)
+	}
+
+	missing := []string{}
+	for name, value := range map[string]string{
+		"recorded":           r.Recorded,
+		"os":                 r.Platform.OS,
+		"os_version":         r.Platform.OSVersion,
+		"os_codename":        r.Platform.OSCodename,
+		"arch":               r.Platform.Arch,
+		"kernel":             r.Platform.Kernel,
+		"engine":             r.Platform.Engine,
+		"api":                r.Platform.API,
+		"cgroup_version":     r.Platform.CgroupVersion,
+		"cgroup_driver":      r.Platform.CgroupDriver,
+		"storage_driver":     r.Platform.StorageDriver,
+		"backing_filesystem": r.Platform.BackingFilesystem,
+		"containerd":         r.Platform.Containerd,
+		"runc":               r.Platform.Runc,
+		"buildx":             r.Platform.Buildx,
+		"compose":            r.Platform.Compose,
+		"iptables":           r.Platform.IPTables,
+		"nftables":           r.Platform.NFTables,
+	} {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("platform manifest is incomplete: %s", strings.Join(missing, ", "))
+	}
+	if r.Platform.Rootless == nil {
+		return fmt.Errorf("platform manifest is incomplete: rootless")
+	}
+	return nil
+}
+
+// RequireFrozen rejects release qualification until an independently reviewed
+// set of exact host facts has replaced the pending reference.
+func (r Reference) RequireFrozen() error {
+	if r.Status != ReferenceStatusFrozen {
+		return fmt.Errorf("release-qualification reference is %s; capture and review the installed stable Docker platform before creating a candidate", r.Status)
+	}
+	return nil
+}
+
+// Mismatch is one property where an observed host differs from the reference.
+type Mismatch struct {
+	Property string
+	Want     string
+	Got      string
+}
+
+func (m Mismatch) String() string {
+	return fmt.Sprintf("%s: reference %q, host has %q", m.Property, m.Want, m.Got)
+}
+
+// Compare reports every observed fact that differs from the qualification
+// reference. Missing observations are mismatches because absent evidence
+// cannot qualify a release.
+func (r Reference) Compare(observed Facts) []Mismatch {
+	if r.Status != ReferenceStatusFrozen {
+		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: r.Status}}
+	}
+	var out []Mismatch
+	check := func(property, want, got string) {
+		if got != want {
+			out = append(out, Mismatch{Property: property, Want: want, Got: got})
+		}
+	}
+	check("os", r.Platform.OS, observed.OS)
+	check("os_version", r.Platform.OSVersion, observed.OSVersion)
+	check("os_codename", r.Platform.OSCodename, observed.OSCodename)
+	check("arch", r.Platform.Arch, observed.Arch)
+	check("kernel", r.Platform.Kernel, observed.Kernel)
+	check("engine", r.Platform.Engine, observed.Engine)
+	check("api", r.Platform.API, observed.API)
+	check("cgroup_version", r.Platform.CgroupVersion, observed.CgroupVersion)
+	check("cgroup_driver", r.Platform.CgroupDriver, observed.CgroupDriver)
+	check("storage_driver", r.Platform.StorageDriver, observed.StorageDriver)
+	check("backing_filesystem", r.Platform.BackingFilesystem, observed.BackingFilesystem)
+	check("containerd", r.Platform.Containerd, observed.Containerd)
+	check("runc", r.Platform.Runc, observed.Runc)
+	check("buildx", r.Platform.Buildx, observed.Buildx)
+	check("compose", r.Platform.Compose, observed.Compose)
+	check("iptables", r.Platform.IPTables, observed.IPTables)
+	check("nftables", r.Platform.NFTables, observed.NFTables)
+	if mismatch, ok := compareBoolFact("rootless", r.Platform.Rootless, observed.Rootless); ok {
+		out = append(out, mismatch)
+	}
+	return out
+}
+
+// CompareDockerFacts is the subset of Compare observable through the Docker
+// API. Qualification contracts use it when they need daemon-only evidence.
+func (r Reference) CompareDockerFacts(observed Facts) []Mismatch {
+	if r.Status != ReferenceStatusFrozen {
+		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: r.Status}}
+	}
+	var out []Mismatch
+	check := func(property, want, got string) {
+		if got != want {
+			out = append(out, Mismatch{Property: property, Want: want, Got: got})
+		}
+	}
+	check("engine", r.Platform.Engine, observed.Engine)
+	check("api", r.Platform.API, observed.API)
+	check("arch", r.Platform.Arch, observed.Arch)
+	check("cgroup_version", r.Platform.CgroupVersion, observed.CgroupVersion)
+	check("cgroup_driver", r.Platform.CgroupDriver, observed.CgroupDriver)
+	if mismatch, ok := compareBoolFact("rootless", r.Platform.Rootless, observed.Rootless); ok {
+		out = append(out, mismatch)
+	}
+	return out
+}
+
+func compareBoolFact(property string, want, got *bool) (Mismatch, bool) {
+	if want != nil && got != nil && *want == *got {
+		return Mismatch{}, false
+	}
+	format := func(value *bool) string {
+		if value == nil {
+			return "<missing>"
+		}
+		return fmt.Sprint(*value)
+	}
+	return Mismatch{Property: property, Want: format(want), Got: format(got)}, true
+}

--- a/internal/platform/platform.lock.json
+++ b/internal/platform/platform.lock.json
@@ -1,0 +1,26 @@
+{
+  "_comment": [
+    "Release qualification is blocked until the production-class Linux host",
+    "has installed Docker from the official stable Debian channel and its exact",
+    "facts have been reviewed and frozen here before a release-candidate tag.",
+    "",
+    "The qualification job must compare the observed host with those frozen",
+    "facts. It must never derive its expected values from the host under test.",
+    "Updating Docker after a freeze requires a new reviewed lock and a complete",
+    "no-skip qualification run; it does not invalidate historical records."
+  ],
+  "schema_version": 1,
+  "status": "pending",
+  "policy": {
+    "os": "debian",
+    "os_version": "13",
+    "os_codename": "trixie",
+    "arch": "amd64",
+    "docker_channel": "stable",
+    "docker_source": "https://download.docker.com/linux/debian",
+    "selection": "latest-stable-at-policy-review",
+    "target_engine": "29.7.2",
+    "reviewed": "2026-08-16",
+    "freeze_point": "before-release-candidate"
+  }
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,152 @@
+package platform
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+// The embedded manifest is what the checks execute; the copy under build/ is
+// what humans review. Byte equality matters because structurally equivalent
+// JSON can still differ from the reviewed artifact.
+func TestEmbeddedManifestMatchesTheReviewedCopy(t *testing.T) {
+	reviewed, err := os.ReadFile("../../build/platform.lock.json")
+	if err != nil {
+		t.Fatalf("read the reviewed manifest: %v", err)
+	}
+	if !bytes.Equal(reviewed, manifestJSON) {
+		t.Error("internal/platform/platform.lock.json differs from build/platform.lock.json; " +
+			"regenerate it with `go generate ./internal/platform/`")
+	}
+}
+
+func TestManifestSelectsTheLatestReviewedStableEngine(t *testing.T) {
+	ref, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ref.Status != ReferenceStatusPending {
+		t.Errorf("status = %q; want pending until the server facts are frozen", ref.Status)
+	}
+	if ref.Policy.TargetEngine != "29.7.2" || ref.Policy.DockerChannel != "stable" {
+		t.Errorf("Docker policy = %+v; want stable Engine 29.7.2", ref.Policy)
+	}
+	if err := ref.RequireFrozen(); err == nil {
+		t.Fatal("a pending reference was accepted for release qualification")
+	}
+	if got := ref.Compare(Facts{}); len(got) != 1 || got[0].Property != "reference_status" {
+		t.Fatalf("pending comparison = %v; want a reference_status mismatch", got)
+	}
+}
+
+func TestManifestRequiresEveryFrozenFact(t *testing.T) {
+	bad := Reference{
+		SchemaVersion: 1,
+		Status:        ReferenceStatusFrozen,
+		Policy:        testPolicy(),
+		Recorded:      "2026-08-14",
+		Platform: Facts{
+			OS: "debian", OSVersion: "13", Arch: "amd64",
+			Engine: "29.7.2", CgroupVersion: "2", CgroupDriver: "systemd",
+			StorageDriver: "overlay2",
+		},
+	}
+	if err := bad.validate(); err == nil {
+		t.Fatal("an incomplete frozen reference validated")
+	}
+
+	missingBoolean := frozenReference()
+	missingBoolean.Platform.Rootless = nil
+	if err := missingBoolean.validate(); err == nil {
+		t.Fatal("a frozen reference without the rootless observation validated")
+	}
+}
+
+// TestCompareNamesEveryDifference keeps qualification evidence fail-closed.
+func TestCompareNamesEveryDifference(t *testing.T) {
+	ref := frozenReference()
+
+	if got := ref.Compare(ref.Platform); len(got) != 0 {
+		t.Errorf("the reference platform mismatched itself: %v", got)
+	}
+
+	drifted := ref.Platform
+	drifted.Engine = "29.6.3"
+	drifted.CgroupDriver = "cgroupfs"
+	drifted.Rootless = boolFact(true)
+	got := ref.Compare(drifted)
+	if len(got) != 3 {
+		t.Fatalf("three drifted properties produced %d mismatches: %v", len(got), got)
+	}
+	for _, mismatch := range got {
+		if mismatch.Want == "" || mismatch.Got == "" {
+			t.Errorf("mismatch %v does not say both sides", mismatch)
+		}
+	}
+
+	partial := Facts{Engine: ref.Platform.Engine, Rootless: ref.Platform.Rootless}
+	if got := ref.Compare(partial); len(got) == 0 {
+		t.Error("an incomplete observation matched the reference platform")
+	}
+}
+
+func TestRuntimeComparisonUsesOnlyDockerFacts(t *testing.T) {
+	ref := frozenReference()
+	observed := Facts{
+		Engine:        ref.Platform.Engine,
+		API:           ref.Platform.API,
+		Arch:          ref.Platform.Arch,
+		CgroupVersion: ref.Platform.CgroupVersion,
+		CgroupDriver:  ref.Platform.CgroupDriver,
+		Rootless:      ref.Platform.Rootless,
+	}
+	if got := ref.CompareDockerFacts(observed); len(got) != 0 {
+		t.Errorf("matching Docker runtime facts produced mismatches: %v", got)
+	}
+}
+
+func testPolicy() Policy {
+	return Policy{
+		OS:            "debian",
+		OSVersion:     "13",
+		OSCodename:    "trixie",
+		Arch:          "amd64",
+		DockerChannel: "stable",
+		DockerSource:  "https://download.docker.com/linux/debian",
+		Selection:     "latest-stable-at-policy-review",
+		TargetEngine:  "29.7.2",
+		Reviewed:      "2026-08-14",
+		FreezePoint:   "before-release-candidate",
+	}
+}
+
+func frozenReference() Reference {
+	return Reference{
+		SchemaVersion: 1,
+		Status:        ReferenceStatusFrozen,
+		Policy:        testPolicy(),
+		Recorded:      "2026-08-14",
+		Platform: Facts{
+			OS:                "debian",
+			OSVersion:         "13",
+			OSCodename:        "trixie",
+			Arch:              "amd64",
+			Kernel:            "6.12.0-amd64",
+			Engine:            "29.7.2",
+			API:               "1.52",
+			CgroupVersion:     "2",
+			CgroupDriver:      "systemd",
+			StorageDriver:     "overlay2",
+			BackingFilesystem: "ext4",
+			Rootless:          boolFact(false),
+			Containerd:        "2.2.6",
+			Runc:              "1.4.0",
+			Buildx:            "0.35.0",
+			Compose:           "2.35.0",
+			IPTables:          "1.8.11",
+			NFTables:          "1.1.3",
+		},
+	}
+}
+
+func boolFact(value bool) *bool { return &value }


### PR DESCRIPTION
## What changes

`internal/platform` arrives with the reviewed host reference it embeds and
the command that compares observed facts against it. The reference is
`pending` until a production-class host has been installed from the
official stable channel and its facts frozen, which is the state this
records today.

## What was found

Two properties decide whether qualification evidence means anything, and
both are structural rather than procedural.

**Expectations cannot come from the host under test.** If the comparison
read its expected engine version off the machine it was qualifying, every
run would pass and the artifact would say nothing. So the reference is
frozen in a reviewed file before a candidate exists, and the comparison
only ever reads that.

**A missing fact is a mismatch.** Absent evidence is the shape a
collection bug takes, and treating it as agreement turns a broken
collector into a clean report. The comparison fails closed on a fact it
cannot find.

The reviewed copy and the embedded copy are the same bytes by test rather
than by convention. `build/platform.lock.json` is where a human reviews
it; the embedded copy is what the code reads; a parity test fails if they
diverge, so a reviewed change that was not regenerated cannot ship.

The floor for ordinary runtime admission is deliberately not the
reference. Holding an operator to the exact patch level a release was
qualified on would make a security update to their engine look like an
unsupported configuration. Doctor enforces a major-version floor; this
package records what a release was measured against.

## Evidence

Hermetic only — the comparison is a pure function over two documents, and
the parity test reads both copies from the tree.

```text
hermetic only — no host is contacted; the reference is still `pending`
and no qualification run has been performed against it
```

## What would notice this regressing

`internal/platform`'s suite. The parity test fails if the embedded lock
stops matching `build/platform.lock.json`. The comparison tests fail if a
missing fact starts reading as a match, or if a mismatch stops naming
which fact differed.

## Risk, compatibility and operations

Trust boundary: none crossed. The package reads two documents and
compares them.

Credentials, ownership, cleanup, networking, resource limits: N/A — no
state, no socket, nothing created.

Operations: the reference is `status: pending`, so no release can claim
qualification evidence yet. Updating the engine after a freeze requires a
newly reviewed lock and a complete no-skip qualification run; it does not
invalidate records already produced.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports this package yet.

## Changelog

```text
NONE
```
