### PR TITLE
feat(capsule): one privileged container per job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Dockerfiles copy the Go module and source trees by allowlist. Exclude
+# repository metadata, documentation, tests, local state, and build output so
+# they cannot enter a builder layer accidentally.
+.git
+.github
+deploy
+docs
+scripts
+test
+
+*.md
+NOTICE
+
+/runpool
+/capsule-supervisor
+/dist
+*.test
+coverage.out
+release-qualification.json
+platform-facts.json
+*-contract.log
+
+# Editor and operating-system metadata.
+.DS_Store
+._*
+.idea
+.vscode

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,23 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+
+  - package-ecosystem: docker
+    directory: /build/capsule
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      capsule-images:
+        patterns: ["*"]
+    ignore:
+      # The builder must compile with the Go that go.mod declares and that
+      # every test ran on. Patch releases keep that true and are welcome;
+      # a minor or major bump does not, and it is also where Go publishes
+      # release candidates, so an unattended update once proposed building
+      # the shipped binary with a compiler no test had used. Those bumps
+      # belong in the same reviewed commit as go.mod.
+      - dependency-name: golang
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,28 @@ jobs:
         # scripts run against real hosts, where a quoting bug deletes
         # the wrong thing.
         run: shellcheck scripts/*/*.sh
+      - name: Lint the Dockerfiles
+        uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
+        with:
+          recursive: true
+          dockerfile: build/*/Dockerfile
+          # DL3008 (pin apt versions) is answered by the digest-pinned
+          # base image plus the image lock; pinning apt versions on top
+          # of that pins us to a distribution's mirror lifetime.
+          ignore: DL3008
       - name: Verify documentation links resolve
         # Offline by design: in-repo links only, which is what a
         # documentation reorganization breaks silently.
         run: scripts/verify/doc-links.sh
+      - name: Verify the builder images match go.mod
+        # An image tag and a module directive belong to different
+        # updaters, so nothing but this keeps them in step.
+        run: scripts/verify/go-version.sh
+      - name: Verify the capsule control surface agrees on both sides
+        # The supervisor cannot import the controller and the controller
+        # cannot import the supervisor, so every shared value is declared
+        # twice. This is the comment on each declaration made executable.
+        run: scripts/verify/capsule-protocol.sh
 
   vulnerabilities:
     name: govulncheck

