### PR TITLE
feat(allocator, disk): admission credits and disk pressure

### DIFF
--- a/docs/adrs/2026-08-11-advertised-capacity.md
+++ b/docs/adrs/2026-08-11-advertised-capacity.md
@@ -1,0 +1,44 @@
+# Advertised capacity is a total, and zero is forever
+
+**Status:** accepted; allocation refined by [admission credits](2026-08-13-admission-credits.md)
+**Date:** 2026-08-11
+
+## Context
+
+Each message-session poll announces a capacity to the broker. Two
+interpretations exist: the instantaneous free gap (parallelism minus active),
+or the design's `advertised = active + grant` — the total number of
+jobs the scale set may hold at once.
+
+The first live crash-recovery exercise settled it. The controller
+announced the free gap; while an adopted capsule was running the gap
+was zero, and a job queued in exactly that window. The broker excluded
+it — and never reconsidered: twelve minutes of subsequent polls
+announcing free capacity, plus two completely fresh sessions, and the
+job stayed `queued` with an assigned backlog of zero. Only cancelling
+and re-dispatching the run recovered it.
+
+## Decision
+
+- The announced capacity is the **total** the binding may hold — the
+  credits allocated to it while the controller is willing to serve — never
+  the instantaneous free gap. The broker keeps up to that many jobs
+  assigned and replaces one as soon as a job finishes.
+- The broker may therefore hand over a replacement before local cleanup
+  returns admission capacity. Durable ready attempts bridge that interval;
+  delivery and attempt identities make redelivery idempotent without relying
+  on an in-memory queue.
+- Announcing less than the intended total is reserved for shutting
+  down; the assignment decision happens once, when the job queues, so
+  an underannouncement is not a throttle — it is a trapdoor.
+
+## Consequences
+
+- The capacity allocator moves *totals* between bindings with
+  `advertised_i = active_i + grant_i`; it never expresses "busy" by
+  announcing zero, because zero excludes rather than defers.
+- Recovery policy for a job that queued against a zero announcement is
+  outside the session protocol entirely: it requires re-queueing the
+  run. The operator documentation must say so.
+- Statistics remain the demand truth; this decision is about what we
+  tell the broker, not about what we believe from it.

--- a/docs/adrs/2026-08-11-capacity-floor.md
+++ b/docs/adrs/2026-08-11-capacity-floor.md
@@ -1,0 +1,34 @@
+# A zero-capacity binding cannot discover queued demand
+
+**Status:** superseded by [admission credits](2026-08-13-admission-credits.md)
+**Date:** 2026-08-11
+
+## Context
+
+A controlled broker experiment showed that a session advertising zero
+capacity received neither assigned jobs nor statistics for work queued while
+it remained at zero. Raising capacity later in the same session did not make
+that queued work visible. A binding with no current demand signal could
+therefore become blind to its first queued job.
+
+## Original decision
+
+The initial remedy assigned every binding a permanent capacity floor of one
+and enforced physical concurrency separately at capsule launch. This kept
+bindings visible, but allowed the sum of advertised capacity to exceed the
+tier's parallelism when the number of bindings was larger than available capacity.
+
+## Superseding decision
+
+[Admission credits](2026-08-13-admission-credits.md) retain the measured
+requirement without permanent over-advertisement. One idle credit rotates
+among bindings that need discovery, while running work and active demand hold
+the remaining credits. Total advertised capacity never exceeds tier
+parallelism.
+
+## Consequences
+
+- The zero-capacity behaviour remains a live upstream contract.
+- Local admission remains a safety limit independent of provider state.
+- A change in broker behaviour can be evaluated against the contract rather
+  than inferred from documentation.

