### PR TITLE
feat(capsule-supervisor): the process that holds a capsule together

### DIFF
--- a/cmd/capsule-supervisor/gateway.go
+++ b/cmd/capsule-supervisor/gateway.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/rhobuild/runpool/internal/gateway"
+)
+
+// The gateway runs from this same binary in a different container, so
+// the capsule image carries one executable. The behaviour lives in
+// internal/gateway, where it can be tested without a container; what
+// remains here is the process shell: signals, the control directory,
+// and the supervisor's state protocol.
+
+const policyEnv = "RUNPOOL_GATEWAY_POLICY"
+
+func runGateway(log *slog.Logger) int {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	err := gateway.Run(ctx, gateway.Config{
+		Policy:     os.Getenv(policyEnv),
+		ControlDir: controlDir,
+		Log:        log,
+		SetState:   setState,
+	})
+	if err != nil {
+		log.Error("gateway failed", "error", err)
+		setState("failed:" + err.Error())
+		return 1
+	}
+	return 0
+}
+
+// runGatewayReload installs a new allow/deny set on a live gateway,
+// reading it from stdin.
+func runGatewayReload() int {
+	if err := gateway.Reload(controlDir, os.Stdin); err != nil {
+		fmt.Fprintln(os.Stderr, "reload:", err)
+		return 1
+	}
+	return 0
+}
+
+// runGatewayDenyAll closes a live gateway's policy to everything. The
+// controller calls it when it cannot prove the policy in force still
+// describes the environment — a gateway relaying under a policy that
+// predates a changed network is the failure this replaces.
+func runGatewayDenyAll() int {
+	if err := gateway.DenyAll(controlDir); err != nil {
+		fmt.Fprintln(os.Stderr, "deny-all:", err)
+		return 1
+	}
+	return 0
+}

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -1,0 +1,599 @@
+// Command capsule-supervisor is PID 1 of the outer capsule: one
+// container holding dockerd, the runner and every inner container the
+// job launches, under a single aggregate cgroup. The supervisor is what
+// makes that one container honest — it boots the daemon, proves its
+// readiness, refuses to let the runner exist before the controller
+// authorizes the start, propagates signals, reaps orphans, and reports
+// exit status where the controller can read it.
+//
+// The control surface is the filesystem under /run/runpool, all tmpfs:
+//
+//	protocol   written at boot: the protocol version, "1"
+//	state      waiting | running | exited:<code> | failed:<reason>
+//	           | aborted:<reason>
+//	           `aborted` is a failure before the runner started, so the job
+//	           was never handed over and must be retried; `failed` is a
+//	           failure after it started, which is an execution outcome.
+//	jitconfig  the JIT bundle, delivered by `deliver` over exec stdin,
+//	           0600 and owned by the runner uid; consumed at start
+//	start      the start authorization: its appearance launches the runner
+//
+// Subcommands `deliver` and `start` run via docker exec in the same
+// container and speak to PID 1 through those files, so the protocol
+// needs no network listener and nothing a job inside dind can reach —
+// the control directory is outside the runner's uid and the daemon
+// socket's group.
+package main
+
+import (
+	"cmp"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	// protocolVersion is what this capsule declares it speaks, written to
+	// protocolFile at boot and read by the controller before it hands the
+	// capsule anything. Part of the control-surface contract; must match
+	// capsule.ProtocolVersion.
+	protocolVersion = "1"
+	// exitAborted says the supervisor stopped before the runner started, so
+	// the job was never handed over and must be retried. It is a distinct
+	// exit code because the state file cannot outlive the container: by the
+	// time a controller inspects an aborted capsule the daemon reports
+	// `exited`, exec is impossible and the tmpfs control surface is gone.
+	// Part of the control-surface contract; must match
+	// capsule.SupervisorAbortedExitCode.
+	exitAborted  = 79
+	controlDir   = "/run/runpool"
+	stateFile    = controlDir + "/state"
+	jitFile      = controlDir + "/jitconfig"
+	startFile    = controlDir + "/start"
+	protocolFile = controlDir + "/protocol"
+
+	dockerSocket = "/run/runpool-docker/docker.sock"
+
+	runnerUID  = 1001
+	runnerGID  = 1001
+	runnerHome = "/home/runner"
+
+	dockerdReadyTimeout = 60 * time.Second
+	startPollInterval   = 200 * time.Millisecond
+	drainTimeout        = 5 * time.Minute
+)
+
+func main() {
+	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "gateway":
+			// A long-running mode, not an exec subcommand: the gateway
+			// container's PID 1.
+			os.Exit(runGateway(log))
+		case "gateway-reload":
+			os.Exit(runGatewayReload())
+		case "gateway-deny-all":
+			os.Exit(runGatewayDenyAll())
+		}
+		os.Exit(runSubcommand(os.Args[1:]))
+	}
+	os.Exit(supervise(log))
+}
+
+// runSubcommand is the exec-side of the protocol, running in the same
+// container as PID 1.
+func runSubcommand(args []string) int {
+	switch args[0] {
+	case "deliver":
+		// The bundle arrives on stdin and lands on tmpfs, 0600 and
+		// runner-owned. This delivery step never places it in Docker
+		// metadata or logs it.
+		payload, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+		if err != nil || len(payload) == 0 {
+			fmt.Fprintln(os.Stderr, "deliver: no credential on stdin")
+			return 1
+		}
+		if err := os.WriteFile(jitFile, payload, 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, "deliver:", err)
+			return 1
+		}
+		if err := os.Chown(jitFile, runnerUID, runnerGID); err != nil {
+			fmt.Fprintln(os.Stderr, "deliver:", err)
+			return 1
+		}
+		return 0
+	case "start":
+		if err := os.WriteFile(startFile, []byte(protocolVersion), 0o600); err != nil {
+			fmt.Fprintln(os.Stderr, "start:", err)
+			return 1
+		}
+		return 0
+	case "state":
+		body, err := os.ReadFile(stateFile)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "state:", err)
+			return 1
+		}
+		fmt.Print(string(body))
+		return 0
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", args[0])
+		return 2
+	}
+}
+
+func supervise(log *slog.Logger) int {
+	if err := boot(log); err != nil {
+		log.Error("capsule boot failed", "error", err)
+		// Boot is entirely before the runner: nothing was ever handed over.
+		setState("aborted:" + err.Error())
+		return exitAborted
+	}
+
+	code, err := run(log)
+	if err != nil {
+		log.Error("capsule run failed", "error", err)
+		state := terminalFailure(currentState(), err)
+		setState(state)
+		if strings.HasPrefix(state, "aborted:") {
+			return exitAborted
+		}
+		return 1
+	}
+	reported := runnerExit(code)
+	if reported != code {
+		log.Warn("the runner exited with the reserved abort code; reporting it as a plain failure",
+			"runner_exit", code, "reported", reported)
+	}
+	setState("exited:" + strconv.Itoa(reported))
+	log.Info("capsule finished", "exit", reported)
+	return reported
+}
+
+// runnerExit keeps a runner's own status out of the reserved code.
+//
+// exitAborted means "the runner never started", and it is the only thing
+// a stopped capsule can still say — the state file dies with the
+// container. But this process also returns the runner's status verbatim,
+// so a job that happened to exit with that number would be read as one
+// that never ran, requeued, and executed a second time. That is the
+// double execution every disposition rule here exists to prevent, and
+// reserving a value out of a range the runner also draws from is not
+// something to hope about.
+//
+// Downstream the exact status is only ever logged — the controller
+// records an observed exit for any code but the reserved one — so 1 says
+// the same thing about a job that ran and did not succeed. The true
+// status is logged above before it is replaced.
+func runnerExit(code int) int {
+	if code == exitAborted {
+		return 1
+	}
+	return code
+}
+
+// boot prepares the control surface and the filesystem chores that used
+// to need helper containers: with one container there is nobody to
+// coordinate with, so root fixes ownership directly before anything
+// runs as the runner uid.
+func boot(log *slog.Logger) error {
+	for _, dir := range []string{controlDir, filepath.Dir(dockerSocket)} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(protocolFile, []byte(protocolVersion), 0o644); err != nil {
+		return err
+	}
+	setState("waiting")
+	// The cache lane, when mounted, must be writable by the runner uid.
+	if info, err := os.Stat("/cache"); err == nil && info.IsDir() {
+		if err := os.Chown("/cache", runnerUID, runnerGID); err != nil {
+			return fmt.Errorf("chown cache lane: %w", err)
+		}
+	}
+	wrote, err := writeDockerProxyConfig(os.Getenv, runnerHome, runnerUID, runnerGID)
+	if err != nil {
+		return err
+	}
+	if wrote {
+		log.Info("job containers take the capsule's proxy")
+	}
+	log.Info("capsule control surface ready", "protocol", protocolVersion)
+	return nil
+}
+
+// writeDockerProxyConfig hands the job's own Docker client the proxy the
+// capsule was given.
+//
+// The capsule's environment reaches the runner, its steps and the inner
+// daemon, so a checkout, a package install and an image pull all take the
+// relay. A container the job starts does not: the daemon creates it, and
+// a daemon does not pass its own environment to what it runs. Under the
+// restricted profile that container has no route out either, so a
+// `docker build` whose Dockerfile fetches anything, or a `docker run`
+// that curls, fails with nothing to point at.
+//
+// The client reads proxies.default from this file and injects it into
+// what it builds and runs, which is the one place the setting can be made
+// once for every container the job starts. Written unconditionally when
+// a proxy exists, before the runner is ever handed a job.
+func writeDockerProxyConfig(environ func(string) string, home string, uid, gid int) (bool, error) {
+	proxy := environ("HTTP_PROXY")
+	if proxy == "" {
+		// No relay: the profile is open egress, and a client configured
+		// to reach a proxy that does not exist would break what works.
+		return false, nil
+	}
+	cfg := map[string]any{"proxies": map[string]any{"default": map[string]string{
+		"httpProxy":  proxy,
+		"httpsProxy": cmp.Or(environ("HTTPS_PROXY"), proxy),
+		"noProxy":    environ("NO_PROXY"),
+	}}}
+	body, err := json.Marshal(cfg)
+	if err != nil {
+		return false, fmt.Errorf("encode docker proxy config: %w", err)
+	}
+	dir := filepath.Join(home, ".docker")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, fmt.Errorf("create %s: %w", dir, err)
+	}
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return false, fmt.Errorf("write %s: %w", path, err)
+	}
+	for _, target := range []string{dir, path} {
+		if err := os.Chown(target, uid, gid); err != nil {
+			return false, fmt.Errorf("chown %s: %w", target, err)
+		}
+	}
+	return true, nil
+}
+
+// reaper owns every wait in the capsule. PID 1 must reap orphans that
+// reparent to it — dind shims, runner leftovers — but a naive
+// wait4(-1) loop races the direct children's own Wait calls and steals
+// their exit statuses. So there is exactly one place that calls wait4,
+// and children start under the reaper's own lock: a child that dies
+// instantly cannot be reaped before it is tracked, because the reap
+// loop waits on the same mutex the registration holds. Tracked children
+// get their status over a channel; everything else is an orphan, reaped
+// and dropped.
+type reaper struct {
+	mu      sync.Mutex
+	tracked map[int]chan int
+	sigchld chan os.Signal
+}
+
+func newReaper() *reaper {
+	r := &reaper{tracked: map[int]chan int{}, sigchld: make(chan os.Signal, 16)}
+	signal.Notify(r.sigchld, syscall.SIGCHLD)
+	go r.loop()
+	return r
+}
+
+// start launches a child and registers it atomically with respect to
+// the reap loop. The returned channel yields the exit code exactly once.
+func (r *reaper) start(cmd *exec.Cmd) (chan int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	ch := make(chan int, 1)
+	r.tracked[cmd.Process.Pid] = ch
+	return ch, nil
+}
+
+func (r *reaper) loop() {
+	for range r.sigchld {
+		for {
+			var status syscall.WaitStatus
+			pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+			if pid <= 0 || err != nil {
+				break
+			}
+			code := status.ExitStatus()
+			if status.Signaled() {
+				code = 128 + int(status.Signal())
+			}
+			r.mu.Lock()
+			if ch, ok := r.tracked[pid]; ok {
+				ch <- code
+				delete(r.tracked, pid)
+			}
+			r.mu.Unlock()
+		}
+	}
+}
+
+func run(log *slog.Logger) (int, error) {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	reap := newReaper()
+
+	dockerd, dockerdExit, err := startDockerd(log, reap)
+	if err != nil {
+		return -1, err
+	}
+	defer stopDockerd(log, dockerd, dockerdExit)
+
+	if err := awaitDockerdReady(ctx); err != nil {
+		return -1, err
+	}
+	log.Info("dockerd ready", "socket", dockerSocket)
+
+	if err := awaitStart(ctx); err != nil {
+		// Cancellation while waiting: the start was never authorized, so
+		// nothing ran — the state says so and the exit is clean shutdown.
+		log.Info("shutdown before any start authorization; nothing ran")
+		return 0, nil
+	}
+
+	return runRunner(ctx, log, reap)
+}
+
+// startDockerd launches the inner daemon on its own socket path — not
+// the default, so an inner job that blindly mounts /var/run cannot find
+// it by accident — with its group set so the runner uid can reach it.
+func startDockerd(log *slog.Logger, reap *reaper) (*exec.Cmd, chan int, error) {
+	cmd := exec.Command("dockerd",
+		"--host=unix://"+dockerSocket,
+		"--group="+strconv.Itoa(runnerGID),
+	)
+	// dockerd's own logs are diagnostics, not job output; they go to
+	// stderr so the structured stream on stdout stays parseable.
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	exit, err := reap.start(cmd)
+	if err != nil {
+		return nil, nil, fmt.Errorf("start dockerd: %w", err)
+	}
+	log.Info("dockerd starting", "pid", cmd.Process.Pid)
+	return cmd, exit, nil
+}
+
+func stopDockerd(log *slog.Logger, dockerd *exec.Cmd, exit chan int) {
+	if dockerd.Process == nil {
+		return
+	}
+	_ = dockerd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-exit:
+	case <-time.After(30 * time.Second):
+		log.Warn("dockerd did not stop in time; killing it")
+		_ = dockerd.Process.Kill()
+		<-exit
+	}
+}
+
+func awaitDockerdReady(ctx context.Context) error {
+	deadline := time.Now().Add(dockerdReadyTimeout)
+	for {
+		probe := exec.Command("docker", "--host=unix://"+dockerSocket, "info")
+		probe.Stdout, probe.Stderr = io.Discard, io.Discard
+		if probe.Run() == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return errors.New("dockerd did not become ready in time")
+		}
+		select {
+		case <-time.After(500 * time.Millisecond):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// awaitStart blocks until the controller authorizes the start. The
+// sentinel is a file because the authorizer runs as a sibling exec in
+// this same container: no listener, no port, nothing an inner job can
+// reach.
+func awaitStart(ctx context.Context) error {
+	for {
+		if _, err := os.Stat(startFile); err == nil {
+			return nil
+		}
+		select {
+		case <-time.After(startPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+// runRunner launches the runner as the runner uid and waits it out. The JIT
+// bundle arrives through tmpfs and the configuration files it instructs the
+// upstream runner to materialize are redirected back onto that tmpfs. GitHub's
+// runner contract requires the encoded bundle in --jitconfig; it therefore
+// exists transiently in the runner's argv, but never in Docker metadata, the
+// controller store, the container environment, or the capsule's disk-backed
+// writable layer.
+func runRunner(ctx context.Context, log *slog.Logger, reap *reaper) (int, error) {
+	payload, err := os.ReadFile(jitFile)
+	if err != nil {
+		return -1, errors.New("start authorized but no credential was delivered")
+	}
+	if len(payload) == 0 {
+		return -1, errors.New("start authorized with an empty credential")
+	}
+	cleanupConfig, err := prepareRunnerConfig(string(payload), runnerHome,
+		filepath.Join(controlDir, "runner-config"), runnerUID, runnerGID)
+	if err != nil {
+		return -1, fmt.Errorf("prepare volatile runner configuration: %w", err)
+	}
+	defer cleanupConfig()
+	if err := os.Remove(jitFile); err != nil {
+		return -1, fmt.Errorf("unlink delivered credential: %w", err)
+	}
+	log.Info("runner starting")
+
+	cmd := exec.Command(filepath.Join(runnerHome, "run.sh"), "--jitconfig", string(payload))
+	cmd.Dir = runnerHome
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	cmd.Env = append(os.Environ(),
+		"DOCKER_HOST=unix://"+dockerSocket,
+		"HOME="+runnerHome,
+		"USER=runner",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{Uid: runnerUID, Gid: runnerGID},
+	}
+	exit, err := reap.start(cmd)
+	// Drop the supervisor's references once fork/exec has copied argv. The
+	// child retains the value because the upstream interface requires it.
+	cmd.Args = nil
+	for i := range payload {
+		payload[i] = 0
+	}
+	if err != nil {
+		// fork/exec failed, so the runner never existed and the job was
+		// never handed over. `running` is written below, after this check,
+		// precisely so this case stays an abort.
+		return -1, fmt.Errorf("start runner: %w", err)
+	}
+	setState("running")
+
+	select {
+	case code := <-exit:
+		return code, nil
+	case <-ctx.Done():
+		// Graceful drain: the runner finishes its current job on
+		// SIGTERM; past the drain window it is killed and the capsule
+		// reports the interruption.
+		log.Info("draining the runner", "timeout", drainTimeout.String())
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case code := <-exit:
+			return code, nil
+		case <-time.After(drainTimeout):
+			log.Warn("runner did not drain in time; killing it")
+			_ = cmd.Process.Kill()
+			<-exit
+			return -1, errors.New("runner killed after drain timeout")
+		}
+	}
+}
+
+// prepareRunnerConfig redirects every file named by the encoded JIT bundle to
+// volatile storage. The upstream runner decodes the same map and writes each
+// value beneath its installation root; pre-creating symlinks lets that write
+// follow the reviewed path while keeping credentials off the container layer.
+func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int) (func(), error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("decode JIT bundle: %w", err)
+	}
+	var files map[string]string
+	if err := json.Unmarshal(decoded, &files); err != nil {
+		return nil, fmt.Errorf("parse JIT bundle: %w", err)
+	}
+	if len(files) == 0 {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(volatileRoot, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Chown(volatileRoot, uid, gid); err != nil {
+		return nil, err
+	}
+	links := make([]string, 0, len(files))
+	cleanup := func() {
+		for _, link := range links {
+			_ = os.Remove(link)
+		}
+		_ = os.RemoveAll(volatileRoot)
+	}
+	for name, content := range files {
+		clean := filepath.Clean(name)
+		if name == "" || clean == "." || clean != name || filepath.IsAbs(name) ||
+			filepath.Base(clean) != clean || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			cleanup()
+			return nil, fmt.Errorf("JIT bundle names unsafe path %q", name)
+		}
+		link := filepath.Join(runnerRoot, clean)
+		if _, err := os.Lstat(link); err == nil {
+			cleanup()
+			return nil, fmt.Errorf("runner configuration path %q already exists", clean)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			cleanup()
+			return nil, err
+		}
+		target := filepath.Join(volatileRoot, clean)
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			cleanup()
+			return nil, err
+		}
+		if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+			cleanup()
+			return nil, err
+		}
+		// The bundle's content is the runner's configuration and it has to
+		// land in the file: the runner reads .runner while constructing
+		// its host context, before it looks at --jitconfig, and aborts on
+		// a file that exists empty. An empty placeholder was enough only
+		// for runner versions that never opened these files. Each value
+		// is base64 of the file's bytes, one more layer than the bundle
+		// itself.
+		decoded, err := base64.StdEncoding.DecodeString(content)
+		if err != nil {
+			cleanup()
+			return nil, fmt.Errorf("decode JIT bundle file %q: %w", clean, err)
+		}
+		if err := os.WriteFile(target, decoded, 0o600); err != nil {
+			cleanup()
+			return nil, err
+		}
+		if err := os.Chown(target, uid, gid); err != nil {
+			cleanup()
+			return nil, err
+		}
+		if err := os.Symlink(target, link); err != nil {
+			cleanup()
+			return nil, err
+		}
+		links = append(links, link)
+	}
+	return cleanup, nil
+}
+
+func setState(s string) {
+	_ = os.WriteFile(stateFile, []byte(s), 0o644)
+}
+
+// terminalFailure names a failure by whether the runner ever started, which
+// is the one thing the controller cannot infer from the outside. `running` is
+// written immediately before the runner is executed, so its presence is the
+// proof that the job was handed over: after it, a failure is an execution
+// outcome. Before it — no credential delivered, configuration unprepared,
+// dockerd never ready — the job never ran, and reporting an exit would settle
+// it as complete and never retry it.
+func terminalFailure(state string, err error) string {
+	if state == "running" {
+		return "failed:" + err.Error()
+	}
+	return "aborted:" + err.Error()
+}
+
+func currentState() string {
+	body, err := os.ReadFile(stateFile)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(body))
+}

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func encodedBundle(t *testing.T, body string) string {
+	t.Helper()
+	return base64.StdEncoding.EncodeToString([]byte(body))
+}
+
+func TestPrepareRunnerConfigUsesVolatileTargets(t *testing.T) {
+	root := t.TempDir()
+	runnerRoot := filepath.Join(root, "runner")
+	volatileRoot := filepath.Join(root, "control", "runner-config")
+	if err := os.MkdirAll(runnerRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Each bundle value is base64 of the file's bytes, as the provider
+	// encodes it - and the content has to arrive: the runner reads
+	// .runner at boot and aborts on a file that exists empty.
+	contents := map[string]string{".runner": `{"agentName":"probe"}`, ".credentials": `{"scheme":"OAuth"}`}
+	bundle := fmt.Sprintf(`{".runner":%q,".credentials":%q}`,
+		base64.StdEncoding.EncodeToString([]byte(contents[".runner"])),
+		base64.StdEncoding.EncodeToString([]byte(contents[".credentials"])))
+	cleanup, err := prepareRunnerConfig(encodedBundle(t, bundle),
+		runnerRoot, volatileRoot, os.Getuid(), os.Getgid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{".runner", ".credentials"} {
+		link := filepath.Join(runnerRoot, name)
+		info, err := os.Lstat(link)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("%s is not a symlink: %v, %v", name, info, err)
+		}
+		body, err := os.ReadFile(link)
+		if err != nil || string(body) != contents[name] {
+			t.Fatalf("materialized %s = %q, %v; want the bundle's decoded bytes", name, body, err)
+		}
+		if err := os.WriteFile(link, []byte("secret"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		body, err = os.ReadFile(filepath.Join(volatileRoot, name))
+		if err != nil || string(body) != "secret" {
+			t.Fatalf("volatile target %s = %q, %v", name, body, err)
+		}
+	}
+	cleanup()
+	if _, err := os.Lstat(filepath.Join(runnerRoot, ".credentials")); !os.IsNotExist(err) {
+		t.Fatalf("cleanup left a runner configuration link: %v", err)
+	}
+	if _, err := os.Stat(volatileRoot); !os.IsNotExist(err) {
+		t.Fatalf("cleanup left volatile configuration: %v", err)
+	}
+}
+
+func TestPrepareRunnerConfigRejectsPathsAndCollisions(t *testing.T) {
+	for _, name := range []string{"../escape", "nested/file", "/absolute"} {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			if _, err := prepareRunnerConfig(encodedBundle(t, `{"`+name+`":"ignored"}`),
+				root, filepath.Join(root, "volatile"), os.Getuid(), os.Getgid()); err == nil {
+				t.Fatalf("unsafe JIT path %q was accepted", name)
+			}
+		})
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".credentials"), []byte("foreign"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareRunnerConfig(encodedBundle(t, `{".credentials":"ignored"}`),
+		root, filepath.Join(root, "volatile"), os.Getuid(), os.Getgid()); err == nil {
+		t.Fatal("an existing runner configuration file was replaced")
+	}
+}
+
+// TestTerminalFailureDistinguishesUnstartedRunners: `running` is written
+// immediately before the runner is executed, so it is the only proof the
+// supervisor has that the job was handed over. A failure before it must not
+// be reported as an execution, or the controller settles a job that never ran.
+func TestTerminalFailureDistinguishesUnstartedRunners(t *testing.T) {
+	err := errors.New("no credential was delivered")
+
+	for _, state := range []string{"", "waiting"} {
+		if got := terminalFailure(state, err); !strings.HasPrefix(got, "aborted:") {
+			t.Errorf("failure from state %q = %q; want an aborted state", state, got)
+		}
+	}
+	// Past `running` the runner owned the job; claiming it never started
+	// would run it a second time.
+	if got := terminalFailure("running", err); !strings.HasPrefix(got, "failed:") {
+		t.Errorf("failure after the runner started = %q; want a failed state", got)
+	}
+}
+
+// The controller reads this code to tell an abort from an execution; see
+// capsule.SupervisorAbortedExitCode. The two binaries cannot import each
+// other, so both pin the literal.
+func TestExitAbortedIsPinned(t *testing.T) {
+	if exitAborted != 79 {
+		t.Errorf("exitAborted = %d; capsule.SupervisorAbortedExitCode is 79", exitAborted)
+	}
+}
+
+// TestRunnerStatusNeverCollidesWithTheAbortCode. This process returns the
+// runner's own status as the capsule's, and the controller reads
+// exitAborted as proof the runner never started — the one account a
+// stopped capsule can still give, since the state file dies with the
+// container. A job that exits with that number would therefore be
+// settled as unstarted and run again, which is the double execution
+// every disposition rule here exists to prevent.
+//
+// Every other status passes through untouched, including zero: the
+// controller distinguishes success from failure by the code it is given,
+// and only the reserved value may not be one of them.
+func TestRunnerStatusNeverCollidesWithTheAbortCode(t *testing.T) {
+	for _, code := range []int{0, 1, 2, 78, 80, 125, 126, 127, 130, 255} {
+		if got := runnerExit(code); got != code {
+			t.Errorf("a runner status of %d was reported as %d; only the reserved code is remapped", code, got)
+		}
+	}
+
+	got := runnerExit(exitAborted)
+	if got == exitAborted {
+		t.Fatalf("a runner that exited %d is reported as an abort; its job would be run twice", exitAborted)
+	}
+	if got == 0 {
+		t.Errorf("a runner that exited %d is reported as success; its job failed", exitAborted)
+	}
+}
+
+// TestWriteDockerProxyConfig: the capsule's environment reaches the
+// runner, its steps and the inner daemon, but not the containers that
+// daemon creates — a daemon does not pass its own environment to what it
+// runs. Under the restricted profile those containers also have no route
+// out, so a `docker build` that fetches anything fails with nothing to
+// point at. The client reads this file and injects the proxy into every
+// container the job starts.
+func TestWriteDockerProxyConfig(t *testing.T) {
+	uid, gid := os.Getuid(), os.Getgid()
+
+	t.Run("a relay reaches the job's own containers", func(t *testing.T) {
+		home := t.TempDir()
+		env := map[string]string{
+			"HTTP_PROXY":  "http://10.0.0.2:3128",
+			"HTTPS_PROXY": "http://10.0.0.2:3128",
+			"NO_PROXY":    "localhost,127.0.0.1",
+		}
+		wrote, err := writeDockerProxyConfig(func(k string) string { return env[k] }, home, uid, gid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !wrote {
+			t.Fatal("no config was written for a capsule that has a relay")
+		}
+		body, err := os.ReadFile(filepath.Join(home, ".docker", "config.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got struct {
+			Proxies struct {
+				Default struct {
+					HTTPProxy  string `json:"httpProxy"`
+					HTTPSProxy string `json:"httpsProxy"`
+					NoProxy    string `json:"noProxy"`
+				} `json:"default"`
+			} `json:"proxies"`
+		}
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("unmarshal %s: %v", body, err)
+		}
+		if got.Proxies.Default.HTTPProxy != env["HTTP_PROXY"] ||
+			got.Proxies.Default.HTTPSProxy != env["HTTPS_PROXY"] ||
+			got.Proxies.Default.NoProxy != env["NO_PROXY"] {
+			t.Errorf("config = %s; want the capsule's own relay", body)
+		}
+	})
+
+	t.Run("https falls back to the one proxy there is", func(t *testing.T) {
+		home := t.TempDir()
+		env := map[string]string{"HTTP_PROXY": "http://10.0.0.2:3128"}
+		if _, err := writeDockerProxyConfig(func(k string) string { return env[k] }, home, uid, gid); err != nil {
+			t.Fatal(err)
+		}
+		body, _ := os.ReadFile(filepath.Join(home, ".docker", "config.json"))
+		if !strings.Contains(string(body), `"httpsProxy":"http://10.0.0.2:3128"`) {
+			t.Errorf("config = %s; want https to fall back rather than be empty", body)
+		}
+	})
+
+	t.Run("open egress writes nothing", func(t *testing.T) {
+		home := t.TempDir()
+		wrote, err := writeDockerProxyConfig(func(string) string { return "" }, home, uid, gid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if wrote {
+			t.Error("a config was written for a capsule with no relay")
+		}
+		// Pointing a client at a proxy that does not exist would break
+		// what works today.
+		if _, err := os.Stat(filepath.Join(home, ".docker", "config.json")); !os.IsNotExist(err) {
+			t.Errorf("stat: %v; want no file at all", err)
+		}
+	})
+}

--- a/docs/adrs/2026-08-11-shared-network-namespace.md
+++ b/docs/adrs/2026-08-11-shared-network-namespace.md
@@ -1,0 +1,36 @@
+# Runner and dockerd share one network namespace
+
+**Status:** accepted; implementation evolved to a single capsule container
+**Date:** 2026-08-11
+
+## Context
+
+CI workloads expect a Docker-published port to be reachable through
+`localhost` from the runner. Separate network namespaces break that contract:
+the daemon publishes into one namespace while the runner resolves localhost
+inside another.
+
+## Decision
+
+The runner, dockerd, and every process the job launches share the execution
+capsule's network namespace. The current implementation places the supervisor,
+runner, and dockerd in one outer container; containers launched by the inner
+daemon are reached through its normal port publishing in that same namespace.
+
+The runner uses `DOCKER_HOST=unix:///var/run/docker.sock`. Dockerd's data root
+is a fresh volume for each workload, and the workspace is fresh. No image,
+layer, workspace, or credential survives unless it belongs to an explicitly
+mounted cache lane.
+
+## Evidence
+
+The live capsule contract verifies the Docker client reaches the inner daemon,
+a published container is reachable on localhost, and the workspace is
+writable by the runner. It also verifies that the complete capsule stays
+inside its aggregate cgroup envelope.
+
+## Consequences
+
+- Runner and inner daemon versions are treated as one tested image set.
+- The outer egress policy has one capsule namespace to confine.
+- One outer cgroup accounts for the runner, daemon, and nested job workload.

--- a/internal/gateway/dns.go
+++ b/internal/gateway/dns.go
@@ -1,0 +1,265 @@
+package gateway
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"time"
+)
+
+// Bounds on the DNS relay.
+const (
+	// DNSTimeout bounds one upstream query.
+	DNSTimeout = 5 * time.Second
+	// MaxDNSInFlight bounds concurrent upstream queries. A capsule can
+	// emit UDP packets far faster than a resolver answers; without this
+	// each one would become a goroutine and a socket.
+	MaxDNSInFlight = 64
+	// MaxDNSMessage is the largest message the relay will carry over
+	// UDP. EDNS(0) advertises up to 4096 in practice, and a datagram is
+	// not the transport for anything larger: an answer that does not fit
+	// is what TC and the TCP retry exist for.
+	MaxDNSMessage = 4096
+	// MaxDNSMessageTCP is the largest it will carry over TCP: everything
+	// a two-byte length prefix can frame. TCP exists precisely to carry
+	// the answers a datagram cannot, so capping it at the UDP size would
+	// leave large but ordinary records — a signed zone's chain, a long
+	// TXT set — unreachable by any transport through this relay. The
+	// memory is still bounded by MaxDNSConns: 32 connections of 64 KiB.
+	MaxDNSMessageTCP = 65535
+	// MinDNSMessage is a header: anything shorter cannot be a query.
+	MinDNSMessage = 12
+	// MaxDNSConns bounds concurrent TCP DNS connections.
+	MaxDNSConns = 32
+	// MaxResolvedAddresses bounds how many addresses the relay will try
+	// for one name, so a hostile answer with hundreds of records cannot
+	// turn one request into hundreds of dial attempts.
+	MaxResolvedAddresses = 8
+)
+
+// defaultUpstream is the daemon's embedded resolver, on this
+// container's loopback. Docker installs the nat rules that make it
+// reachable, which is why the gateway's own ruleset must never flush
+// the nat table.
+const defaultUpstream = "127.0.0.11:53"
+
+// DNSRelay is the capsule's resolver: a bounded payload relay from the
+// internal leg to the daemon's embedded resolver.
+//
+// It deliberately does not parse names or filter answers. A name is not
+// a destination — the address policy is applied at connect time, where
+// an answer cannot be swapped afterwards — so inspecting answers here
+// would add a parser without adding a defence. What it does enforce is
+// shape: a message must be a plausible DNS message, of bounded size,
+// and its answer must carry the same transaction ID as the query.
+type DNSRelay struct {
+	Log *slog.Logger
+	// Upstream is the resolver every query is relayed to. Empty means
+	// the daemon's embedded one, which is what production runs; a test
+	// points it at a resolver it controls, because the answers worth
+	// testing are the ones a real resolver cannot be asked to give.
+	Upstream string
+}
+
+func (d *DNSRelay) resolver() string {
+	if d.Upstream != "" {
+		return d.Upstream
+	}
+	return defaultUpstream
+}
+
+// Listen starts the UDP and TCP resolvers on the internal leg.
+func (d *DNSRelay) Listen(ctx context.Context, ip string) error {
+	pc, err := net.ListenPacket("udp", net.JoinHostPort(ip, "53"))
+	if err != nil {
+		return err
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "53"))
+	if err != nil {
+		pc.Close()
+		return err
+	}
+	go func() { <-ctx.Done(); pc.Close(); ln.Close() }()
+	go d.serveUDP(pc)
+	go d.serveTCP(ln)
+	d.Log.Info("dns relay listening", "address", ip, "max_in_flight", MaxDNSInFlight,
+		"max_message_udp", MaxDNSMessage, "max_message_tcp", MaxDNSMessageTCP)
+	return nil
+}
+
+func (d *DNSRelay) serveUDP(pc net.PacketConn) {
+	sem := make(chan struct{}, MaxDNSInFlight)
+	// One byte over the bound, so a datagram that does not fit is seen
+	// not to fit. Reading into exactly MaxDNSMessage returns a full
+	// buffer and no error while the kernel discards the rest, which is
+	// indistinguishable from a message that happened to be that long.
+	buf := make([]byte, MaxDNSMessage+1)
+	for {
+		n, client, err := pc.ReadFrom(buf)
+		if err != nil {
+			return // closed on shutdown
+		}
+		if n > MaxDNSMessage || !plausibleQuery(buf[:n]) {
+			continue
+		}
+		query := make([]byte, n)
+		copy(query, buf[:n])
+		select {
+		case sem <- struct{}{}:
+		default:
+			// At the in-flight bound: drop rather than queue. DNS is
+			// already a lossy transport with client retries, so a drop
+			// is the response a resolver under load is expected to
+			// give, and queueing would only convert load into memory.
+			continue
+		}
+		go func(query []byte, client net.Addr) {
+			defer func() { <-sem }()
+			answer, err := exchangeUDP(d.resolver(), query)
+			if err != nil {
+				return
+			}
+			_, _ = pc.WriteTo(answer, client)
+		}(query, client)
+	}
+}
+
+func exchangeUDP(resolver string, query []byte) ([]byte, error) {
+	up, err := net.Dial("udp", resolver)
+	if err != nil {
+		return nil, err
+	}
+	defer up.Close()
+	_ = up.SetDeadline(time.Now().Add(DNSTimeout))
+	if _, err := up.Write(query); err != nil {
+		return nil, err
+	}
+	answer := make([]byte, MaxDNSMessage+1)
+	n, err := up.Read(answer)
+	if err != nil {
+		return nil, err
+	}
+	if n > MaxDNSMessage {
+		// Cut by this buffer, not by the resolver: the header still
+		// claims the records that were lost and TC is not set, so
+		// forwarding it hands the client a message that ends mid-record
+		// and says it is whole. Dropping it leaves the client to retry
+		// over TCP, which is what a truncated answer would have told it
+		// to do anyway.
+		return nil, errors.New("upstream answer does not fit a datagram")
+	}
+	if !plausibleQuery(answer[:n]) {
+		return nil, errors.New("upstream answer is not a DNS message")
+	}
+	// The answer must belong to the query. The socket is connected, so
+	// this is defence in depth rather than the primary check, but an
+	// answer with a different ID is never correct to forward.
+	if binary.BigEndian.Uint16(answer[:2]) != binary.BigEndian.Uint16(query[:2]) {
+		return nil, errors.New("upstream answer has a different transaction id")
+	}
+	return answer[:n], nil
+}
+
+func (d *DNSRelay) serveTCP(ln net.Listener) {
+	sem := make(chan struct{}, MaxDNSConns)
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		select {
+		case sem <- struct{}{}:
+		default:
+			conn.Close()
+			continue
+		}
+		go func(conn net.Conn) {
+			defer func() { <-sem }()
+			defer conn.Close()
+			d.serveTCPConn(conn)
+		}(conn)
+	}
+}
+
+// serveTCPConn carries length-prefixed DNS messages. The prefix is
+// honoured rather than trusted: a length above the bound is refused
+// before any allocation, which is what keeps a two-byte header from
+// asking for 64 KiB per connection.
+func (d *DNSRelay) serveTCPConn(conn net.Conn) {
+	up, err := net.DialTimeout("tcp", d.resolver(), DNSTimeout)
+	if err != nil {
+		return
+	}
+	defer up.Close()
+	for {
+		_ = conn.SetDeadline(time.Now().Add(DNSTimeout))
+		query, err := readDNSMessage(conn)
+		if err != nil {
+			return
+		}
+		_ = up.SetDeadline(time.Now().Add(DNSTimeout))
+		if err := writeDNSMessage(up, query); err != nil {
+			return
+		}
+		answer, err := readDNSMessage(up)
+		if err != nil {
+			return
+		}
+		if binary.BigEndian.Uint16(answer[:2]) != binary.BigEndian.Uint16(query[:2]) {
+			return
+		}
+		if err := writeDNSMessage(conn, answer); err != nil {
+			return
+		}
+	}
+}
+
+func readDNSMessage(r io.Reader) ([]byte, error) {
+	var prefix [2]byte
+	if _, err := io.ReadFull(r, prefix[:]); err != nil {
+		return nil, err
+	}
+	length := int(binary.BigEndian.Uint16(prefix[:]))
+	if length < MinDNSMessage || length > MaxDNSMessageTCP {
+		return nil, errors.New("dns message length out of bounds")
+	}
+	msg := make([]byte, length)
+	if _, err := io.ReadFull(r, msg); err != nil {
+		return nil, err
+	}
+	if !plausibleQuery(msg) {
+		return nil, errors.New("not a dns message")
+	}
+	return msg, nil
+}
+
+func writeDNSMessage(w io.Writer, msg []byte) error {
+	var prefix [2]byte
+	binary.BigEndian.PutUint16(prefix[:], uint16(len(msg)))
+	if _, err := w.Write(prefix[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(msg)
+	return err
+}
+
+// plausibleQuery checks the shape a DNS message must have before the
+// relay spends anything on it: a full header, and at least one question
+// or answer to talk about. It is not a parser and does not pretend to
+// validate the message body.
+//
+// The upper bound is the caller's, because it is a property of the
+// transport rather than of the message: a datagram carries what the
+// resolver agreed to, a TCP stream carries what its length prefix can
+// frame, and the two differ by sixteen times.
+func plausibleQuery(msg []byte) bool {
+	if len(msg) < MinDNSMessage {
+		return false
+	}
+	questions := binary.BigEndian.Uint16(msg[4:6])
+	answers := binary.BigEndian.Uint16(msg[6:8])
+	return questions > 0 || answers > 0
+}

--- a/internal/gateway/dns_test.go
+++ b/internal/gateway/dns_test.go
@@ -1,0 +1,233 @@
+package gateway
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+)
+
+// header builds a minimal DNS message: transaction id, flags, and the
+// four section counts.
+func header(id uint16, questions, answers uint16, payload int) []byte {
+	msg := make([]byte, MinDNSMessage+payload)
+	binary.BigEndian.PutUint16(msg[0:2], id)
+	binary.BigEndian.PutUint16(msg[4:6], questions)
+	binary.BigEndian.PutUint16(msg[6:8], answers)
+	return msg
+}
+
+// TestPlausibleQuery is the shape gate every message passes before the
+// relay spends a socket or a goroutine on it. It is not a parser; it
+// rejects what cannot be a DNS message at all.
+func TestPlausibleQuery(t *testing.T) {
+	if !plausibleQuery(header(1, 1, 0, 20)) {
+		t.Error("a normal query was rejected")
+	}
+	if !plausibleQuery(header(1, 0, 1, 20)) {
+		t.Error("an answer was rejected")
+	}
+	if plausibleQuery(header(1, 0, 0, 20)) {
+		t.Error("a message with no questions and no answers was accepted")
+	}
+	if plausibleQuery(make([]byte, MinDNSMessage-1)) {
+		t.Error("a truncated header was accepted")
+	}
+	if plausibleQuery(nil) {
+		t.Error("an empty message was accepted")
+	}
+	// The upper bound belongs to the transport, not to the shape: a
+	// datagram and a TCP stream carry different maxima, and this gate
+	// runs on buffers the caller has already bounded.
+	if !plausibleQuery(header(1, 1, 0, MaxDNSMessageTCP)) {
+		t.Error("a message a TCP stream can legitimately frame was rejected on shape")
+	}
+}
+
+// TestReadDNSMessageBounds: the TCP length prefix is honoured, never
+// trusted. A prefix above the bound must be refused before anything is
+// allocated — otherwise two bytes from a workload buy 64 KiB.
+func TestReadDNSMessageBounds(t *testing.T) {
+	frame := func(length int, body []byte) []byte {
+		var buf bytes.Buffer
+		var prefix [2]byte
+		binary.BigEndian.PutUint16(prefix[:], uint16(length))
+		buf.Write(prefix[:])
+		buf.Write(body)
+		return buf.Bytes()
+	}
+
+	good := header(7, 1, 0, 10)
+	msg, err := readDNSMessage(bytes.NewReader(frame(len(good), good)))
+	if err != nil || len(msg) != len(good) {
+		t.Fatalf("a valid framed message failed: %v", err)
+	}
+
+	if _, err := readDNSMessage(bytes.NewReader(frame(3, []byte{1, 2, 3}))); err == nil {
+		t.Error("an undersized length prefix was accepted")
+	}
+	// A prefix that promises more than the body delivers must fail
+	// rather than return a short message. There is no case above the
+	// bound to test: the prefix is two bytes, so MaxDNSMessageTCP is
+	// every value it can hold, and the refusal that used to matter here
+	// is now the datagram bound in exchangeUDP.
+	if _, err := readDNSMessage(bytes.NewReader(frame(100, good))); err == nil {
+		t.Error("a truncated body was accepted")
+	}
+
+	// The whole point of raising the TCP bound: an answer larger than a
+	// datagram can carry is exactly what this transport is for.
+	big := header(9, 1, 1, 20000)
+	msg, err = readDNSMessage(bytes.NewReader(frame(len(big), big)))
+	if err != nil {
+		t.Fatalf("a %d byte answer over TCP failed: %v", len(big), err)
+	}
+	if len(msg) != len(big) {
+		t.Errorf("read %d bytes of a %d byte answer", len(msg), len(big))
+	}
+}
+
+// FuzzReadDNSMessage: whatever it accepts is within bounds and is a
+// plausible message. It must never panic on hostile framing.
+func FuzzReadDNSMessage(f *testing.F) {
+	good := header(1, 1, 0, 10)
+	var seed bytes.Buffer
+	var prefix [2]byte
+	binary.BigEndian.PutUint16(prefix[:], uint16(len(good)))
+	seed.Write(prefix[:])
+	seed.Write(good)
+	f.Add(seed.Bytes())
+	f.Add([]byte{0xff, 0xff})
+	f.Add([]byte{0x00, 0x00})
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, in []byte) {
+		msg, err := readDNSMessage(bytes.NewReader(in))
+		if err != nil {
+			return
+		}
+		if len(msg) < MinDNSMessage || len(msg) > MaxDNSMessageTCP {
+			t.Fatalf("accepted a message of length %d", len(msg))
+		}
+		if !plausibleQuery(msg) {
+			t.Fatalf("accepted an implausible message")
+		}
+	})
+}
+
+// TestWriteDNSMessageRoundTrip keeps the framing symmetric: what the
+// relay writes, it can read back.
+func TestWriteDNSMessageRoundTrip(t *testing.T) {
+	msg := header(42, 1, 0, 30)
+	var buf bytes.Buffer
+	if err := writeDNSMessage(&buf, msg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readDNSMessage(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, msg) {
+		t.Error("the framed message did not round-trip")
+	}
+}
+
+// answerWith starts a UDP resolver that echoes the query's transaction
+// id and pads the answer to total bytes, so a test can ask for the
+// answers a real resolver cannot be told to give.
+func answerWith(t *testing.T, total int) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { pc.Close() })
+	go func() {
+		buf := make([]byte, MaxDNSMessage+1)
+		for {
+			n, client, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if n < MinDNSMessage {
+				continue
+			}
+			answer := header(binary.BigEndian.Uint16(buf[:2]), 1, 1, total-MinDNSMessage)
+			_, _ = pc.WriteTo(answer, client)
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
+// TestUDPAnswerTooLargeForADatagramIsDropped. Reading into a buffer of
+// exactly the bound returns a full buffer and no error while the kernel
+// throws the tail away — so the relay would forward a message that ends
+// mid-record with its header still claiming every record it had, and TC
+// unset. The client would parse a lie. Dropping it leaves the retry to
+// TCP, which is where an answer this size belongs.
+func TestUDPAnswerTooLargeForADatagramIsDropped(t *testing.T) {
+	query := header(0x1234, 1, 0, 30)
+
+	fits := answerWith(t, MaxDNSMessage)
+	answer, err := exchangeUDP(fits, query)
+	if err != nil {
+		t.Fatalf("an answer of exactly the bound was rejected: %v", err)
+	}
+	if len(answer) != MaxDNSMessage {
+		t.Errorf("answer of %d bytes; want the full %d", len(answer), MaxDNSMessage)
+	}
+
+	oversized := answerWith(t, MaxDNSMessage+400)
+	if answer, err := exchangeUDP(oversized, query); err == nil {
+		t.Errorf("forwarded %d bytes of an answer that did not fit; it is cut mid-record "+
+			"and its header still claims what was cut", len(answer))
+	}
+}
+
+// TestTCPCarriesWhatADatagramCannot drives one whole relayed exchange
+// over TCP with an answer four times the UDP bound. Capping TCP at the
+// datagram size left large but ordinary answers unreachable by any
+// transport: UDP truncates them and the fallback that exists to carry
+// them refused them too, closing the connection with no reason given.
+func TestTCPCarriesWhatADatagramCannot(t *testing.T) {
+	const answerSize = 4 * MaxDNSMessage
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		query, err := readDNSMessage(conn)
+		if err != nil {
+			return
+		}
+		_ = writeDNSMessage(conn, header(binary.BigEndian.Uint16(query[:2]), 1, 1, answerSize-MinDNSMessage))
+	}()
+
+	d := &DNSRelay{Log: discardLogger(), Upstream: ln.Addr().String()}
+	client, relay := net.Pipe()
+	defer client.Close()
+	go func() { defer relay.Close(); d.serveTCPConn(relay) }()
+
+	_ = client.SetDeadline(time.Now().Add(5 * time.Second))
+	if err := writeDNSMessage(client, header(0x4321, 1, 0, 40)); err != nil {
+		t.Fatal(err)
+	}
+	answer, err := readDNSMessage(client)
+	if err != nil {
+		t.Fatalf("a %d byte answer did not survive the relay: %v", answerSize, err)
+	}
+	if len(answer) != answerSize {
+		t.Errorf("relayed %d bytes of a %d byte answer", len(answer), answerSize)
+	}
+	if got := binary.BigEndian.Uint16(answer[:2]); got != 0x4321 {
+		t.Errorf("answer transaction id = %#x; want the query's", got)
+	}
+}

--- a/internal/gateway/firewall.go
+++ b/internal/gateway/firewall.go
@@ -1,0 +1,30 @@
+package gateway
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/egress"
+)
+
+// ApplyFirewall installs the filter ruleset in one restore call, which
+// the kernel applies atomically: there is no instant in which half a
+// policy is in force. The nat table is left alone on purpose — the
+// gateway routes nothing, and flushing nat would delete the daemon's
+// own rules for the embedded resolver this container resolves through.
+func ApplyFirewall(p egress.Policy, l Legs) error {
+	if err := restore("iptables-restore", p.RenderIPTables(l.InternalIf, egress.ProxyPort)); err != nil {
+		return err
+	}
+	return restore("ip6tables-restore", egress.RenderIP6Tables())
+}
+
+func restore(tool, rules string) error {
+	cmd := exec.Command(tool)
+	cmd.Stdin = strings.NewReader(rules)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s: %v: %s", tool, err, out)
+	}
+	return nil
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -1,0 +1,172 @@
+// Package gateway is the capsule's egress gateway: the process that
+// runs in the only container attached to both the capsule's isolated
+// bridge and the Runpool uplink.
+//
+// It does not route. The capsule's bridge is internal in Engine 28's
+// isolated gateway mode, which makes the host kernel drop every packet
+// the capsule addresses outside that subnet — a deny no privileged
+// capsule can lift, because the rule is not in its namespace. What
+// stays reachable is the gateway itself, so egress happens by
+// relaying: the gateway resolves names for the capsule and opens
+// connections on its behalf, checking every resolved address against
+// the policy before it dials.
+//
+// Everything here is bounded on purpose. The work this process does is
+// driven by a workload, so unbounded connections, goroutines or buffers
+// would be a way for a job to consume resources outside its own budget.
+// Every limit has a named constant and a test.
+//
+// Nothing is optional: a policy that will not compile, an interface
+// that cannot be classified, a ruleset that will not install or a
+// listener that will not bind all report failed, and the controller
+// never starts a capsule whose gateway is not ready.
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/netip"
+	"os"
+	"path/filepath"
+
+	"github.com/rhobuild/runpool/internal/egress"
+)
+
+// Config is what the gateway needs to start. The caller supplies the
+// policy text (the controller passes it in the environment) and the
+// directory holding the control files.
+type Config struct {
+	Policy     string
+	ControlDir string
+	Log        *slog.Logger
+	// SetState reports readiness or failure through the supervisor's
+	// protocol; the controller polls it and refuses to start a capsule
+	// whose gateway never reported ready.
+	SetState func(string)
+}
+
+// PolicyPath is the policy in force, on the gateway's tmpfs. The relay
+// reloads it when it changes, which is how a reload arriving as a
+// separate exec reaches this running process.
+func PolicyPath(controlDir string) string {
+	return filepath.Join(controlDir, "gateway-policy.json")
+}
+
+// Run is the gateway container's PID 1. It returns when ctx is done.
+func Run(ctx context.Context, cfg Config) error {
+	if err := os.MkdirAll(cfg.ControlDir, 0o755); err != nil {
+		return err
+	}
+	policy, err := ParsePolicy(cfg.Policy)
+	if err != nil {
+		return fmt.Errorf("policy: %w", err)
+	}
+	legs, err := ClassifyLegs(policy)
+	if err != nil {
+		return fmt.Errorf("interfaces: %w", err)
+	}
+	if err := ApplyFirewall(policy, legs); err != nil {
+		return fmt.Errorf("ruleset: %w", err)
+	}
+	// The policy in force lives in a file from here on, so a reload
+	// exec and this process agree on one source.
+	path := PolicyPath(cfg.ControlDir)
+	if err := writeFileAtomic(path, []byte(cfg.Policy)); err != nil {
+		return fmt.Errorf("policy file: %w", err)
+	}
+	store := &PolicyStore{Path: path}
+	if _, err := store.Current(); err != nil {
+		return fmt.Errorf("policy: %w", err)
+	}
+
+	dns := &DNSRelay{Log: cfg.Log}
+	if err := dns.Listen(ctx, legs.InternalIP); err != nil {
+		return fmt.Errorf("dns relay: %w", err)
+	}
+	relay := &Relay{Policy: store, Log: cfg.Log}
+	if err := relay.Listen(ctx, legs.InternalIP); err != nil {
+		return fmt.Errorf("egress relay: %w", err)
+	}
+
+	cfg.SetState("ready")
+	cfg.Log.Info("gateway ready",
+		"internal", legs.InternalIf, "uplink", legs.UplinkIf,
+		"proxy", net.JoinHostPort(legs.InternalIP, fmt.Sprint(egress.ProxyPort)),
+		"deny", len(policy.Deny), "allow", len(policy.Allow),
+		"max_connections", MaxProxyConnections, "max_dns_inflight", MaxDNSInFlight)
+	<-ctx.Done()
+	cfg.SetState("exited:0")
+	return nil
+}
+
+// Legs are the gateway's two interfaces, identified by matching this
+// container's addresses against the policy's subnets. Interface names
+// are attachment-order trivia — the daemon hands out eth0 and eth1 in
+// an order that depends on when each network was connected — so the
+// addresses are what classify them.
+type Legs struct {
+	InternalIf string
+	UplinkIf   string
+	InternalIP string
+}
+
+// ClassifyLegs finds which interface faces the capsule and which faces
+// the uplink. Failing to find both is fatal: a gateway that cannot tell
+// its legs apart cannot write a correct ruleset.
+func ClassifyLegs(p egress.Policy) (Legs, error) {
+	internal, err := netip.ParsePrefix(p.InternalSubnet)
+	if err != nil {
+		return Legs{}, err
+	}
+	uplink, err := netip.ParsePrefix(p.UplinkSubnet)
+	if err != nil {
+		return Legs{}, err
+	}
+	var l Legs
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return l, err
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return l, err
+		}
+		for _, a := range addrs {
+			ipnet, ok := a.(*net.IPNet)
+			if !ok {
+				continue
+			}
+			v4 := ipnet.IP.To4()
+			if v4 == nil {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(v4)
+			if !ok {
+				continue
+			}
+			if internal.Contains(addr) {
+				l.InternalIf, l.InternalIP = iface.Name, addr.String()
+			}
+			if uplink.Contains(addr) {
+				l.UplinkIf = iface.Name
+			}
+		}
+	}
+	if l.InternalIf == "" || l.UplinkIf == "" {
+		return l, fmt.Errorf("not attached to both networks (internal %q, uplink %q)", l.InternalIf, l.UplinkIf)
+	}
+	return l, nil
+}
+
+// writeFileAtomic replaces a control file by rename, so a reader never
+// observes a half-written policy.
+func writeFileAtomic(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -1,0 +1,189 @@
+package gateway
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/rhobuild/runpool/internal/egress"
+)
+
+// MaxPolicyBytes bounds a policy document. The real one is a few
+// kilobytes of CIDRs; anything larger is a mistake or an attempt.
+const MaxPolicyBytes = 1 << 20
+
+// ParsePolicy decodes and validates a policy document.
+func ParsePolicy(raw string) (egress.Policy, error) {
+	var p egress.Policy
+	if raw == "" {
+		return p, errors.New("policy is empty")
+	}
+	if len(raw) > MaxPolicyBytes {
+		return p, fmt.Errorf("policy exceeds %d bytes", MaxPolicyBytes)
+	}
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return p, err
+	}
+	return p, p.Validate()
+}
+
+// PolicyStore holds the compiled policy and reloads it when the file
+// changes. A reload arrives as a separate exec into this container, so
+// the file is the only channel into the running relay; re-reading it on
+// change means the new policy binds the very next connection while
+// established ones are unaffected.
+//
+// A policy that cannot be read or compiled is not replaced by an empty
+// one — Current returns the error and every dial refuses, because a
+// gateway with no policy must deny, not allow.
+type PolicyStore struct {
+	Path string
+
+	mu      sync.Mutex
+	decider *egress.Decider
+	stamp   string
+	// generation counts installed policies. A pooled HTTP connection was
+	// authorised by whichever policy was in force when it was dialled, and
+	// http.Transport reuses it without consulting the dialer again, so the
+	// relay needs to know the policy moved in order to drop those
+	// connections. A counter says that; comparing deciders does not.
+	generation uint64
+}
+
+// Current returns the compiled policy in force, reloading it if the
+// file changed since the last read.
+func (s *PolicyStore) Current() (*egress.Decider, error) {
+	info, err := os.Stat(s.Path)
+	if err != nil {
+		return nil, err
+	}
+	stamp := fmt.Sprintf("%d/%d", info.ModTime().UnixNano(), info.Size())
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.decider != nil && s.stamp == stamp {
+		return s.decider, nil
+	}
+	raw, err := os.ReadFile(s.Path)
+	if err != nil {
+		return nil, err
+	}
+	policy, err := ParsePolicy(string(raw))
+	if err != nil {
+		return nil, err
+	}
+	decider, err := policy.Compile()
+	if err != nil {
+		return nil, err
+	}
+	s.decider, s.stamp = decider, stamp
+	s.generation++
+	return decider, nil
+}
+
+// Generation is how many policies this store has installed. It changes
+// only when a new one takes effect, so a caller holding connections
+// authorised under the previous policy can tell that they are stale.
+func (s *PolicyStore) Generation() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.generation
+}
+
+// Reload installs a new allow/deny set on a live gateway, given the
+// sets on a reader. The subnets already in force are kept: which two
+// networks this gateway bridges is a fact of its own creation, not
+// something a later discovery pass may redefine.
+//
+// The handover is transactional on each half — one kernel restore, one
+// rename — but not across them, and the window between is deliberately
+// the *stricter* of the two policies: the firewall is installed first,
+// so during the window the kernel already enforces the new denies while
+// the relay still applies the old ones. A capsule therefore never sees
+// a moment in which a newly denied destination is reachable.
+func Reload(controlDir string, r io.Reader) error {
+	payload, err := io.ReadAll(io.LimitReader(r, MaxPolicyBytes))
+	if err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		return errors.New("no policy supplied")
+	}
+	var incoming egress.Policy
+	if err := json.Unmarshal(payload, &incoming); err != nil {
+		return err
+	}
+	return installPolicy(controlDir, func(current egress.Policy) (egress.Policy, error) {
+		next := egress.Policy{
+			InternalSubnet: current.InternalSubnet,
+			UplinkSubnet:   current.UplinkSubnet,
+			Allow:          incoming.Allow,
+			Deny:           incoming.Deny,
+		}
+		// Validated here, not in installPolicy: these prefixes arrived
+		// from outside this process, and this is the trust boundary they
+		// cross. DenyAll's do not, so hoisting the check into the shared
+		// path would misread why it is here.
+		return next, next.Validate()
+	})
+}
+
+// DenyAll installs the most restrictive posture a live gateway can
+// take without dying: a policy whose deny set covers the entire IPv4
+// space, applied to both the kernel ruleset and the relay's own check.
+//
+// It exists for the case the controller cannot prove a policy is
+// current — discovery failed, or a required deny could not be
+// installed. Continuing to relay under a policy that predates a changed
+// environment is the failure mode this replaces: the old set is not
+// "narrower", it is merely older, and a subnet that appeared since is
+// reachable under it.
+func DenyAll(controlDir string) error {
+	return installPolicy(controlDir, func(current egress.Policy) (egress.Policy, error) {
+		return egress.Policy{
+			InternalSubnet: current.InternalSubnet,
+			UplinkSubnet:   current.UplinkSubnet,
+			Deny:           []string{"0.0.0.0/0"},
+		}, nil
+	})
+}
+
+// installPolicy is the part both paths share: read what is in force,
+// let the caller build the successor from it, then apply the successor
+// to the kernel before writing the file the relay reads. That order is
+// the whole point — the ruleset tightens first, so a newly denied
+// destination is never reachable in between.
+//
+// The two legs always come from the policy in force. Which networks a
+// gateway bridges is a fact of its own creation, not something a later
+// discovery pass may redefine.
+func installPolicy(controlDir string, build func(current egress.Policy) (egress.Policy, error)) error {
+	path := PolicyPath(controlDir)
+	inForce, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("no policy in force: %w", err)
+	}
+	var current egress.Policy
+	if err := json.Unmarshal(inForce, &current); err != nil {
+		return err
+	}
+	next, err := build(current)
+	if err != nil {
+		return err
+	}
+	legs, err := ClassifyLegs(next)
+	if err != nil {
+		return err
+	}
+	if err := ApplyFirewall(next, legs); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(next)
+	if err != nil {
+		return err
+	}
+	return writeFileAtomic(path, encoded)
+}

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -1,0 +1,98 @@
+package gateway
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestPolicyGenerationAdvancesOnlyOnChange: the relay drops pooled
+// connections when the policy moves, because a connection authorised under
+// the previous one is reused without ever reaching the dialer where the
+// address check lives. That hinges on the counter advancing exactly when a
+// new policy takes effect — never on an unchanged re-read, or every request
+// would tear down the pool.
+func TestPolicyGenerationAdvancesOnlyOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	write := func(deny string) {
+		body := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("10.0.0.0/8")
+
+	s := &PolicyStore{Path: path}
+	if _, err := s.Current(); err != nil {
+		t.Fatal(err)
+	}
+	first := s.Generation()
+	if first == 0 {
+		t.Fatal("generation stayed zero after the first policy was installed")
+	}
+
+	// An unchanged file is served from cache and must not advance.
+	for range 3 {
+		if _, err := s.Current(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := s.Generation(); got != first {
+		t.Errorf("generation moved to %d on an unchanged policy; the pool would be dropped every request", got)
+	}
+
+	// A restriction that actually changed must advance it.
+	time.Sleep(10 * time.Millisecond) // distinct mtime
+	write("192.168.0.0/16")
+	if _, err := s.Current(); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.Generation(); got == first {
+		t.Error("generation did not move on a new policy; connections pooled under the old one would keep it")
+	}
+}
+
+// TestRelayNoticesAPolicyChangeWithoutDialing is the regression this fix
+// first got wrong. The generation only advances when Current() re-reads the
+// file, and Current() is otherwise reached only from dial() — which a
+// request served from the connection pool never calls. Checking the
+// generation without reading the policy therefore could not detect a change
+// in precisely the case the pool-expiry exists for.
+func TestRelayNoticesAPolicyChangeWithoutDialing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	write := func(deny string) {
+		body := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("10.0.0.0/8")
+
+	r := &Relay{Policy: &PolicyStore{Path: path}, Log: discardLogger()}
+	r.roundTripper() // the transport must exist before the pool can be dropped
+
+	// Two observations settle the baseline; no dial happens in either.
+	r.expireStaleConnections()
+	r.expireStaleConnections()
+	baseline := r.policyGen.Load()
+	if baseline == 0 {
+		t.Fatal("the relay never read the policy; a pooled request would keep the old one forever")
+	}
+
+	r.expireStaleConnections()
+	if got := r.policyGen.Load(); got != baseline {
+		t.Errorf("generation moved to %d with an unchanged policy; the pool would be dropped every request", got)
+	}
+
+	time.Sleep(10 * time.Millisecond) // distinct mtime
+	write("192.168.0.0/16")
+	r.expireStaleConnections()
+	if got := r.policyGen.Load(); got == baseline {
+		t.Error("the relay did not notice a new policy without dialing; pooled connections would keep the old one")
+	}
+}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -1,0 +1,490 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/netip"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/egress"
+)
+
+// Bounds on the relay. Every one of them exists because the work is
+// driven by a workload: without them a job could spend the host's file
+// descriptors, memory and goroutines from outside its own cgroup.
+const (
+	// MaxProxyConnections is the number of concurrent client
+	// connections the relay will serve. Beyond it, new connections are
+	// refused rather than queued — a CI job that needs more than this
+	// many simultaneous egress connections is pathological, and
+	// queueing would only convert refusal into latency plus memory.
+	MaxProxyConnections = 256
+	// MaxHeaderBytes bounds one request's headers.
+	MaxHeaderBytes = 64 << 10
+	// ReadHeaderTimeout bounds how long a client may take to send its
+	// request line and headers — the slowloris bound.
+	ReadHeaderTimeout = 15 * time.Second
+	// IdleTimeout closes a connection that goes quiet, so an abandoned
+	// tunnel does not hold a slot forever.
+	IdleTimeout = 2 * time.Minute
+	// TunnelIdleTimeout bounds silence inside an established CONNECT
+	// tunnel. It is generous: a long docker pull is legitimately quiet
+	// between chunks, and cutting those would break real work.
+	TunnelIdleTimeout = 10 * time.Minute
+	// DialTimeout bounds establishing an upstream connection.
+	DialTimeout = 30 * time.Second
+	// MaxUpstreamConns bounds the pooled transport used for plain HTTP.
+	MaxUpstreamConns = 128
+)
+
+// AllowedConnectPorts is the explicit egress port set, applied to every
+// destination the relay dials — CONNECT tunnels and absolute-URI plain
+// HTTP alike. The name kept its CONNECT origin; the rule did not.
+//
+// This is the honest statement of the relay's contract. Direct TCP from
+// a capsule cannot leave — the host drops it — but CONNECT is a TCP
+// tunnel, so a proxy-aware client can carry any protocol over it to an
+// allowed address. Restricting the port set is what keeps that from
+// silently being "arbitrary TCP egress to the public internet": these
+// are the ports CI actually needs, and anything else is refused with a
+// reason. The relay does not inspect what flows inside a tunnel and
+// does not claim to.
+var AllowedConnectPorts = map[int]string{
+	443: "HTTPS",
+	80:  "HTTP",
+}
+
+// hopByHop are the headers a proxy must not forward. RFC 9110 §7.6.1:
+// they describe the single-hop connection, not the message, and passing
+// them on is how request smuggling and connection confusion start.
+var hopByHop = []string{
+	"Connection",
+	"Proxy-Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"TE",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+// Relay is the capsule's only way out: an HTTP proxy that applies the
+// address policy to every destination it is asked for. CONNECT carries
+// TLS and anything else tunnelled over it; absolute-URI requests carry
+// plain HTTP. In both cases the relay resolves the name itself and
+// dials only an address the policy allows, so the capsule never
+// influences which address a connection actually reaches — and a
+// resolver answering with a private address (DNS rebinding) changes
+// nothing, because the address that was checked is the address dialed.
+type Relay struct {
+	Policy *PolicyStore
+	Log    *slog.Logger
+
+	once      sync.Once
+	transport *http.Transport
+	// policyGen is the policy generation the pooled connections were
+	// authorised under.
+	policyGen atomic.Uint64
+}
+
+// Listen starts the relay on the internal leg.
+func (r *Relay) Listen(ctx context.Context, ip string) error {
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(egress.ProxyPort)))
+	if err != nil {
+		return err
+	}
+	return r.serve(ctx, ln)
+}
+
+func (r *Relay) serve(ctx context.Context, ln net.Listener) error {
+	// The connection quota is enforced at accept, before any per-request
+	// work exists: a refused connection costs one accept and one close.
+	limited := &limitListener{Listener: ln, sem: make(chan struct{}, MaxProxyConnections)}
+	srv := &http.Server{
+		Handler:           r,
+		ReadHeaderTimeout: ReadHeaderTimeout,
+		IdleTimeout:       IdleTimeout,
+		MaxHeaderBytes:    MaxHeaderBytes,
+		ErrorLog:          slog.NewLogLogger(r.Log.Handler(), slog.LevelDebug),
+	}
+	go func() {
+		<-ctx.Done()
+		shutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdown)
+	}()
+	go func() {
+		if err := srv.Serve(limited); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			r.Log.Error("egress relay stopped", "error", err)
+		}
+	}()
+	return nil
+}
+
+// ServeHTTP dispatches the two proxy shapes: CONNECT tunnels and
+// absolute-URI plain HTTP. A request that is neither is not a proxy
+// request, and this server has nothing else to serve.
+func (r *Relay) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Method == http.MethodConnect {
+		r.connect(w, req)
+		return
+	}
+	if !req.URL.IsAbs() {
+		http.Error(w, "runpool egress relay: only proxy requests are served", http.StatusBadRequest)
+		return
+	}
+	r.forward(w, req)
+}
+
+// connect tunnels a TCP stream after the policy check. The authority is
+// parsed strictly — a CONNECT target is host:port and nothing else, and
+// accepting anything looser is how a proxy is talked into connecting
+// somewhere its policy never saw.
+func (r *Relay) connect(w http.ResponseWriter, req *http.Request) {
+	host, port, err := parseAuthority(req.Host)
+	if err != nil {
+		http.Error(w, "runpool egress relay: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	upstream, err := r.dial(req.Context(), host, port)
+	if err != nil {
+		r.refuse(w, err)
+		return
+	}
+	defer upstream.Close()
+
+	r.establishTunnel(w, upstream)
+}
+
+// establishTunnel answers the CONNECT and joins the two streams. It is
+// separated from the policy decision above because joining is the half
+// that can be tested without a network, and it is the half where bytes
+// can go missing.
+func (r *Relay) establishTunnel(w http.ResponseWriter, upstream net.Conn) {
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "runpool egress relay: cannot tunnel", http.StatusInternalServerError)
+		return
+	}
+	client, buffered, err := hijacker.Hijack()
+	if err != nil {
+		return
+	}
+	defer client.Close()
+	if _, err := io.WriteString(client, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {
+		return
+	}
+	// Whatever the client pipelined behind its CONNECT header block is
+	// already out of the socket and inside the server's reader: parsing
+	// the headers reads by the block, not by the byte, and a client that
+	// does not wait for the 200 — legal, and the dial above gives it up
+	// to a minute to happen — has its first payload sitting there. Read
+	// from the raw connection and those bytes are simply gone: the
+	// upstream never sees a ClientHello, the client waits for a
+	// ServerHello, and the tunnel holds a connection slot until the idle
+	// timeout ten minutes later.
+	if n := buffered.Reader.Buffered(); n > 0 {
+		_ = upstream.SetWriteDeadline(time.Now().Add(TunnelIdleTimeout))
+		if _, err := io.CopyN(upstream, buffered.Reader, int64(n)); err != nil {
+			return
+		}
+		_ = upstream.SetWriteDeadline(time.Time{})
+	}
+	tunnel(client, upstream)
+}
+
+// tunnel copies both directions and returns when either ends. Each side
+// carries an idle deadline, so a tunnel nobody is using releases its
+// connection slot instead of holding it until the job ends.
+func tunnel(client, upstream net.Conn) {
+	done := make(chan struct{}, 2)
+	copyIdle := func(dst, src net.Conn) {
+		buf := make([]byte, 32<<10)
+		for {
+			_ = src.SetReadDeadline(time.Now().Add(TunnelIdleTimeout))
+			n, err := src.Read(buf)
+			if n > 0 {
+				_ = dst.SetWriteDeadline(time.Now().Add(TunnelIdleTimeout))
+				if _, werr := dst.Write(buf[:n]); werr != nil {
+					break
+				}
+			}
+			if err != nil {
+				break
+			}
+		}
+		// Unblock the peer direction rather than leaving its goroutine
+		// parked on a read that will never return.
+		_ = src.SetReadDeadline(time.Now())
+		_ = dst.SetReadDeadline(time.Now())
+		done <- struct{}{}
+	}
+	go copyIdle(upstream, client)
+	go copyIdle(client, upstream)
+	<-done
+}
+
+// forward relays a plain HTTP request through a shared, bounded
+// transport. Hop-by-hop headers are stripped in both directions: they
+// describe a single connection, and a proxy that forwards them invites
+// request smuggling.
+func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
+	// Validate the authority here, where a bad one can still be
+	// answered with 400. The transport's dialer parses it again because
+	// that is where the connection is actually made, and the check that
+	// matters is the one next to the dial.
+	if _, _, err := parseAuthority(defaultPort(req.URL.Host, req.URL.Scheme)); err != nil {
+		http.Error(w, "runpool egress relay: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	outbound := req.Clone(req.Context())
+	outbound.RequestURI = ""
+	stripHopByHop(outbound.Header)
+
+	rt := r.roundTripper()
+	r.expireStaleConnections()
+	resp, err := rt.RoundTrip(outbound)
+	if err != nil {
+		r.refuse(w, err)
+		return
+	}
+	defer resp.Body.Close()
+	stripHopByHop(resp.Header)
+	for k, values := range resp.Header {
+		for _, v := range values {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// expireStaleConnections drops pooled connections once the policy moves.
+// The address check lives in the transport's dialer, and http.Transport
+// only dials when no idle connection exists for the destination — so a
+// restriction installed while a job kept a connection warm would not bind
+// to its next request until IdleConnTimeout expired. Closing idle
+// connections forces the next request back through the dialer, where the
+// check is. Connections mid-request are left alone, which is the
+// documented "established ones are unaffected".
+func (r *Relay) expireStaleConnections() {
+	if r.Policy == nil {
+		return
+	}
+	// Current() is what notices the file changed, and it is otherwise only
+	// reached from dial() — which a pooled request never calls. Reading it
+	// here is the whole point: without it the generation could not move in
+	// exactly the case this function exists for. A cached hit is one stat.
+	if _, err := r.Policy.Current(); err != nil {
+		// An unreadable policy is not in force. Drop the pool so the next
+		// request must dial, where that error refuses the connection.
+		r.transport.CloseIdleConnections()
+		return
+	}
+	gen := r.Policy.Generation()
+	// The first observation only records where the policy started; there is
+	// nothing pooled under an older one yet.
+	if prev := r.policyGen.Swap(gen); prev != 0 && prev != gen {
+		r.transport.CloseIdleConnections()
+	}
+}
+
+// roundTripper is built once. A transport per request — the shape this
+// replaces — leaks a connection pool and its idle goroutines on every
+// call, which is unbounded growth driven by the workload.
+func (r *Relay) roundTripper() http.RoundTripper {
+	r.once.Do(func() {
+		r.transport = &http.Transport{
+			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+				host, port, err := parseAuthority(addr)
+				if err != nil {
+					return nil, err
+				}
+				return r.dial(ctx, host, port)
+			},
+			MaxConnsPerHost:        MaxUpstreamConns,
+			MaxIdleConns:           MaxUpstreamConns,
+			IdleConnTimeout:        90 * time.Second,
+			TLSHandshakeTimeout:    15 * time.Second,
+			ExpectContinueTimeout:  5 * time.Second,
+			ResponseHeaderTimeout:  60 * time.Second,
+			MaxResponseHeaderBytes: MaxHeaderBytes,
+		}
+	})
+	return r.transport
+}
+
+func stripHopByHop(h http.Header) {
+	// Headers named by Connection are hop-by-hop for this message,
+	// which is the mechanism a smuggling attempt uses to hide one.
+	for _, name := range h.Values("Connection") {
+		for _, part := range strings.Split(name, ",") {
+			if named := strings.TrimSpace(part); named != "" {
+				h.Del(named)
+			}
+		}
+	}
+	for _, name := range hopByHop {
+		h.Del(name)
+	}
+}
+
+// parseAuthority accepts exactly host:port with a numeric port in
+// range, and refuses anything else — empty hosts, missing ports,
+// userinfo, paths, control characters or a second colon outside
+// brackets. Strictness here is the point: this string decides what the
+// gateway connects to.
+func parseAuthority(authority string) (host string, port int, err error) {
+	if authority == "" {
+		return "", 0, errors.New("no destination")
+	}
+	if len(authority) > 300 {
+		return "", 0, errors.New("destination is implausibly long")
+	}
+	if strings.ContainsAny(authority, " \t\r\n\x00/@?#") {
+		return "", 0, errors.New("destination contains invalid characters")
+	}
+	h, p, err := net.SplitHostPort(authority)
+	if err != nil {
+		return "", 0, errors.New("destination must be host:port")
+	}
+	if h == "" {
+		return "", 0, errors.New("destination has no host")
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil || n < 1 || n > 65535 {
+		return "", 0, errors.New("destination has no valid port")
+	}
+	// An IPv6 literal would have survived SplitHostPort; the sandbox
+	// denies IPv6 outright, so refuse it here with a reason instead of
+	// failing later at dial.
+	if addr, perr := netip.ParseAddr(h); perr == nil && !addr.Unmap().Is4() {
+		return "", 0, errors.New("IPv6 destinations are not supported")
+	}
+	return h, n, nil
+}
+
+func defaultPort(hostport, scheme string) string {
+	if _, _, err := net.SplitHostPort(hostport); err == nil {
+		return hostport
+	}
+	if scheme == "https" {
+		return net.JoinHostPort(hostport, "443")
+	}
+	return net.JoinHostPort(hostport, "80")
+}
+
+// ErrDenied is the policy refusing a destination.
+var ErrDenied = errors.New("destination denied by the capsule egress policy")
+
+// dial resolves the target and connects to the first address the policy
+// allows. Resolving here, in the gateway, is what makes the check
+// meaningful: the capsule hands over a name, never an address, and the
+// connection goes to an address validated after resolution.
+func (r *Relay) dial(ctx context.Context, host string, port int) (net.Conn, error) {
+	// The port set is checked here, not in the callers, because both
+	// CONNECT and absolute-URI requests reach the network through this one
+	// function. Guarding only the tunnel would leave `GET http://host:9200/`
+	// as an unpoliced path to the same destination and port.
+	if _, ok := AllowedConnectPorts[port]; !ok {
+		r.Log.Warn("egress refused: port outside the allowed set", "host", host, "port", port)
+		return nil, fmt.Errorf("%w: port %d is not allowed", ErrDenied, port)
+	}
+	policy, err := r.Policy.Current()
+	if err != nil {
+		// A policy that cannot be read is a policy that is not in
+		// force: refuse rather than fall back to anything.
+		return nil, fmt.Errorf("%w: policy unavailable: %v", ErrDenied, err)
+	}
+	resolveCtx, cancel := context.WithTimeout(ctx, DNSTimeout)
+	defer cancel()
+	addrs, err := net.DefaultResolver.LookupNetIP(resolveCtx, "ip4", host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", host, err)
+	}
+	if len(addrs) > MaxResolvedAddresses {
+		addrs = addrs[:MaxResolvedAddresses]
+	}
+	var lastErr error
+	for _, addr := range addrs {
+		addr = addr.Unmap()
+		if !policy.Allowed(addr) {
+			r.Log.Warn("egress denied", "host", host, "address", addr.String(), "port", port)
+			lastErr = fmt.Errorf("%w: %s resolves to %s", ErrDenied, host, addr)
+			continue
+		}
+		dialer := net.Dialer{Timeout: DialTimeout}
+		conn, err := dialer.DialContext(ctx, "tcp4", net.JoinHostPort(addr.String(), strconv.Itoa(port)))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no address for %s", host)
+	}
+	return nil, lastErr
+}
+
+// refuse answers a denied or failed destination. A denial is 403 and
+// says so: a job that hits the policy should find the reason in its own
+// log, not a timeout.
+func (r *Relay) refuse(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrDenied) {
+		http.Error(w, "runpool egress relay: "+err.Error(), http.StatusForbidden)
+		return
+	}
+	http.Error(w, "runpool egress relay: "+err.Error(), http.StatusBadGateway)
+}
+
+// limitListener caps concurrent connections. net.Listener has no such
+// bound, and the standard library's Server accepts until the process
+// runs out of descriptors.
+type limitListener struct {
+	net.Listener
+	sem chan struct{}
+}
+
+// Accept loops rather than recursing on a refusal. Go does not eliminate
+// the tail call, so `return l.Accept()` grew one stack frame per refused
+// connection and only unwound when one was finally admitted — unbounded
+// growth driven by workload input, inside a 128 MiB gateway.
+func (l *limitListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := l.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+		select {
+		case l.sem <- struct{}{}:
+			return &limitConn{Conn: conn, release: func() { <-l.sem }}, nil
+		default:
+			// Over quota: close immediately. The client sees a closed
+			// connection, which is the honest answer — the gateway is at
+			// its bound, and holding the connection open would consume the
+			// very resource the bound protects.
+			conn.Close()
+		}
+	}
+}
+
+type limitConn struct {
+	net.Conn
+	once    sync.Once
+	release func()
+}
+
+func (c *limitConn) Close() error {
+	c.once.Do(c.release)
+	return c.Conn.Close()
+}

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -1,0 +1,295 @@
+package gateway
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestParseAuthority is the strictest surface in the gateway: this
+// string decides what the process connects to on a workload's behalf.
+// Everything that is not exactly host:port must be refused, because a
+// looser parser is how a proxy is talked into reaching an address its
+// policy never evaluated.
+func TestParseAuthority(t *testing.T) {
+	valid := map[string]struct {
+		host string
+		port int
+	}{
+		"example.com:443":     {"example.com", 443},
+		"1.1.1.1:80":          {"1.1.1.1", 80},
+		"sub.domain.test:993": {"sub.domain.test", 993},
+	}
+	for in, want := range valid {
+		host, port, err := parseAuthority(in)
+		if err != nil || host != want.host || port != want.port {
+			t.Errorf("parseAuthority(%q) = %q, %d, %v; want %q, %d", in, host, port, err, want.host, want.port)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"example.com",             // no port
+		"example.com:",            // empty port
+		":443",                    // no host
+		"example.com:0",           // port out of range
+		"example.com:65536",       // port out of range
+		"example.com:https",       // non-numeric port
+		"example.com:443/path",    // a path is not part of an authority
+		"user@example.com:443",    // userinfo
+		"example.com:443?q=1",     // query
+		"example.com:443#f",       // fragment
+		"exa mple.com:443",        // space
+		"example.com:443\r\nX: y", // header injection
+		"example.com:443\x00",     // NUL
+		"[2606:4700::1111]:443",   // IPv6 has no path out of the sandbox
+		strings.Repeat("a", 400) + ":443",
+	}
+	for _, in := range invalid {
+		if host, port, err := parseAuthority(in); err == nil {
+			t.Errorf("parseAuthority(%q) accepted %q:%d; want an error", in, host, port)
+		}
+	}
+}
+
+// FuzzParseAuthority: whatever it accepts must be a host and a port in
+// range, and must round-trip through net.JoinHostPort unchanged. A
+// parser that accepts something it cannot reconstruct is a parser two
+// components will disagree about.
+func FuzzParseAuthority(f *testing.F) {
+	for _, seed := range []string{
+		"example.com:443", "1.1.1.1:80", "", ":", "a:b", "[::1]:53",
+		"host:443/x", "h:99999", "h:443\r\n",
+	} {
+		f.Add(seed)
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		host, port, err := parseAuthority(in)
+		if err != nil {
+			return
+		}
+		if host == "" {
+			t.Fatalf("accepted %q with an empty host", in)
+		}
+		if port < 1 || port > 65535 {
+			t.Fatalf("accepted %q with port %d", in, port)
+		}
+		if strings.ContainsAny(host, " \t\r\n\x00/@?#") {
+			t.Fatalf("accepted %q with a hostile host %q", in, host)
+		}
+	})
+}
+
+// TestStripHopByHop: hop-by-hop headers describe one connection, and a
+// proxy that forwards them invites request smuggling. Headers *named*
+// by Connection are hop-by-hop for that message, which is exactly the
+// mechanism used to hide one.
+func TestStripHopByHop(t *testing.T) {
+	h := http.Header{}
+	h.Set("Connection", "X-Custom-Hop, Upgrade")
+	h.Set("X-Custom-Hop", "smuggled")
+	h.Set("Transfer-Encoding", "chunked")
+	h.Set("Proxy-Authorization", "secret")
+	h.Set("Keep-Alive", "timeout=5")
+	h.Set("Upgrade", "websocket")
+	h.Set("X-Kept", "yes")
+
+	stripHopByHop(h)
+
+	for _, gone := range []string{
+		"Connection", "X-Custom-Hop", "Transfer-Encoding",
+		"Proxy-Authorization", "Keep-Alive", "Upgrade",
+	} {
+		if h.Get(gone) != "" {
+			t.Errorf("%s survived the hop-by-hop strip", gone)
+		}
+	}
+	if h.Get("X-Kept") != "yes" {
+		t.Error("an end-to-end header was stripped")
+	}
+}
+
+// TestConnectPortPolicy pins the relay's honest contract: CONNECT is a
+// TCP tunnel, so the port set is what keeps it from being arbitrary TCP
+// egress. A port outside the set is refused before any dial, with a
+// reason a job can read.
+func TestConnectPortPolicy(t *testing.T) {
+	r := &Relay{Log: discardLogger()}
+
+	for _, port := range []string{"22", "25", "3306", "6379", "9999"} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodConnect, "http://example.com", nil)
+		req.Host = "example.com:" + port
+		r.connect(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("CONNECT to port %s = %d; want 403", port, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "not allowed") {
+			t.Errorf("CONNECT to port %s did not say why: %q", port, rec.Body.String())
+		}
+	}
+	for _, port := range []int{80, 443} {
+		if _, ok := AllowedConnectPorts[port]; !ok {
+			t.Errorf("port %d must be in the allowed set; CI cannot work without it", port)
+		}
+	}
+}
+
+// TestMalformedRequests: a request that is not a proxy request gets a
+// 400, not a panic and not a connection attempt.
+func TestMalformedRequests(t *testing.T) {
+	r := &Relay{Log: discardLogger()}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/relative/path", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("relative-path request = %d; want 400", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	bad := httptest.NewRequest(http.MethodConnect, "http://example.com", nil)
+	bad.Host = "not an authority"
+	r.connect(rec, bad)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed CONNECT authority = %d; want 400", rec.Code)
+	}
+}
+
+// TestDeniedWithoutPolicy: a relay whose policy cannot be read refuses
+// every destination. A gateway with no policy must deny, not allow.
+func TestDeniedWithoutPolicy(t *testing.T) {
+	r := &Relay{Policy: &PolicyStore{Path: t.TempDir() + "/absent.json"}, Log: discardLogger()}
+	if _, err := r.dial(t.Context(), "example.com", 443); err == nil {
+		t.Fatal("dial succeeded with no policy in force")
+	}
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestForwardAppliesThePortPolicy: the plain-HTTP path reaches the network
+// through the same dialer as CONNECT, so the port set has to bind there too.
+// Guarding only the tunnel left `GET http://host:9200/` as an unpoliced route
+// to the very destination and port CONNECT refuses.
+func TestForwardAppliesThePortPolicy(t *testing.T) {
+	r := &Relay{Log: discardLogger()}
+
+	for _, target := range []string{
+		"http://example.com:9200/_cluster/state",
+		"http://example.com:6379/",
+		"http://example.com:2375/containers/json",
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, target, nil))
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("plain HTTP to %s = %d; want 403", target, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "not allowed") {
+			t.Errorf("%s refusal did not say why: %q", target, rec.Body.String())
+		}
+	}
+}
+
+// hijackedClient is a ResponseWriter that hands back a connection plus a
+// reader which already holds bytes — the state net/http leaves behind
+// when a client pipelines its first payload into the same segment as the
+// CONNECT header block. The stdlib documents it plainly: "the returned
+// bufio.Reader may contain unprocessed buffered data from the client".
+type hijackedClient struct {
+	conn     net.Conn
+	buffered *bufio.ReadWriter
+}
+
+func (h *hijackedClient) Header() http.Header         { return http.Header{} }
+func (h *hijackedClient) Write(b []byte) (int, error) { return len(b), nil }
+func (h *hijackedClient) WriteHeader(int)             {}
+func (h *hijackedClient) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return h.conn, h.buffered, nil
+}
+
+// TestTunnelCarriesTheBytesTheServerAlreadyRead. A client may send its
+// first payload without waiting for the 200 — pipelining after CONNECT
+// is legal, and the dial that precedes the hijack gives it up to a
+// minute of opportunity. Those bytes are out of the socket and inside
+// the server's own reader by then, so a tunnel that copies from the raw
+// connection loses them: upstream never sees the ClientHello, the client
+// waits for a ServerHello, and neither side errors. It hangs until the
+// idle timeout, holding one of the relay's connection slots.
+func TestTunnelCarriesTheBytesTheServerAlreadyRead(t *testing.T) {
+	pipelined := []byte("\x16\x03\x01\x00\x2fClientHello-pipelined")
+	afterwards := []byte("...and what the client sends next")
+
+	// The upstream records the stream in the order it arrives.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	got := make(chan []byte, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, len(pipelined)+len(afterwards))
+		n, _ := io.ReadFull(conn, buf)
+		got <- buf[:n]
+	}()
+	upstream, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstream.Close()
+
+	// The client's end, with the pipelined bytes already buffered ahead
+	// of the live connection — exactly how net/http hands them over.
+	clientSide, serverSide := net.Pipe()
+	defer clientSide.Close()
+	reader := bufio.NewReader(io.MultiReader(bytes.NewReader(pipelined), serverSide))
+	if _, err := reader.Peek(1); err != nil {
+		t.Fatal(err)
+	}
+	if reader.Buffered() != len(pipelined) {
+		t.Fatalf("fixture buffered %d bytes; want the whole pipelined payload, %d",
+			reader.Buffered(), len(pipelined))
+	}
+	w := &hijackedClient{
+		conn:     serverSide,
+		buffered: bufio.NewReadWriter(reader, bufio.NewWriter(serverSide)),
+	}
+
+	r := &Relay{Log: discardLogger()}
+	done := make(chan struct{})
+	go func() { defer close(done); r.establishTunnel(w, upstream) }()
+
+	// Drain the 200 the relay writes, then send the rest.
+	if _, err := bufio.NewReader(clientSide).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := clientSide.Write(afterwards); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case stream := <-got:
+		want := append(append([]byte{}, pipelined...), afterwards...)
+		if !bytes.Equal(stream, want) {
+			t.Errorf("upstream received %q;\nwant the pipelined payload first, then the rest: %q",
+				stream, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("upstream never received the full stream; the pipelined bytes were dropped")
+	}
+	clientSide.Close()
+	<-done
+}