--- a/build/capsule/Dockerfile
+++ b/build/capsule/Dockerfile
@@ -1,0 +1,63 @@
+# The outer capsule image: one container holding the runner, dockerd and
+# every inner container a job launches, so one cgroup carries the whole
+# job. The base is the pinned actions runner — the runner's externals
+# tree and .NET dependencies are the fragile half — and the engine
+# arrives as static binaries copied from the pinned dind image, the same
+# bytes the two-container capsule ran.
+#
+# Both sources are digest-pinned to the entries in build/images.lock.json;
+# a moving tag here would put unreviewed bytes inside a privileged
+# container.
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+# Copied by allowlist: the supervisor is built from the module
+# definition and the source trees, nothing else.
+COPY cmd/ cmd/
+COPY internal/ internal/
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
+      -o /out/capsule-supervisor ./cmd/capsule-supervisor
+
+FROM docker:29.7.2-dind@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07 AS engine
+
+FROM ghcr.io/actions/actions-runner:2.336.0@sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda
+
+# Root both to install the engine below and to keep it at runtime: the
+# supervisor is PID 1 and needs root to boot the inner dockerd. It drops
+# the runner to uid 1001 itself, which the image's last USER cannot say.
+#
+# Numeric, because a name has to resolve against the image's passwd and
+# uid 0 never does.
+# hadolint ignore=DL3002
+USER 0
+
+# The engine, containerd and their runtime dependencies, verbatim from
+# the pinned dind image. iptables comes from the base distribution: the
+# static bundle's xtables links against Alpine paths.
+COPY --from=engine /usr/local/bin/dockerd /usr/local/bin/docker \
+     /usr/local/bin/containerd /usr/local/bin/containerd-shim-runc-v2 \
+     /usr/local/bin/runc /usr/local/bin/ctr \
+     /usr/local/bin/docker-init /usr/local/bin/docker-proxy \
+     /usr/local/bin/
+# iptables serves both the inner dockerd and this image's gateway mode;
+# iproute2 serves the route initializer and the host discovery probe.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends iptables uidmap iproute2 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/capsule-supervisor /usr/local/bin/capsule-supervisor
+
+# dockerd's data root must be a volume: overlayfs cannot stack on the
+# container's own overlayfs. The controller mounts a fresh volume per
+# job, which is also what guarantees no image, layer, build cache or
+# runner bootstrap state survives to the next job.
+VOLUME /var/lib/docker
+
+# The control surface, delivered JIT bundle, and runner configuration files
+# live on tmpfs declared by the controller (--tmpfs /run/runpool).
+
+# The supervisor is PID 1: it boots dockerd, proves readiness, waits for
+# the start authorization, runs the runner as uid 1001, propagates
+# signals and reaps everything.
+ENTRYPOINT ["/usr/local/bin/capsule-supervisor"]

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -1,0 +1,546 @@
+// Package capsule orchestrates one per-job execution capsule: a single
+// outer container that holds the runner, its own Docker daemon and
+// every inner container the job launches, under one aggregate cgroup.
+// One container means one budget the kernel enforces over the whole job
+// — runner, daemon and inner workloads cannot escape into separate
+// envelopes — and one object whose state answers what became of the
+// work.
+//
+// Inside, the first-party supervisor (cmd/capsule-supervisor) is PID 1:
+// it boots dockerd, proves readiness, holds the runner unstarted until
+// the controller authorizes it, and reports through a versioned
+// filesystem protocol on tmpfs. The daemon's data root is a fresh volume per
+// capsule, and the complete capsule is deleted after the job, so no image,
+// layer, build cache, or runner bootstrap state reaches a later workload.
+package capsule
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+const (
+	// SupervisorPath is where the capsule image installs the supervisor;
+	// its subcommands are the control protocol's exec surface, used
+	// from here and by the controller's own gateway reloads.
+	SupervisorPath = "/usr/local/bin/capsule-supervisor"
+	supervisorPath = SupervisorPath
+	// controlDir is the tmpfs control surface, declared at creation so
+	// nothing under it can reach a disk or a Docker-persisted field.
+	controlDir = "/run/runpool"
+	// protocolFile is where the supervisor writes the version of the
+	// control protocol it speaks, at boot, before it is asked anything.
+	protocolFile = controlDir + "/protocol"
+	// ProtocolVersion is the control protocol this build speaks. Part of
+	// the control-surface contract; must match the supervisor's own
+	// protocolVersion, which is where a capsule declares it.
+	ProtocolVersion = "1"
+	// dindDataDir is the inner daemon's data root — the one mount that
+	// must be a volume, because overlayfs cannot stack on the
+	// container's own overlayfs.
+	dindDataDir = "/var/lib/docker"
+
+	readyTimeout      = 90 * time.Second
+	readyPollInterval = 500 * time.Millisecond
+)
+
+// Resource kinds and roles stamped on every capsule object, mirrored
+// into the resource intents so reconciliation can find and order them.
+const (
+	KindContainer = "container"
+	KindNetwork   = "network"
+	KindVolume    = "volume"
+
+	RoleNetwork  = "capsule-net"
+	RoleDindData = "dind-data"
+	// RoleCapsule is the outer container itself — the adoptable object
+	// whose exit is the job's exit.
+	RoleCapsule = "capsule"
+	// RoleGateway is the capsule's egress gateway: the only container on
+	// both the internal isolated bridge and the Runpool uplink.
+	RoleGateway = "gateway"
+	// RoleUplink is the instance's one egress network: gateways' second
+	// leg. Like a cache lane it carries no lease, and sweeps must read
+	// that as "infrastructure", never as "orphan".
+	RoleUplink = "uplink"
+)
+
+const (
+	// GatewayProxyPort is where a sandboxed capsule's egress relay
+	// listens; it is the capsule's whole outbound surface. The port is
+	// named in the egress policy vocabulary both sides share, so this
+	// package does not import the gateway to learn one integer.
+	GatewayProxyPort = egress.ProxyPort
+	// innerDockerCIDR is the default bridge the capsule's own daemon
+	// creates. Traffic to it never leaves the capsule, so it must not
+	// be sent to the relay.
+	innerDockerCIDR = "172.17.0.0/16"
+)
+
+type Spec struct {
+	LeaseID    string
+	InstanceID string
+	// AttemptID, TargetID and TierID are provider-neutral correlation
+	// labels. They make ephemeral resources intelligible in a shared
+	// daemon's container view without exposing credentials or source URLs.
+	AttemptID string
+	TargetID  string
+	TierID    string
+	// CapsuleImage is the first-party outer image: supervisor, runner
+	// and engine in one filesystem.
+	CapsuleImage string
+	JITConfig    string
+	// Resources is the tier envelope, applied once to the outer
+	// container: the aggregate cgroup is the whole point of it.
+	Resources config.Resources
+	// Cache, when set, is the repository cache lane mounted at /cache in
+	// the capsule — its only persistent state. The supervisor makes it
+	// writable by the runner uid at boot.
+	Cache CacheMount
+	// Sandbox, when set, encapsulates the capsule's network: internal
+	// isolated bridge, per-capsule egress gateway on the instance
+	// uplink, default-deny policy, gateway DNS. Nil is the
+	// unsafe-open-egress profile: a plain bridge with host egress.
+	Sandbox *Sandbox
+	// CgroupDriver is the daemon's driver ("systemd" or "cgroupfs"). It
+	// decides the form of the lease's parent cgroup, which the daemon
+	// validates — a slice unit for systemd, a path for cgroupfs.
+	CgroupDriver string
+}
+
+// Sandbox is the controller-computed sandbox input: where the uplink
+// is, and the policy the gateway must install before the capsule may
+// run. Deny is a complete snapshot — baseline ranges, host addresses,
+// Docker subnets, the uplink itself; incomplete discovery must fail
+// admission upstream, never launch with a partial deny set.
+type Sandbox struct {
+	UplinkNetworkID string
+	UplinkSubnet    string
+	Allow           []string
+	Deny            []string
+}
+
+// CacheMount names a cache lane: one named volume, mounted whole. No
+// path and no subpath exists to resolve, which is what makes the mount
+// identical however the controller is deployed.
+type CacheMount struct {
+	Volume string
+}
+
+func (c CacheMount) empty() bool { return c.Volume == "" }
+
+// CachePath is where a repository cache lane is mounted in the capsule;
+// workflows point CARGO_HOME, and so on, beneath it.
+const CachePath = "/cache"
+
+// ResourceRecorder makes every external object durable around its
+// creation, not after it. Plan commits the intent — kind, role and the
+// deterministic name — before any effect; Creating marks the ambiguous
+// window just before the create call; Confirm records the object's id
+// once it exists. A crash anywhere leaves an intent whose name finds
+// the object or proves its absence, which is why no compensation logic
+// lives here anymore: the record cannot be lost, only unconfirmed.
+type ResourceRecorder interface {
+	Plan(kind, role, name string) (int64, error)
+	Creating(intentID int64) error
+	Confirm(intentID int64, dockerID string) error
+}
+
+// create wraps one object creation in its intent lifecycle. When the
+// create call reports a name conflict, resolve settles it: the object
+// is ours from an earlier incarnation of this same intent — adopted by
+// proven ownership, never by name — or it is foreign and the launch
+// fails closed.
+func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind, role, name string,
+	createFn func() (string, error), resolve func() (string, error)) (string, error) {
+	intentID, err := rec.Plan(kind, role, name)
+	if err != nil {
+		return "", err
+	}
+	if err := rec.Creating(intentID); err != nil {
+		return "", err
+	}
+	dockerID, err := createFn()
+	if err != nil {
+		existing, rerr := resolve()
+		if rerr != nil || existing == "" {
+			if rerr == nil {
+				rerr = err
+			}
+			return "", fmt.Errorf("create %s %s: %w", kind, role, rerr)
+		}
+		dockerID = existing
+	}
+	if err := rec.Confirm(intentID, dockerID); err != nil {
+		// The object exists and the intent still names it in its
+		// creating state: recovery resolves it by name. Nothing is
+		// removed here, because losing the object is worse than
+		// re-finding it.
+		return "", fmt.Errorf("confirming %s %s: %w", kind, role, err)
+	}
+	return dockerID, nil
+}
+
+// Launcher builds capsules. It holds no per-capsule state: everything a
+// launch needs arrives in its Spec, and everything it creates is
+// recorded through the caller's ResourceRecorder.
+type Launcher struct {
+	dock *docker.Client
+	// gatewayImage is what every egress gateway runs, whatever a tier
+	// configured for its jobs. It belongs to the launcher rather than to
+	// a Spec because it is not a per-launch decision: the gateway is the
+	// container that applies the policy confining a job, and a deployment
+	// extending the image its jobs run in is not asking to replace that.
+	// A Spec field would be one more thing a caller can leave empty, and
+	// the caller who does is launching an unconfined job.
+	gatewayImage string
+}
+
+func NewLauncher(d *docker.Client, gatewayImage string) *Launcher {
+	return &Launcher{dock: d, gatewayImage: gatewayImage}
+}
+
+// PreparedRuntime is a capsule that exists but has not been asked to
+// run: the outer container is up, its daemon is ready, the credential
+// is delivered, and the supervisor holds the runner unstarted. It is
+// the value that separates preparation from execution.
+type PreparedRuntime struct {
+	// RuntimeID is the outer container: the one object whose state —
+	// and whose supervisor's state file — answers whether execution
+	// ever began.
+	RuntimeID string
+}
+
+// Prepare builds the capsule and stops short of the one effect that can
+// begin execution. The outer container runs from here — its daemon must
+// boot and prove readiness — but the supervisor refuses to launch the
+// runner until Start, so nothing the job could observe has happened. A
+// failure anywhere in here is retriable by construction.
+func (m *Launcher) Prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (PreparedRuntime, error) {
+	outerID, err := m.prepare(ctx, spec, rec)
+	if err != nil {
+		return PreparedRuntime{}, err
+	}
+	return PreparedRuntime{RuntimeID: outerID}, nil
+}
+
+// Start authorizes the runner. It is deliberately one exec that drops
+// the start sentinel: the caller persists the authorization first, so
+// the ambiguous window is exactly one request wide, and
+// InspectExecution can classify whatever a crash left behind.
+func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
+	code, out, err := m.dock.Exec(ctx, prepared.RuntimeID, []string{supervisorPath, "start"})
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("start authorization exited %d: %s", code, out)
+	}
+	return nil
+}
+
+func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (string, error) {
+	short := spec.LeaseID
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	name := func(role string) string { return "runpool-" + role + "-" + short }
+	labels := func(kind, role string) map[string]string {
+		return map[string]string{
+			docker.LabelManaged:  "true",
+			docker.LabelInstance: spec.InstanceID,
+			docker.LabelKind:     kind,
+			docker.LabelLease:    spec.LeaseID,
+			docker.LabelRole:     role,
+			docker.LabelAttempt:  spec.AttemptID,
+			docker.LabelTarget:   spec.TargetID,
+			docker.LabelTier:     spec.TierID,
+		}
+	}
+	resolve := func(kind, objName string) func() (string, error) {
+		return func() (string, error) {
+			return m.dock.OwnedIDByName(ctx, kind, objName, spec.InstanceID, spec.LeaseID)
+		}
+	}
+
+	// Sandboxed, the capsule's only network is internal with Engine 28's
+	// isolated gateway mode: the bridge holds no host address, so the
+	// gateway container is the single path out. Unsandboxed (the
+	// explicit unsafe-open-egress profile) it is a plain bridge.
+	sandboxed := spec.Sandbox != nil
+
+	// One envelope for the lease, split between the capsule and — when
+	// there is one — its gateway, and placed under one parent cgroup.
+	cgroupParent := LeaseCgroupParent(spec.CgroupDriver, spec.LeaseID)
+	capsuleShare := SplitEnvelope(spec.Resources, sandboxed)
+	netID, err := m.create(ctx, rec, KindNetwork, RoleNetwork, name(RoleNetwork),
+		func() (string, error) {
+			return m.dock.CreateNetwork(ctx, docker.NetworkSpec{
+				Name:     name(RoleNetwork),
+				Internal: sandboxed,
+				Isolated: sandboxed,
+				Labels:   labels(KindNetwork, RoleNetwork),
+			})
+		}, resolve(KindNetwork, name(RoleNetwork)))
+	if err != nil {
+		return "", err
+	}
+
+	var gatewayIP netip.Addr
+	var internalSubnet string
+	if sandboxed {
+		if gatewayIP, internalSubnet, err = m.prepareGateway(ctx, spec, rec, netID, name, labels, resolve); err != nil {
+			return "", err
+		}
+	}
+
+	dindData, err := m.create(ctx, rec, KindVolume, RoleDindData, name(RoleDindData),
+		func() (string, error) {
+			return m.dock.CreateVolume(ctx, name(RoleDindData), labels(KindVolume, RoleDindData))
+		}, resolve(KindVolume, name(RoleDindData)))
+	if err != nil {
+		return "", err
+	}
+
+	mounts := []docker.Mount{{Volume: dindData, Target: dindDataDir}}
+	if !spec.Cache.empty() {
+		mounts = append(mounts, docker.Mount{Volume: spec.Cache.Volume, Target: CachePath})
+	}
+
+	capsuleSpec := docker.ContainerSpec{
+		Name:       name(RoleCapsule),
+		Image:      spec.CapsuleImage,
+		Labels:     labels(KindContainer, RoleCapsule),
+		Privileged: true,
+		Network:    netID,
+		Mounts:     mounts,
+		// The control surface and delivered JIT bundle live on tmpfs and
+		// die with the container.
+		Tmpfs: map[string]string{controlDir: "rw,size=1m,mode=0755"},
+		// The capsule's share of the tier envelope, applied exactly
+		// once: this cgroup is the aggregate over runner, daemon and
+		// every inner container the job launches. When a gateway
+		// exists it holds the rest of the same envelope, so the two
+		// together are the tier and never more.
+		MemoryBytes:     capsuleShare.MemoryBytes,
+		MemorySwapBytes: capsuleShare.MemorySwapBytes,
+		NanoCPUs:        capsuleShare.NanoCPUs,
+		PIDsLimit:       capsuleShare.PIDsLimit,
+		CgroupParent:    cgroupParent,
+	}
+	if sandboxed {
+		// The capsule resolves and reaches the network only through its
+		// gateway. Both are pinned at creation: the resolver because
+		// the runner must not consult the daemon's default, and the
+		// proxy because it is the only egress that exists — the host
+		// drops anything the capsule addresses beyond its own bridge.
+		// The environment is inherited by the runner, by the job, and
+		// by the inner daemon the supervisor starts, so image pulls
+		// take the same path as everything else.
+		capsuleSpec.DNS = []netip.Addr{gatewayIP}
+		proxy := fmt.Sprintf("http://%s:%d", gatewayIP, GatewayProxyPort)
+		noProxy := strings.Join([]string{"localhost", "127.0.0.1", innerDockerCIDR, internalSubnet}, ",")
+		capsuleSpec.Env = append(capsuleSpec.Env,
+			"HTTP_PROXY="+proxy, "http_proxy="+proxy,
+			"HTTPS_PROXY="+proxy, "https_proxy="+proxy,
+			"NO_PROXY="+noProxy, "no_proxy="+noProxy,
+		)
+	}
+	outerID, err := m.create(ctx, rec, KindContainer, RoleCapsule, name(RoleCapsule),
+		func() (string, error) {
+			return m.dock.CreateContainer(ctx, capsuleSpec)
+		}, resolve(KindContainer, name(RoleCapsule)))
+	if err != nil {
+		return "", err
+	}
+	if err := m.dock.StartContainer(ctx, outerID); err != nil {
+		return "", err
+	}
+	if err := m.awaitReady(ctx, outerID); err != nil {
+		return "", err
+	}
+	if err := m.checkProtocol(ctx, outerID); err != nil {
+		return "", err
+	}
+	// The JIT bundle travels over exec stdin onto the capsule's tmpfs, where
+	// the supervisor holds it 0600 and runner-owned until Start consumes it.
+	// The upstream runner's required --jitconfig argv boundary is inside the
+	// capsule and is documented as accepted exposure in the threat model.
+	code, out, err := m.dock.ExecWithInput(ctx, outerID,
+		[]string{supervisorPath, "deliver"}, []byte(spec.JITConfig))
+	if err != nil {
+		return "", fmt.Errorf("deliver credential: %w", err)
+	}
+	if code != 0 {
+		return "", fmt.Errorf("deliver credential: exited %d: %s", code, out)
+	}
+	return outerID, nil
+}
+
+// checkProtocol refuses a capsule that does not speak this build's
+// control protocol, before anything is handed to it.
+//
+// It runs after readiness rather than before it. The supervisor writes the
+// file at boot, ahead of the daemon, so an earlier read would be racing a
+// capsule that has not written it yet and would need a poll of its own.
+// Readiness is the first moment a capsule is known to answer anything,
+// and it is still before the credential.
+//
+// The supervisor writes its version at boot, so this reads a fact the
+// capsule states about itself rather than inferring one from a verb that
+// happened to work. Without it a capsule whose supervisor is older
+// answers some verbs and not others, and the mismatch arrives as a job
+// that failed rather than as an image that cannot be used — which is the
+// difference between one operator reading one error and every job on that
+// tier failing until someone correlates them.
+func (m *Launcher) checkProtocol(ctx context.Context, outerID string) error {
+	code, out, err := m.dock.Exec(ctx, outerID, []string{"cat", protocolFile})
+	if err != nil {
+		return fmt.Errorf("read the capsule control protocol: %w", err)
+	}
+	return protocolVerdict(code, out)
+}
+
+// ErrIncompatibleImage reports a capsule that does not speak this
+// controller's control protocol. It is named so the caller can tell it
+// from every other preparation failure: retrying is what a transient
+// deserves, and this is a configured image that will fail the same way on
+// every attempt until someone changes it.
+var ErrIncompatibleImage = errors.New("the capsule image and this controller are not a pair")
+
+// protocolVerdict is the decision the read produces, separated from the
+// read so what can be wrong about it — the trimming, an exit code that is
+// not zero, the message an operator acts on — is decidable without a
+// daemon. The read itself is exercised by every capsule the live contract
+// suite prepares, since a capsule that could not answer would not launch.
+func protocolVerdict(code int, out string) error {
+	got := strings.TrimSpace(out)
+	switch {
+	case code != 0:
+		return fmt.Errorf("%w: it declares no control protocol at %s: exited %d: %s; "+
+			"an operator's capsule image is built from the one this controller ships",
+			ErrIncompatibleImage, protocolFile, code, got)
+	case got != ProtocolVersion:
+		return fmt.Errorf("%w: it speaks control protocol %q and this controller speaks %q",
+			ErrIncompatibleImage, got, ProtocolVersion)
+	}
+	return nil
+}
+
+// prepareGateway builds the capsule's egress path before the capsule
+// exists: gateway container on the internal bridge, second leg on the
+// uplink, policy installed atomically, forwarder up — proven by the
+// gateway reporting ready. Any failure here fails the launch closed;
+// a capsule is never started with a half-made sandbox.
+func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRecorder, netID string,
+	name func(string) string, labels func(string, string) map[string]string,
+	resolve func(string, string) func() (string, error)) (netip.Addr, string, error) {
+
+	subnet, err := m.dock.NetworkSubnet(ctx, netID)
+	if err != nil {
+		return netip.Addr{}, "", fmt.Errorf("internal subnet: %w", err)
+	}
+	policy := egress.Policy{
+		InternalSubnet: subnet,
+		UplinkSubnet:   spec.Sandbox.UplinkSubnet,
+		Allow:          spec.Sandbox.Allow,
+		Deny:           spec.Sandbox.Deny,
+	}
+	if err := policy.Validate(); err != nil {
+		return netip.Addr{}, "", fmt.Errorf("gateway policy: %w", err)
+	}
+	policyJSON, err := json.Marshal(policy)
+	if err != nil {
+		return netip.Addr{}, "", err
+	}
+
+	gwID, err := m.create(ctx, rec, KindContainer, RoleGateway, name(RoleGateway),
+		func() (string, error) {
+			return m.dock.CreateContainer(ctx, docker.ContainerSpec{
+				Name:       name(RoleGateway),
+				Image:      m.gatewayImage,
+				Entrypoint: []string{supervisorPath, "gateway"},
+				// The policy is configuration, not secret; the one
+				// secret in the system never touches the gateway.
+				Env:     []string{"RUNPOOL_GATEWAY_POLICY=" + string(policyJSON)},
+				Labels:  labels(KindContainer, RoleGateway),
+				Network: netID,
+				// NET_ADMIN for the ruleset, and nothing else: not
+				// privileged, no socket, no volumes, no credentials.
+				CapAdd: []string{"NET_ADMIN"},
+				Tmpfs:  map[string]string{controlDir: "rw,size=1m,mode=0755"},
+				// The gateway's share of the lease's envelope, under
+				// the lease's parent cgroup. Every connection a job
+				// opens is work this container performs, so it lives
+				// inside the budget rather than beside it.
+				MemoryBytes:     GatewayEnvelope().MemoryBytes,
+				MemorySwapBytes: GatewayEnvelope().MemorySwapBytes,
+				NanoCPUs:        GatewayEnvelope().NanoCPUs,
+				PIDsLimit:       GatewayEnvelope().PIDsLimit,
+				CgroupParent:    LeaseCgroupParent(spec.CgroupDriver, spec.LeaseID),
+			})
+		}, resolve(KindContainer, name(RoleGateway)))
+	if err != nil {
+		return netip.Addr{}, "", err
+	}
+	if err := m.dock.ConnectNetwork(ctx, spec.Sandbox.UplinkNetworkID, gwID); err != nil {
+		return netip.Addr{}, "", fmt.Errorf("attach gateway to uplink: %w", err)
+	}
+	if err := m.dock.StartContainer(ctx, gwID); err != nil {
+		return netip.Addr{}, "", err
+	}
+	if err := m.awaitState(ctx, gwID, "ready"); err != nil {
+		return netip.Addr{}, "", fmt.Errorf("gateway: %w", err)
+	}
+	ip, _, err := m.dock.ContainerIPOn(ctx, gwID, netID)
+	if err != nil {
+		return netip.Addr{}, "", err
+	}
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return netip.Addr{}, "", err
+	}
+	return addr, subnet, nil
+}
+
+// awaitReady polls the supervisor's state until the capsule reports
+// waiting: daemon booted, readiness proven, runner deliberately not
+// started.
+func (m *Launcher) awaitReady(ctx context.Context, outerID string) error {
+	return m.awaitState(ctx, outerID, "waiting")
+}
+
+// awaitState polls a supervisor-family container until it reports the
+// wanted state. The supervisor writing `failed:` is a boot failure
+// worth its reason.
+func (m *Launcher) awaitState(ctx context.Context, containerID, want string) error {
+	deadline := time.Now().Add(readyTimeout)
+	for {
+		code, out, err := m.dock.Exec(ctx, containerID, []string{supervisorPath, "state"})
+		if err == nil && code == 0 {
+			switch s := strings.TrimSpace(out); {
+			case s == want:
+				return nil
+			case strings.HasPrefix(s, "failed:"):
+				return fmt.Errorf("boot failed: %s", strings.TrimPrefix(s, "failed:"))
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("container %s did not reach %q within %s", containerID[:12], want, readyTimeout)
+		}
+		select {
+		case <-time.After(readyPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/internal/capsule/envelope.go
+++ b/internal/capsule/envelope.go
@@ -1,0 +1,104 @@
+package capsule
+
+import (
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// The gateway's share of a lease's tier envelope. Configuration validation
+// refuses a tier too small to reserve these resources.
+const (
+	GatewayReserveMemory = config.GatewayReserveMemory
+	GatewayReserveCPUs   = config.GatewayReserveCPUs
+	GatewayReservePIDs   = config.GatewayReservePIDs
+)
+
+// Envelope is a resolved resource budget in the units Docker takes.
+type Envelope struct {
+	MemoryBytes     int64
+	MemorySwapBytes int64
+	NanoCPUs        int64
+	PIDsLimit       int64
+}
+
+// SplitEnvelope divides a tier between the capsule and its gateway. Without a
+// gateway the capsule takes the whole tier. With one, the two shares add up to
+// exactly the configured tier.
+func SplitEnvelope(r config.Resources, withGateway bool) Envelope {
+	e := Envelope{
+		MemoryBytes:     int64(r.Memory),
+		MemorySwapBytes: int64(r.Memory) + int64(r.Swap),
+		NanoCPUs:        int64(r.CPU),
+		PIDsLimit:       r.PIDs,
+	}
+	if !withGateway {
+		return e
+	}
+	e.MemoryBytes -= GatewayReserveMemory
+	// Swap is additional capacity. The gateway's RAM reserve therefore
+	// reduces Docker's total by the same amount and leaves swap with the
+	// workload capsule.
+	e.MemorySwapBytes -= GatewayReserveMemory
+	e.NanoCPUs -= GatewayReserveCPUs
+	e.PIDsLimit -= GatewayReservePIDs
+	return e
+}
+
+// GatewayEnvelope returns the gateway's fixed share of a tier.
+func GatewayEnvelope() Envelope {
+	return Envelope{
+		MemoryBytes:     GatewayReserveMemory,
+		MemorySwapBytes: GatewayReserveMemory,
+		NanoCPUs:        GatewayReserveCPUs,
+		PIDsLimit:       GatewayReservePIDs,
+	}
+}
+
+// LeaseCgroupParent names the parent cgroup shared by a lease's containers.
+// systemd expects a slice unit while cgroupfs expects a path. An unknown driver
+// returns no parent so callers cannot guess a daemon-specific representation.
+func LeaseCgroupParent(driver, leaseID string) string {
+	name := sliceSafe(leaseID)
+	if name == "" {
+		return ""
+	}
+	switch driver {
+	case "systemd":
+		return "runpool-lease-" + name + ".slice"
+	case "cgroupfs":
+		return "/runpool-lease-" + name
+	default:
+		return ""
+	}
+}
+
+// KnownCgroupDriver reports whether a parent cgroup can be written for
+// this daemon's driver.
+//
+// It is exported because the answer has to be reached before a capsule
+// exists. LeaseCgroupParent returns an empty parent for a driver it
+// cannot address, and Docker reads an empty CgroupParent as "no parent" —
+// so the capsule and its gateway would land in separate budgets and the
+// tier would quietly stop being their sum. Nothing later in the launch
+// says anything about it.
+func KnownCgroupDriver(driver string) bool {
+	return driver == "systemd" || driver == "cgroupfs"
+}
+
+// sliceSafe reduces a lease id to the bounded alphanumeric component accepted
+// by systemd unit names. Lease ids are currently hexadecimal, but the cgroup
+// contract does not depend on that implementation detail.
+func sliceSafe(leaseID string) string {
+	var b strings.Builder
+	for _, r := range leaseID {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		}
+		if b.Len() == 16 {
+			break
+		}
+	}
+	return b.String()
+}

--- a/internal/capsule/envelope_test.go
+++ b/internal/capsule/envelope_test.go
@@ -1,0 +1,135 @@
+package capsule
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// TestSplitEnvelopeIsConserving is the property the threat model rests
+// on: a lease cannot spend more than its tier. The gateway is
+// workload-driven work, so it comes out of the same envelope — the sum
+// of the two shares must be exactly the tier, never the tier plus a
+// container nobody budgeted for.
+func TestSplitEnvelopeIsConserving(t *testing.T) {
+	tier := config.Resources{
+		Memory: 4 << 30,
+		Swap:   1 << 30,
+		CPU:    4_000_000_000,
+		PIDs:   1024,
+	}
+	capsuleShare := SplitEnvelope(tier, true)
+	gw := GatewayEnvelope()
+
+	if got := capsuleShare.MemoryBytes + gw.MemoryBytes; got != int64(tier.Memory) {
+		t.Errorf("memory: capsule %d + gateway %d = %d; want the tier's %d",
+			capsuleShare.MemoryBytes, gw.MemoryBytes, got, int64(tier.Memory))
+	}
+	if got := capsuleShare.MemorySwapBytes + gw.MemorySwapBytes; got != int64(tier.Memory+tier.Swap) {
+		t.Errorf("memory+swap total = %d; want %d", got, int64(tier.Memory+tier.Swap))
+	}
+	if got := capsuleShare.NanoCPUs + gw.NanoCPUs; got != int64(tier.CPU) {
+		t.Errorf("cpu: %d + %d = %d; want %d", capsuleShare.NanoCPUs, gw.NanoCPUs, got, int64(tier.CPU))
+	}
+	if got := capsuleShare.PIDsLimit + gw.PIDsLimit; got != tier.PIDs {
+		t.Errorf("pids: %d + %d = %d; want %d", capsuleShare.PIDsLimit, gw.PIDsLimit, got, tier.PIDs)
+	}
+}
+
+// TestSplitEnvelopeWithoutGateway: the unsafe-open profile has no
+// gateway, so the capsule takes the whole tier and nothing is withheld.
+func TestSplitEnvelopeWithoutGateway(t *testing.T) {
+	tier := config.Resources{Memory: 2 << 30, Swap: 512 << 20, CPU: 2e9, PIDs: 512}
+	got := SplitEnvelope(tier, false)
+	if got.MemoryBytes != int64(tier.Memory) || got.MemorySwapBytes != int64(tier.Memory+tier.Swap) ||
+		got.NanoCPUs != int64(tier.CPU) || got.PIDsLimit != tier.PIDs {
+		t.Errorf("without a gateway the capsule share = %+v; want the whole tier", got)
+	}
+}
+
+// TestLeaseCgroupParentMatchesTheDriver: the daemon validates this
+// string and refuses the wrong form, so the driver decides it. A
+// systemd host wants a slice unit; a cgroupfs host wants a path.
+func TestLeaseCgroupParentMatchesTheDriver(t *testing.T) {
+	const lease = "abcdef0123456789"
+
+	systemd := LeaseCgroupParent("systemd", lease)
+	if !strings.HasSuffix(systemd, ".slice") {
+		t.Errorf("systemd parent %q must be a slice unit", systemd)
+	}
+	if strings.HasPrefix(systemd, "/") {
+		t.Errorf("systemd parent %q must not be a path", systemd)
+	}
+
+	// A dash is systemd's hierarchy separator, so an id carrying one
+	// once produced `runpool-lease-x-.slice` — rejected by the daemon,
+	// which failed the whole launch. Ids are sanitized, not trusted.
+	for _, hostile := range []string{"contract-", "-", "a-b-c-", "with.dots", "sp ace", ""} {
+		got := LeaseCgroupParent("systemd", hostile)
+		if got == "" {
+			continue // nothing usable in the id: no parent, the honest answer
+		}
+		name := strings.TrimSuffix(got, ".slice")
+		if strings.HasSuffix(name, "-") {
+			t.Errorf("lease %q produced %q, which systemd rejects for the trailing dash", hostile, got)
+		}
+		if strings.ContainsAny(name, ". /") {
+			t.Errorf("lease %q produced %q, which is not a valid unit name", hostile, got)
+		}
+	}
+
+	// A driver the code does not know means no parent at all: guessing
+	// produces a container the daemon refuses to create.
+	if got := LeaseCgroupParent("", lease); got != "" {
+		t.Errorf("unknown driver produced parent %q; want none", got)
+	}
+
+	cgroupfs := LeaseCgroupParent("cgroupfs", lease)
+	if !strings.HasPrefix(cgroupfs, "/") {
+		t.Errorf("cgroupfs parent %q must be a path", cgroupfs)
+	}
+	if strings.HasSuffix(cgroupfs, ".slice") {
+		t.Errorf("cgroupfs parent %q must not be a slice unit", cgroupfs)
+	}
+
+	// Two leases never share a parent: the aggregate is per lease, and
+	// sharing one would let a lease read — or be charged for — another.
+	if LeaseCgroupParent("systemd", "aaaaaaaaaaaa") == LeaseCgroupParent("systemd", "bbbbbbbbbbbb") {
+		t.Error("two leases produced the same parent cgroup")
+	}
+	// The same lease always names the same parent, which is what puts
+	// its capsule and its gateway in one place — they are created by
+	// separate calls, so a non-deterministic name would silently give
+	// them separate budgets.
+	first := LeaseCgroupParent("systemd", lease)
+	second := LeaseCgroupParent("systemd", lease)
+	if first != second {
+		t.Errorf("the parent cgroup is not deterministic: %q then %q", first, second)
+	}
+}
+
+// TestKnownCgroupDriverGuardsTheEnvelope: the parent cgroup's form is
+// written per driver, and a driver with no form produces no parent at
+// all — which Docker reads as "no parent", putting the capsule and its
+// gateway in separate budgets. The tier stops being their sum, silently,
+// so the answer has to be reachable before a capsule is created.
+func TestKnownCgroupDriverGuardsTheEnvelope(t *testing.T) {
+	for driver, known := range map[string]bool{
+		"systemd":  true,
+		"cgroupfs": true,
+		"":         false,
+		"none":     false,
+		"Systemd":  false, // the daemon reports it lowercase; anything else is not it
+	} {
+		if got := KnownCgroupDriver(driver); got != known {
+			t.Errorf("KnownCgroupDriver(%q) = %v, want %v", driver, got, known)
+		}
+		// The guard and the generator have to agree, or the guard is
+		// approving a driver that still yields no parent.
+		parent := LeaseCgroupParent(driver, "lease-abc123")
+		if known != (parent != "") {
+			t.Errorf("driver %q: known=%v but parent=%q", driver, known, parent)
+		}
+	}
+}

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -1,0 +1,102 @@
+package capsule
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// InspectExecution classifies a prepared runtime whose start outcome is
+// unknown. The result comes from the daemon and supervisor, never from the
+// controller's intended transition.
+func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntime) (assignment.ExecutionObservation, error) {
+	state, err := m.dock.ContainerStatus(ctx, prepared.RuntimeID)
+	switch {
+	case err == nil:
+	case docker.IsNotFound(err):
+		return assignment.ObservedAbsent, nil
+	default:
+		return assignment.ObservedUnavailable, err
+	}
+	obs, askSupervisor, err := classifyContainerState(prepared.RuntimeID, state)
+	if !askSupervisor {
+		return obs, err
+	}
+
+	code, out, err := m.dock.Exec(ctx, prepared.RuntimeID, []string{supervisorPath, "state"})
+	if err != nil || code != 0 {
+		return assignment.ObservedUnavailable, fmt.Errorf("capsule state unreadable (exit %d): %s", code, out)
+	}
+	return classifySupervisorState(strings.TrimSpace(out))
+}
+
+// SupervisorAbortedExitCode is the status the capsule supervisor exits with
+// when it stops before handing the job to the runner. It is part of the
+// control-surface contract and must match `exitAborted` in
+// cmd/capsule-supervisor.
+//
+// It is a distinct code rather than a state-file value because the state
+// file dies with the container: by the time a controller inspects an
+// aborted capsule, the daemon reports `exited` and nothing inside can be
+// read. Without this, every abort read as an ordinary exit — and an
+// attempt that never ran was settled as complete and never requeued.
+const SupervisorAbortedExitCode = 79
+
+// classifySupervisorExit reads a stopped capsule's exit code. Any code but
+// the reserved one means the runner owned the job, which includes a job
+// that failed: that is an execution outcome, not an unstarted runtime.
+func classifySupervisorExit(code int) assignment.ExecutionObservation {
+	if code == SupervisorAbortedExitCode {
+		return assignment.ObservedCreated
+	}
+	return assignment.ObservedExited
+}
+
+// classifySupervisorState reads the supervisor's own account of itself. The
+// distinction that matters is whether the runner ever started: the supervisor
+// writes `running` immediately before executing it, so `aborted` means the job
+// was never handed over and `failed` means it was. Collapsing the two settles
+// an attempt that never ran as complete, and nothing requeues it.
+func classifySupervisorState(state string) (assignment.ExecutionObservation, error) {
+	switch {
+	case state == "waiting":
+		return assignment.ObservedCreated, nil
+	case state == "running":
+		return assignment.ObservedRunning, nil
+	case strings.HasPrefix(state, "aborted:"):
+		return assignment.ObservedCreated, nil
+	case strings.HasPrefix(state, "exited:"), strings.HasPrefix(state, "failed:"):
+		return assignment.ObservedExited, nil
+	default:
+		return assignment.ObservedUnavailable, fmt.Errorf("capsule reports unrecognized state %q", state)
+	}
+}
+
+// classifyContainerState decides what the daemon alone proves, and whether
+// the supervisor still has to be asked. It is separated from the exec so
+// the decision can be tested without a daemon: the defect this replaced
+// was a short-circuit here, invisible to any test of the supervisor
+// vocabulary because the supervisor was never reached.
+//
+// askSupervisor is true only while the container still runs, which is the
+// only time an exec can succeed.
+func classifyContainerState(runtimeID string, state docker.ContainerState) (obs assignment.ExecutionObservation, askSupervisor bool, err error) {
+	switch state.Status {
+	case "created":
+		return assignment.ObservedCreated, false, nil
+	case "exited", "dead":
+		// A stopped capsule cannot be asked anything: exec needs a running
+		// container and the control surface is tmpfs. The exit code is the
+		// only account it left, which is why the supervisor reserves one
+		// for "the runner never started".
+		return classifySupervisorExit(state.ExitCode), false, nil
+	case "running", "paused", "restarting":
+		return assignment.ObservedUnavailable, true, nil
+	default:
+		return assignment.ObservedUnavailable, false,
+			fmt.Errorf("capsule %s status %q does not prove whether execution began", runtimeID, state.Status)
+	}
+}

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -1,0 +1,118 @@
+package capsule
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// TestClassifySupervisorStateSeparatesAbortFromExit is the job-loss guard.
+// `aborted` and `failed` both mean the supervisor stopped early, but only one
+// of them means the runner had the job. Reading an abort as an exit records
+// exit_observed, which disposes the attempt as completed and never requeues
+// it — a job GitHub handed over, that never ran, and that nobody retries.
+func TestClassifySupervisorStateSeparatesAbortFromExit(t *testing.T) {
+	for state, want := range map[string]assignment.ExecutionObservation{
+		"waiting": assignment.ObservedCreated,
+		"running": assignment.ObservedRunning,
+		"aborted:start authorized but no credential": assignment.ObservedCreated,
+		"aborted:prepare volatile runner config":     assignment.ObservedCreated,
+		"exited:0":                                   assignment.ObservedExited,
+		"exited:1":                                   assignment.ObservedExited,
+		"failed:runner killed after drain timeout":   assignment.ObservedExited,
+	} {
+		got, err := classifySupervisorState(state)
+		if err != nil {
+			t.Errorf("state %q: %v", state, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("state %q classified %q; want %q", state, got, want)
+		}
+	}
+}
+
+// An unknown state refuses to guess rather than settling the attempt on an
+// assumption: the whole point of the observation is that it is observed.
+func TestClassifySupervisorStateRefusesToGuess(t *testing.T) {
+	for _, state := range []string{"", "wat", "exited", "aborted", "done:0"} {
+		got, err := classifySupervisorState(state)
+		if err == nil {
+			t.Errorf("state %q classified %q; want an error", state, got)
+		}
+		if got != assignment.ObservedUnavailable {
+			t.Errorf("state %q = %q; want unavailable", state, got)
+		}
+	}
+}
+
+// TestClassifySupervisorExitSeparatesAbortFromExit is the job-loss guard at
+// the only place it can still be applied. A stopped capsule cannot be
+// asked anything — exec needs a running container and the control surface
+// is tmpfs — so the state file that distinguishes an abort is already gone
+// when the controller looks. The reserved exit code is what survives.
+func TestClassifySupervisorExitSeparatesAbortFromExit(t *testing.T) {
+	if got := classifySupervisorExit(SupervisorAbortedExitCode); got != assignment.ObservedCreated {
+		t.Errorf("the reserved abort code classified %q; want an unstarted runtime", got)
+	}
+	// Every other code means the runner owned the job, a failed job
+	// included: that is an execution outcome, not an unstarted runtime.
+	for _, code := range []int{0, 1, 2, 78, 80, 125, 137, 255, -1} {
+		if got := classifySupervisorExit(code); got != assignment.ObservedExited {
+			t.Errorf("exit code %d classified %q; want an execution outcome", code, got)
+		}
+	}
+}
+
+// The exit code is a contract between two binaries that cannot import each
+// other: the supervisor ships inside the capsule image and must stay free
+// of the controller's dependency tree. Both sides pin the literal, so
+// changing one without the other fails here or in cmd/capsule-supervisor.
+func TestSupervisorAbortedExitCodeIsPinned(t *testing.T) {
+	if SupervisorAbortedExitCode != 79 {
+		t.Errorf("SupervisorAbortedExitCode = %d; the supervisor's exitAborted is 79",
+			SupervisorAbortedExitCode)
+	}
+}
+
+// TestClassifyContainerStateNeverAsksAStoppedCapsule is the shape of the
+// defect this replaced: an exited container short-circuited to
+// assignment.ObservedExited before the supervisor was ever consulted, so an abort
+// could not be seen no matter what vocabulary the supervisor used. The
+// daemon's own facts have to carry that distinction, because a stopped
+// container cannot be asked.
+func TestClassifyContainerStateNeverAsksAStoppedCapsule(t *testing.T) {
+	for _, tc := range []struct {
+		status        string
+		exit          int
+		want          assignment.ExecutionObservation
+		askSupervisor bool
+	}{
+		{"created", 0, assignment.ObservedCreated, false},
+		{"running", 0, assignment.ObservedUnavailable, true},
+		{"paused", 0, assignment.ObservedUnavailable, true},
+		{"restarting", 0, assignment.ObservedUnavailable, true},
+		{"exited", 0, assignment.ObservedExited, false},
+		{"exited", 1, assignment.ObservedExited, false},
+		{"exited", SupervisorAbortedExitCode, assignment.ObservedCreated, false},
+		{"dead", SupervisorAbortedExitCode, assignment.ObservedCreated, false},
+	} {
+		got, ask, err := classifyContainerState("c1", docker.ContainerState{Status: tc.status, ExitCode: tc.exit})
+		if err != nil {
+			t.Errorf("status %q exit %d: %v", tc.status, tc.exit, err)
+			continue
+		}
+		if ask != tc.askSupervisor {
+			t.Errorf("status %q: askSupervisor = %v; want %v", tc.status, ask, tc.askSupervisor)
+		}
+		if !tc.askSupervisor && got != tc.want {
+			t.Errorf("status %q exit %d classified %q; want %q", tc.status, tc.exit, got, tc.want)
+		}
+	}
+
+	// An unknown status refuses to guess rather than settling an attempt.
+	if _, ask, err := classifyContainerState("c1", docker.ContainerState{Status: "removing"}); err == nil || ask {
+		t.Error("an unrecognised status must be an error, not a supervisor query")
+	}
+}

--- a/internal/capsule/protocol_test.go
+++ b/internal/capsule/protocol_test.go
@@ -1,0 +1,56 @@
+package capsule
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProtocolVerdict: the capsule states the protocol it speaks, and a
+// capsule that states something else is refused before it is handed a
+// credential. Without this the mismatch arrives as a job that failed
+// instead of an image that cannot be used.
+func TestProtocolVerdict(t *testing.T) {
+	for name, tc := range map[string]struct {
+		code int
+		out  string
+		want string // empty means the capsule is accepted
+	}{
+		"the version this build speaks":   {0, ProtocolVersion, ""},
+		"trailing newline from the file":  {0, ProtocolVersion + "\n", ""},
+		"surrounding whitespace":          {0, "  " + ProtocolVersion + "  \n", ""},
+		"an older supervisor":             {0, "0\n", "not a pair"},
+		"a newer supervisor":              {0, "2\n", "not a pair"},
+		"no protocol file at all":         {1, "cat: /run/runpool/protocol: No such file or directory", "declares no control protocol"},
+		"an empty file":                   {0, "\n", "not a pair"},
+		"a file the read could not parse": {0, "one", "not a pair"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := protocolVerdict(tc.code, tc.out)
+			switch {
+			case tc.want == "" && err != nil:
+				t.Fatalf("accepted capsule refused: %v", err)
+			case tc.want == "":
+				return
+			case err == nil:
+				t.Fatalf("capsule accepted; want a refusal containing %q", tc.want)
+			case !strings.Contains(err.Error(), tc.want):
+				t.Errorf("error = %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestTheLauncherOwnsTheGatewayImage: the container that applies a job's
+// egress policy runs what the launcher was built with, and a Spec cannot
+// name it. That is the point — the field it used to share with the
+// capsule made "extend the image my jobs run in" mean "replace what
+// confines them", and a required field a caller can leave empty is a
+// caller who eventually does. The live contract suite exercises the
+// container this decides.
+func TestTheLauncherOwnsTheGatewayImage(t *testing.T) {
+	const shipped = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"1111111111111111111111111111111111111111111111111111111111111111"
+	if got := NewLauncher(nil, shipped).gatewayImage; got != shipped {
+		t.Errorf("gateway image = %q, want the one the launcher was built with", got)
+	}
+}

--- a/scripts/contracts/capsule.sh
+++ b/scripts/contracts/capsule.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run the outer-capsule contract suite against a real daemon over SSH:
+# build the capsule image from the pinned inputs on the host, ship the
+# cross-compiled suite, and drive the whole supervisor lifecycle with a
+# fake credential — the real runner runs and holds it, and the drain is
+# what ends the serving, which proves the runner ran without needing a
+# provider.
+#
+# Usage: scripts/contracts/capsule.sh <ssh-host>
+#   RUNPOOL_CONTRACT_HOST  default for <ssh-host>
+cd "$(dirname "$0")/../.."
+host=${1:-${RUNPOOL_CONTRACT_HOST:-}}
+if [ -z "$host" ]; then
+  echo "usage: scripts/contracts/capsule.sh <ssh-host>   (a Linux Docker host)" >&2
+  exit 2
+fi
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+echo "== cross-compile linux/amd64 (CGO_ENABLED=0) =="
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$out/capsule-contract.test" ./test/contract/capsule
+
+echo "== ship the tree and build the capsule image on $host =="
+COPYFILE_DISABLE=1 git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$out/src.tgz" --null -T - 2>/dev/null
+remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-capsule-contract.XXXXXX')
+remote_dir_q=$(printf '%q' "$remote_dir")
+trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
+scp -q "$out/src.tgz" "$out/capsule-contract.test" "$host":"$remote_dir/"
+# shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
+ssh "$host" "set -e
+mkdir -p '$remote_dir/src'
+tar -xzf '$remote_dir/src.tgz' -C '$remote_dir/src' 2>/dev/null
+cd '$remote_dir/src'
+docker build -q -f build/capsule/Dockerfile -t runpool-capsule:dev . >/dev/null
+RUNPOOL_CAPSULE_CONTRACT=1 '$remote_dir/capsule-contract.test' -test.v -test.count=1"

--- a/scripts/verify/capsule-protocol.sh
+++ b/scripts/verify/capsule-protocol.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# The capsule's control surface is a contract between two programs that
+# cannot import each other: the supervisor is the capsule image's PID 1
+# and depends on nothing, and the controller drives it over exec. Every
+# value they must agree on is therefore declared twice, and a comment on
+# each side names its counterpart. This is that comment made executable.
+#
+# Drift here is silent in a green build and expensive in production: a
+# protocol version that disagrees refuses every capsule, and an abort
+# exit code that disagrees reads a job that never started as one that ran.
+#
+# Usage: scripts/verify/capsule-protocol.sh
+cd "$(dirname "$0")/../.."
+status=0
+
+supervisor=cmd/capsule-supervisor/main.go
+
+check() {
+  local what=$1 supervisor_expr=$2 launcher=$3 launcher_expr=$4
+  local mine theirs
+  # Either form a Go declaration takes: inside a const block, or a
+  # single `const NAME = value` of its own.
+  local pattern='s/^[[:space:]]*\(const[[:space:]]\{1,\}\)\{0,1\}NAME[[:space:]]*=[[:space:]]*\([^[:space:]]*\).*/\2/p'
+  mine=$(sed -n "${pattern//NAME/$supervisor_expr}" "$supervisor")
+  theirs=$(sed -n "${pattern//NAME/$launcher_expr}" "$launcher")
+  if [ -z "$mine" ]; then
+    echo "FAIL  $supervisor declares no $supervisor_expr"
+    status=1
+  elif [ -z "$theirs" ]; then
+    echo "FAIL  $launcher declares no $launcher_expr"
+    status=1
+  elif [ "$mine" = "$theirs" ]; then
+    echo "ok    $what agrees on both sides ($mine)"
+  else
+    echo "FAIL  $what disagrees: $supervisor_expr is $mine, $launcher_expr is $theirs"
+    status=1
+  fi
+}
+
+check "the control protocol version" protocolVersion \
+  internal/capsule/capsule.go ProtocolVersion
+check "the aborted exit code" exitAborted \
+  internal/capsule/observation.go SupervisorAbortedExitCode
+
+exit $status

--- a/scripts/verify/go-version.sh
+++ b/scripts/verify/go-version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# The builder images must name the Go that go.mod declares. Nothing else
+# ties them: an image tag and a module directive are separate ecosystems to
+# every updater, so they drift silently and the drift is invisible in a
+# green build. The binary an image ships would then be compiled by a
+# toolchain no test ever ran, which is the one thing a reproducible build
+# is supposed to rule out.
+#
+# Dependabot is configured to propose only patch bumps for the builder, so
+# this is the check behind that policy rather than a substitute for it.
+#
+# Usage: scripts/verify/go-version.sh
+cd "$(dirname "$0")/../.."
+status=0
+
+want=$(awk '/^go [0-9]/ {print $2; exit}' go.mod)
+if [ -z "$want" ]; then
+  echo "FAIL  go.mod declares no Go version"
+  exit 1
+fi
+
+for dockerfile in build/*/Dockerfile; do
+  # Taken without a pipe: head would be free to close on sed mid-write.
+  builders=$(sed -n 's/^FROM golang:\([0-9][^-@ ]*\).*/\1/p' "$dockerfile")
+  got=${builders%%$'\n'*}
+  if [ -z "$got" ]; then
+    echo "FAIL  $dockerfile: no golang builder stage found"
+    status=1
+  elif [ "$got" = "$want" ]; then
+    echo "ok    $dockerfile golang:$got"
+  else
+    echo "FAIL  $dockerfile builds with golang:$got, go.mod declares $want"
+    status=1
+  fi
+done
+
+exit $status

--- a/test/contract/capsule/budget_test.go
+++ b/test/contract/capsule/budget_test.go
@@ -1,0 +1,196 @@
+package capsulecontract
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// TestLeaseResourceBudget proves on a real kernel what the threat model
+// claims: a lease cannot spend more than its tier, and that includes
+// its gateway.
+//
+// The gateway is workload-driven — every connection a job opens is work
+// it performs — so leaving it outside the envelope would let a job
+// consume host resources its tier never granted. This asserts the three
+// things that make the claim true: both containers sit under one parent
+// cgroup, the sum of their kernel-enforced limits is the tier, and the
+// gateway's own limits are the reserve the capsule gave up.
+func TestLeaseResourceBudget(t *testing.T) {
+	m, dock, leaseID := launcher(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	info, err := dock.Info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &memRecorder{}
+
+	uplinkID, err := dock.CreateNetwork(ctx, docker.NetworkSpec{
+		Name:   leaseID + "-uplink",
+		Labels: map[string]string{docker.LabelManaged: "true", docker.LabelInstance: "contract", docker.LabelRole: capsule.RoleUplink},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupSandbox(t, dock, rec, uplinkID) })
+	uplinkSubnet, err := dock.NetworkSubnet(ctx, uplinkID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tier := config.Resources{
+		Memory: 2 << 30,
+		Swap:   256 << 20,
+		CPU:    2_000_000_000,
+		PIDs:   512,
+	}
+	prepared, err := m.Prepare(ctx, capsule.Spec{
+		LeaseID:      leaseID,
+		InstanceID:   "contract",
+		CapsuleImage: image,
+		JITConfig:    fakeJITConfig,
+		Resources:    tier,
+		CgroupDriver: info.CgroupDriver,
+		Sandbox: &capsule.Sandbox{
+			UplinkNetworkID: uplinkID,
+			UplinkSubnet:    uplinkSubnet,
+			Deny:            egress.BuildDeny(uplinkSubnet, []string{"192.168.0.0/16"}, nil),
+		},
+	}, rec)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	short := leaseID
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	if err != nil || gwID == "" {
+		t.Fatalf("resolve gateway: %q, %v", gwID, err)
+	}
+
+	// Both containers report the same parent cgroup, so the kernel
+	// accounts them as one aggregate and one path reports the lease.
+	wantParent := capsule.LeaseCgroupParent(info.CgroupDriver, leaseID)
+	for name, id := range map[string]string{"capsule": prepared.RuntimeID, "gateway": gwID} {
+		got, err := dock.ContainerCgroupParent(ctx, id)
+		if err != nil {
+			t.Fatalf("%s cgroup parent: %v", name, err)
+		}
+		if got != wantParent {
+			t.Errorf("%s parent cgroup = %q; want %q", name, got, wantParent)
+		}
+	}
+
+	// The kernel's own numbers, read from inside each container's
+	// cgroup: what the daemon was asked for is not evidence, what the
+	// kernel enforces is.
+	capsuleLimits := readCgroupLimits(ctx, t, dock, prepared.RuntimeID)
+	gatewayLimits := readCgroupLimits(ctx, t, dock, gwID)
+
+	if got := capsuleLimits.memory + gatewayLimits.memory; got != int64(tier.Memory) {
+		t.Errorf("memory: capsule %d + gateway %d = %d; the tier is %d — the lease can exceed its budget",
+			capsuleLimits.memory, gatewayLimits.memory, got, int64(tier.Memory))
+	}
+	if got := capsuleLimits.swap + gatewayLimits.swap; got != int64(tier.Swap) {
+		t.Errorf("swap: capsule %d + gateway %d = %d; the tier is %d",
+			capsuleLimits.swap, gatewayLimits.swap, got, int64(tier.Swap))
+	}
+	if got := capsuleLimits.pids + gatewayLimits.pids; got != tier.PIDs {
+		t.Errorf("pids: capsule %d + gateway %d = %d; the tier is %d",
+			capsuleLimits.pids, gatewayLimits.pids, got, tier.PIDs)
+	}
+	if gatewayLimits.memory != int64(config.GatewayReserveMemory) {
+		t.Errorf("gateway memory = %d; want the reserve %d", gatewayLimits.memory, config.GatewayReserveMemory)
+	}
+	if gatewayLimits.pids != config.GatewayReservePIDs {
+		t.Errorf("gateway pids = %d; want the reserve %d", gatewayLimits.pids, config.GatewayReservePIDs)
+	}
+
+	// The gateway's limits are enforced, not advisory. A fork storm
+	// inside it must stop at its own ceiling rather than reaching the
+	// tier, let alone the host's process table.
+	//
+	// The storm runs detached and the evidence is read by a separate
+	// exec: a shell that has exhausted its own PID budget cannot fork
+	// the process that would report the result, so asking it to would
+	// measure nothing. The first attempt at this test did exactly that
+	// and passed while proving nothing.
+	if _, _, err := dock.Exec(ctx, gwID, []string{"bash", "-c",
+		`(n=0; while [ $n -lt 4000 ]; do sleep 20 & n=$((n+1)); done) >/dev/null 2>&1 &`}); err != nil {
+		t.Fatalf("start the fork storm: %v", err)
+	}
+	time.Sleep(3 * time.Second)
+
+	code, out, err := dock.Exec(ctx, gwID, []string{"cat", "/sys/fs/cgroup/pids.current"})
+	if err != nil || code != 0 {
+		t.Fatalf("read pids.current: exit %d, %v", code, err)
+	}
+	current, perr := strconv.ParseInt(strings.TrimSpace(out), 10, 64)
+	if perr != nil {
+		t.Fatalf("pids.current is %q: %v", strings.TrimSpace(out), perr)
+	}
+	t.Logf("gateway pids.current under a fork storm: %d (ceiling %d, tier %d)",
+		current, config.GatewayReservePIDs, tier.PIDs)
+
+	// The pids controller blocks fork, not migration: a `docker exec`
+	// attaches its process to the cgroup without passing the limit, so
+	// the reader itself appears above the ceiling. Measured here as
+	// exactly one over. The allowance covers the reader and its shell,
+	// and stays far below the tier — which is the claim that matters:
+	// the gateway cannot spend the lease's whole budget.
+	const execAllowance = 4
+	if current > config.GatewayReservePIDs+execAllowance {
+		t.Errorf("the gateway holds %d processes; its ceiling is %d — the limit is not enforced",
+			current, config.GatewayReservePIDs)
+	}
+	if current >= tier.PIDs {
+		t.Errorf("the gateway reached %d processes, the tier's whole budget of %d", current, tier.PIDs)
+	}
+	if _, err := dock.ContainerStatus(ctx, gwID); err != nil {
+		t.Errorf("the gateway did not survive its own PID ceiling: %v", err)
+	}
+}
+
+type cgroupLimits struct {
+	memory int64
+	swap   int64
+	pids   int64
+}
+
+// readCgroupLimits reads the limits from inside the container's own
+// cgroup namespace, where cgroup v2 exposes them at the root.
+func readCgroupLimits(ctx context.Context, t *testing.T, dock *docker.Client, id string) cgroupLimits {
+	t.Helper()
+	read := func(file string) int64 {
+		code, out, err := dock.Exec(ctx, id, []string{"cat", "/sys/fs/cgroup/" + file})
+		if err != nil || code != 0 {
+			t.Fatalf("read %s from %s: exit %d, %v", file, id[:12], code, err)
+		}
+		text := strings.TrimSpace(out)
+		if text == "max" {
+			t.Fatalf("%s is unlimited in %s; the envelope was not applied", file, id[:12])
+		}
+		n, perr := strconv.ParseInt(text, 10, 64)
+		if perr != nil {
+			t.Fatalf("%s in %s is %q: %v", file, id[:12], text, perr)
+		}
+		return n
+	}
+	return cgroupLimits{
+		memory: read("memory.max"),
+		swap:   read("memory.swap.max"),
+		pids:   read("pids.max"),
+	}
+}

--- a/test/contract/capsule/bypass_test.go
+++ b/test/contract/capsule/bypass_test.go
@@ -1,0 +1,205 @@
+package capsulecontract
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// TestNetworkSandboxBypass is the egress bypass suite, run against a
+// real sandboxed capsule on a real daemon. The claim under test has two
+// halves, and this proves both from inside the capsule's own namespace:
+//
+//   - Nothing routes out. The capsule's bridge is internal in isolated
+//     gateway mode, so the host kernel drops every packet the capsule
+//     addresses beyond that bridge — public addresses included. A
+//     privileged capsule cannot lift that rule, because the rule is not
+//     in its namespace.
+//   - What does work is the relay, and only within its policy: the
+//     gateway resolves and connects on the capsule's behalf, refusing
+//     any address the policy denies, so private ranges, the host, the
+//     uplink, other Docker networks and metadata services stay
+//     unreachable by name as well as by address.
+//
+// Then the gateway is removed, and egress must go with it.
+func TestNetworkSandboxBypass(t *testing.T) {
+	m, dock, leaseID := launcher(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
+	defer cancel()
+
+	rec := &memRecorder{}
+
+	// The uplink stands in for the instance's shared egress network.
+	uplinkID, err := dock.CreateNetwork(ctx, docker.NetworkSpec{
+		Name:   leaseID + "-uplink",
+		Labels: map[string]string{docker.LabelManaged: "true", docker.LabelInstance: "contract", docker.LabelRole: capsule.RoleUplink},
+	})
+	if err != nil {
+		t.Fatalf("uplink: %v", err)
+	}
+	t.Cleanup(func() { cleanupSandbox(t, dock, rec, uplinkID) })
+	uplinkSubnet, err := dock.NetworkSubnet(ctx, uplinkID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Real serve discovers host and Docker subnets; stating them here
+	// keeps the assertions independent of whatever this host runs.
+	deny := egress.BuildDeny(uplinkSubnet,
+		[]string{"192.168.0.0/16"}, // stand-in host LAN
+		[]string{"172.30.0.0/16"})  // stand-in other Docker network
+
+	prepared, err := m.Prepare(ctx, capsule.Spec{
+		LeaseID:      leaseID,
+		InstanceID:   "contract",
+		CapsuleImage: image,
+		JITConfig:    fakeJITConfig,
+		Resources:    config.Resources{Memory: 2 << 30, Swap: 0, CPU: 2e9, PIDs: 512},
+		CgroupDriver: cgroupDriver(ctx, t, dock),
+		Sandbox: &capsule.Sandbox{
+			UplinkNetworkID: uplinkID,
+			UplinkSubnet:    uplinkSubnet,
+			Deny:            deny,
+		},
+	}, rec)
+	if err != nil {
+		t.Fatalf("prepare sandboxed capsule: %v", err)
+	}
+	capsuleID := prepared.RuntimeID
+
+	// direct opens a raw TCP connection from the capsule, with no
+	// proxy: the path the host must refuse in every case.
+	direct := func(host string, port int) bool {
+		code, _, err := dock.Exec(ctx, capsuleID, []string{
+			"bash", "-c", fmt.Sprintf("timeout 5 bash -c 'echo > /dev/tcp/%s/%d' 2>/dev/null", host, port),
+		})
+		return err == nil && code == 0
+	}
+	// relayed asks the gateway to reach a URL. Exit 0 means the relay
+	// connected; the body is irrelevant.
+	relayed := func(url string) (bool, string) {
+		code, out, err := dock.Exec(ctx, capsuleID, []string{
+			"bash", "-c", fmt.Sprintf(
+				"curl -sS -o /dev/null -w '%%{http_code}' --max-time 20 %s 2>&1", url),
+		})
+		return err == nil && code == 0, strings.TrimSpace(out)
+	}
+
+	// Nothing routes out — not even to a public address. This is the
+	// kernel's answer, not the gateway's.
+	for _, d := range []struct {
+		name string
+		host string
+		port int
+	}{
+		{"public internet, unproxied", "1.1.1.1", 443},
+		{"cloud metadata / link-local", "169.254.169.254", 80},
+		{"RFC1918 host LAN", "192.168.1.1", 22},
+		{"RFC1918 10-space", "10.0.0.1", 22},
+		{"another Docker network", "172.30.0.1", 80},
+		{"the uplink subnet itself", firstHost(uplinkSubnet), 80},
+		{"a public DNS resolver", "8.8.8.8", 53},
+	} {
+		if direct(d.host, d.port) {
+			t.Errorf("%s (%s:%d) was directly reachable; the capsule has a route that bypasses the relay",
+				d.name, d.host, d.port)
+			dumpSandboxDiag(ctx, t, dock, capsuleID, leaseID)
+		}
+	}
+
+	// DNS resolves — through the gateway's relay, the only resolver the
+	// capsule can reach.
+	if code, out, err := dock.Exec(ctx, capsuleID, []string{"getent", "hosts", "example.com"}); err != nil || code != 0 {
+		t.Errorf("DNS through the gateway failed: exit %d, %v, %s", code, err, out)
+		dumpSandboxDiag(ctx, t, dock, capsuleID, leaseID)
+	}
+
+	// Public egress works through the relay: this is the path a job's
+	// checkout, package install and image pull take.
+	if ok, out := relayed("https://example.com"); !ok {
+		t.Errorf("relayed public egress failed: %s", out)
+		dumpSandboxDiag(ctx, t, dock, capsuleID, leaseID)
+	}
+
+	// The relay applies the policy to what it resolves, so a name that
+	// answers with a denied address is refused — the DNS rebinding
+	// case, and the reason names are not the unit of policy.
+	for _, denied := range []string{
+		"http://169.254.169.254/latest/meta-data/",
+		"http://192.168.1.1/",
+		"http://10.0.0.1/",
+		"http://" + firstHost(uplinkSubnet) + "/",
+	} {
+		ok, out := relayed(denied)
+		if ok && !strings.HasPrefix(out, "403") {
+			t.Errorf("relay reached %s (status %s); the address policy leaked", denied, out)
+		}
+	}
+
+	// Losing the gateway must not degrade into open egress: with the
+	// relay gone the capsule has nothing at all.
+	short := leaseID
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	if err != nil || gwID == "" {
+		t.Fatalf("resolve gateway: %q, %v", gwID, err)
+	}
+	if err := dock.RemoveContainer(ctx, gwID); err != nil {
+		t.Fatalf("remove gateway: %v", err)
+	}
+	if ok, _ := relayed("https://example.com"); ok {
+		t.Error("egress survived the gateway's removal")
+	}
+	if direct("1.1.1.1", 443) {
+		t.Error("the capsule reached the internet directly after the gateway was removed")
+	}
+}
+
+// dumpSandboxDiag prints the sandbox's live state when an assertion
+// fails, so a failure is diagnosed from the actual routes and rules
+// rather than guessed at.
+func dumpSandboxDiag(ctx context.Context, t *testing.T, dock *docker.Client, capsuleID, leaseID string) {
+	t.Helper()
+	show := func(container, label string, cmd ...string) {
+		code, out, err := dock.Exec(ctx, container, cmd)
+		t.Logf("--- %s (exit %d, err %v) ---\n%s", label, code, err, out)
+	}
+	show(capsuleID, "capsule: ip route", "ip", "route")
+	show(capsuleID, "capsule: resolv.conf", "cat", "/etc/resolv.conf")
+	show(capsuleID, "capsule: proxy env", "bash", "-c", "env | grep -i proxy | sort")
+
+	short := leaseID
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	if err != nil || gwID == "" {
+		t.Logf("could not resolve gateway for diagnostics: %v", err)
+		return
+	}
+	show(gwID, "gateway: addresses", "ip", "-o", "addr")
+	show(gwID, "gateway: iptables-save", "iptables-save")
+	logs, _ := dock.TailLogs(ctx, gwID, 50)
+	t.Logf("--- gateway logs ---\n%s", logs)
+}
+
+// firstHost returns the first host address of a CIDR (network + 1),
+// which on the uplink is where the host's own bridge sits — a
+// destination the capsule must never reach.
+func firstHost(cidr string) string {
+	base, _, _ := strings.Cut(cidr, "/")
+	octets := strings.Split(base, ".")
+	if len(octets) != 4 {
+		return base
+	}
+	return fmt.Sprintf("%s.%s.%s.1", octets[0], octets[1], octets[2])
+}

--- a/test/contract/capsule/contract_test.go
+++ b/test/contract/capsule/contract_test.go
@@ -1,0 +1,249 @@
+// Package capsulecontract exercises the outer capsule against a real
+// daemon and the first-party image: the supervisor protocol, the
+// prepare/start separation, and the observation machine that recovery
+// depends on. A fake credential drives the whole lifecycle — the real
+// runner parses it, rejects it and exits, which proves the runner
+// actually ran without needing a provider.
+//
+// Gated by RUNPOOL_CAPSULE_CONTRACT; the capsule image must exist on
+// the daemon (scripts/contracts/capsule.sh builds it first).
+package capsulecontract
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+const (
+	image = "runpool-capsule:dev"
+	// The outer object names the files the upstream runner materializes; each
+	// value is itself base64. The contents are intentionally invalid settings,
+	// so the real runner exercises configuration and exits without a provider.
+	fakeJITConfig = "eyIucnVubmVyIjoiZTMwPSIsIi5jcmVkZW50aWFscyI6ImUzMD0ifQ=="
+)
+
+func launcher(t *testing.T) (*capsule.Launcher, *docker.Client, string) {
+	t.Helper()
+	if os.Getenv("RUNPOOL_CAPSULE_CONTRACT") == "" {
+		t.Skip("set RUNPOOL_CAPSULE_CONTRACT=1 to run against a real daemon with the capsule image")
+	}
+	dock, err := docker.New(t.Context())
+	if err != nil {
+		t.Fatalf("connect to daemon: %v", err)
+	}
+	t.Cleanup(func() { dock.Close() })
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	// The gateway runs the same image here: the suite builds one capsule
+	// and the launcher is what decides the gateway's, so a test that
+	// passed a different one would be testing a shape production cannot
+	// produce.
+	return capsule.NewLauncher(dock, image), dock, "capcontract-" + hex.EncodeToString(buf)
+}
+
+// cgroupDriver reads the driver from the daemon under test. The parent
+// cgroup's form depends on it and the daemon rejects the wrong one, so
+// no suite may assume which host it is running against.
+func cgroupDriver(ctx context.Context, t *testing.T, dock *docker.Client) string {
+	t.Helper()
+	info, err := dock.Info(ctx)
+	if err != nil {
+		t.Fatalf("read daemon facts: %v", err)
+	}
+	return info.CgroupDriver
+}
+
+// memRecorder is an in-memory ResourceRecorder: the intent lifecycle
+// itself is qualified by the state suite; here it only has to hand the
+// cleanup its objects.
+type memRecorder struct {
+	mu      sync.Mutex
+	objects []struct{ kind, id string }
+}
+
+func (r *memRecorder) Plan(kind, role, name string) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.objects = append(r.objects, struct{ kind, id string }{kind, name})
+	return int64(len(r.objects)), nil
+}
+func (r *memRecorder) Creating(int64) error { return nil }
+func (r *memRecorder) Confirm(id int64, dockerID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.objects[id-1].id = dockerID
+	return nil
+}
+
+func (r *memRecorder) cleanup(t *testing.T, dock *docker.Client) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// Containers before the network and volumes that hold them.
+	for _, o := range r.objects {
+		if o.kind == capsule.KindContainer {
+			if err := dock.RemoveContainer(ctx, o.id); err != nil {
+				t.Errorf("cleanup container %s: %v", o.id, err)
+			}
+		}
+	}
+	for _, o := range r.objects {
+		switch o.kind {
+		case capsule.KindNetwork:
+			if err := dock.RemoveNetwork(ctx, o.id); err != nil {
+				t.Errorf("cleanup network %s: %v", o.id, err)
+			}
+		case capsule.KindVolume:
+			if err := dock.RemoveVolume(ctx, o.id); err != nil {
+				t.Errorf("cleanup volume %s: %v", o.id, err)
+			}
+		}
+	}
+}
+
+// cleanupSandbox removes capsule-owned resources before the shared uplink.
+// The gateway is attached to both networks, so reversing this order would
+// leave the uplink behind and turn a passing contract into a leaking one.
+func cleanupSandbox(t *testing.T, dock *docker.Client, rec *memRecorder, uplinkID string) {
+	t.Helper()
+	rec.cleanup(t, dock)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := dock.RemoveNetwork(ctx, uplinkID); err != nil {
+		t.Errorf("cleanup uplink network %s: %v", uplinkID, err)
+	}
+}
+
+// TestCapsuleLifecycle drives the whole machine: prepare proves
+// readiness with the runner deliberately unstarted, inspection reports
+// exactly that, the authorized start launches the real runner, and the
+// serving ends the way the platform ends one - a TERM to the supervisor,
+// whose drain is what docker stop and a host shutdown deliver.
+//
+// The runner cannot be made to exit by the credential itself: a listener
+// that cannot use its configuration exits retryable, and the upstream
+// run helper relaunches it without bound. Running is therefore the
+// steady state a fake credential produces, which is exactly what the
+// running observation needs, and the drain is what ends it.
+func TestCapsuleLifecycle(t *testing.T) {
+	m, dock, leaseID := launcher(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+
+	rec := &memRecorder{}
+	t.Cleanup(func() { rec.cleanup(t, dock) })
+
+	prepared, err := m.Prepare(ctx, capsule.Spec{
+		LeaseID:      leaseID,
+		InstanceID:   "contract",
+		CapsuleImage: image,
+		JITConfig:    fakeJITConfig,
+		Resources: config.Resources{
+			Memory: 2 << 30, Swap: 0, CPU: 2e9, PIDs: 512,
+		},
+		CgroupDriver: cgroupDriver(ctx, t, dock),
+	}, rec)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	// Prepared means ready-and-waiting: the daemon booted, and no start
+	// has taken effect — which inspection must prove, because recovery
+	// requeues on exactly this answer.
+	obs, err := m.InspectExecution(ctx, prepared)
+	if err != nil || obs != assignment.ObservedCreated {
+		t.Fatalf("pre-start observation = %s, %v; want created", obs, err)
+	}
+
+	if err := m.Start(ctx, prepared); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// The authorized start is observable as running while the runner
+	// holds the fake credential's retry loop.
+	deadline := time.Now().Add(2 * time.Minute)
+	var last assignment.ExecutionObservation
+	for time.Now().Before(deadline) {
+		last, err = m.InspectExecution(ctx, prepared)
+		if err != nil && last == assignment.ObservedUnavailable {
+			t.Logf("transient inspection: %v", err)
+		}
+		if last == assignment.ObservedRunning {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if last != assignment.ObservedRunning {
+		t.Fatalf("post-start observation never reached running; last = %s", last)
+	}
+
+	// End the serving the way the platform ends one. PID 1 is the
+	// supervisor, and its TERM path drains the runner and the inner
+	// daemon before reporting the exit.
+	if code, out, err := dock.ExecWithInput(ctx, prepared.RuntimeID,
+		[]string{"kill", "-TERM", "1"}, nil); err != nil || code != 0 {
+		t.Fatalf("signal the supervisor: exit %d, %v: %s", code, err, out)
+	}
+
+	deadline = time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		last, err = m.InspectExecution(ctx, prepared)
+		if err != nil && last == assignment.ObservedUnavailable {
+			t.Logf("transient inspection: %v", err)
+		}
+		if last == assignment.ObservedExited {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if last != assignment.ObservedExited {
+		t.Fatalf("drained observation never reached exited; last = %s", last)
+	}
+
+	// The capsule's exit is the job's exit: the daemon-side wait must
+	// agree with the observation.
+	exit, err := dock.WaitExit(ctx, prepared.RuntimeID)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	t.Logf("capsule exited %d after the drain ended the runner", exit)
+
+	// The JIT bundle must not have reached the container log driver.
+	tail, err := dock.TailLogs(ctx, prepared.RuntimeID, 200)
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if strings.Contains(tail, fakeJITConfig) {
+		t.Error("the credential appears in the capsule log; the delivery channel leaked it")
+	}
+
+	// The listener has to have run and to have failed in its own
+	// controlled way. A crash aborts before the credential is parsed and
+	// proves nothing about delivery - and the upstream helper masks it
+	// into the same exit a healthy runner produces, so only the log
+	// tells.
+	if !strings.Contains(tail, "[RUNNER") {
+		t.Error("no runner output in the capsule log; the listener never ran")
+	}
+	for _, marker := range []string{"Unhandled exception", "core dumped"} {
+		if strings.Contains(tail, marker) {
+			t.Errorf("the runner crashed rather than running (%q in the log); a crash "+
+				"before the credential is parsed proves nothing about delivery", marker)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

`internal/capsule` arrives: the launcher that builds a job's capsule,
drives the supervisor's control protocol, observes the outcome and tears
everything down. Its live contract suite arrives with it, along with the
script that checks the two sides of the control protocol still agree.

CI gains three gates whose targets now exist: Dockerfile linting, the
builder-image check against `go.mod`, and the capsule protocol check.

## What was found

**The gateway image cannot be a per-job field.** The gateway is what
enforces the capsule's egress policy. If the job's own specification
named the image, a job could name a gateway that enforces nothing — the
contained choosing its container. It is a constructor argument on the
launcher instead, so there is no code path that reads it from a job.
This is the difference between a rule and a shape: a rule can be
forgotten by the next caller, and a missing constructor argument does not
compile.

**One container, not several.** Running the runner, the daemon and the
job's containers as siblings would give each its own cgroup, and a
per-job memory or CPU budget would then bound only one of them. Nesting
them under one outer container makes the budget the kernel enforces the
same budget the tier declared.

**Nothing survives a capsule.** The daemon's data root is a per-capsule
volume, and the capsule is deleted when the job ends. That is what keeps
a build cache, a pulled image or leftover runner bootstrap state from
reaching the next job — the leak a long-lived shared runner has by
construction.

**An incompatible capsule image is held, not retried.** The image
declares the protocol version it speaks; if this build does not speak it,
retrying cannot help, and consuming the retry budget against it hides the
real cause behind a generic exhaustion. The launcher returns a distinct
error so the attempt is held for review with the reason named.

**The two sides of the protocol cannot import each other.** The
supervisor is the capsule image's PID 1 and depends on nothing; the
controller drives it over exec. Every value they must agree on — the
protocol version, the abort exit code — is therefore declared twice, with
a comment on each naming its counterpart. The script added here makes
that comment executable, because the drift is invisible in a green build
and expensive in production: a version that disagrees refuses every
capsule, and an abort code that disagrees reads a job that never started
as one that ran.

## Evidence

Hermetic only in CI: the envelope construction, the observation parsing
and the protocol constants are covered by unit tests, and the protocol
script compares both declarations. The behaviours that need a real
kernel — that the aggregate cgroup actually bounds inner containers, and
that the capsule cannot bypass its gateway — are in the contract suite,
which needs a Docker host and is environment-gated.

```text
hermetic only in CI — the live capsule contract is environment-gated and
ran nothing in this run
```

## What would notice this regressing

`internal/capsule`'s suite fails if the envelope stops nesting inner
containers under the aggregate budget, or if an incompatible protocol
version stops producing its distinct error. `scripts/verify/capsule-protocol.sh`
fails if the supervisor and the launcher ever disagree on the protocol
version or the abort exit code. The contract suite's budget and bypass
tests are what would notice the kernel-level guarantees failing.

There is no test for "the gateway image comes from a job field", because
the launcher has no field to read it from.

## Risk, compatibility and operations

Trust boundary: a capsule runs a workflow's code with a privileged Docker
daemon. Runpool is a resource and hygiene boundary for CI you trust, not
a sandbox for hostile code. What this change guarantees is narrower and
real: the job's budget is enforced by the kernel over everything the job
starts, its only route out is a gateway it cannot choose, and nothing it
leaves behind reaches another job.

Credentials: the JIT bundle is delivered over exec stdin to tmpfs inside
the capsule; it is never a container argument, an environment variable or
a build context.

Ownership and cleanup: every object a capsule creates is labelled and
recorded, and the capsule plus its volume are removed when the job ends.

Networking: the capsule's only network is an internal bridge with the
gateway as its single neighbour.

Resource limits: the tier's CPU and memory become one aggregate cgroup
on the outer container.

Failure behaviour: an unready daemon, an unauthorized start or an
incompatible image all keep the runner from existing, and the last is
held for review rather than retried.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports this package yet.

## Changelog

```text
NONE
```