--- a/docs/adrs/2026-08-13-admission-credits.md
+++ b/docs/adrs/2026-08-13-admission-credits.md
@@ -1,0 +1,68 @@
+# Admission is a pool of credits with a rotating discovery credit
+
+**Status:** accepted
+**Date:** 2026-08-13
+**Supersedes:** [the per-binding capacity floor](2026-08-11-capacity-floor.md)
+
+## Context
+
+The floor ADR established a measured fact and a temporary remedy. The
+fact: a binding whose session announces `0` is not throttled, it is
+blinded — GitHub delivers it no job and no statistics, so it can never
+learn it has queued work and never raise itself. The remedy: floor every
+live binding at one advertised capacity unit, permanently.
+
+The remedy cost the invariant. With floors, `sum(advertised)` exceeds a
+tier's parallelism whenever running capsules already fill it, and a tier with
+more bindings than parallelism cannot be configured at all — the allocator,
+the config validator and the doctor all had to refuse it. The overshoot
+was absorbed as backlog because the physical gate (`TryReserve`) is
+absolute, but "the promise is wrong and the gate catches it" is not a
+capacity model.
+
+## Decision
+
+A tier holds exactly as many credits as its configured parallelism. They are distributed, in
+this order, from one consistent read of the pool:
+
+1. **Running capsules hold their credit.** A job in flight cannot be
+   retracted, so advertised is never below active.
+2. **Free credits follow demand,** max-min fair by water-filling, ties
+   broken by registration order. Deterministic, so two callers reading
+   the pool at the same state compute the same distribution.
+3. **One credit, if still unclaimed, is the discovery credit.** It goes
+   to a single binding with no demand signal and no running capsule.
+
+The discovery credit rotates. Each empty long-poll advances it to the
+next binding that could use it, skipping any binding that already has
+demand or a running capsule — those can already see and be seen.
+Skipping them is what bounds the wait: every silent binding holds the
+credit within one pass of the pool.
+
+So the floor's guarantee survives in a weaker, affordable form. Sight is
+no longer a permanent per-binding reservation; it is a bounded wait for
+a shared credit, funded only out of genuinely idle capacity.
+
+`Hold` withholds new credit from every binding without touching running
+ones. The disk monitor sets it when an emergency closes admission:
+capacity that will not be served must not be announced.
+
+## Consequences
+
+- `sum(advertised) <= tier parallelism` holds for any single state of a pool, and
+  the tests assert it across the states a pool passes through and under
+  concurrent traffic. The invariant is a statement about the pool, so it
+  is read through `AdvertisedAll`; summing per-binding calls samples as
+  many instants as there are bindings and proves nothing.
+- More bindings than tier parallelism is a legal configuration. The validator
+  accepts it and the doctor warns instead of failing, because the cost
+  is real but bounded: a first job for a silent binding may wait one
+  rotation to be noticed.
+- A binding announcing zero is expected, not a fault. `PoolReport` gives
+  the operator the whole tier's accounting — demand, reserved,
+  advertised, and who holds discovery — and the controller logs it
+  whenever a binding's announcement changes.
+- Release qualification includes the live upstream behaviour: a silent binding must
+  discover a queued job through the rotating credit against the real broker.
+  Hermetic tests prove the local allocation contract; they do not replace that
+  provider evidence.

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -1,0 +1,497 @@
+// Package allocator distributes finite execution capacity among the
+// bindings that draw on it. It does two jobs with one set of counts: it
+// gates capsule launches to the admission budget (TryReserve/Release),
+// and it computes the capacity each binding should advertise to the broker
+// (Advertised).
+//
+// Capacity is credit, not entitlement. A tier holds exactly as many
+// credits as its parallelism permits; a running capsule holds one; what is
+// left is shared by demand. The sum of what every binding advertises never
+// exceeds either its tier limit or the optional instance-wide limit.
+//
+// One discovery credit rotates per independent tier, or across the instance
+// when a global limit is set. A silent binding announces one in turn and can
+// therefore observe its queue. The rotation reaches every eligible binding
+// within one pass. See
+// docs/adrs/2026-08-13-admission-credits.md.
+package allocator
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pool is one tier's parallelism budget and the bindings sharing it.
+type pool struct {
+	parallelism int
+	order       []string // binding keys, registration order, stable
+	state       map[string]*binding
+	// discovery is the index in order of the binding currently holding
+	// the discovery credit. Rotate advances it.
+	discovery int
+}
+
+type binding struct {
+	active int // capsules currently reserved/running for this binding
+	// assignedDemand is what the provider has committed to this
+	// binding: running plus waiting workloads, as its latest statistics
+	// reported. It is demand already owed, not capacity on offer.
+	assignedDemand int
+	// held is true while this binding must not be offered new work —
+	// disk pressure, quarantine, or any other contract that withholds
+	// credit. Running capsules still count; only new capacity stops.
+	held bool
+}
+
+type Allocator struct {
+	mu sync.Mutex
+	// globalParallelism is zero when tiers are intentionally independent.
+	globalParallelism int
+	pools             map[string]*pool
+	tierOf            map[string]string
+	order             []string // all binding keys, registration order
+	discovery         int      // instance-wide cursor when a global limit is set
+	// held is the instance-wide hold. It is kept here, not only on the
+	// bindings, because a hold is a statement about the instance and
+	// outlives the set of bindings that existed when it was applied:
+	// startup resumes a persisted emergency before the bindings are
+	// registered, and a hold that only touched the current map would be
+	// silently lost.
+	held bool
+}
+
+// New creates an allocator whose tiers are independent.
+func New() *Allocator { return NewWithGlobalParallelism(0) }
+
+// NewWithGlobalParallelism creates an allocator with an instance-wide limit.
+// Validation guarantees globalParallelism is positive; zero is reserved for
+// the independent-tier behavior used by New.
+func NewWithGlobalParallelism(globalParallelism int) *Allocator {
+	return &Allocator{
+		globalParallelism: globalParallelism,
+		pools:             map[string]*pool{},
+		tierOf:            map[string]string{},
+	}
+}
+
+// Register adds a binding to its tier pool. parallelism is the pool size for the
+// tier; every binding in a tier must pass the same value. More bindings
+// than the limit is legal: they share the tier's credits and take turns at
+// discovery rather than each reserving one.
+func (a *Allocator) Register(tierID, key string, parallelism int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	p := a.pools[tierID]
+	if p == nil {
+		p = &pool{parallelism: parallelism, state: map[string]*binding{}}
+		a.pools[tierID] = p
+	}
+	if p.parallelism != parallelism {
+		return fmt.Errorf("tier %q registered with conflicting parallelism %d and %d", tierID, p.parallelism, parallelism)
+	}
+	if _, dup := p.state[key]; dup {
+		return fmt.Errorf("binding %q already registered", key)
+	}
+	p.order = append(p.order, key)
+	p.state[key] = &binding{held: a.held}
+	a.tierOf[key] = tierID
+	a.order = append(a.order, key)
+	return nil
+}
+
+// SetAssignedDemand records what the provider has committed to a
+// binding — running plus waiting workloads, from its latest statistics
+// — which is what the free credits are shared by.
+func (a *Allocator) SetAssignedDemand(key string, demand int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if b := a.binding(key); b != nil {
+		if demand < 0 {
+			demand = 0
+		}
+		b.assignedDemand = demand
+	}
+}
+
+// Hold withholds new credit from every binding, or restores it. The disk
+// monitor calls it when an emergency closes admission: capacity that
+// cannot be served must not be announced, or the broker assigns work
+// that then waits on a full disk. Running capsules are unaffected —
+// they are already counted and cannot be retracted.
+func (a *Allocator) Hold(held bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.held = held
+	for _, p := range a.pools {
+		for _, b := range p.state {
+			b.held = held
+		}
+	}
+}
+
+// TryReserve claims one admission credit for key if its tier and the instance
+// both have capacity, counting active capsules across the whole pool. It
+// returns false when the pool is full, in which case the job waits in the
+// caller's local pending queue. A successful reserve must be paired with Release.
+func (a *Allocator) TryReserve(key string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.poolOf(key)
+	if p == nil {
+		return false
+	}
+	if a.poolActive(p) >= p.parallelism {
+		return false
+	}
+	if a.globalParallelism > 0 && a.active() >= a.globalParallelism {
+		return false
+	}
+	p.state[key].active++
+	return true
+}
+
+// Adopt accounts a lease that already exists at startup. It never
+// refuses: the capsule is running and its resources are committed, so
+// the only question is whether the books admit it.
+//
+// It reports whether that took the pool past its budget, which a restart
+// does whenever parallelism was lowered while capsules were running.
+// Until those leases release the pool holds more than its limit, and
+// because advertised capacity is seeded from active, the invariant that
+// the sum never exceeds parallelism is suspended for exactly that long.
+// It converges on its own; what it must not do is converge silently,
+// leaving an operator to meet it as a capacity figure that makes no
+// sense. Reporting rather than logging keeps the decision here and the
+// logger where the wiring is.
+func (a *Allocator) Adopt(key string) (overBudget bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	b := a.binding(key)
+	if b == nil {
+		return false
+	}
+	b.active++
+	// Both of the limits TryReserve gates on. A tier still inside its own
+	// parallelism can put the instance past the one every tier shares, and
+	// reporting only the tier's is how that arrives as an unexplained
+	// capacity figure instead of a line.
+	p := a.poolOf(key)
+	if p != nil && a.poolActive(p) > p.parallelism {
+		return true
+	}
+	return a.globalParallelism > 0 && a.active() > a.globalParallelism
+}
+
+// Release frees admission capacity when cleanup releases the lease.
+func (a *Allocator) Release(key string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if b := a.binding(key); b != nil && b.active > 0 {
+		b.active--
+	}
+}
+
+// Active reports a binding's current reserved/running capsule count.
+func (a *Allocator) Active(key string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if b := a.binding(key); b != nil {
+		return b.active
+	}
+	return 0
+}
+
+// Rotate advances every pool's discovery credit to the next binding that
+// could use it: one with no demand signal and no running capsule. A
+// binding that already has demand does not need discovery, so the
+// rotation skips it, which is what bounds the wait — every silent
+// binding holds the credit within one pass of the pool.
+func (a *Allocator) Rotate() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.globalParallelism > 0 {
+		a.discovery = a.nextDiscovery(a.order, a.discovery)
+		return
+	}
+	for _, p := range a.pools {
+		if len(p.order) == 0 {
+			continue
+		}
+		p.discovery = a.nextDiscovery(p.order, p.discovery)
+	}
+}
+
+// DiscoveryHolder reports which binding currently holds the tier's
+// discovery credit — the one datum an operator needs to answer "why is
+// that binding announcing zero".
+func (a *Allocator) DiscoveryHolder(tierID string) string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.pools[tierID]
+	if p == nil || len(p.order) == 0 {
+		return ""
+	}
+	if a.globalParallelism > 0 {
+		if len(a.order) == 0 {
+			return ""
+		}
+		holder := a.order[a.discovery]
+		if a.tierOf[holder] == tierID {
+			return holder
+		}
+		return ""
+	}
+	return p.order[p.discovery]
+}
+
+// Advertised computes the capacity key should announce now. It is a pure
+// function of pool state, so every binding's independent call sees the
+// same distribution and the pool's advertised sum stays within its
+// parallelism.
+//
+// The order is forced by what each part means. Running capsules cannot
+// be retracted, so they are counted first. What remains is free credit,
+// shared max-min fairly among bindings whose demand exceeds what they
+// hold. Whatever is still unclaimed can fund the discovery credit, so a
+// silent binding gets sight only out of genuinely idle capacity.
+func (a *Allocator) Advertised(key string) int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.poolOf(key)
+	if p == nil {
+		return 0
+	}
+	return a.distributeAll()[key]
+}
+
+// AdvertisedAll is the whole tier's distribution under one lock. The
+// per-binding call is what a session announces, but the invariant is a
+// statement about the pool, and reading it one binding at a time
+// samples four different instants rather than one state.
+func (a *Allocator) AdvertisedAll(tierID string) map[string]int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.pools[tierID]
+	if p == nil {
+		return nil
+	}
+	all := a.distributeAll()
+	out := make(map[string]int, len(p.order))
+	for _, key := range p.order {
+		out[key] = all[key]
+	}
+	return out
+}
+
+// BindingCredit is one binding's line in the pool report: the demand it
+// reported, the credits it holds, and what it would announce now.
+type BindingCredit struct {
+	Key            string
+	AssignedDemand int
+	Reserved       int
+	Advertised     int
+	Discovery      bool
+}
+
+// PoolReport is the tier's credit accounting, for operators and for the
+// log line that explains why a binding announces what it does.
+func (a *Allocator) PoolReport(tierID string) (parallelism int, rows []BindingCredit) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.pools[tierID]
+	if p == nil {
+		return 0, nil
+	}
+	adv := a.distributeAll()
+	discovery := ""
+	if a.globalParallelism > 0 {
+		if len(a.order) > 0 && a.tierOf[a.order[a.discovery]] == tierID {
+			discovery = a.order[a.discovery]
+		}
+	} else if len(p.order) > 0 {
+		discovery = p.order[p.discovery]
+	}
+	for _, k := range p.order {
+		b := p.state[k]
+		rows = append(rows, BindingCredit{
+			Key: k, AssignedDemand: b.assignedDemand, Reserved: b.active,
+			Advertised: adv[k], Discovery: k == discovery,
+		})
+	}
+	return p.parallelism, rows
+}
+
+// CapacityReport is the instance-wide admission accounting. Parallelism is
+// the effective limit: the configured global limit, or the sum of tier limits
+// when tiers are independent. Global says which of those it is — the sum is
+// arithmetic, not a limit anyone configured, and a reader deciding whether an
+// instance-wide figure means anything needs to know the difference.
+type CapacityReport struct {
+	Parallelism int
+	Active      int
+	Advertised  int
+	Available   int
+	Global      bool
+}
+
+func (a *Allocator) CapacityReport() CapacityReport {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	limit := a.globalParallelism
+	global := limit > 0
+	if limit == 0 {
+		for _, p := range a.pools {
+			limit += p.parallelism
+		}
+	}
+	active := a.active()
+	advertised := 0
+	for _, n := range a.distributeAll() {
+		advertised += n
+	}
+	available := limit - active
+	if available < 0 {
+		available = 0
+	}
+	return CapacityReport{
+		Parallelism: limit, Active: active, Advertised: advertised,
+		Available: available, Global: global,
+	}
+}
+
+func (a *Allocator) distributeAll() map[string]int {
+	if a.globalParallelism > 0 {
+		return a.distributeGlobal()
+	}
+	out := make(map[string]int, len(a.order))
+	for _, p := range a.pools {
+		for key, credit := range a.distributeTier(p) {
+			out[key] = credit
+		}
+	}
+	return out
+}
+
+func (a *Allocator) distributeTier(p *pool) map[string]int {
+	adv := make(map[string]int, len(p.order))
+	for _, k := range p.order {
+		adv[k] = p.state[k].active
+	}
+	remaining := p.parallelism - a.poolActive(p)
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	// Water-fill: hand each free credit to the least-filled binding that
+	// still wants more, breaking ties by registration order. Max-min
+	// fair and deterministic — no cursor to make two callers disagree
+	// about who got the credit.
+	for remaining > 0 {
+		pick, best := "", int(^uint(0)>>1)
+		for _, k := range p.order {
+			b := p.state[k]
+			if !b.held && adv[k] < b.assignedDemand && adv[k] < best {
+				pick, best = k, adv[k]
+			}
+		}
+		if pick == "" {
+			break
+		}
+		adv[pick]++
+		remaining--
+	}
+
+	// The discovery credit: one, to one binding, only if a credit is
+	// still unclaimed. A binding with demand or a running capsule does
+	// not need it — it can already see and be seen.
+	if remaining > 0 && len(p.order) > 0 {
+		holder := p.order[p.discovery]
+		if b := p.state[holder]; !b.held && b.assignedDemand == 0 && b.active == 0 {
+			adv[holder] = 1
+		}
+	}
+	return adv
+}
+
+func (a *Allocator) distributeGlobal() map[string]int {
+	adv := make(map[string]int, len(a.order))
+	tierAdvertised := make(map[string]int, len(a.pools))
+	for _, key := range a.order {
+		active := a.binding(key).active
+		adv[key] = active
+		tierAdvertised[a.tierOf[key]] += active
+	}
+	remaining := a.globalParallelism - a.active()
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	for remaining > 0 {
+		pick, best := "", int(^uint(0)>>1)
+		for _, key := range a.order {
+			b := a.binding(key)
+			tierID := a.tierOf[key]
+			if !b.held && tierAdvertised[tierID] < a.pools[tierID].parallelism &&
+				adv[key] < b.assignedDemand && adv[key] < best {
+				pick, best = key, adv[key]
+			}
+		}
+		if pick == "" {
+			break
+		}
+		adv[pick]++
+		tierAdvertised[a.tierOf[pick]]++
+		remaining--
+	}
+
+	if remaining > 0 && len(a.order) > 0 {
+		holder := a.order[a.discovery]
+		b := a.binding(holder)
+		tierID := a.tierOf[holder]
+		if !b.held && b.assignedDemand == 0 && b.active == 0 &&
+			tierAdvertised[tierID] < a.pools[tierID].parallelism {
+			adv[holder] = 1
+		}
+	}
+	return adv
+}
+
+func (a *Allocator) nextDiscovery(order []string, current int) int {
+	if len(order) == 0 {
+		return 0
+	}
+	for i := 1; i <= len(order); i++ {
+		next := (current + i) % len(order)
+		b := a.binding(order[next])
+		if b != nil && !b.held && b.assignedDemand == 0 && b.active == 0 {
+			return next
+		}
+	}
+	return current
+}
+
+func (a *Allocator) binding(key string) *binding {
+	if p := a.poolOf(key); p != nil {
+		return p.state[key]
+	}
+	return nil
+}
+
+func (a *Allocator) poolOf(key string) *pool { return a.pools[a.tierOf[key]] }
+
+func (a *Allocator) poolActive(p *pool) int {
+	total := 0
+	for _, b := range p.state {
+		total += b.active
+	}
+	return total
+}
+
+func (a *Allocator) active() int {
+	total := 0
+	for _, p := range a.pools {
+		total += a.poolActive(p)
+	}
+	return total
+}

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -1,0 +1,780 @@
+package allocator
+
+import (
+	"sync"
+	"testing"
+)
+
+func mustRegister(t *testing.T, a *Allocator, tier, key string, parallelism int) {
+	t.Helper()
+	if err := a.Register(tier, key, parallelism); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// advertisedSum is the invariant's left-hand side. It reads the whole
+// tier at once: summing per-binding calls would sample as many
+// different instants as there are bindings, which says nothing about
+// any single state of the pool.
+func advertisedSum(a *Allocator, _ ...string) int {
+	total := 0
+	for _, v := range a.AdvertisedAll("std") {
+		total += v
+	}
+	return total
+}
+
+// TestMoreBindingsThanParallelism: credits removed the floor, and with it the
+// registration limit. Three bindings share two capacity units; nobody is
+// rejected and the pool never promises more than it has.
+func TestMoreBindingsThanParallelism(t *testing.T) {
+	a := New()
+	for _, key := range []string{"a", "b", "c"} {
+		mustRegister(t, a, "std", key, 2)
+	}
+	if got := advertisedSum(a, "a", "b", "c"); got > 2 {
+		t.Errorf("sum(advertised) = %d; the tier parallelism is 2", got)
+	}
+}
+
+func TestRegisterRejectsConflictingParallelism(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 2)
+	if err := a.Register("std", "b", 3); err == nil {
+		t.Error("a tier registered with conflicting parallelism should fail")
+	}
+}
+
+// TestInvariantHoldsAcrossStates is the gate's first requirement, swept
+// over the states a pool actually passes through: idle, partial demand,
+// saturated demand, and running capsules.
+func TestInvariantHoldsAcrossStates(t *testing.T) {
+	keys := []string{"a", "b", "c"}
+	for _, tc := range []struct {
+		name        string
+		parallelism int
+		wants       []int
+		holds       []int // capsules to reserve, per binding
+	}{
+		{"idle pool", 3, []int{0, 0, 0}, []int{0, 0, 0}},
+		{"one binding wants everything", 3, []int{9, 0, 0}, []int{0, 0, 0}},
+		{"all want everything", 3, []int{9, 9, 9}, []int{0, 0, 0}},
+		{"demand plus running", 3, []int{9, 9, 0}, []int{1, 1, 0}},
+		{"pool saturated by one", 2, []int{5, 5, 5}, []int{2, 0, 0}},
+		{"more bindings than parallelism", 1, []int{0, 0, 0}, []int{0, 0, 0}},
+		{"more bindings than parallelism, all busy", 1, []int{3, 3, 3}, []int{1, 0, 0}},
+	} {
+		a := New()
+		for _, k := range keys {
+			mustRegister(t, a, "std", k, tc.parallelism)
+		}
+		for i, k := range keys {
+			a.SetAssignedDemand(k, tc.wants[i])
+			for range tc.holds[i] {
+				if !a.TryReserve(k) {
+					t.Fatalf("%s: %s could not reserve within budget", tc.name, k)
+				}
+			}
+		}
+		if got := advertisedSum(a, keys...); got > tc.parallelism {
+			t.Errorf("%s: sum(advertised) = %d > parallelism %d", tc.name, got, tc.parallelism)
+		}
+	}
+}
+
+// TestRunningCapsulesAreNeverRetracted: a job in flight cannot be taken
+// back, so advertised is at least active — and the invariant still
+// holds, because active is drawn from the same credits.
+func TestRunningCapsulesAreNeverRetracted(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 3)
+	mustRegister(t, a, "std", "b", 3)
+	for range 3 {
+		if !a.TryReserve("a") {
+			t.Fatal("a should claim capacity")
+		}
+	}
+	a.SetAssignedDemand("a", 3)
+	if got := a.Advertised("a"); got != 3 {
+		t.Errorf("a advertised %d; want its 3 running capsules", got)
+	}
+	if got := a.Advertised("b"); got != 0 {
+		t.Errorf("b advertised %d; the pool has no free credit to offer", got)
+	}
+	if a.TryReserve("b") {
+		t.Fatal("pool full; b must wait")
+	}
+}
+
+// TestSurplusFollowsDemand: free credits go to bindings that want them,
+// max-min fairly, and a binding with no demand does not hold capacity
+// hostage.
+func TestSurplusFollowsDemand(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 4)
+	mustRegister(t, a, "std", "b", 4)
+	mustRegister(t, a, "std", "c", 4)
+	a.SetAssignedDemand("a", 10)
+	a.SetAssignedDemand("b", 1)
+
+	if got := a.Advertised("b"); got != 1 {
+		t.Errorf("b advertised %d; want its single unit of demand", got)
+	}
+	if got := a.Advertised("a"); got != 3 {
+		t.Errorf("a advertised %d; want the remaining credits", got)
+	}
+	if got := a.Advertised("c"); got != 0 {
+		t.Errorf("c advertised %d; it has no demand and the credits are spoken for", got)
+	}
+}
+
+func TestWaterFillIsMaxMin(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 5)
+	mustRegister(t, a, "std", "b", 5)
+	mustRegister(t, a, "std", "c", 5)
+	a.SetAssignedDemand("a", 10)
+	a.SetAssignedDemand("b", 10)
+	a.SetAssignedDemand("c", 1)
+
+	got := map[string]int{"a": a.Advertised("a"), "b": a.Advertised("b"), "c": a.Advertised("c")}
+	want := map[string]int{"a": 2, "b": 2, "c": 1}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("max-min share = %v; want %v", got, want)
+			break
+		}
+	}
+}
+
+func TestDistributionIsConsistentAcrossCallers(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 3)
+	mustRegister(t, a, "std", "b", 3)
+	a.SetAssignedDemand("a", 5)
+	a.SetAssignedDemand("b", 5)
+	for range 10 {
+		if a.Advertised("a")+a.Advertised("b") > 3 {
+			t.Fatal("two independent callers disagreed and oversubscribed the pool")
+		}
+	}
+}
+
+// TestDiscoveryCreditMakesASilentBindingVisible is the trapdoor the
+// floor existed to close: a binding with no demand signal must
+// eventually announce one, or it never learns it has queued work.
+func TestDiscoveryCreditMakesASilentBindingVisible(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 2)
+	mustRegister(t, a, "std", "b", 2)
+	mustRegister(t, a, "std", "c", 2)
+
+	seen := map[string]bool{}
+	// One pass of the pool must reach every silent binding: that is the
+	// starvation bound, and it is what makes waiting for the credit
+	// safe.
+	for range 3 {
+		for _, k := range []string{"a", "b", "c"} {
+			if a.Advertised(k) > 0 {
+				seen[k] = true
+			}
+		}
+		a.Rotate()
+	}
+	for _, k := range []string{"a", "b", "c"} {
+		if !seen[k] {
+			t.Errorf("binding %q never held the discovery credit in a full pass; it would stay blind", k)
+		}
+	}
+}
+
+// TestDiscoveryIsNotOfferedToEveryoneAtOnce: the credit is one credit.
+// Handing it to every silent binding simultaneously is the overshoot
+// the floor caused.
+func TestDiscoveryIsNotOfferedToEveryoneAtOnce(t *testing.T) {
+	a := New()
+	keys := []string{"a", "b", "c", "d"}
+	for _, k := range keys {
+		mustRegister(t, a, "std", k, 2)
+	}
+	holders := 0
+	for _, k := range keys {
+		if a.Advertised(k) > 0 {
+			holders++
+		}
+	}
+	if holders != 1 {
+		t.Errorf("%d bindings announced capacity; the discovery credit is one", holders)
+	}
+}
+
+// TestRotationSkipsBindingsThatCanAlreadySee: a binding with demand or a
+// running capsule does not need discovery, and spending the rotation on
+// it would lengthen every other binding's wait.
+func TestRotationSkipsBindingsThatCanAlreadySee(t *testing.T) {
+	a := New()
+	for _, k := range []string{"a", "b", "c"} {
+		mustRegister(t, a, "std", k, 3)
+	}
+	a.SetAssignedDemand("b", 5) // b has demand: it is visible without the credit
+
+	held := map[string]int{}
+	for range 6 {
+		a.Rotate()
+		held[a.DiscoveryHolder("std")]++
+	}
+	if held["b"] != 0 {
+		t.Errorf("rotation gave the discovery credit to a binding with demand %d times", held["b"])
+	}
+	if held["a"] == 0 || held["c"] == 0 {
+		t.Errorf("rotation starved a silent binding: %v", held)
+	}
+}
+
+// TestDiscoveryNeedsAFreeCredit: sight is funded out of idle capacity,
+// never out of a saturated pool, or the invariant would break exactly
+// when the host is busiest.
+func TestDiscoveryNeedsAFreeCredit(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "busy", 1)
+	mustRegister(t, a, "std", "silent", 1)
+	a.SetAssignedDemand("busy", 4)
+	if !a.TryReserve("busy") {
+		t.Fatal("busy should claim the only capacity unit")
+	}
+	if got := a.Advertised("silent"); got != 0 {
+		t.Errorf("silent advertised %d with no free credit in the pool", got)
+	}
+	if got := advertisedSum(a, "busy", "silent"); got > 1 {
+		t.Errorf("sum(advertised) = %d > parallelism 1", got)
+	}
+}
+
+// TestHoldWithholdsNewCapacity: an emergency that closes admission must
+// stop the broker assigning more work, while the capsules already
+// running stay counted.
+func TestHoldWithholdsNewCapacity(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 3)
+	mustRegister(t, a, "std", "b", 3)
+	a.SetAssignedDemand("a", 5)
+	if !a.TryReserve("a") {
+		t.Fatal("a should reserve")
+	}
+
+	a.Hold(true)
+	if got := a.Advertised("a"); got != 1 {
+		t.Errorf("a advertised %d under hold; want only its running capsule", got)
+	}
+	if got := a.Advertised("b"); got != 0 {
+		t.Errorf("b advertised %d under hold; want 0", got)
+	}
+
+	a.Hold(false)
+	if got := a.Advertised("a"); got != 3 {
+		t.Errorf("a advertised %d after the hold lifted; want its demand again", got)
+	}
+}
+
+func TestPhysicalGate(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 2)
+	mustRegister(t, a, "std", "b", 2)
+	for i := range 2 {
+		if !a.TryReserve("a") {
+			t.Fatalf("a should claim pool capacity unit %d", i+1)
+		}
+	}
+	if a.TryReserve("b") {
+		t.Fatal("pool is full; b must be refused")
+	}
+	a.Release("a")
+	if !a.TryReserve("b") {
+		t.Fatal("after a frees capacity, b should reserve")
+	}
+}
+
+func TestReleaseFloorAtZero(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 1)
+	a.Release("a") // release with nothing active must not underflow
+	if got := a.Active("a"); got != 0 {
+		t.Errorf("active = %d; want 0", got)
+	}
+}
+
+func TestConcurrentReserveWithinBudget(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 4)
+	mustRegister(t, a, "std", "b", 4)
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	granted := 0
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if a.TryReserve("a") {
+				mu.Lock()
+				granted++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	if granted != 4 {
+		t.Errorf("granted %d reservations; want exactly the parallelism budget of 4", granted)
+	}
+}
+
+// TestNoOvershootUnderConcurrentTraffic: reserves, releases, demand
+// updates and rotations run together while the invariant is sampled.
+// This is the race the gate cares about — advertised is read by every
+// binding's own loop while the pool moves under it.
+func TestNoOvershootUnderConcurrentTraffic(t *testing.T) {
+	a := New()
+	keys := []string{"a", "b", "c", "d"}
+	const parallelism = 3
+	for _, k := range keys {
+		mustRegister(t, a, "std", k, parallelism)
+	}
+
+	var workers sync.WaitGroup
+	stop := make(chan struct{})
+	for _, k := range keys {
+		workers.Add(1)
+		go func(k string) {
+			defer workers.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				a.SetAssignedDemand(k, i%5)
+				if a.TryReserve(k) {
+					a.Release(k)
+				}
+				a.Rotate()
+			}
+		}(k)
+	}
+
+	// Sample the invariant while the pool moves underneath.
+	for range 2000 {
+		if got := advertisedSum(a, keys...); got > parallelism {
+			t.Errorf("sum(advertised) = %d > parallelism %d", got, parallelism)
+			break
+		}
+	}
+	close(stop)
+	workers.Wait()
+}
+
+func TestGlobalParallelismConstrainsEveryTier(t *testing.T) {
+	a := NewWithGlobalParallelism(1)
+	mustRegister(t, a, "small", "small-a", 1)
+	mustRegister(t, a, "large", "large-a", 1)
+	a.SetAssignedDemand("small-a", 1)
+	a.SetAssignedDemand("large-a", 1)
+
+	advertised := a.Advertised("small-a") + a.Advertised("large-a")
+	if advertised != 1 {
+		t.Fatalf("globally advertised capacity = %d; want 1", advertised)
+	}
+	if !a.TryReserve("small-a") {
+		t.Fatal("first tier should reserve the global credit")
+	}
+	if a.TryReserve("large-a") {
+		t.Fatal("second tier reserved beyond instance parallelism")
+	}
+	if got := a.CapacityReport(); got.Active != 1 || got.Available != 0 || got.Parallelism != 1 {
+		t.Fatalf("capacity report = %+v", got)
+	}
+	a.Release("small-a")
+	if !a.TryReserve("large-a") {
+		t.Fatal("released global capacity was not reusable by another tier")
+	}
+}
+
+func TestGlobalDiscoveryRotatesAcrossTiers(t *testing.T) {
+	a := NewWithGlobalParallelism(1)
+	mustRegister(t, a, "small", "small-a", 1)
+	mustRegister(t, a, "large", "large-a", 1)
+
+	seen := map[string]bool{}
+	for range 2 {
+		for _, key := range []string{"small-a", "large-a"} {
+			if a.Advertised(key) == 1 {
+				seen[key] = true
+			}
+		}
+		if a.Advertised("small-a")+a.Advertised("large-a") > 1 {
+			t.Fatal("global discovery oversubscribed advertised capacity")
+		}
+		a.Rotate()
+	}
+	if !seen["small-a"] || !seen["large-a"] {
+		t.Fatalf("global discovery did not reach every tier: %v", seen)
+	}
+}
+
+func TestAdoptedLeaseCountsAgainstGlobalParallelism(t *testing.T) {
+	a := NewWithGlobalParallelism(1)
+	mustRegister(t, a, "small", "small-a", 1)
+	mustRegister(t, a, "large", "large-a", 1)
+	a.Adopt("large-a")
+
+	if a.TryReserve("small-a") {
+		t.Fatal("startup reconciliation did not restore the global admission count")
+	}
+	if got := a.Advertised("small-a"); got != 0 {
+		t.Fatalf("small tier advertised %d while an adopted lease holds global capacity", got)
+	}
+}
+
+// TestGlobalRespectsTheSmallerTierCap: an instance limit does not let a tier
+// exceed its own parallelism. With a global budget of three and a tier that
+// only holds one, the spare credits must land in the tier that can take them
+// rather than oversubscribing the small one.
+func TestGlobalRespectsTheSmallerTierCap(t *testing.T) {
+	a := NewWithGlobalParallelism(3)
+	mustRegister(t, a, "small", "small-a", 1)
+	mustRegister(t, a, "large", "large-a", 3)
+	a.SetAssignedDemand("small-a", 5)
+	a.SetAssignedDemand("large-a", 5)
+
+	small, large := a.Advertised("small-a"), a.Advertised("large-a")
+	if small != 1 {
+		t.Errorf("small tier advertised %d; its own parallelism is 1", small)
+	}
+	if large != 2 {
+		t.Errorf("large tier advertised %d; want the remaining global credit", large)
+	}
+	if got := a.CapacityReport(); got.Advertised != 3 || got.Parallelism != 3 {
+		t.Errorf("capacity report = %+v; want three advertised of three", got)
+	}
+
+	// The small tier is full at one: its second reserve must be refused even
+	// though the instance still has budget.
+	if !a.TryReserve("small-a") {
+		t.Fatal("the small tier should claim its single credit")
+	}
+	if a.TryReserve("small-a") {
+		t.Error("the small tier reserved beyond its own parallelism")
+	}
+	if !a.TryReserve("large-a") {
+		t.Error("the large tier should still claim global capacity")
+	}
+}
+
+// TestCapacityReportSumsTiersWhenIndependent: without a global limit the
+// effective instance parallelism is the sum of the tiers, which is the number
+// `runpool status` shows an operator.
+func TestCapacityReportSumsTiersWhenIndependent(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "small", "small-a", 2)
+	mustRegister(t, a, "large", "large-a", 3)
+
+	if got := a.CapacityReport(); got.Parallelism != 5 || got.Active != 0 || got.Available != 5 {
+		t.Fatalf("idle report = %+v; want parallelism 5, nothing active", got)
+	}
+	if !a.TryReserve("small-a") {
+		t.Fatal("small tier should reserve")
+	}
+	if got := a.CapacityReport(); got.Parallelism != 5 || got.Active != 1 || got.Available != 4 {
+		t.Fatalf("report after one reserve = %+v; want 1 active of 5", got)
+	}
+}
+
+// TestNoGlobalOvershootUnderConcurrentTraffic is the global-mode counterpart
+// of the per-tier race: the instance-wide sum is sampled while reserves,
+// releases, demand updates and rotations run across two tiers at once.
+// CapacityReport reads every tier under one lock, so the sample is a single
+// state rather than one instant per tier.
+func TestNoGlobalOvershootUnderConcurrentTraffic(t *testing.T) {
+	const global = 3
+	a := NewWithGlobalParallelism(global)
+	keys := []string{"small-a", "small-b", "large-a"}
+	mustRegister(t, a, "small", "small-a", 2)
+	mustRegister(t, a, "small", "small-b", 2)
+	mustRegister(t, a, "large", "large-a", 3)
+
+	var workers sync.WaitGroup
+	stop := make(chan struct{})
+	for _, key := range keys {
+		workers.Add(1)
+		go func(key string) {
+			defer workers.Done()
+			for i := 0; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				a.SetAssignedDemand(key, i%5)
+				if a.TryReserve(key) {
+					a.Release(key)
+				}
+				a.Rotate()
+			}
+		}(key)
+	}
+
+	for range 2000 {
+		got := a.CapacityReport()
+		if got.Advertised > global {
+			t.Errorf("sum(advertised) = %d > instance parallelism %d", got.Advertised, global)
+			break
+		}
+		if got.Active > global {
+			t.Errorf("active = %d > instance parallelism %d", got.Active, global)
+			break
+		}
+	}
+	close(stop)
+	workers.Wait()
+}
+
+// TestHoldSurvivesLaterRegistration is the startup ordering hole. The
+// controller resumes a persisted disk emergency before it builds its
+// bindings, so a hold that only walked the bindings registered at the time
+// touched an empty map and was silently lost — leaving every binding
+// advertising capacity into the very emergency that closed admission.
+func TestHoldSurvivesLaterRegistration(t *testing.T) {
+	a := New()
+	a.Hold(true) // resumed before any binding exists
+
+	mustRegister(t, a, "std", "a", 2)
+	a.SetAssignedDemand("a", 5)
+	if got := a.Advertised("a"); got != 0 {
+		t.Errorf("a advertised %d under a hold applied before it registered; want 0", got)
+	}
+
+	a.Hold(false)
+	if got := a.Advertised("a"); got != 2 {
+		t.Errorf("a advertised %d after the hold lifted; want its demand", got)
+	}
+
+	// A binding registered while admission is open must not inherit a stale
+	// hold either.
+	a.Hold(true)
+	a.Hold(false)
+	mustRegister(t, a, "std", "b", 2)
+	a.SetAssignedDemand("b", 5)
+	if got := a.Advertised("b"); got == 0 {
+		t.Error("b inherited a hold that had already been lifted")
+	}
+}
+
+// TestPoolReportExplainsEveryBinding: the report is what an operator reads
+// to answer "why is that binding announcing zero", so every column has to
+// be right in both scheduling modes — and the discovery flag has to name
+// exactly one holder, or the answer points at nobody.
+func TestPoolReportExplainsEveryBinding(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 3)
+	mustRegister(t, a, "std", "b", 3)
+	a.SetAssignedDemand("a", 5)
+	if !a.TryReserve("a") {
+		t.Fatal("a should reserve")
+	}
+
+	parallelism, rows := a.PoolReport("std")
+	if parallelism != 3 {
+		t.Errorf("parallelism = %d; want 3", parallelism)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d; want one per binding", len(rows))
+	}
+	if rows[0].Key != "a" || rows[0].AssignedDemand != 5 || rows[0].Reserved != 1 {
+		t.Errorf("row a = %+v", rows[0])
+	}
+	if rows[0].Advertised < rows[0].Reserved {
+		t.Errorf("row a advertised %d below its %d running", rows[0].Advertised, rows[0].Reserved)
+	}
+	// b is silent, so it is the one that can hold the discovery credit.
+	if rows[1].Key != "b" || rows[1].AssignedDemand != 0 || rows[1].Reserved != 0 {
+		t.Errorf("row b = %+v", rows[1])
+	}
+	holders := 0
+	for _, r := range rows {
+		if r.Discovery {
+			holders++
+		}
+	}
+	if holders != 1 {
+		t.Errorf("%d bindings flagged as discovery holder; the credit is one", holders)
+	}
+
+	// An unknown tier is not an error with empty rows: it is no report.
+	if p, rows := a.PoolReport("nope"); p != 0 || rows != nil {
+		t.Errorf("unknown tier report = (%d, %v); want (0, nil)", p, rows)
+	}
+}
+
+// TestPoolReportUnderAGlobalLimit: the discovery cursor is instance-wide in
+// this mode, so a tier that does not hold it must say so rather than
+// pointing at one of its own bindings.
+func TestPoolReportUnderAGlobalLimit(t *testing.T) {
+	a := NewWithGlobalParallelism(2)
+	mustRegister(t, a, "small", "small-a", 1)
+	mustRegister(t, a, "large", "large-a", 2)
+
+	flagged := map[string]bool{}
+	for _, tier := range []string{"small", "large"} {
+		_, rows := a.PoolReport(tier)
+		for _, r := range rows {
+			if r.Discovery {
+				flagged[r.Key] = true
+			}
+		}
+		holder := a.DiscoveryHolder(tier)
+		if holder != "" && !flagged[holder] {
+			t.Errorf("tier %s reports holder %q that its own rows do not flag", tier, holder)
+		}
+	}
+	if len(flagged) != 1 {
+		t.Errorf("%d bindings flagged across every tier: %v; the global credit is one", len(flagged), flagged)
+	}
+
+	// A tier nobody registered has no holder.
+	if got := a.DiscoveryHolder("absent"); got != "" {
+		t.Errorf("DiscoveryHolder of an unknown tier = %q; want empty", got)
+	}
+}
+
+// Active and the internal binding lookup have to tolerate a key that was
+// never registered: the reporting paths call them with whatever the caller
+// has, and a panic there takes down a serving loop.
+func TestUnknownKeysAreAnsweredNotPanicked(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 1)
+
+	if got := a.Active("ghost"); got != 0 {
+		t.Errorf("Active of an unregistered key = %d; want 0", got)
+	}
+	if got := a.Advertised("ghost"); got != 0 {
+		t.Errorf("Advertised of an unregistered key = %d; want 0", got)
+	}
+	if a.TryReserve("ghost") {
+		t.Error("an unregistered key reserved capacity")
+	}
+	if got := a.AdvertisedAll("absent"); got != nil {
+		t.Errorf("AdvertisedAll of an unknown tier = %v; want nil", got)
+	}
+	// These must not panic and must not change the pool.
+	a.SetAssignedDemand("ghost", 5)
+	a.Release("ghost")
+	a.Adopt("ghost")
+	if got := a.CapacityReport(); got.Active != 0 {
+		t.Errorf("an unregistered key changed the pool: %+v", got)
+	}
+}
+
+// TestAdoptionOverBudgetIsReportedAndConverges is the invariant's blind
+// spot.
+//
+// The sweep above only ever reserves, and reservation is bounded — so it
+// proves the invariant for the path that cannot break it. Adoption can:
+// it never refuses, because the capsule is already running and its
+// resources are committed, so a restart after parallelism was lowered
+// leaves the pool holding more than its limit. Advertised capacity is
+// seeded from active, so the sum exceeds parallelism for exactly as long
+// as those leases live.
+//
+// That is correct — retracting a running capsule is not an option — but
+// it has to be said out loud and it has to end.
+func TestAdoptionOverBudgetIsReportedAndConverges(t *testing.T) {
+	a := New()
+	keys := []string{"a", "b"}
+	for _, k := range keys {
+		mustRegister(t, a, "std", k, 1) // the tier shrank to one
+	}
+
+	// Two capsules survived the restart; the tier now allows one.
+	if over := a.Adopt("a"); over {
+		t.Error("the first adoption is within budget and must not report otherwise")
+	}
+	if over := a.Adopt("b"); !over {
+		t.Fatal("adopting past the tier's parallelism was not reported; the advertised " +
+			"total now exceeds the budget and nothing says why")
+	}
+
+	if got := advertisedSum(a, keys...); got <= 1 {
+		t.Fatalf("sum(advertised) = %d; the point of this case is that it exceeds "+
+			"parallelism while the adopted capsules run", got)
+	}
+
+	// Convergence: as the adopted leases release, the pool returns under
+	// its budget without anything else intervening.
+	a.Release("b")
+	if got := advertisedSum(a, keys...); got > 1 {
+		t.Errorf("after one release sum(advertised) = %d > parallelism 1; the pool "+
+			"is not converging", got)
+	}
+	a.Release("a")
+	if got := advertisedSum(a, keys...); got > 1 {
+		t.Errorf("with nothing adopted sum(advertised) = %d > parallelism 1", got)
+	}
+}
+
+// TestAdoptionOverTheInstanceBudgetIsReported is the same invariant seen
+// from the other limit. Under scheduling.parallelism a tier can sit
+// comfortably inside its own budget while the instance is past the one
+// every tier shares, and TryReserve gates on both. An adoption that
+// breaches only the shared limit is the case a tier-only check calls
+// within budget - after which the capacity report shows more active than
+// parallelism with nothing having said so.
+func TestAdoptionOverTheInstanceBudgetIsReported(t *testing.T) {
+	a := NewWithGlobalParallelism(2)
+	mustRegister(t, a, "std", "a", 4) // roomy tier, tight instance
+	mustRegister(t, a, "big", "b", 4)
+
+	if over := a.Adopt("a"); over {
+		t.Error("the first adoption is within both budgets and must not report otherwise")
+	}
+	if over := a.Adopt("b"); over {
+		t.Error("the second adoption fills the instance limit exactly; that is not past it")
+	}
+	if over := a.Adopt("a"); !over {
+		t.Fatal("adopting past scheduling.parallelism was not reported; every tier is " +
+			"inside its own limit, so nothing else would say the instance is over")
+	}
+
+	report := a.CapacityReport()
+	if !report.Global {
+		t.Fatal("the report does not say the instance limit is configured; a reader " +
+			"cannot tell it from the fallback sum")
+	}
+	if report.Active <= report.Parallelism {
+		t.Fatalf("active %d against parallelism %d; the point of this case is that the "+
+			"instance holds more than its limit while it converges",
+			report.Active, report.Parallelism)
+	}
+
+	a.Release("a")
+	if got := a.CapacityReport(); got.Active > got.Parallelism {
+		t.Errorf("after one release active %d > parallelism %d; the instance is not converging",
+			got.Active, got.Parallelism)
+	}
+}
+
+// TestIndependentTiersReportNoInstanceLimit. Without scheduling.parallelism
+// the report's Parallelism is the sum of tier limits - arithmetic, not a
+// limit anyone configured - and Global is what tells a reader so. The
+// adoption warning leans on it: printed as a limit, the sum sits beside a
+// breach announcement contradicting it.
+func TestIndependentTiersReportNoInstanceLimit(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 2)
+	mustRegister(t, a, "big", "b", 3)
+
+	report := a.CapacityReport()
+	if report.Global {
+		t.Error("independent tiers report a configured instance limit; the figure is a sum")
+	}
+	if report.Parallelism != 5 {
+		t.Errorf("effective parallelism = %d; want the sum of tiers, 5", report.Parallelism)
+	}
+}