### PR DESCRIPTION
## What changes

`cmd/capsule-supervisor` and `internal/gateway` arrive: the process that
is PID 1 inside a job capsule, and the relay that is the capsule's only
path off its bridge. The supervisor's control protocol — the tmpfs
directory, the state vocabulary and the protocol version — is established
here.

## What was found

**The runner must not exist before the controller says so.** If the
capsule started its runner at boot, the runner would register with the
provider and could be assigned work before the controller had delivered
the JIT bundle or decided the capsule was healthy. The supervisor
therefore blocks on a start file and launches nothing until it appears.

**"Before it started" and "after it started" are different outcomes.**
A capsule that dies before handing over to the runner never consumed the
job: retrying it is correct. A capsule that dies after the runner began
consumed it: retrying would run the job twice. The state vocabulary keeps
`aborted` and `failed` apart for that reason, and the abort exit code is
a value both sides declare rather than a convention.

**The control surface has no listener on purpose.** Everything inside the
capsule is hostile-adjacent by design — it is a privileged Docker daemon
running a workflow's code. A socket would be reachable from inside dind;
a tmpfs directory owned outside the runner's uid is not, and `docker exec`
reaches it from the host side without opening anything.

**Readiness is proven, not assumed.** The supervisor waits for the daemon
to answer rather than sleeping and hoping, because a runner that starts
against a half-open daemon fails in the middle of a job instead of at
boot.

