### PR TITLE
feat(cache): warm build state in labelled lanes

### DIFF
--- a/docs/adrs/2026-08-11-repository-cache-scope.md
+++ b/docs/adrs/2026-08-11-repository-cache-scope.md
@@ -1,0 +1,65 @@
+# Persistent cache binds to repository-scoped scale sets only
+
+**Status:** accepted
+**Date:** 2026-08-11
+
+## Context
+
+Persistent cache lanes are Runpool's core performance feature, and the
+demand messages a scale-set session delivers expose the repository's
+identity before anything is provisioned. The temptation follows
+immediately: react to a message from repository A by provisioning a
+runner with A's cache lane mounted. On a repository-scoped scale set
+that is safe by construction — every job belongs to the same repository.
+On an organization-scoped scale set it would leak one repository's cache
+state into another's build, because nothing ties the runner to the job
+that motivated it.
+
+## Decision
+
+Persistent local cache lanes exist only for repository-scoped scale
+sets. Organization- and enterprise-scoped targets never mount a lane in
+V1 — configuration validation rejects `cache.enabled` on them — and
+their workflows use remote caches such as GitHub-managed `actions/cache`
+instead. An organization repository that needs a hot local cache gets a
+repository-scoped scale set of its own; the scope, not a runtime
+heuristic, is what makes the binding safe.
+
+## Evidence
+
+`test/contract/githubactions/assignment_test.go`, executed live against a
+real organization with `actions/scaleset` v0.4.0, proves the crossover
+symmetrically:
+
+- repository B's job and then repository A's job were assigned to one
+  organization scale set;
+- a JIT runner nominally provisioned "for A" executed **B's** job;
+- a second runner nominally "for B" executed **A's** job;
+- both runs concluded `completed/success`.
+
+JIT generation accepts only a runner name and work folder — there is no
+job or request parameter that could bind the runner.
+
+The experiment also pinned two broker behaviors the architecture must
+respect:
+
+- **Announcing capacity is admission.** While the session advertises
+  free capacity, queued jobs arrive directly as `JobAssigned` (with
+  `runnerRequestId=0`) — no `JobAvailable`, no `AcquireJobs`, no
+  per-job local acceptance step. The capacity allocator's control over
+  advertised capacity is therefore the only admission gate.
+- **Lifecycle messages are hints.** `JobCompleted` messages failed to
+  arrive for over six minutes after both jobs had succeeded. Completion
+  truth is the runner exiting plus polled state; cleanup triggers on
+  runner exit, hints, timeouts and reconciliation — never one signal.
+
+## Consequences
+
+- The scheduler may use demand-message repository identity for
+  diagnostics and lane pre-selection only when the scale set is
+  repository-scoped; the cache manager cannot infer organization
+  affinity from messages at all.
+- A future local organization cache would require a mechanism that
+  selects the namespace only after the runner knows its assigned
+  repository, without making other namespaces reachable; nothing in the
+  current upstream contract provides that.

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,140 @@
+// Package cache manages persistent per-repository cache lanes. A lane
+// is one named Docker volume a repository-scoped job mounts whole at
+// /cache; its warm contents survive between jobs and are reused by the
+// next lease, which is the whole point — cache is performance state,
+// never correctness state, so any lane may be evicted safely.
+//
+// The volume model is what makes reuse independent of how the
+// controller is deployed. The volume's name derives from the lane's opaque
+// local id — never from repository text, which is attacker-influenced — and
+// its labels carry the ownership and identity needed for reconciliation and
+// garbage collection.
+package cache
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Volume labels a cache lane carries, alongside the instance ownership
+// pair every managed object has. RoleCacheLane distinguishes persistent
+// lanes from a lease's ephemeral volumes in every sweep: a lane belongs
+// to the instance, not to any lease.
+const (
+	// LabelProject carries the opaque source-project id a lane is warm for.
+	LabelProject   = "io.runpool.cache.project"
+	LabelGen       = "io.runpool.cache.generation"
+	LabelLane      = "io.runpool.cache.lane"
+	RoleCacheLane  = "cache-lane"
+	volumePrefix   = "runpool-cache-"
+	labelRoleValue = RoleCacheLane
+)
+
+// LaneMount tells a capsule which volume its lane is. There is no path
+// and no subpath left to resolve: the daemon mounts the whole volume.
+type LaneMount struct {
+	Volume string
+
+	// Identity of the lane handed over, logged so a cache miss can be
+	// traced to the lane it should have hit rather than guessed at.
+	ProjectID  string
+	LaneID     string
+	Generation string
+}
+
+// laneVolumes is what the manager needs from Docker: make a lane's
+// volume exist under proven ownership, prove ownership before deletion,
+// remove it — fail-closed on anyone else's volume throughout — and
+// measure what this instance's volumes weigh, for the GC planner.
+type laneVolumes interface {
+	EnsureOwnedVolume(ctx context.Context, name string, labels map[string]string) error
+	OwnedIDByName(ctx context.Context, kind, name, instanceID, leaseID string) (string, error)
+	RemoveVolume(ctx context.Context, name string) error
+	OwnedVolumeUsage(ctx context.Context, instanceID string) ([]docker.VolumeUsage, error)
+}
+
+type LaneManager struct {
+	store      *store.Store
+	volumes    laneVolumes
+	instanceID string
+}
+
+// New returns a cache manager. It touches no filesystem: lanes are
+// daemon-side volumes, and the store carries their exclusivity.
+func New(st *store.Store, volumes laneVolumes, instanceID string) *LaneManager {
+	return &LaneManager{store: st, volumes: volumes, instanceID: instanceID}
+}
+
+// VolumeName is the deterministic, opaque name of a lane's volume.
+func VolumeName(laneID string) string { return volumePrefix + laneID }
+
+// Acquire leases an exclusive lane for a repository job and ensures its
+// volume exists. It returns ok=false with no error when the pool is
+// momentarily exhausted; the job then runs without a cache rather than
+// corrupting a shared one.
+func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation, leaseID string, maxLanes int) (LaneMount, bool, error) {
+	var lane store.CacheLane
+	err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		projectID, err := tx.EnsureCacheProject(sourceProjectKey)
+		if err != nil {
+			return err
+		}
+		lane, err = tx.LeaseCacheLane(projectID, generation, leaseID, maxLanes)
+		return err
+	})
+	if err == store.ErrNoLane {
+		return LaneMount{}, false, nil
+	}
+	if err != nil {
+		return LaneMount{}, false, err
+	}
+
+	name := VolumeName(lane.ID)
+	labels := map[string]string{
+		docker.LabelManaged:  "true",
+		docker.LabelInstance: m.instanceID,
+		docker.LabelRole:     labelRoleValue,
+		LabelProject:         lane.ProjectID,
+		LabelGen:             lane.Generation,
+		LabelLane:            lane.ID,
+	}
+	if err := m.volumes.EnsureOwnedVolume(ctx, name, labels); err != nil {
+		// The lane lease must not outlive a volume that cannot be used:
+		// give it back so the job runs uncached and the next acquire can
+		// try again.
+		rerr := m.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.ReleaseCacheLane(leaseID)
+		})
+		if rerr != nil {
+			return LaneMount{}, false, fmt.Errorf("ensure lane volume: %w (and the lane lease could not be returned: %v)", err, rerr)
+		}
+		return LaneMount{}, false, fmt.Errorf("ensure lane volume: %w", err)
+	}
+	return LaneMount{
+		Volume:    name,
+		ProjectID: lane.ProjectID, LaneID: lane.ID, Generation: lane.Generation,
+	}, true, nil
+}
+
+// DeleteLane evicts an unleased lane. The row is deleted first so the
+// id can never be handed to a lease again, then the volume — proving
+// ownership before touching it, because the volume namespace is shared
+// with the world and a name collision must not delete someone else's
+// data. A leased lane refuses with store.ErrLaneBusy; a crash between
+// the two steps leaves a labeled volume the GC sweep can find.
+func (m *LaneManager) DeleteLane(ctx context.Context, laneID string) error {
+	err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.DeleteCacheLane(laneID)
+	})
+	if err != nil {
+		return err
+	}
+	name := VolumeName(laneID)
+	if _, err := m.volumes.OwnedIDByName(ctx, "volume", name, m.instanceID, ""); err != nil {
+		return fmt.Errorf("lane volume %s: %w", name, err)
+	}
+	return m.volumes.RemoveVolume(ctx, name)
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,354 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// fakeVolumes stands in for the daemon: it remembers what was ensured
+// with which labels, and what was removed. The real EnsureOwnedVolume
+// and removal semantics are proven against a live daemon in
+// test/contract/cache; here the subject is the manager's own logic.
+type fakeVolumes struct {
+	ensured   map[string]map[string]string
+	sizes     map[string]int64
+	removed   []string
+	ensureErr error
+	foreign   bool
+}
+
+func (f *fakeVolumes) EnsureOwnedVolume(_ context.Context, name string, labels map[string]string) error {
+	if f.ensureErr != nil {
+		return f.ensureErr
+	}
+	if f.ensured == nil {
+		f.ensured = map[string]map[string]string{}
+	}
+	f.ensured[name] = labels
+	return nil
+}
+
+func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind, name, instanceID, leaseID string) (string, error) {
+	if f.foreign {
+		return "", docker.ErrForeignResource
+	}
+	if _, ok := f.ensured[name]; !ok {
+		return "", nil
+	}
+	return name, nil
+}
+
+func (f *fakeVolumes) RemoveVolume(_ context.Context, name string) error {
+	delete(f.ensured, name)
+	f.removed = append(f.removed, name)
+	return nil
+}
+
+// sizes lets a GC test weigh volumes; unset names report unknown (-1),
+// like a daemon that could not compute a size.
+func (f *fakeVolumes) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+	var out []docker.VolumeUsage
+	for name, labels := range f.ensured {
+		size := int64(-1)
+		if f.sizes != nil {
+			if s, ok := f.sizes[name]; ok {
+				size = s
+			}
+		}
+		out = append(out, docker.VolumeUsage{Name: name, Labels: labels, Size: size})
+	}
+	return out, nil
+}
+
+func newManager(t *testing.T) (*LaneManager, *store.Store, *fakeVolumes) {
+	t.Helper()
+	st, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	vols := &fakeVolumes{}
+	return New(st, vols, st.InstanceID()), st, vols
+}
+
+const repoURL = "https://github.com/acme/app"
+
+// release frees a lease's lane the way production does: inside a store
+// transaction, where the finalizing commit runs it alongside the lease's
+// own release.
+func release(t *testing.T, st *store.Store, leaseID string) error {
+	t.Helper()
+	return st.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.ReleaseCacheLane(leaseID)
+	})
+}
+
+// TestLaneIsReusedAcrossLeases: a second job for the same repository and
+// generation must receive the same lane — the same volume name — so the
+// warm data left by the first is what it mounts. That the data itself
+// survives inside the volume is the live daemon's contract test.
+func TestLaneIsReusedAcrossLeases(t *testing.T) {
+	m, store, _ := newManager(t)
+
+	first, ok, err := m.Acquire(t.Context(), repoURL, "rust-v1", "lease-1", 1)
+	if err != nil || !ok {
+		t.Fatalf("first acquire = %+v, ok=%v, %v", first, ok, err)
+	}
+	if err := release(t, store, "lease-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	second, ok, err := m.Acquire(t.Context(), repoURL, "rust-v1", "lease-2", 1)
+	if err != nil || !ok {
+		t.Fatalf("second acquire = %+v, ok=%v, %v", second, ok, err)
+	}
+	if second.LaneID != first.LaneID {
+		t.Fatalf("second lease got lane %q; want the first lane %q reused", second.LaneID, first.LaneID)
+	}
+	if second.Volume != first.Volume || second.Volume != VolumeName(first.LaneID) {
+		t.Fatalf("volume changed between leases: %q then %q", first.Volume, second.Volume)
+	}
+}
+
+// TestLaneIsExclusiveWhileLeased: a lane in use is never handed to a
+// second job, because two writers would corrupt the cache. With the pool
+// exhausted the caller is told to run without one.
+func TestLaneIsExclusiveWhileLeased(t *testing.T) {
+	m, _, _ := newManager(t)
+
+	if _, ok, err := m.Acquire(t.Context(), repoURL, "gen", "lease-1", 1); err != nil || !ok {
+		t.Fatalf("first acquire: ok=%v, %v", ok, err)
+	}
+	loc, ok, err := m.Acquire(t.Context(), repoURL, "gen", "lease-2", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Errorf("a leased lane was handed to a second job: %+v", loc)
+	}
+}
+
+// TestDifferentRepositoriesAndGenerationsAreSeparate: cache is only safe
+// because a lane belongs to one repository and one generation.
+func TestDifferentRepositoriesAndGenerationsAreSeparate(t *testing.T) {
+	m, _, _ := newManager(t)
+
+	a, _, err := m.Acquire(t.Context(), repoURL, "gen-1", "lease-a", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := m.Acquire(t.Context(), "https://github.com/acme/other", "gen-1", "lease-b", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, _, err := m.Acquire(t.Context(), repoURL, "gen-2", "lease-c", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Volume == b.Volume || a.Volume == c.Volume || b.Volume == c.Volume {
+		t.Errorf("lanes collided across repository or generation: %q %q %q", a.Volume, b.Volume, c.Volume)
+	}
+	if a.ProjectID == b.ProjectID {
+		t.Error("two repositories share one opaque id")
+	}
+}
+
+// TestVolumeNamesAreOpaque: repository text is attacker-influenced and
+// must never reach the volume namespace; the name derives only from the
+// lane's minted id. Identity travels in labels, as opaque ids.
+func TestVolumeNamesAreOpaque(t *testing.T) {
+	m, _, vols := newManager(t)
+
+	hostile := "https://github.com/acme/..%2f..%2fetc"
+	loc, ok, err := m.Acquire(t.Context(), hostile, "gen", "lease-1", 1)
+	if err != nil || !ok {
+		t.Fatalf("acquire: ok=%v, %v", ok, err)
+	}
+	if loc.Volume != VolumeName(loc.LaneID) {
+		t.Errorf("volume %q is not the lane's deterministic name %q", loc.Volume, VolumeName(loc.LaneID))
+	}
+	if strings.Contains(loc.Volume, "acme") || strings.Contains(loc.Volume, "..") || strings.Contains(loc.Volume, "/") {
+		t.Errorf("repository text reached the volume name: %q", loc.Volume)
+	}
+	labels := vols.ensured[loc.Volume]
+	if labels == nil {
+		t.Fatalf("the lane volume was never ensured; ensured = %v", vols.ensured)
+	}
+	if labels[LabelProject] != loc.ProjectID || labels[LabelGen] != "gen" || labels[LabelLane] != loc.LaneID {
+		t.Errorf("identity labels wrong: %v", labels)
+	}
+	if strings.Contains(labels[LabelProject], "acme") {
+		t.Errorf("repository text reached the labels: %q", labels[LabelProject])
+	}
+	if labels[docker.LabelManaged] != "true" || labels[docker.LabelRole] != RoleCacheLane {
+		t.Errorf("ownership labels wrong: %v", labels)
+	}
+}
+
+// TestEnsureFailureReturnsTheLane: a lane lease must not outlive a
+// volume that could not be provided — the job runs uncached and the
+// lane is immediately available to the next acquire.
+func TestEnsureFailureReturnsTheLane(t *testing.T) {
+	m, _, vols := newManager(t)
+
+	vols.ensureErr = errors.New("daemon unreachable")
+	if _, ok, err := m.Acquire(t.Context(), repoURL, "gen", "lease-1", 1); err == nil || ok {
+		t.Fatalf("acquire with a failing daemon: ok=%v, err=%v; want an error", ok, err)
+	}
+
+	vols.ensureErr = nil
+	loc, ok, err := m.Acquire(t.Context(), repoURL, "gen", "lease-2", 1)
+	if err != nil || !ok {
+		t.Fatalf("the failed acquire did not return its lane: ok=%v, %v", ok, err)
+	}
+	if loc.Volume == "" {
+		t.Error("no volume after recovery")
+	}
+}
+
+// TestReleaseIsIdempotent: cleanup may retry, and a lease that holds no
+// lane must not disturb one that does.
+func TestReleaseIsIdempotent(t *testing.T) {
+	m, store, _ := newManager(t)
+
+	held, _, err := m.Acquire(t.Context(), repoURL, "gen", "holder", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := release(t, store, "never-held-a-lane"); err != nil {
+		t.Errorf("releasing an unheld lane: %v", err)
+	}
+	if err := release(t, store, "holder"); err != nil {
+		t.Fatal(err)
+	}
+	if err := release(t, store, "holder"); err != nil {
+		t.Errorf("second release: %v", err)
+	}
+	again, ok, err := m.Acquire(t.Context(), repoURL, "gen", "next", 2)
+	if err != nil || !ok {
+		t.Fatalf("acquire after release: ok=%v, %v", ok, err)
+	}
+	if again.LaneID != held.LaneID {
+		t.Errorf("the released lane was not reused: %q then %q", held.LaneID, again.LaneID)
+	}
+}
+
+// TestLaneLeaseSurvivesRestart: the lane lease is durable state. After
+// a controller restart the lane is still held by its lease — recovery
+// decides its fate with the lease, and a restart must never hand a
+// possibly-active lane to a new job.
+func TestLaneLeaseSurvivesRestart(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(st, &fakeVolumes{}, st.InstanceID())
+	if _, ok, err := m.Acquire(t.Context(), repoURL, "gen", "holder", 1); err != nil || !ok {
+		t.Fatalf("acquire: ok=%v, %v", ok, err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st2, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st2.Close() })
+	m2 := New(st2, &fakeVolumes{}, st2.InstanceID())
+	if loc, ok, err := m2.Acquire(t.Context(), repoURL, "gen", "other", 1); err != nil || ok {
+		t.Fatalf("after restart the held lane was handed out: %+v, ok=%v, %v", loc, ok, err)
+	}
+	if err := st2.Tx(t.Context(), func(tx *store.Tx) error { return tx.ReleaseCacheLane("holder") }); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := m2.Acquire(t.Context(), repoURL, "gen", "other", 1); err != nil || !ok {
+		t.Fatalf("after release the lane is still unavailable: ok=%v, %v", ok, err)
+	}
+}
+
+// TestDeleteLaneRemovesOnlyThatLane: eviction deletes the row first —
+// so the id can never be leased again — and then exactly one volume.
+func TestDeleteLaneRemovesOnlyThatLane(t *testing.T) {
+	m, store, vols := newManager(t)
+
+	a, _, err := m.Acquire(t.Context(), repoURL, "gen", "lease-a", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, _, err := m.Acquire(t.Context(), "https://github.com/acme/other", "gen", "lease-b", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := release(t, store, "lease-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := m.DeleteLane(t.Context(), a.LaneID); err != nil {
+		t.Fatal(err)
+	}
+	if len(vols.removed) != 1 || vols.removed[0] != a.Volume {
+		t.Errorf("removed = %v; want exactly %q", vols.removed, a.Volume)
+	}
+	if _, ok := vols.ensured[b.Volume]; !ok {
+		t.Errorf("the other lane's volume went with it")
+	}
+
+	// The id is gone for good: the same repo+generation now mints a
+	// fresh lane rather than resurrecting the deleted one.
+	if err := release(t, store, "lease-a-again"); err != nil {
+		t.Fatal(err)
+	}
+	fresh, ok, err := m.Acquire(t.Context(), repoURL, "gen", "lease-c", 2)
+	if err != nil || !ok {
+		t.Fatalf("acquire after delete: ok=%v, %v", ok, err)
+	}
+	if fresh.LaneID == a.LaneID {
+		t.Errorf("a deleted lane id was handed out again: %q", fresh.LaneID)
+	}
+}
+
+// TestDeleteLaneRefusesALeasedLane: eviction must not race the job that
+// is writing to the volume.
+func TestDeleteLaneRefusesALeasedLane(t *testing.T) {
+	m, _, vols := newManager(t)
+
+	loc, _, err := m.Acquire(t.Context(), repoURL, "gen", "holder", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.DeleteLane(t.Context(), loc.LaneID); !errors.Is(err, store.ErrLaneBusy) {
+		t.Fatalf("deleting a leased lane = %v; want ErrLaneBusy", err)
+	}
+	if len(vols.removed) != 0 {
+		t.Errorf("a leased lane's volume was removed: %v", vols.removed)
+	}
+}
+
+// TestDeleteLaneStopsAtAForeignVolume: a name collision must not delete
+// someone else's data; ownership is proven before removal.
+func TestDeleteLaneStopsAtAForeignVolume(t *testing.T) {
+	m, store, vols := newManager(t)
+
+	loc, _, err := m.Acquire(t.Context(), repoURL, "gen", "holder", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := release(t, store, "holder"); err != nil {
+		t.Fatal(err)
+	}
+
+	vols.foreign = true
+	if err := m.DeleteLane(t.Context(), loc.LaneID); !errors.Is(err, docker.ErrForeignResource) {
+		t.Fatalf("deleting over a foreign volume = %v; want ErrForeignResource", err)
+	}
+	if len(vols.removed) != 0 {
+		t.Errorf("a foreign volume was removed: %v", vols.removed)
+	}
+}

--- a/internal/cache/gc.go
+++ b/internal/cache/gc.go
@@ -1,0 +1,270 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// GC evicts cache lanes and nothing else. The universe is defined by
+// the role label: only this instance's cache-lane volumes are ever
+// candidates, so a leased workspace, a dind data volume or an open
+// attempt's resources are structurally out of reach — they carry other
+// roles and other owners. Within the universe, a leased lane is never
+// taken: the row-first delete refuses it atomically, which also closes
+// the race where a lane is leased between planning and execution.
+
+// GCOptions bound one collection pass.
+type GCOptions struct {
+	// TTL evicts free lanes not used for this long. Zero disables TTL
+	// eviction.
+	TTL time.Duration
+	// TargetBytes evicts free lanes, least recently used first, until
+	// the managed total is at or under this. Negative disables the
+	// watermark pass.
+	TargetBytes int64
+	// AllFree evicts every free lane whatever it measures, which is the
+	// soft-emergency posture. It is a separate field rather than a target
+	// of zero because a byte target cannot express it: a volume the
+	// daemon cannot size counts as zero bytes, so a pool of unsized lanes
+	// is already at any zero target and the watermark pass would plan
+	// nothing in the one posture that asks for everything.
+	AllFree bool
+	// Now anchors TTL arithmetic so a plan is reproducible.
+	Now time.Time
+}
+
+// Eviction is one planned removal and the reason it was chosen —
+// "ttl", "lru", "emergency" or "orphan". Orphans are labeled lane volumes without a
+// row: a crash between DeleteLane's row delete and volume removal
+// leaves one, and only this sweep can find it.
+type Eviction struct {
+	LaneID           string
+	Volume           string
+	SourceProjectKey string
+	Generation       string
+	Reason           string
+	Bytes            int64
+	Orphan           bool
+}
+
+// GCPlan is what a pass would do, computed before anything is touched:
+// the CLI prints it as the dry run, and apply executes exactly it.
+type GCPlan struct {
+	Evictions []Eviction
+	// ManagedBytes is the measured total before eviction; KeptBytes
+	// what remains if every eviction succeeds. Volumes whose size the
+	// daemon could not compute count as zero in both, so the watermark
+	// pass treats unknown as unreclaimable rather than guessing.
+	ManagedBytes int64
+	KeptBytes    int64
+}
+
+// PlanGC measures and decides. The daemon is listed before the store
+// on purpose: a volume is created only after its row committed, so a
+// volume seen now whose row is absent in the later read is a true
+// orphan — the reverse order would misread every lane created between
+// the two reads as one.
+func (m *LaneManager) PlanGC(ctx context.Context, opts GCOptions) (GCPlan, error) {
+	usage, err := m.volumes.OwnedVolumeUsage(ctx, m.instanceID)
+	if err != nil {
+		return GCPlan{}, fmt.Errorf("measure volumes: %w", err)
+	}
+	sizes := map[string]int64{} // lane id -> bytes
+	orphaned := map[string]int64{}
+	for _, u := range usage {
+		if u.Labels[docker.LabelRole] != RoleCacheLane {
+			continue
+		}
+		size := u.Size
+		if size < 0 {
+			size = 0
+		}
+		if lane := u.Labels[LabelLane]; lane != "" {
+			sizes[lane] = size
+		} else {
+			orphaned[u.Name] = size
+		}
+	}
+
+	var lanes []store.CacheLaneInfo
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		lanes, err = tx.CacheLanes()
+		return err
+	}); err != nil {
+		return GCPlan{}, err
+	}
+
+	var plan GCPlan
+	known := map[string]bool{}
+	var free []store.CacheLaneInfo
+	for _, lane := range lanes {
+		known[lane.ID] = true
+		plan.ManagedBytes += sizes[lane.ID]
+		if lane.LeasedBy == "" {
+			free = append(free, lane)
+		}
+	}
+	for _, u := range usage {
+		if u.Labels[docker.LabelRole] != RoleCacheLane {
+			continue
+		}
+		lane := u.Labels[LabelLane]
+		if lane != "" && !known[lane] {
+			orphaned[u.Name] = sizes[lane]
+		}
+	}
+
+	evicted := map[string]bool{}
+	evict := func(lane store.CacheLaneInfo, reason string) {
+		evicted[lane.ID] = true
+		plan.Evictions = append(plan.Evictions, Eviction{
+			LaneID: lane.ID, Volume: VolumeName(lane.ID),
+			SourceProjectKey: lane.SourceProjectKey, Generation: lane.Generation,
+			Reason: reason, Bytes: sizes[lane.ID],
+		})
+	}
+
+	if opts.TTL > 0 {
+		cutoff := opts.Now.Add(-opts.TTL).Unix()
+		for _, lane := range free {
+			if lane.LastUsed < cutoff {
+				evict(lane, "ttl")
+			}
+		}
+	}
+
+	if opts.AllFree {
+		for _, lane := range free {
+			if !evicted[lane.ID] {
+				evict(lane, "emergency")
+			}
+		}
+	} else if opts.TargetBytes >= 0 {
+		remaining := plan.ManagedBytes
+		for _, e := range plan.Evictions {
+			remaining -= e.Bytes
+		}
+		// Deterministic LRU: oldest first, id as the tiebreak so two
+		// plans over the same facts are the same plan.
+		sort.Slice(free, func(i, j int) bool {
+			if free[i].LastUsed != free[j].LastUsed {
+				return free[i].LastUsed < free[j].LastUsed
+			}
+			return free[i].ID < free[j].ID
+		})
+		for _, lane := range free {
+			if remaining <= opts.TargetBytes {
+				break
+			}
+			if evicted[lane.ID] {
+				continue
+			}
+			evict(lane, "lru")
+			remaining -= sizes[lane.ID]
+		}
+	}
+
+	for name, size := range orphaned {
+		plan.Evictions = append(plan.Evictions, Eviction{
+			Volume: name, Reason: "orphan", Bytes: size, Orphan: true,
+		})
+	}
+	// Orphans in name order, after the lane passes: same facts, same plan.
+	sort.SliceStable(plan.Evictions, func(i, j int) bool {
+		if plan.Evictions[i].Orphan != plan.Evictions[j].Orphan {
+			return !plan.Evictions[i].Orphan
+		}
+		if plan.Evictions[i].Orphan {
+			return plan.Evictions[i].Volume < plan.Evictions[j].Volume
+		}
+		return false
+	})
+
+	plan.KeptBytes = plan.ManagedBytes
+	for _, e := range plan.Evictions {
+		if !e.Orphan {
+			plan.KeptBytes -= e.Bytes
+		}
+	}
+	return plan, nil
+}
+
+// GCResult is what actually happened: evictions applied, skipped
+// because a lease took the lane between plan and apply, or failed with
+// a retryable error.
+type GCResult struct {
+	Applied int
+	Skipped int
+	Failed  []error
+	// AuditFailed are evictions that succeeded but whose audit row could
+	// not be written. They are kept apart from Failed because the lane is
+	// already gone: reporting them as failed evictions told the operator a
+	// later pass would retry them, and no pass can — the lane is not in
+	// any plan anymore. The trail has a hole; the collection worked.
+	AuditFailed []error
+}
+
+// RunGC executes a plan. Every applied eviction is recorded in the
+// audit log under the given actor; failures are collected, not fatal —
+// the next pass retries what this one could not remove.
+func (m *LaneManager) RunGC(ctx context.Context, plan GCPlan, actor string) (GCResult, error) {
+	var res GCResult
+	for _, e := range plan.Evictions {
+		var err error
+		if e.Orphan {
+			err = m.removeOrphanVolume(ctx, e.Volume)
+		} else {
+			err = m.DeleteLane(ctx, e.LaneID)
+		}
+		switch {
+		case errors.Is(err, store.ErrLaneBusy):
+			// Leased between plan and apply: the lane won the race and
+			// stays. Not a failure.
+			res.Skipped++
+			continue
+		case err != nil:
+			res.Failed = append(res.Failed, fmt.Errorf("evict %s: %w", e.Volume, err))
+			continue
+		}
+		res.Applied++
+		detail := fmt.Sprintf("reason=%s bytes=%d project=%s generation=%s",
+			e.Reason, e.Bytes, e.SourceProjectKey, e.Generation)
+		if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordAudit(actor, "gc_evict", e.Volume, detail)
+		}); err != nil {
+			res.AuditFailed = append(res.AuditFailed, fmt.Errorf("audit %s: %w", e.Volume, err))
+		}
+	}
+	return res, nil
+}
+
+// removeOrphanVolume removes a labeled lane volume that has no row. No
+// lease can reach it — rows are created before volumes and deleted
+// before them too — but ownership is still proven first, because the
+// volume namespace is shared.
+func (m *LaneManager) removeOrphanVolume(ctx context.Context, name string) error {
+	if _, err := m.volumes.OwnedIDByName(ctx, "volume", name, m.instanceID, ""); err != nil {
+		return err
+	}
+	return m.volumes.RemoveVolume(ctx, name)
+}
+
+// GCTarget is the managed-byte ceiling a collection pass works down to:
+// the low watermark as a fraction of the budget. Wanting every free lane
+// gone is not a ceiling and is asked for with GCOptions.AllFree.
+//
+// It lives here, in one function, because it was computed in two places
+// with the same arithmetic — the serving controller's monitor and the
+// operator's `gc`. The command that owns the second copy documents the
+// invariant the duplication broke: "a gc run must not invent thresholds
+// the serving controller would not use". Two copies of a formula is how
+// one of them eventually invents something.
+func GCTarget(maxManagedBytes int64, lowPct int) int64 {
+	return maxManagedBytes * int64(lowPct) / 100
+}

--- a/internal/cache/gc_test.go
+++ b/internal/cache/gc_test.go
@@ -1,0 +1,227 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// gcFixture builds lanes with controlled ages and sizes. Ages are set
+// directly in the store because LastUsed is the LRU clock under test.
+func gcFixture(t *testing.T) (*LaneManager, *store.Store, *fakeVolumes) {
+	m, st, vols := newManager(t)
+	vols.sizes = map[string]int64{}
+	return m, st, vols
+}
+
+func addLane(t *testing.T, m *LaneManager, st *store.Store, vols *fakeVolumes, repo, gen, lease string, ageDays int, size int64) LaneMount {
+	t.Helper()
+	loc, ok, err := m.Acquire(t.Context(), repo, gen, lease, 10)
+	if err != nil || !ok {
+		t.Fatalf("acquire: ok=%v, %v", ok, err)
+	}
+	vols.sizes[loc.Volume] = size
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		if err := tx.BackdateCacheLane(loc.LaneID, time.Duration(ageDays)*day); err != nil {
+			return err
+		}
+		return tx.ReleaseCacheLane(lease)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return loc
+}
+
+const day = 24 * time.Hour
+
+// TestGCPlanTTL: free lanes idle past the TTL go, fresh ones stay, and
+// the plan is computed against the caller's clock so it is reproducible.
+func TestGCPlanTTL(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	old := addLane(t, m, st, vols, repoURL, "gen", "l1", 30, 100)
+	fresh := addLane(t, m, st, vols, "https://github.com/acme/other", "gen", "l2", 1, 100)
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{TTL: 14 * day, TargetBytes: -1, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Evictions) != 1 || plan.Evictions[0].LaneID != old.LaneID || plan.Evictions[0].Reason != "ttl" {
+		t.Fatalf("plan = %+v; want exactly the idle lane by ttl", plan.Evictions)
+	}
+	if plan.ManagedBytes != 200 || plan.KeptBytes != 100 {
+		t.Errorf("managed=%d kept=%d; want 200/100", plan.ManagedBytes, plan.KeptBytes)
+	}
+	_ = fresh
+}
+
+// TestGCPlanLRUTowardTarget: over the watermark, the oldest free lanes
+// go first and eviction stops at the target — deterministically, so the
+// same facts always produce the same plan.
+func TestGCPlanLRUTowardTarget(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	oldest := addLane(t, m, st, vols, repoURL, "g1", "l1", 9, 400)
+	middle := addLane(t, m, st, vols, repoURL, "g2", "l2", 5, 400)
+	newest := addLane(t, m, st, vols, repoURL, "g3", "l3", 1, 400)
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{TargetBytes: 500, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Evictions) != 2 {
+		t.Fatalf("evictions = %+v; want the two oldest", plan.Evictions)
+	}
+	if plan.Evictions[0].LaneID != oldest.LaneID || plan.Evictions[1].LaneID != middle.LaneID {
+		t.Errorf("order = %s, %s; want oldest %s then %s", plan.Evictions[0].LaneID, plan.Evictions[1].LaneID, oldest.LaneID, middle.LaneID)
+	}
+	if plan.KeptBytes != 400 {
+		t.Errorf("kept = %d; want 400", plan.KeptBytes)
+	}
+	_ = newest
+}
+
+// TestGCNeverPlansALeasedLane: whatever the pressure, a lane a job is
+// writing to is untouchable.
+func TestGCNeverPlansALeasedLane(t *testing.T) {
+	m, _, vols := gcFixture(t)
+	loc, ok, err := m.Acquire(t.Context(), repoURL, "gen", "holder", 1)
+	if err != nil || !ok {
+		t.Fatal(err)
+	}
+	vols.sizes[loc.Volume] = 1 << 30
+
+	// Aggressive posture: every free lane goes — and the leased one
+	// still stays.
+	plan, err := m.PlanGC(t.Context(), GCOptions{TTL: time.Nanosecond, AllFree: true, Now: time.Now().Add(time.Hour)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Evictions) != 0 {
+		t.Fatalf("a leased lane was planned for eviction: %+v", plan.Evictions)
+	}
+}
+
+// TestGCPlansOrphanVolumes: a labeled lane volume without a row is
+// unreachable by any lease and only this sweep can find it.
+func TestGCPlansOrphanVolumes(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	loc := addLane(t, m, st, vols, repoURL, "gen", "l1", 1, 50)
+
+	// Simulate the DeleteLane crash window: row gone, volume left.
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.DeleteCacheLane(loc.LaneID)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{TargetBytes: -1, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plan.Evictions) != 1 || !plan.Evictions[0].Orphan || plan.Evictions[0].Volume != loc.Volume {
+		t.Fatalf("plan = %+v; want the orphan volume", plan.Evictions)
+	}
+
+	res, err := m.RunGC(t.Context(), plan, "test")
+	if err != nil || res.Applied != 1 || len(res.Failed) != 0 {
+		t.Fatalf("run = %+v, %v", res, err)
+	}
+	if len(vols.removed) != 1 || vols.removed[0] != loc.Volume {
+		t.Errorf("removed = %v; want the orphan", vols.removed)
+	}
+}
+
+// TestRunGCAuditsAndSkipsRaced: every applied eviction leaves an audit
+// entry; a lane leased between plan and apply is skipped, not failed.
+func TestRunGCAuditsAndSkipsRaced(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	victim := addLane(t, m, st, vols, repoURL, "g1", "l1", 30, 100)
+	raced := addLane(t, m, st, vols, repoURL, "g2", "l2", 30, 100)
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{TTL: day, TargetBytes: -1, Now: time.Now()})
+	if err != nil || len(plan.Evictions) != 2 {
+		t.Fatalf("plan = %+v, %v", plan.Evictions, err)
+	}
+
+	// A job takes one lane between plan and apply.
+	if _, ok, err := m.Acquire(t.Context(), repoURL, "g2", "late-lease", 10); err != nil || !ok {
+		t.Fatal(err)
+	}
+
+	res, err := m.RunGC(t.Context(), plan, "test-actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Applied != 1 || res.Skipped != 1 || len(res.Failed) != 0 {
+		t.Fatalf("result = %+v; want 1 applied, 1 skipped", res)
+	}
+	if len(vols.removed) != 1 || vols.removed[0] != victim.Volume {
+		t.Errorf("removed = %v; want only %q", vols.removed, victim.Volume)
+	}
+
+	var audits []store.AuditEntry
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		audits, err = tx.AuditTail(10)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(audits) != 1 || audits[0].Actor != "test-actor" || audits[0].Action != "gc_evict" || audits[0].Subject != victim.Volume {
+		t.Fatalf("audit = %+v; want one gc_evict for %q", audits, victim.Volume)
+	}
+	_ = raced
+}
+
+// TestGCTarget pins the formula that used to exist in two places — the
+// serving monitor's and the operator's `gc`. The invariant the second one
+// documents is that a gc run must not invent thresholds the controller
+// would not use, and two copies of an arithmetic is how one of them
+// eventually does.
+func TestGCTarget(t *testing.T) {
+	const budget = 100 << 30 // 100 GiB
+	for name, tc := range map[string]struct {
+		max    int64
+		lowPct int
+		want   int64
+	}{
+		"low watermark of the budget": {budget, 70, 70 << 30},
+		"no budget, nothing to keep":  {0, 70, 0},
+		"a zero low mark empties":     {budget, 0, 0},
+		"a full low mark keeps all":   {budget, 100, budget},
+	} {
+		if got := GCTarget(tc.max, tc.lowPct); got != tc.want {
+			t.Errorf("%s: GCTarget(%d, %d) = %d; want %d",
+				name, tc.max, tc.lowPct, got, tc.want)
+		}
+	}
+}
+
+// TestAggressiveCollectionPlansLanesTheDaemonCannotSize: a soft emergency
+// asks for every free lane, and a lane whose volume the daemon reports no
+// usage data for measures as zero. Sizing the pass by bytes would find a
+// zero total already under any ceiling and plan nothing, in the one
+// posture that exists to reclaim everything.
+func TestAggressiveCollectionPlansLanesTheDaemonCannotSize(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	// Size zero is what the measurement floors an unsizeable volume to.
+	addLane(t, m, st, vols, repoURL+"-a", "gen", "lease-a", 1, 0)
+	addLane(t, m, st, vols, repoURL+"-b", "gen", "lease-b", 1, 0)
+	addLane(t, m, st, vols, repoURL+"-c", "gen", "lease-c", 1, 0)
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{AllFree: true, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.ManagedBytes != 0 {
+		t.Fatalf("fixture is not the case under test: managed = %d, want 0", plan.ManagedBytes)
+	}
+	if len(plan.Evictions) != 3 {
+		t.Fatalf("planned %d evictions for 3 unsized free lanes: %+v",
+			len(plan.Evictions), plan.Evictions)
+	}
+	for _, e := range plan.Evictions {
+		if e.Reason != "emergency" {
+			t.Errorf("lane %s evicted as %q, want emergency", e.LaneID, e.Reason)
+		}
+	}
+}

--- a/scripts/contracts/docker.sh
+++ b/scripts/contracts/docker.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run the Docker client contract suite against a real daemon over SSH.
+# The suite runs on the host rather than inside a container because the
+# contract under test is the daemon API itself, and the resource-envelope
+# check reads cgroup v2 paths, so a Linux host is required.
+#
+# Usage: scripts/contracts/docker.sh <ssh-host>
+#   RUNPOOL_CONTRACT_HOST     default for <ssh-host>
+#   RUNPOOL_CONTRACT_QUALIFY  non-empty: qualification mode — the suite
+#                             additionally requires the exact platform
+#                             named in build/platform.lock.json.
+#
+# The expectation comes from the reviewed manifest, never from the host under
+# test.
+cd "$(dirname "$0")/../.."
+host=${1:-${RUNPOOL_CONTRACT_HOST:-}}
+if [ -z "$host" ]; then
+  echo "usage: scripts/contracts/docker.sh <ssh-host>   (a Linux Docker host)" >&2
+  exit 2
+fi
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+# The pull fixture must match the digest the suite pins.
+pull_fixture='busybox:1.36.1-uclibc@sha256:0872fb3a7632ba9d0ae46a8e832a62b30ce83a6f220b8bb52903d9cf477dabe3'
+
+echo "== cross-compile linux/amd64 (CGO_ENABLED=0) =="
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$out/docker-contract.test" ./test/contract/docker
+
+echo "== host under test =="
+ssh "$host" 'docker version --format "engine {{.Server.Version}} api {{.Server.APIVersion}}"; docker info --format "cgroup {{.CgroupVersion}} driver {{.CgroupDriver}} security {{.SecurityOptions}}"'
+echo "== release-qualification reference (build/platform.lock.json) =="
+grep -E '"(engine|api|os|os_version|arch|cgroup_driver)"' build/platform.lock.json
+
+# The pull-on-missing-image path only exists while the image is missing:
+# after one run the daemon has it cached and the test passes without
+# exercising a pull. Remove it and verify it is gone — a removal that
+# silently failed turns the pull test into a no-op.
+echo "== clearing the pull fixture so the pull path is real =="
+# shellcheck disable=SC2029 # client-side expansion is intended: the fixture reference is a constant defined above
+ssh "$host" "docker image rm -f '$pull_fixture' >/dev/null 2>&1 || true"
+# shellcheck disable=SC2029 # the fixture is a fixed local constant, intentionally expanded before SSH
+if ssh "$host" "docker image inspect '$pull_fixture' >/dev/null 2>&1"; then
+  echo 'the pull fixture is still present; the pull test would exercise nothing' >&2
+  exit 1
+fi
+
+echo "== contract suite on $host =="
+# The remote directory is run-scoped: a fixed path lets two runs — or
+# two operators — overwrite each other's binaries mid-test. printf %q
+# quotes it portably; ${var@Q} needs bash 4.4, which macOS lacks.
+remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-docker-contract.XXXXXX')
+remote_dir_q=$(printf '%q' "$remote_dir")
+trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
+scp -q "$out/docker-contract.test" "$host":"$remote_dir/"
+qualify_env=""
+if [ -n "${RUNPOOL_CONTRACT_QUALIFY:-}" ]; then
+  # No expected version travels from here: the suite embeds the
+  # reviewed manifest and compares the host against it.
+  qualify_env="RUNPOOL_CONTRACT_QUALIFY=1"
+fi
+# shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
+ssh "$host" "RUNPOOL_DOCKER_CONTRACT=1 $qualify_env '$remote_dir/docker-contract.test' -test.v -test.count=1"

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -1,0 +1,852 @@
+// Package dockercontract is the live contract suite for the pinned
+// github.com/moby/moby/client — the daemon mechanics every capsule rests
+// on. Compilation cannot verify that options were mapped to the correct API
+// fields, so the boundary is exercised against a real daemon.
+//
+// The suite is gated: without RUNPOOL_DOCKER_CONTRACT set it skips, so
+// `go test ./...` stays hermetic. Every resource carries the ownership
+// labels under a unique run-scoped instance id and is removed by
+// cleanup, so an aborted run leaves objects that ListOwned* can find.
+//
+//	RUNPOOL_DOCKER_CONTRACT=1 go test ./test/contract/docker/...
+package dockercontract
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/platform"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// busybox is the smallest image that can run a command. It is pinned by
+// digest like every image the product itself creates containers from: a
+// moving tag would make a failure here unreproducible, and "it is only
+// test scaffolding" is how an unpinned dependency gets in.
+const busybox = "busybox:1.37@sha256:f85340bf132ae937d2c2a763b8335c9bab35d6e8293f70f606b9c6178d84f42b"
+
+// missingImage exercises the pull-on-missing path: the harness removes
+// it from the daemon before the suite runs, and verifies the removal,
+// so the pull is real on every run. It is digest-pinned like everything
+// else — what makes the path real is the daemon-side removal, not a
+// moving reference.
+const missingImage = "busybox:1.36.1-uclibc@sha256:0872fb3a7632ba9d0ae46a8e832a62b30ce83a6f220b8bb52903d9cf477dabe3"
+
+func client(t *testing.T) (*docker.Client, string) {
+	t.Helper()
+	if os.Getenv("RUNPOOL_DOCKER_CONTRACT") == "" {
+		t.Skip("set RUNPOOL_DOCKER_CONTRACT=1 to run against a real daemon")
+	}
+	c, err := docker.New(t.Context())
+	if err != nil {
+		t.Fatalf("connect to daemon: %v", err)
+	}
+	t.Cleanup(func() { c.Close() })
+
+	// A unique instance id per test keeps the ownership queries scoped
+	// to what this test created, even with suites running in parallel.
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatalf("generate a run-scoped instance id: %v", err)
+	}
+	return c, "contract-" + hex.EncodeToString(buf)
+}
+
+func labels(instance, lease, kind, role string) map[string]string {
+	return map[string]string{
+		docker.LabelManaged:  "true",
+		docker.LabelInstance: instance,
+		docker.LabelLease:    lease,
+		docker.LabelKind:     kind,
+		docker.LabelRole:     role,
+	}
+}
+
+// TestContainerLifecycle covers create, start, wait and log capture —
+// the RunTask path every chown and seed helper takes.
+func TestContainerLifecycle(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	code, out, err := c.RunTask(ctx, docker.ContainerSpec{
+		Name:   instance + "-task",
+		Image:  busybox,
+		Cmd:    []string{"sh", "-c", "echo marker-out; echo marker-err >&2; exit 7"},
+		Labels: labels(instance, "lease-task", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("run task: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit code = %d; want 7 — the wait result is read from the wrong channel", code)
+	}
+	// Both streams demultiplexed: stdcopy moved packages in the
+	// migration, and a wrong reader yields framing bytes or nothing.
+	if !strings.Contains(out, "marker-out") || !strings.Contains(out, "marker-err") {
+		t.Errorf("combined output = %q; want both stream markers", out)
+	}
+}
+
+// TestRemoveIsIdempotent is the contract the cleanup saga depends on:
+// removing what is already gone must succeed. It is decided by the
+// client's typed errors, and the migration changed which module those
+// errors come from.
+func TestRemoveIsIdempotent(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-gone",
+		Image:  busybox,
+		Cmd:    []string{"true"},
+		Labels: labels(instance, "lease-gone", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := c.RemoveContainer(ctx, id); err != nil {
+		t.Fatalf("first remove: %v", err)
+	}
+	if err := c.RemoveContainer(ctx, id); err != nil {
+		t.Errorf("second remove: %v; absence must be success or a crashed cleanup can never finish", err)
+	}
+	if err := c.RemoveVolume(ctx, instance+"-never-created"); err != nil {
+		t.Errorf("remove absent volume: %v", err)
+	}
+	if err := c.RemoveNetwork(ctx, instance+"-never-created"); err != nil {
+		t.Errorf("remove absent network: %v", err)
+	}
+}
+
+// TestPullOnMissingImage covers the one create failure worth retrying.
+// The retry is chosen by a typed not-found check, so it fails closed if
+// the client stops classifying that error.
+func TestPullOnMissingImage(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	// A tag no local daemon has cached: create must fail not-found,
+	// pull, and succeed on the second attempt.
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-pull",
+		Image:  missingImage,
+		Cmd:    []string{"true"},
+		Labels: labels(instance, "lease-pull", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("create with a missing image: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+}
+
+// TestExec covers the readiness-probe path: the capsule reads the dind
+// socket gid and polls daemon liveness this way. Exec was renamed in the
+// migration (ContainerExec* became Exec*), so this is the call most
+// likely to have been mapped to the wrong method.
+func TestExec(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-exec",
+		Image:  busybox,
+		Cmd:    []string{"sleep", "60"},
+		Labels: labels(instance, "lease-exec", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+	if err := c.StartContainer(ctx, id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	code, out, err := c.Exec(ctx, id, []string{"sh", "-c", "echo from-exec; exit 3"})
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if code != 3 {
+		t.Errorf("exec exit = %d; want 3 — the code is read from the inspect result", code)
+	}
+	if !strings.Contains(out, "from-exec") {
+		t.Errorf("exec output = %q; want the command's stdout", out)
+	}
+	if !c.ExecOK(ctx, id, []string{"true"}) {
+		t.Error("ExecOK on a succeeding command reported failure")
+	}
+	if c.ExecOK(ctx, id, []string{"false"}) {
+		t.Error("ExecOK on a failing command reported success")
+	}
+}
+
+// TestExecWithInput covers the credential channel: stdin into an exec
+// is the one path into a running container that Docker persists nowhere
+// — not in the container config, not in an image layer, not in the log
+// driver. The digest proves the bytes arrived intact without the test
+// creating a second copy of them, and the log check proves the channel
+// itself leaks nothing.
+func TestExecWithInput(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-stdin",
+		Image:  busybox,
+		Cmd:    []string{"sleep", "60"},
+		Tmpfs:  map[string]string{"/secrets": "rw,size=64k"},
+		Labels: labels(instance, "lease-stdin", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+	if err := c.StartContainer(ctx, id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	secret := []byte("contract-value")
+	want := sha256.Sum256(secret)
+	code, out, err := c.ExecWithInput(ctx, id,
+		[]string{"sh", "-c", "cat > /secrets/token && sha256sum /secrets/token | cut -d' ' -f1"},
+		secret)
+	if err != nil || code != 0 {
+		t.Fatalf("exec with input: exit %d, %v: %s", code, err, out)
+	}
+	if !strings.Contains(out, hex.EncodeToString(want[:])) {
+		t.Errorf("the payload did not arrive intact on the tmpfs; digest output = %q", out)
+	}
+
+	// Exec streams go to the attach connection only; nothing may reach
+	// the container's log driver, which outlives the tmpfs.
+	logs, err := c.TailLogs(ctx, id, 50)
+	if err != nil {
+		t.Fatalf("logs: %v", err)
+	}
+	if strings.Contains(logs, string(secret)) || strings.Contains(logs, hex.EncodeToString(want[:])) {
+		t.Error("the exec stream reached the log driver; the channel is not private")
+	}
+}
+
+// TestOwnershipQueries is the reconciliation working set: after a crash
+// the controller finds what it owns through labels alone. All three
+// list calls changed result shape in the migration — a wrong field
+// yields an empty slice, which reads as "nothing to reconcile".
+func TestOwnershipQueries(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-owned",
+		Image:  busybox,
+		Cmd:    []string{"sleep", "60"},
+		Labels: labels(instance, "lease-owned", "capsule", "runner"),
+	})
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+	if err := c.StartContainer(ctx, id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	vol := instance + "-owned-vol"
+	if _, err := c.CreateVolume(ctx, vol, labels(instance, "lease-owned", "volume", "workspace")); err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.RemoveVolume(context.WithoutCancel(ctx), vol); err != nil {
+			t.Errorf("cleanup: volume %s was not removed: %v", vol, err)
+		}
+	})
+
+	netID, err := c.CreateNetwork(ctx, docker.NetworkSpec{
+		Name: instance + "-owned-net", Labels: labels(instance, "lease-owned", "network", "capsule"),
+	})
+	if err != nil {
+		t.Fatalf("create network: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.RemoveNetwork(context.WithoutCancel(ctx), netID); err != nil {
+			t.Errorf("cleanup: network %s was not removed: %v", netID, err)
+		}
+	})
+
+	containers, err := c.ListOwnedContainers(ctx, instance)
+	if err != nil {
+		t.Fatalf("list containers: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("owned containers = %d; want 1", len(containers))
+	}
+	got := containers[0]
+	if got.Name != instance+"-owned" || got.Kind != "capsule" || got.Role != "runner" || got.LeaseID != "lease-owned" {
+		t.Errorf("owned container = %+v; labels did not survive the round trip", got)
+	}
+	// Running state decides whether recovery adopts or cleans up.
+	if !got.Running {
+		t.Error("a started container reported as not running; recovery would clean up live work")
+	}
+
+	volumes, err := c.ListOwnedVolumes(ctx, instance)
+	if err != nil {
+		t.Fatalf("list volumes: %v", err)
+	}
+	if len(volumes) != 1 || volumes[0].ID != vol || volumes[0].LeaseID != "lease-owned" {
+		t.Errorf("owned volumes = %+v; want the one just created", volumes)
+	}
+
+	networks, err := c.ListOwnedNetworks(ctx, instance)
+	if err != nil {
+		t.Fatalf("list networks: %v", err)
+	}
+	if len(networks) != 1 || networks[0].ID != netID || networks[0].LeaseID != "lease-owned" {
+		t.Errorf("owned networks = %+v; want the one just created", networks)
+	}
+
+	// Another instance's query must not see any of it: the instance
+	// label is what keeps two controllers on one host from sweeping
+	// each other's capsules.
+	foreign, err := c.ListOwnedContainers(ctx, instance+"-other")
+	if err != nil {
+		t.Fatalf("list for a foreign instance: %v", err)
+	}
+	if len(foreign) != 0 {
+		t.Errorf("a foreign instance sees %d containers; ownership is not scoped", len(foreign))
+	}
+}
+
+// TestResourceLimits confirms the tier envelope reaches the daemon.
+// The limits are set through a nested Resources struct that the
+// migration moved inside a new options envelope; silently dropping them
+// would leave every capsule unbounded.
+func TestResourceLimits(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	const (
+		memBytes  = 64 * 1024 * 1024
+		swapBytes = 32 * 1024 * 1024
+	)
+	code, out, err := c.RunTask(ctx, docker.ContainerSpec{
+		Name:  instance + "-limits",
+		Image: busybox,
+		// cgroup v2 reports the container's own envelope in these files.
+		// Checking only memory.max would let swap, CPU or PIDs be
+		// dropped silently — and an unbounded fork or CPU budget is as
+		// much a capacity lie as unbounded memory.
+		Cmd: []string{"sh", "-c",
+			"cat /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory.swap.max " +
+				"/sys/fs/cgroup/cpu.max /sys/fs/cgroup/pids.max"},
+		Labels:          labels(instance, "lease-limits", "task", "helper"),
+		MemoryBytes:     memBytes,
+		MemorySwapBytes: memBytes + swapBytes,
+		NanoCPUs:        500_000_000,
+		PIDsLimit:       128,
+	})
+	if err != nil {
+		t.Fatalf("run task: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("reading the cgroup limit exited %d: %s", code, out)
+	}
+	// The four files are read in a fixed order, so the output is
+	// position-for-position comparable. Substring matching here once let
+	// a value pass by appearing anywhere — "0" matches inside
+	// "67108864" — which is no check at all.
+	lines := strings.Fields(strings.TrimSpace(out))
+	// cpu.max is one line with two fields (quota period), so five fields
+	// in total.
+	want := []string{
+		"67108864", // memory.max
+		"33554432", // memory.swap.max — additional swap, not Docker's combined value
+		"50000",    // cpu.max quota for 0.5 CPU
+		"100000",   // cpu.max period, the daemon default
+		"128",      // pids.max
+	}
+	if len(lines) != len(want) {
+		t.Fatalf("cgroup readback has %d fields, want %d:\n%s", len(lines), len(want), out)
+	}
+	names := []string{"memory.max", "memory.swap.max", "cpu.max quota", "cpu.max period", "pids.max"}
+	for i, w := range want {
+		if lines[i] != w {
+			t.Errorf("%s = %q; want %q — the tier envelope did not reach the daemon intact",
+				names[i], lines[i], w)
+		}
+	}
+}
+
+// TestOwnedIDByName is the fail-closed resolution the intent model
+// rests on: an object found by its deterministic name is returned only
+// with proven ownership, a foreign object with the same name is a typed
+// refusal, and absence is an answer, not an error.
+func TestOwnedIDByName(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	name := instance + "-owned-by-name"
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   name,
+		Image:  busybox,
+		Cmd:    []string{"true"},
+		Labels: labels(instance, "lease-own", "container", "runner"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+
+	got, err := c.OwnedIDByName(ctx, "container", name, instance, "lease-own")
+	if err != nil || got != id {
+		t.Errorf("owned resolution = %q, %v; want the created id", got, err)
+	}
+
+	// Same name, different lease: name equality is not ownership.
+	if _, err := c.OwnedIDByName(ctx, "container", name, instance, "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
+		t.Errorf("foreign resolution = %v; want ErrForeignResource — adopting by name "+
+			"would run work through someone else's object and later delete it", err)
+	}
+	if err := c.RemoveOwnedContainer(ctx, name, instance, "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
+		t.Fatalf("foreign removal = %v; want ErrForeignResource", err)
+	}
+	if got, err := c.OwnedIDByName(ctx, "container", name, instance, "lease-own"); err != nil || got != id {
+		t.Fatalf("foreign removal changed the owned object: id=%q err=%v", got, err)
+	}
+
+	// Absence is an answer: the create never took effect.
+	if got, err := c.OwnedIDByName(ctx, "container", instance+"-never-existed", instance, "lease-own"); err != nil || got != "" {
+		t.Errorf("absent resolution = %q, %v; want empty and no error", got, err)
+	}
+}
+
+// TestOwnedRemovalRefusesForeignNetworkAndVolume covers the destructive
+// branches whose daemon identity is not a container id. In particular, Docker
+// volumes are addressed only by name, so the immediate label proof is the
+// guard against deleting a name another owner now holds.
+func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	networkName := instance + "-owned-removal-network"
+	networkID, err := c.CreateNetwork(ctx, docker.NetworkSpec{
+		Name:   networkName,
+		Labels: labels(instance, "lease-owner", "network", "capsule-net"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := c.RemoveNetwork(context.WithoutCancel(ctx), networkID); err != nil {
+			t.Errorf("cleanup network %s: %v", networkID, err)
+		}
+	})
+	if err := c.RemoveOwnedNetwork(ctx, networkID, instance, "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
+		t.Fatalf("foreign network removal = %v; want ErrForeignResource", err)
+	}
+	if got, err := c.OwnedIDByName(ctx, "network", networkName, instance, "lease-owner"); err != nil || got != networkID {
+		t.Fatalf("network changed after refused removal: id=%q err=%v", got, err)
+	}
+
+	volumeName := instance + "-owned-removal-volume"
+	if _, err := c.CreateVolume(ctx, volumeName, labels(instance, "lease-owner", "volume", "dind-data")); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := c.RemoveVolume(context.WithoutCancel(ctx), volumeName); err != nil {
+			t.Errorf("cleanup volume %s: %v", volumeName, err)
+		}
+	})
+	if err := c.RemoveOwnedVolume(ctx, volumeName, instance, "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
+		t.Fatalf("foreign volume removal = %v; want ErrForeignResource", err)
+	}
+	if got, err := c.OwnedIDByName(ctx, "volume", volumeName, instance, "lease-owner"); err != nil || got != volumeName {
+		t.Fatalf("volume changed after refused removal: id=%q err=%v", got, err)
+	}
+}
+
+// TestHostInfo covers the doctor's view of the daemon. Runpool refuses
+// hosts it cannot honour the capsule contract on, and every field here
+// is read from a result struct the migration introduced.
+//
+// Under RUNPOOL_CONTRACT_QUALIFY the check hardens from populated fields to
+// an exact match with the release-qualification reference.
+func TestHostInfo(t *testing.T) {
+	c, _ := client(t)
+
+	info, err := c.Info(t.Context())
+	if err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	if info.ServerVersion == "" || info.APIVersion == "" {
+		t.Errorf("info = %+v; version fields are how the host gate decides", info)
+	}
+	if info.CgroupVersion == "" {
+		t.Error("cgroup version is empty; the v2 requirement cannot be checked")
+	}
+	if info.OSType == "" || info.Architecture == "" {
+		t.Errorf("info = %+v; platform fields are empty", info)
+	}
+
+	if os.Getenv("RUNPOOL_CONTRACT_QUALIFY") == "" {
+		return
+	}
+	// The expectation comes from the reviewed manifest, never from the host
+	// being evaluated.
+	reference := platform.MustLoad()
+	arch := info.Architecture
+	if arch == "x86_64" {
+		arch = "amd64"
+	}
+	rootless := info.Rootless
+	observed := platform.Facts{
+		Engine:        info.ServerVersion,
+		API:           info.APIVersion,
+		Arch:          arch,
+		CgroupVersion: info.CgroupVersion,
+		CgroupDriver:  info.CgroupDriver,
+		Rootless:      &rootless,
+	}
+	for _, m := range reference.CompareDockerFacts(observed) {
+		t.Errorf("not the release-qualification reference — %s", m)
+	}
+	// OSType and Architecture use the daemon's own spelling, which
+	// differs from the manifest's (x86_64 against amd64), so they are
+	// compared here rather than by mapping one onto the other.
+	if info.OSType != "linux" || info.Architecture != "x86_64" {
+		t.Errorf("platform = %s/%s; the qualification reference is linux/x86_64", info.OSType, info.Architecture)
+	}
+	t.Logf("release-qualification reference confirmed: engine %s, api %s, cgroup v%s/%s, rootful",
+		info.ServerVersion, info.APIVersion, info.CgroupVersion, info.CgroupDriver)
+}
+
+// TestEnsureOwnedVolume is the fail-closed half of the cache hand-off:
+// Docker's volume create silently adopts an existing name whatever its
+// labels say, so the ensure must prove ownership itself. A foreign
+// volume with the expected name must never be handed to a job.
+func TestEnsureOwnedVolume(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	own := map[string]string{
+		docker.LabelManaged:  "true",
+		docker.LabelInstance: instance,
+		docker.LabelRole:     cache.RoleCacheLane,
+	}
+	name := instance + "-ensure"
+	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
+
+	if err := c.EnsureOwnedVolume(ctx, name, own); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	// Idempotent: the second ensure adopts the volume it created.
+	if err := c.EnsureOwnedVolume(ctx, name, own); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+
+	foreign := instance + "-foreign"
+	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), foreign) })
+	if _, err := c.CreateVolume(ctx, foreign, map[string]string{"someone": "else"}); err != nil {
+		t.Fatal(err)
+	}
+	err := c.EnsureOwnedVolume(ctx, foreign, own)
+	if !errors.Is(err, docker.ErrForeignResource) {
+		t.Fatalf("ensuring over a foreign volume = %v; want ErrForeignResource", err)
+	}
+}
+
+// TestCacheLaneVolumes is the live cache contract, end to end through
+// the real manager and store against the real daemon: warm data left by
+// one job is what the next job of the same lane mounts; another
+// generation is blind to it; eviction removes exactly the evicted
+// lane's volume. Because a lane is a daemon-side named volume, where the
+// controller runs cannot change the object mounted by a capsule.
+func TestCacheLaneVolumes(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	st, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	mgr := cache.New(st, c, instance)
+
+	release := func(lease string) {
+		t.Helper()
+		if err := st.Tx(ctx, func(tx *store.Tx) error { return tx.ReleaseCacheLane(lease) }); err != nil {
+			t.Fatal(err)
+		}
+	}
+	acquire := func(gen, lease string) cache.LaneMount {
+		t.Helper()
+		loc, ok, err := mgr.Acquire(ctx, "https://github.com/acme/app", gen, lease, 2)
+		if err != nil || !ok {
+			t.Fatalf("acquire %s/%s: ok=%v, %v", gen, lease, ok, err)
+		}
+		t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), loc.Volume) })
+		return loc
+	}
+	// job runs a container with the lane mounted whole at /cache, the
+	// way a capsule mounts it.
+	job := func(name, volume, cmd string) (int64, string) {
+		t.Helper()
+		code, out, err := c.RunTask(ctx, docker.ContainerSpec{
+			Name:   instance + "-" + name,
+			Image:  busybox,
+			Cmd:    []string{"sh", "-c", cmd},
+			Labels: labels(instance, "lease-"+name, "task", "helper"),
+			Mounts: []docker.Mount{{Volume: volume, Target: "/cache"}},
+		})
+		if err != nil {
+			t.Fatalf("job %s: %v", name, err)
+		}
+		return code, out
+	}
+
+	first := acquire("gen-1", "lease-1")
+	if code, out := job("write", first.Volume, "echo run-1 > /cache/marker"); code != 0 {
+		t.Fatalf("writer exited %d: %s", code, out)
+	}
+	release("lease-1")
+
+	// The same repository and generation reuses the lane, and the
+	// marker written by the first job is exactly what the second sees.
+	second := acquire("gen-1", "lease-2")
+	if second.Volume != first.Volume {
+		t.Fatalf("same repo+generation got volume %q; want %q reused", second.Volume, first.Volume)
+	}
+	code, out := job("read", second.Volume, "cat /cache/marker")
+	if code != 0 || strings.TrimSpace(out) != "run-1" {
+		t.Fatalf("the second job did not see the first's data: exit %d, %q", code, out)
+	}
+	release("lease-2")
+
+	// Another generation gets its own lane and finds nothing in it.
+	other := acquire("gen-2", "lease-3")
+	if other.Volume == first.Volume {
+		t.Fatalf("generation gen-2 was handed gen-1's volume %q", other.Volume)
+	}
+	if code, _ := job("blind", other.Volume, "test -e /cache/marker"); code == 0 {
+		t.Fatal("another generation can see the first lane's data")
+	}
+	release("lease-3")
+
+	// Eviction removes exactly the evicted lane's volume.
+	if err := mgr.DeleteLane(ctx, first.LaneID); err != nil {
+		t.Fatal(err)
+	}
+	gone, err := c.OwnedIDByName(ctx, "volume", first.Volume, instance, "")
+	if err != nil || gone != "" {
+		t.Errorf("evicted volume still resolves: %q, %v", gone, err)
+	}
+	left, err := c.OwnedIDByName(ctx, "volume", other.Volume, instance, "")
+	if err != nil || left == "" {
+		t.Errorf("the surviving lane's volume is gone: %q, %v", left, err)
+	}
+}
+
+// TestFilesystemProbe is the disk monitor's measurement contract: the
+// probe answers for the daemon's storage filesystem from inside it,
+// with sane numbers, wherever the controller runs.
+func TestFilesystemProbe(t *testing.T) {
+	c, instance := client(t)
+
+	free, err := c.ProbeFilesystemFree(t.Context(), busybox, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if free.FreeBytes <= 0 {
+		t.Errorf("FreeBytes = %d; the daemon's filesystem is not empty", free.FreeBytes)
+	}
+	if free.FreeInodes == 0 {
+		t.Errorf("FreeInodes = 0; want a positive count or -1 for a filesystem that does not account inodes")
+	}
+}
+
+// TestOwnedVolumeUsage: the GC planner weighs lanes with the daemon's
+// own accounting; a volume with data in it must report its size and
+// carry its labels through.
+func TestOwnedVolumeUsage(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	name := instance + "-usage"
+	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
+	if _, err := c.CreateVolume(ctx, name, labels(instance, "", "volume", cache.RoleCacheLane)); err != nil {
+		t.Fatal(err)
+	}
+	code, out, err := c.RunTask(ctx, docker.ContainerSpec{
+		Name:   instance + "-usage-writer",
+		Image:  busybox,
+		Cmd:    []string{"sh", "-c", "dd if=/dev/zero of=/v/data bs=1024 count=512 2>/dev/null"},
+		Labels: labels(instance, "lease-usage", "task", "helper"),
+		Mounts: []docker.Mount{{Volume: name, Target: "/v"}},
+	})
+	if err != nil || code != 0 {
+		t.Fatalf("writer: exit %d, %v, %s", code, err, out)
+	}
+
+	usage, err := c.OwnedVolumeUsage(ctx, instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *docker.VolumeUsage
+	for i := range usage {
+		if usage[i].Name == name {
+			found = &usage[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("volume %q not in usage %+v", name, usage)
+	}
+	if found.Size < 512*1024 {
+		t.Errorf("size = %d; want at least the 512KiB written", found.Size)
+	}
+	if found.Labels[docker.LabelRole] != cache.RoleCacheLane {
+		t.Errorf("labels did not travel through disk usage: %v", found.Labels)
+	}
+}
+
+// TestContainerDiskFull: a job that fills its filesystem must fail with
+// a clean out-of-space error inside the container, and the daemon must
+// stay healthy and keep running other work — the host-level failure the
+// disk monitor exists to prevent must not be reachable from inside one
+// capped mount.
+func TestContainerDiskFull(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	code, out, err := c.RunTask(ctx, docker.ContainerSpec{
+		Name:   instance + "-diskfull",
+		Image:  busybox,
+		Cmd:    []string{"sh", "-c", "dd if=/dev/zero of=/scratch/fill bs=1M count=64"},
+		Labels: labels(instance, "lease-diskfull", "task", "helper"),
+		Tmpfs:  map[string]string{"/scratch": "rw,size=8m"},
+	})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code == 0 {
+		t.Fatal("64MiB fit in an 8MiB mount; the cap was not applied")
+	}
+	if !strings.Contains(strings.ToLower(out), "no space left") {
+		t.Errorf("output %q; want a clean no-space-left error", out)
+	}
+
+	// The daemon is unharmed: it answers and runs the next task.
+	if _, err := c.Info(ctx); err != nil {
+		t.Fatalf("daemon after disk-full: %v", err)
+	}
+	code, _, err = c.RunTask(ctx, docker.ContainerSpec{
+		Name:   instance + "-after-diskfull",
+		Image:  busybox,
+		Cmd:    []string{"true"},
+		Labels: labels(instance, "lease-diskfull", "task", "helper"),
+	})
+	if err != nil || code != 0 {
+		t.Fatalf("task after disk-full: exit %d, %v", code, err)
+	}
+}
+
+// TestCleanupSurvivesCancellation is why RunTask holds its own deadline:
+// a cancelled job must not cancel its own cleanup, or every timeout
+// leaks a helper container until some later sweep.
+func TestCleanupSurvivesCancellation(t *testing.T) {
+	c, instance := client(t)
+
+	var cleanupErr error
+	c.OnCleanupError(func(string, error) { cleanupErr = errors.New("cleanup reported a failure") })
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	_, _, err := c.RunTask(ctx, docker.ContainerSpec{
+		Name:   instance + "-cancelled",
+		Image:  busybox,
+		Cmd:    []string{"sleep", "60"},
+		Labels: labels(instance, "lease-cancelled", "task", "helper"),
+	})
+	if err == nil {
+		t.Fatal("a task outliving its context should fail")
+	}
+	if cleanupErr != nil {
+		t.Errorf("%v; the removal deadline is not independent of the job context", cleanupErr)
+	}
+
+	// The helper is gone despite the cancellation.
+	left, err := c.ListOwnedContainers(context.Background(), instance)
+	if err != nil {
+		t.Fatalf("list after cancellation: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("%d helper(s) left behind after a cancelled task: %+v", len(left), left)
+	}
+}
+
+func mustRemoveContainer(t *testing.T, c *docker.Client, ctx context.Context, id string) {
+	t.Helper()
+	cctx := context.WithoutCancel(ctx)
+	if err := c.RemoveContainer(cctx, id); err != nil {
+		t.Errorf("cleanup: container %s was not removed: %v", id, err)
+		return
+	}
+	// Absence is verified, not assumed: a removal the daemon accepted
+	// but did not complete leaves a privileged leftover this suite
+	// exists to notice.
+	if _, err := c.ContainerStatus(cctx, id); !docker.IsNotFound(err) {
+		t.Errorf("cleanup: container %s still exists after removal (status error: %v)", id, err)
+	}
+}
+
+// TestContainerRemovalSparesNamedVolumes. Removal takes a container's
+// anonymous volumes with it — an image that declares VOLUME grows one
+// per container wherever a mount does not cover the path, and nothing
+// labelled ever finds them. The half with data in it is the one this
+// suite has to pin: a named volume mounted into the container is not
+// touched by that flag.
+func TestContainerRemovalSparesNamedVolumes(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	named := instance + "-keep"
+	if _, err := c.CreateVolume(ctx, named, map[string]string{
+		docker.LabelManaged:  "true",
+		docker.LabelInstance: instance,
+	}); err != nil {
+		t.Fatalf("create named volume: %v", err)
+	}
+	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), named) })
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:  instance + "-anonvol",
+		Image: busybox,
+		Cmd:   []string{"true"},
+		Labels: map[string]string{
+			docker.LabelManaged:  "true",
+			docker.LabelInstance: instance,
+		},
+		Mounts: []docker.Mount{
+			{Volume: named, Target: "/data"},
+			{Volume: "", Target: "/anon"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("create container: %v", err)
+	}
+	if err := c.RemoveContainer(ctx, id); err != nil {
+		t.Fatalf("remove container: %v", err)
+	}
+
+	// Removing the named volume now must succeed, which is what proves
+	// the container's removal left it standing.
+	if err := c.RemoveVolume(ctx, named); err != nil {
+		t.Fatalf("the named volume did not survive the container's removal: %v", err)
+	}
+}


### PR DESCRIPTION
## What changes

`internal/cache` arrives: persistent per-repository cache lanes, their
labelling, and the collection that reclaims them. The live Docker
contract suite arrives with it, since it needs both the daemon adapter
and something that creates real volumes to exercise.

## What was found

**A volume name must not derive from repository text.** Repository and
owner names arrive from the provider, so they are attacker-influenced. A
name built from them lets a repository decide what a Docker object is
called, and a collision is not a naming annoyance — it is two
repositories mounting the same warm volume and reading each other's build
state. Names derive from the lane's opaque local id instead.

**Lanes are repository-scoped because that is where identity binds.** An
organization-scoped binding serves every repository in the organization
through one scale set. A lane at that scope would be warm for whichever
repository ran last, and the next job — a different project — would mount
it. Repository scope is not a limitation here; it is the only scope at
which "warm for this project" means anything.

**Cache is performance state, so eviction is always safe.** That is
stated as a property the code keeps rather than an aspiration: nothing a
job needs for correctness is stored in a lane, which is what lets
collection reclaim any lane at any time without coordinating with a
running job.

**A lane belongs to the instance, not to a lease.** Every sweep has to
tell a persistent lane from a lease's ephemeral volume, because they have
opposite lifetimes — one is removed when its lease ends, the other must
survive. A distinct role label carries that difference so no sweep has to
infer it.

## Evidence

Hermetic only in CI. The lane model, label construction and collection
policy are covered by unit tests. Whether a volume actually mounts, what
the daemon reports for its size, and how collection behaves against real
objects need a daemon, so they are in the Docker contract suite, which is
environment-gated.

```text
hermetic only in CI — the live Docker contract is environment-gated and
ran nothing in this run
```

## What would notice this regressing

`internal/cache`'s suite fails if a volume name starts deriving from
repository text, if a lane is created for a non-repository scope, or if
collection stops distinguishing a lane from a lease's ephemeral volume.
The Docker contract is what would notice a lane failing to mount or
collection failing against real objects.

## Risk, compatibility and operations

Trust boundary: repository identifiers reach this package from the
provider and are treated as untrusted text. They are stored as data and
never interpolated into an object name.

Ownership and cleanup: lanes carry the instance ownership pair plus a
role label. Collection reclaims lanes by label, so a lane whose
repository is gone does not linger for want of a record.

Resource limits: lane storage counts toward the managed bytes the disk
machine reads, which is what lets disk pressure reclaim cache before it
refuses work.

Networking, credentials, schema, migration: N/A.

Deployment: cache lanes are the controller's own named volumes and are
deliberately not declared in any deployment file — they are disposable
warm state and belong outside a backup, unlike the state volume.

CLI, configuration, status API, rollback, runbook: N/A — nothing imports
this package yet.

Constrains what the code may do later, so it arrives with its record:
[persistent lanes only where identity binds](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-11-repository-cache-scope.md).

## Changelog

```text
NONE
```