--- a/internal/allocator/quarantine_test.go
+++ b/internal/allocator/quarantine_test.go
@@ -1,0 +1,56 @@
+package allocator
+
+import "testing"
+
+// TestCapacitySurvivesUnresolvedLease is the allocator's half of the
+// capacity rule. The scheduler releases capacity only when its lease
+// reaches a terminal state; a lease that ends quarantined still owns privileged
+// containers, networks and volumes, so its capacity must stay reserved. This
+// asserts the property the allocator has to provide for that to work:
+// reservations are held until an explicit release, and a release that
+// never comes is not silently forgiven.
+func TestCapacitySurvivesUnresolvedLease(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 2)
+	mustRegister(t, a, "std", "b", 2)
+
+	// Two capsules run; one ends cleanly, the other is quarantined and so
+	// is never released.
+	if !a.TryReserve("a") || !a.TryReserve("b") {
+		t.Fatal("both capacity units should be claimable")
+	}
+	a.Release("a") // resolved to released
+	// "b" is quarantined: no Release call.
+
+	if got := a.Active("b"); got != 1 {
+		t.Fatalf("quarantined lease holds %d capacity units; want 1", got)
+	}
+	if !a.TryReserve("a") {
+		t.Fatal("the freed capacity should be reusable")
+	}
+	if a.TryReserve("a") {
+		t.Error("the quarantined lease's capacity was handed out; the host would be oversubscribed")
+	}
+
+	// Once cleanup resolves the quarantine, the capacity returns.
+	a.Release("b")
+	if !a.TryReserve("b") {
+		t.Error("after the quarantine is resolved its capacity should be available again")
+	}
+}
+
+// TestAdoptAccountsExistingCapsules covers reconciliation: capsules found
+// at startup already occupy the host, so adoption must not be gated on
+// free budget, and it must still count against it.
+func TestAdoptAccountsExistingCapsules(t *testing.T) {
+	a := New()
+	mustRegister(t, a, "std", "a", 1)
+
+	a.Adopt("a") // a capsule survived the previous controller
+	if got := a.Active("a"); got != 1 {
+		t.Fatalf("adopted capsule not accounted: active = %d", got)
+	}
+	if a.TryReserve("a") {
+		t.Error("the pool is full with the adopted capsule; a new one must be refused")
+	}
+}