**The gateway validates and then connects to the same address.** Checking
a name and then connecting by name would let a resolver answer twice with
different addresses. Resolving first and connecting to the resolved
address closes that, so DNS rebinding changes nothing.

**Default-deny is applied before ready is reported.** A gateway that
announces readiness while still installing its ruleset has a window in
which the capsule's traffic is unfiltered, and that window is exactly
when the capsule starts.

## Evidence

Hermetic only in CI. The supervisor's protocol and the gateway's policy,
DNS and proxy paths are covered by unit tests; the behaviours that need a
real kernel and a real daemon belong to the capsule contract, which
arrives with the launcher that drives it.

```text
hermetic only — the protocol is exercised through files in a temporary
directory; no daemon, kernel or network is involved
```

## What would notice this regressing

The supervisor's suite fails if the runner can start without
authorization, if `aborted` and `failed` collapse into one state, or if
the protocol version stops being written at boot. The gateway's suite
fails if a denied destination is reached, if resolution and connection
stop agreeing on an address, or if the ruleset is not in place before
ready is reported.

The value both sides must agree on — the protocol version and the abort
exit code — is checked by a verification script that arrives with the
launcher, because it can only compare two declarations once both exist.

## Risk, compatibility and operations

Trust boundary: this is the inside of the capsule, which runs a
workflow's code with a privileged Docker daemon. Runpool is a resource
and hygiene boundary for CI you trust, not a sandbox for hostile code,
and nothing here changes that. What it does provide is that the capsule's
only route out is the gateway, and the gateway enforces the controller's
policy.

Credentials: the JIT bundle is written `0600`, owned by the runner uid,
on tmpfs, and consumed at start. It is never written to disk that
outlives the capsule.

Ownership and cleanup: the supervisor reaps orphans and propagates
signals, so a capsule that is stopped stops its whole process tree rather
than leaving a daemon behind.

Networking: the gateway holds two legs — the capsule's internal bridge
and an uplink — and relays between them under the policy it is given. It
never forwards at layer 3.

Failure behaviour: fails closed. An invalid policy, an unready daemon or
a missing authorization all keep the runner from existing.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports these yet, and the capsule image that
would ship the supervisor lands with the launcher.

Constrains what the code may do later, so it arrives with its record:
[the runner joins dind rather than attaching itself](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-11-shared-network-namespace.md).

## Changelog

```text
NONE
```