--- a/internal/disk/disk.go
+++ b/internal/disk/disk.go
@@ -1,0 +1,165 @@
+// Package disk is the disk-pressure state machine. It is pure: the
+// caller measures (daemon filesystem free space and inodes, managed
+// cache bytes) and the machine says what level the host is at and what
+// that level obliges — GC toward the low watermark, closing admission,
+// or failing closed. Keeping it pure is what makes every transition,
+// including the hysteresis on recovery, enumerable in a hermetic test.
+//
+// The levels, worst first:
+//
+//	hard_emergency  free space below the hard floor: fail closed. New
+//	                work is refused, nothing that holds state is
+//	                deleted, the operator is alerted.
+//	soft_emergency  free space below the soft floor or the configured
+//	                host reserve: admission closes and GC turns
+//	                aggressive on free resources.
+//	high            managed cache bytes crossed the high watermark:
+//	                GC runs until the low watermark.
+//	normal          none of the above.
+//
+// Recovery is hysteretic so the actions do not flap at a boundary: an
+// emergency exits only after free space clears the floor by the same
+// band that separates the soft and hard floors, and high exits only at
+// the low watermark — the configured pair is itself the hysteresis.
+package disk
+
+import "fmt"
+
+type Level int
+
+const (
+	Normal Level = iota
+	High
+	SoftEmergency
+	HardEmergency
+)
+
+func (l Level) String() string {
+	switch l {
+	case Normal:
+		return "normal"
+	case High:
+		return "high"
+	case SoftEmergency:
+		return "soft_emergency"
+	case HardEmergency:
+		return "hard_emergency"
+	}
+	return fmt.Sprintf("level(%d)", int(l))
+}
+
+// ParseLevel is the inverse of String, for the persisted level.
+func ParseLevel(s string) (Level, error) {
+	for _, l := range []Level{Normal, High, SoftEmergency, HardEmergency} {
+		if l.String() == s {
+			return l, nil
+		}
+	}
+	return Normal, fmt.Errorf("unknown pressure level %q", s)
+}
+
+// Inode floors. Filesystems that account inodes run out of them the
+// same way they run out of bytes — a node_modules tree is millions of
+// tiny files — but no configuration knob exists for a quantity
+// operators never think in, so the floors are fixed where any real CI
+// host is either fine or in genuine trouble.
+const (
+	softInodeFloor = 100_000
+	hardInodeFloor = 10_000
+	// inodeRecoveryBand is the inode dimension's hysteresis margin, in the
+	// same proportion the byte floors use: an emergency entered on inodes
+	// is left only once free inodes clear the floor by this much. Without
+	// it a workload hovering at the floor flips admission on every pass.
+	inodeRecoveryBand = softInodeFloor - hardInodeFloor
+)
+
+// Thresholds are the configured boundaries, all in bytes of the
+// daemon's storage filesystem except the watermark pair, which is a
+// percentage of the managed cache budget.
+type Thresholds struct {
+	MaxManagedBytes int64
+	HighPct, LowPct int
+	SoftFreeBytes   int64
+	HardFreeBytes   int64
+	// ReserveFreeBytes is host.reserve.freeDisk: free space the
+	// operator told scheduling to keep its hands off. Falling under it
+	// means the reserve cannot be maintained, which closes admission
+	// exactly like the soft floor.
+	ReserveFreeBytes int64
+}
+
+// Facts are one measurement pass.
+type Facts struct {
+	FreeBytes int64
+	// FreeInodes is -1 when the filesystem does not account inodes.
+	FreeInodes int64
+	// ManagedBytes is the daemon-measured total of this instance's
+	// cache-lane volumes.
+	ManagedBytes int64
+}
+
+// softFloor is the effective admission floor: the soft emergency
+// threshold or the host reserve, whichever asks for more.
+func (t Thresholds) softFloor() int64 {
+	if t.ReserveFreeBytes > t.SoftFreeBytes {
+		return t.ReserveFreeBytes
+	}
+	return t.SoftFreeBytes
+}
+
+// Next computes the level after one measurement, given the previous
+// level. Worst condition wins; recovery passes through the hysteresis
+// band before an emergency releases its actions.
+func Next(prev Level, f Facts, t Thresholds) Level {
+	soft := t.softFloor()
+	// The band is the configured soft-hard separation, not a quantity
+	// derived from the floor in force. Deriving it from softFloor made the
+	// exit edge `2*softFloor - hard`, which grows with the host reserve:
+	// with a 20GiB reserve and a 10GiB hard floor, an emergency entered
+	// below 20GiB free could only be left above 30GiB. A data root whose
+	// healthy steady state sits between those two latches closed forever,
+	// and the disk monitor reloads that across restarts.
+	band := t.SoftFreeBytes - t.HardFreeBytes
+	if band < 0 {
+		band = 0
+	}
+
+	inodesKnown := f.FreeInodes >= 0
+	switch {
+	case f.FreeBytes < t.HardFreeBytes || (inodesKnown && f.FreeInodes < hardInodeFloor):
+		return HardEmergency
+	case f.FreeBytes < soft || (inodesKnown && f.FreeInodes < softInodeFloor):
+		return SoftEmergency
+	// Recovery clears the entry edge by one band on whichever dimension
+	// triggered. Testing bytes alone let an inode emergency — which by
+	// construction happens while bytes are plentiful — exit the instant
+	// free inodes ticked one over the floor, flipping admission and
+	// wiping the free lane pool on every pass.
+	case prev >= SoftEmergency && f.FreeBytes < soft+band:
+		return SoftEmergency
+	case prev >= SoftEmergency && inodesKnown && f.FreeInodes < softInodeFloor+inodeRecoveryBand:
+		return SoftEmergency
+	}
+
+	if t.MaxManagedBytes > 0 {
+		high := t.MaxManagedBytes * int64(t.HighPct) / 100
+		low := t.MaxManagedBytes * int64(t.LowPct) / 100
+		switch {
+		case f.ManagedBytes >= high:
+			return High
+		case prev >= High && f.ManagedBytes > low:
+			return High
+		}
+	}
+	return Normal
+}
+
+// AdmissionClosed says whether new work may start at this level. The
+// distinction from GC posture is deliberate: high pressure garbage
+// collects but keeps admitting; the emergencies do not.
+func (l Level) AdmissionClosed() bool { return l >= SoftEmergency }
+
+// WantsGC says whether this level obliges a collection pass, and
+// Aggressive whether that pass may take free lanes before their TTL.
+func (l Level) WantsGC() bool    { return l == High || l == SoftEmergency }
+func (l Level) Aggressive() bool { return l == SoftEmergency }

--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -1,0 +1,167 @@
+package disk
+
+import "testing"
+
+// GiB-scale fixture: budget 10 GiB with watermarks at 80/60, soft floor
+// 5 GiB, hard floor 1 GiB, no extra reserve. The soft-hard band (4 GiB)
+// is the recovery hysteresis.
+var th = Thresholds{
+	MaxManagedBytes: 10 << 30,
+	HighPct:         80,
+	LowPct:          60,
+	SoftFreeBytes:   5 << 30,
+	HardFreeBytes:   1 << 30,
+}
+
+const gib = int64(1) << 30
+
+func facts(freeGiB, managedGiB int64) Facts {
+	return Facts{FreeBytes: freeGiB * gib, FreeInodes: -1, ManagedBytes: managedGiB * gib}
+}
+
+// TestTransitions enumerates the machine: every row is (previous level,
+// measurement) -> level. The table is the reproducible record the gate
+// asks for.
+func TestTransitions(t *testing.T) {
+	cases := []struct {
+		name string
+		prev Level
+		f    Facts
+		want Level
+	}{
+		{"plenty of everything", Normal, facts(100, 2), Normal},
+		{"managed crosses high watermark", Normal, facts(100, 8), High},
+		{"exactly at high watermark", Normal, facts(100, 8), High},
+		{"high holds above low watermark", High, facts(100, 7), High},
+		{"high exits at low watermark", High, facts(100, 6), Normal},
+		{"normal stays normal between watermarks", Normal, facts(100, 7), Normal},
+
+		{"free under soft floor", Normal, facts(4, 2), SoftEmergency},
+		{"free under hard floor", Normal, facts(0, 2), HardEmergency},
+		{"hard beats high", Normal, facts(0, 9), HardEmergency},
+		{"soft beats high", Normal, facts(4, 9), SoftEmergency},
+
+		// Recovery hysteresis: the band is soft-hard = 4 GiB, so an
+		// emergency releases only at free >= 5+4 = 9 GiB.
+		{"soft holds inside the band", SoftEmergency, facts(6, 2), SoftEmergency},
+		{"soft holds at band edge", SoftEmergency, facts(8, 2), SoftEmergency},
+		{"soft releases past the band", SoftEmergency, facts(9, 2), Normal},
+		{"hard falls back to soft first", HardEmergency, facts(2, 2), SoftEmergency},
+		{"hard releases only past the band", HardEmergency, facts(9, 2), Normal},
+		{"release lands on high when managed is high", SoftEmergency, facts(9, 9), High},
+	}
+	for _, tc := range cases {
+		if got := Next(tc.prev, tc.f, th); got != tc.want {
+			t.Errorf("%s: Next(%s, free=%d managed=%d) = %s; want %s",
+				tc.name, tc.prev, tc.f.FreeBytes/gib, tc.f.ManagedBytes/gib, got, tc.want)
+		}
+	}
+}
+
+// TestReserveRaisesTheFloor: host.reserve.freeDisk is a promise to the
+// host; scheduling must close before it would be broken.
+func TestReserveRaisesTheFloor(t *testing.T) {
+	withReserve := th
+	withReserve.ReserveFreeBytes = 20 * gib
+
+	if got := Next(Normal, facts(10, 2), withReserve); got != SoftEmergency {
+		t.Errorf("free below reserve = %s; want soft_emergency", got)
+	}
+	// The reserve raises the floor; it does not widen the hysteresis. The
+	// band stays the configured soft-hard separation (5-1 = 4 GiB), so the
+	// exit edge is 20+4 = 24.
+	//
+	// Deriving the band from the floor instead made the edge
+	// `2*floor - hard`, which grows without bound as the reserve grows: at
+	// these thresholds a 20 GiB reserve demanded 39 GiB free to recover. A
+	// data root whose healthy steady state sits between entry and exit
+	// latches closed forever, and the disk monitor reloads that across
+	// restarts, so a restart does not clear it either.
+	if got := Next(SoftEmergency, facts(23, 2), withReserve); got != SoftEmergency {
+		t.Errorf("inside the recovery band = %s; want soft_emergency held", got)
+	}
+	if got := Next(SoftEmergency, facts(24, 2), withReserve); got != Normal {
+		t.Errorf("past the recovery band = %s; want normal", got)
+	}
+	// A reserve far above the soft floor must not make recovery harder in
+	// proportion: the band is the same 4 GiB whatever the reserve is.
+	huge := th
+	huge.ReserveFreeBytes = 100 * gib
+	if got := Next(SoftEmergency, facts(104, 2), huge); got != Normal {
+		t.Errorf("a large reserve widened the recovery band: %s", got)
+	}
+}
+
+// TestInodeEmergencyHasHysteresis: an emergency entered on inodes happens
+// while bytes are plentiful, so testing bytes alone let it exit the instant
+// free inodes ticked one over the floor. A workload hovering at the floor
+// then flipped admission on every pass — withdrawing announced capacity and
+// wiping the free lane pool each time.
+func TestInodeEmergencyHasHysteresis(t *testing.T) {
+	plentiful := func(inodes int64) Facts {
+		return Facts{FreeBytes: 500 * gib, FreeInodes: inodes, ManagedBytes: 0}
+	}
+	if got := Next(Normal, plentiful(softInodeFloor-1), th); got != SoftEmergency {
+		t.Fatalf("below the inode floor = %s; want soft_emergency", got)
+	}
+	if got := Next(SoftEmergency, plentiful(softInodeFloor+1), th); got != SoftEmergency {
+		t.Errorf("one inode over the floor = %s; want the emergency held", got)
+	}
+	if got := Next(SoftEmergency, plentiful(softInodeFloor+inodeRecoveryBand), th); got != Normal {
+		t.Errorf("past the inode recovery band = %s; want normal", got)
+	}
+	// A filesystem that does not account inodes must not be held by this.
+	if got := Next(SoftEmergency, facts(500, 0), th); got != Normal {
+		t.Errorf("unaccounted inodes held an emergency: %s", got)
+	}
+}
+
+// TestInodeFloors: running out of inodes is running out of disk, but a
+// filesystem that does not account them must never look empty.
+func TestInodeFloors(t *testing.T) {
+	f := facts(100, 2)
+	f.FreeInodes = 5_000
+	if got := Next(Normal, f, th); got != HardEmergency {
+		t.Errorf("5k inodes = %s; want hard_emergency", got)
+	}
+	f.FreeInodes = 50_000
+	if got := Next(Normal, f, th); got != SoftEmergency {
+		t.Errorf("50k inodes = %s; want soft_emergency", got)
+	}
+	f.FreeInodes = -1
+	if got := Next(Normal, f, th); got != Normal {
+		t.Errorf("unknown inodes = %s; want normal", got)
+	}
+}
+
+// TestObligations pins what each level means for the rest of the
+// system; renumbering the constants must not silently invert a gate.
+func TestObligations(t *testing.T) {
+	for _, tc := range []struct {
+		l          Level
+		closed, gc bool
+		aggressive bool
+	}{
+		{Normal, false, false, false},
+		{High, false, true, false},
+		{SoftEmergency, true, true, true},
+		{HardEmergency, true, false, false},
+	} {
+		if tc.l.AdmissionClosed() != tc.closed || tc.l.WantsGC() != tc.gc || tc.l.Aggressive() != tc.aggressive {
+			t.Errorf("%s: closed=%v gc=%v aggressive=%v; want %v %v %v", tc.l,
+				tc.l.AdmissionClosed(), tc.l.WantsGC(), tc.l.Aggressive(), tc.closed, tc.gc, tc.aggressive)
+		}
+	}
+}
+
+func TestLevelStringsRoundTrip(t *testing.T) {
+	for _, l := range []Level{Normal, High, SoftEmergency, HardEmergency} {
+		got, err := ParseLevel(l.String())
+		if err != nil || got != l {
+			t.Errorf("round trip %s: %v, %v", l, got, err)
+		}
+	}
+	if _, err := ParseLevel("frobnicated"); err == nil {
+		t.Error("unknown level parsed")
+	}
+}


### PR DESCRIPTION
## What changes

`internal/allocator` and `internal/disk` arrive: the two limits that
decide whether a capsule may start, and what the controller owes when the
host runs short of space.

The allocator gates launches and computes advertised capacity from one
set of counts. The disk machine classifies a measurement into a level and
the obligation that level carries.

## What was found

**Advertised capacity and admission capacity must come from the same
counts.** They are two questions asked of one budget — "may this start"
and "how much should the broker believe is available" — and computing
them separately lets them disagree. When advertised exceeds admissible,
the broker sends work that is refused on arrival, and the queue fills
with assignments nobody can run.

**A binding with no capacity is blind, not merely idle.** Capacity is how
a binding is allowed to observe its queue, so a binding holding zero
credits cannot discover that work is waiting for it — and will therefore
never ask for any. One discovery credit rotates so every eligible binding
gets a turn to look. Without the rotation a busy tier starves a quiet one
permanently rather than temporarily.

**Hysteresis on recovery is not a refinement.** A host sitting on a
watermark crosses it repeatedly, and a machine without hysteresis
alternates between admitting and refusing work on each measurement. The
recovery threshold is therefore separated from the trigger.

**At the hardest level, nothing stateful is deleted.** The obvious
response to "out of space" is to free some, and the state directory is
the largest thing the controller owns. Deleting it turns a recoverable
disk condition into an unrecoverable loss of the record of what is
running. The hard level refuses new work and alerts instead.

Both packages are pure. The caller measures and the machine decides,
which is what makes every level transition — including the hysteretic
ones — testable without a full filesystem.

## Evidence

Hermetic only — both packages are functions over their inputs, and the
suites enumerate the transitions rather than sampling them.

```text
hermetic only — no filesystem is measured and no daemon is contacted
```

## What would notice this regressing

`internal/allocator`'s suite fails if the sum of advertised capacity
exceeds a tier or instance limit, if the discovery credit stops rotating,
or if a binding can hold more credits than its parallelism allows.
`internal/disk`'s suite enumerates the level transitions and fails if
hysteresis disappears or if the hard level starts permitting deletion of
state.

## Risk, compatibility and operations

Trust boundary: none crossed. Neither package performs I/O.

Resource limits: this is where the instance-wide and per-tier limits are
enforced, and where the guarantee that advertised never exceeds
admissible lives.

Failure behaviour: at `hard_emergency` the controller refuses new work
and alerts rather than reclaiming space from anything that holds state.

Ownership, cleanup, credentials, networking: N/A — no state, no secrets,
nothing created.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports these packages yet.

Constrains what the code may do later, so the records arrive with it:
[admission credits](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-13-admission-credits.md),
[advertised capacity is a total, not a delta](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-11-advertised-capacity.md),
and the [capacity floor](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-11-capacity-floor.md)
it superseded.

## Changelog

```text
NONE
```
