### PR TITLE
feat(lease): the lifecycle of one attempt's host resources

### DIFF
--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -1,0 +1,541 @@
+// Package lease owns the lifecycle of the host resources one attempt
+// consumes: the lease state machine, the durable resource-intent saga
+// that removes every Docker object the capsule created, and the single
+// transaction that ends both — release, cache-lane return and the
+// attempt's disposition, committed together.
+//
+// It knows nothing about providers. A lease carries a binding id and the
+// attempt it serves; who that binding is, and what has to be told about
+// the runner, is the composition layer's business. That separation is
+// the point: cleanup that has to reach a provider is cleanup that stops
+// working when the provider is unreachable.
+//
+// Disposition rests on evidence alone, never on how far cleanup got. A
+// lease state describes cleanup; reading it as an execution outcome is
+// how a job that never ran gets settled as if it had.
+package lease
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"slices"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Remover is the slice of the Docker client cleanup drives intents to
+// absent through. Removal of an already-absent object is success — that
+// contract is what makes retrying a removal safe.
+type Remover interface {
+	RemoveOwnedContainer(ctx context.Context, reference, instanceID, leaseID string) error
+	RemoveOwnedNetwork(ctx context.Context, reference, instanceID, leaseID string) error
+	RemoveOwnedVolume(ctx context.Context, reference, instanceID, leaseID string) error
+}
+
+// Manager drives leases. One per controller; it holds no per-lease
+// state, so every method is safe to call from a capsule's own goroutine.
+type Manager struct {
+	store  *store.Store
+	remove Remover
+	log    *slog.Logger
+}
+
+func NewManager(st *store.Store, remove Remover, log *slog.Logger) *Manager {
+	return &Manager{store: st, remove: remove, log: log}
+}
+
+// Transition moves a lease along its state machine.
+func (m *Manager) Transition(ctx context.Context, leaseID string, from, to store.LeaseState) error {
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.TransitionLease(leaseID, from, to)
+	})
+}
+
+// RecordEvidence makes an observation about execution durable against
+// the attempt the lease serves. It runs on a context detached from the
+// job's: the observation must outlive a cancelled job, because it is
+// what stops that job being run twice.
+func (m *Manager) RecordEvidence(ctx context.Context, leaseID string, e store.Evidence) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.RecordEvidenceForLease(leaseID, e)
+	})
+}
+
+// EvidenceOf reads what is known about the execution of the attempt a
+// lease serves.
+func (m *Manager) EvidenceOf(ctx context.Context, lease store.Lease) (store.Evidence, error) {
+	var evidence store.Evidence
+	err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		attempt, err := tx.Get(lease.AttemptID)
+		if err != nil {
+			return err
+		}
+		evidence = attempt.Evidence
+		return nil
+	})
+	return evidence, err
+}
+
+// Release walks a live lease from `from` through cleaning to released,
+// removing every owned resource on the way. A removal failure parks the
+// lease in quarantined until a later reconciliation retries.
+func (m *Manager) Release(ctx context.Context, leaseID string, from store.LeaseState) error {
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		if err := tx.TransitionLease(leaseID, from, store.LeaseDraining); err != nil {
+			return err
+		}
+		return tx.TransitionLease(leaseID, store.LeaseDraining, store.LeaseCleaning)
+	}); err != nil {
+		return err
+	}
+	if err := m.RemoveResources(ctx, leaseID); err != nil {
+		m.Quarantine(leaseID)
+		return err
+	}
+	return m.Finalize(ctx, leaseID, "")
+}
+
+// ToCleaning moves a lease into cleaning from wherever a crash or a
+// failure left it, and reports the state it was in. Beginning from the
+// lease's actual state is the point: a lease already failed or
+// quarantined cannot move to failed again, and attempting it once
+// aborted the very cleanup those states exist to retry.
+func (m *Manager) ToCleaning(ctx context.Context, leaseID string) (store.Lease, error) {
+	var was store.Lease
+	err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		lease, err := tx.LeaseByID(leaseID)
+		if err != nil {
+			return err
+		}
+		was = lease
+		switch lease.State {
+		case store.LeaseCleaning:
+			return nil
+		case store.LeaseFailed, store.LeaseQuarantined:
+			return tx.TransitionLease(leaseID, lease.State, store.LeaseCleaning)
+		default:
+			if err := tx.TransitionLease(leaseID, lease.State, store.LeaseFailed); err != nil {
+				return err
+			}
+			return tx.TransitionLease(leaseID, store.LeaseFailed, store.LeaseCleaning)
+		}
+	})
+	return was, err
+}
+
+// FinishCleaning completes a release that was interrupted partway: the
+// lease is already draining or cleaning, so its resources are removed
+// and the finalizing transaction commits release, cache-lane return and
+// attempt disposition together. A lease reaches cleaning from failure
+// paths too, without a runner ever having existed, so the disposition
+// comes from evidence, never from how far cleanup got.
+func (m *Manager) FinishCleaning(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) error {
+	if lease.State == store.LeaseDraining {
+		if err := m.Transition(ctx, lease.ID, store.LeaseDraining, store.LeaseCleaning); err != nil {
+			return err
+		}
+	}
+	if err := m.RemoveResources(ctx, lease.ID); err != nil {
+		return err
+	}
+	return m.Finalize(ctx, lease.ID, obs)
+}
+
+// Finalize is the single transaction that ends a capsule's life.
+// External cleanup has already finished while the lease was `cleaning`;
+// here, atomically: no resource record may remain, the lease commits to
+// released, the cache lane is freed in the books, and the attempt is
+// disposed of by evidence. One commit, so no crash can separate a
+// released lease from its attempt's disposition. Only after this commit
+// may the admission credit be released.
+func (m *Manager) Finalize(ctx context.Context, leaseID string, startObs assignment.ExecutionObservation) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		// A surviving resource record means external cleanup did not
+		// finish: releasing anyway would free a credit whose privileged
+		// containers may still exist.
+		resources, err := tx.Resources(leaseID)
+		if err != nil {
+			return err
+		}
+		if len(resources) > 0 {
+			return fmt.Errorf("lease %s still owns %d resource records; refusing to finalize", leaseID, len(resources))
+		}
+		lease, err := tx.LeaseByID(leaseID)
+		if err != nil {
+			return err
+		}
+		if err := tx.TransitionLease(leaseID, store.LeaseCleaning, store.LeaseReleased); err != nil {
+			return err
+		}
+		if err := tx.ReleaseCacheLane(leaseID); err != nil {
+			return err
+		}
+		return m.disposeAttempt(tx, lease, startObs)
+	})
+}
+
+// disposeAttempt applies the evidence's ruling to the attempt a lease
+// serves, inside the caller's transaction. A lease with no attempt is
+// quietly complete — disposition already happened — which is what makes
+// retrying the final transaction safe. Four rulings:
+//
+//   - execution was observed: settled, completed_observed or
+//     started_observed by what the daemon showed;
+//   - nothing was ever authorized to start: back to ready, because
+//     nothing consumed the work;
+//   - a start was authorized and the daemon proved it never took
+//     effect: equally back to ready;
+//   - a start was authorized and its outcome cannot be proven either
+//     way: held for a person — settling it could drop a job that never
+//     ran, requeueing it could run a job twice.
+func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assignment.ExecutionObservation) error {
+	attempt, err := tx.Get(lease.AttemptID)
+	if errors.Is(err, store.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	// Keyed by lease: an attempt is served once per lease, and a fixed key
+	// would have the second serving's cleanup swallowed as a replay of the
+	// first.
+	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+lease.ID, "cleanup_completed"); err != nil {
+		return err
+	}
+	switch {
+	case attempt.Evidence == store.EvidenceExitObserved:
+		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionCompletedObserved)
+	case attempt.Evidence == store.EvidenceRunningObserved:
+		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionStartedObserved)
+	case attempt.Evidence.Retriable():
+		m.log.Warn("delivery failed before any start was authorized; the attempt stays servable",
+			"attempt", attempt.ID, "lease", lease.ID)
+		return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
+	case startObs == assignment.ObservedCreated:
+		// Authorized, and the daemon proved the start never took effect:
+		// the work was not consumed, and this is the one path allowed
+		// back to ready past the authorization.
+		m.log.Warn("the authorized start never took effect; the attempt stays servable",
+			"attempt", attempt.ID, "lease", lease.ID)
+		if attempt.State == "starting" {
+			return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), lease.ID)
+		}
+		return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
+	default:
+		m.log.Warn("start outcome is unproven; the attempt is held for review",
+			"attempt", attempt.ID, "lease", lease.ID, "observation", string(startObs))
+		return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
+	}
+}
+
+// HoldAttempt takes an attempt out of the retry cycle and names why.
+//
+// It exists for the failures a retry cannot fix: the next attempt would
+// launch the same configured image, meet the same answer, and spend
+// another of the three servings finding out. Naming the reason is what
+// turns three identical failures per job into one thing to change.
+func (m *Manager) HoldAttempt(ctx context.Context, leaseID, reason string) {
+	m.withAttemptOfLease(ctx, leaseID, func(tx *store.Tx, attempt store.Attempt) error {
+		m.log.Warn("holding the attempt for review", "attempt", attempt.ID,
+			"lease", leaseID, "reason", reason)
+		return tx.HoldForReview(attempt.ID, reason)
+	})
+}
+
+// requeueOrReview turns a refused retry into a review rather than an
+// error. The budget is not a safety rule - the work provably never began
+// either way - so the attempt is held for someone to look at, not
+// settled and not retried forever.
+func (m *Manager) requeueOrReview(tx *store.Tx, attemptID string, err error, leaseID string) error {
+	if !errors.Is(err, store.ErrRetryBudgetExhausted) {
+		return err
+	}
+	m.log.Warn("the attempt has used every serving its retry budget allows; holding it for review",
+		"attempt", attemptID, "lease", leaseID)
+	return tx.HoldForReview(attemptID, store.ReviewReasonRetryBudgetExhausted)
+}
+
+// DisposeStranded applies the evidence's ruling to an attempt whose
+// lease already finished its own lifecycle. Release and disposition
+// commit together, so this should be unreachable; it exists because an
+// invariant nothing checks is an assumption.
+func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, evidence store.Evidence, obs assignment.ExecutionObservation) {
+	switch {
+	case evidence == store.EvidenceExitObserved:
+		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionCompletedObserved)
+	case evidence == store.EvidenceRunningObserved:
+		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionStartedObserved)
+	case evidence.Retriable(), obs == assignment.ObservedCreated:
+		m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
+			// The same split disposeAttempt makes: a stranded attempt in
+			// starting is past the plain requeue's guard, and only the
+			// proven-inert path may bring it back. Without this the
+			// requeue matches zero rows and the attempt never converges.
+			if attempt.State == "starting" {
+				return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), lease.ID)
+			}
+			return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
+		})
+	case obs == assignment.ObservedRunning:
+		// Running reaches here only when the binding is gone and
+		// adoption was impossible; the runtime demonstrably began.
+		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionStartedObserved)
+	default:
+		m.log.Warn("start outcome cannot be proven; holding the attempt for review", "lease", lease.ID)
+		m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
+			return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
+		})
+	}
+}
+
+// withAttemptOfLease resolves the attempt a lease serves and runs one
+// disposition against it in the same transaction. A lease with no
+// attempt is quietly complete: disposition already happened.
+func (m *Manager) withAttemptOfLease(ctx context.Context, leaseID string, fn func(*store.Tx, store.Attempt) error) {
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		attempt, err := tx.AttemptByLease(leaseID)
+		if errors.Is(err, store.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		return fn(tx, attempt)
+	}); err != nil {
+		m.log.Error("cannot dispose of the attempt of a released lease",
+			"lease", leaseID, "error", err)
+	}
+}
+
+func (m *Manager) settleAttemptOfLease(ctx context.Context, leaseID, resolution string) {
+	m.withAttemptOfLease(ctx, leaseID, func(tx *store.Tx, attempt store.Attempt) error {
+		return tx.Settle(attempt.ID, attempt.State, resolution)
+	})
+}
+
+// Quarantine parks a lease whose cleanup failed. It keeps consuming
+// capacity until a later pass resolves it, which is the honest shape of
+// "its privileged containers may still exist".
+func (m *Manager) Quarantine(leaseID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.TransitionLease(leaseID, store.LeaseCleaning, store.LeaseQuarantined)
+	}); err != nil {
+		// The lease stays wherever the failed transition left it, which is
+		// still a live state, so the periodic reconciler keeps seeing it:
+		// that pass works from ownership over every live state, not from
+		// quarantine by name. What is lost is the record of why cleanup
+		// gave up, and swallowing this error is how that becomes
+		// invisible.
+		m.log.Error("cannot quarantine the lease; it stays in its current state",
+			"lease", leaseID, "error", err)
+	}
+}
+
+// RemoveResources drives every one of a lease's intents to absent, in
+// dependency order — containers before the network and volumes that
+// hold them. Each removal walks its own intent: cleanup_pending, then
+// deleting just before the call, then the row's deletion once absence
+// is proven. A failure is booked on the intent with backoff, so the
+// periodic reconciler retries that resource alone; the FK RESTRICT
+// means a surviving intent keeps the lease un-releasable.
+func (m *Manager) RemoveResources(ctx context.Context, leaseID string) error {
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.MarkResourceCleanup(leaseID)
+	}); err != nil {
+		return err
+	}
+	var intents []store.ResourceIntent
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		intents, err = tx.Resources(leaseID)
+		return err
+	}); err != nil {
+		return err
+	}
+
+	order := map[store.ResourceKind]int{
+		store.ResourceContainer: 0,
+		store.ResourceNetwork:   1,
+		store.ResourceVolume:    2,
+	}
+	slices.SortFunc(intents, func(a, b store.ResourceIntent) int {
+		return order[a.Kind] - order[b.Kind]
+	})
+
+	for _, in := range intents {
+		if err := m.removeIntent(ctx, in); err != nil {
+			return fmt.Errorf("remove %s %s: %w", in.Kind, in.Role, err)
+		}
+	}
+	return nil
+}
+
+// removeIntent drives one intent to absent: deleting before the call,
+// the removal addressed by the confirmed id or the deterministic name,
+// and the row deleted only once absence is proven. A failure books
+// bounded backoff on the intent and returns it.
+func (m *Manager) removeIntent(ctx context.Context, in store.ResourceIntent) error {
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.MarkResourceDeleting(in.ID)
+	}); err != nil {
+		return err
+	}
+	if err := m.removeObject(ctx, in.Kind, in.Handle(), in.LeaseID); err != nil {
+		if berr := m.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordResourceError(in.ID, err, time.Now().Add(removalBackoff(in.Retries)))
+		}); berr != nil {
+			m.log.Error("cannot book the removal failure", "intent", in.ID, "error", berr)
+		}
+		return err
+	}
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.ForgetResource(in.ID)
+	})
+}
+
+// removalBackoff paces retries per resource: exponential with jitter,
+// capped, so a wedged object neither hammers the daemon nor waits
+// forever.
+func removalBackoff(retries int64) time.Duration {
+	backoff := min(time.Duration(1<<min(retries, 6))*10*time.Second, 5*time.Minute)
+	jitter := time.Duration(rand.Int64N(int64(backoff / 4)))
+	return backoff + jitter
+}
+
+func (m *Manager) removeObject(ctx context.Context, kind store.ResourceKind, handle, leaseID string) error {
+	instanceID := m.store.InstanceID()
+	switch kind {
+	case store.ResourceContainer:
+		return m.remove.RemoveOwnedContainer(ctx, handle, instanceID, leaseID)
+	case store.ResourceNetwork:
+		return m.remove.RemoveOwnedNetwork(ctx, handle, instanceID, leaseID)
+	case store.ResourceVolume:
+		return m.remove.RemoveOwnedVolume(ctx, handle, instanceID, leaseID)
+	default:
+		return fmt.Errorf("unknown resource kind %q", kind)
+	}
+}
+
+// ForgetResource drops the intent of a Docker object that has just been
+// removed by something else — the orphan sweep — matching by the
+// confirmed id or the deterministic name, since an unconfirmed intent's
+// object is only reachable by name. A lease with no matching intent is
+// unaffected; the point is that a row never outlives its object.
+func (m *Manager) ForgetResource(ctx context.Context, leaseID, dockerID string) error {
+	if leaseID == "" {
+		return nil // never recorded, so nothing to reconcile
+	}
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		intents, err := tx.Resources(leaseID)
+		if err != nil {
+			return err
+		}
+		for _, in := range intents {
+			if in.DockerID == dockerID || in.Name == dockerID {
+				return tx.ForgetResource(in.ID)
+			}
+		}
+		return nil
+	})
+}
+
+// IntentsDue reports whether every booked backoff on the lease's intents
+// has elapsed. A lease with no intents is due by definition: only its
+// finalizing transaction remains.
+func (m *Manager) IntentsDue(ctx context.Context, leaseID string) (bool, error) {
+	var due bool
+	err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		intents, err := tx.Resources(leaseID)
+		if err != nil {
+			return err
+		}
+		now := time.Now().Unix()
+		for _, in := range intents {
+			if in.NotBefore > now {
+				return nil
+			}
+		}
+		due = true
+		return nil
+	})
+	return due, err
+}
+
+// WalkToRunning advances an adopted lease's bookkeeping to
+// workload_running so the normal release path applies, whatever step the
+// crash interrupted. It moves the lease machine only: what the workload
+// did is the attempt's evidence, recorded from observation before this
+// runs, and nothing here can fabricate it. States from draining onward,
+// and failed/quarantined, are left for the caller's release path.
+func (m *Manager) WalkToRunning(ctx context.Context, lease store.Lease) error {
+	steps := map[store.LeaseState]store.LeaseState{
+		store.LeaseReserved:          store.LeaseProvisioning,
+		store.LeaseProvisioning:      store.LeaseRuntimeRegistered,
+		store.LeaseRuntimeRegistered: store.LeaseWorkloadRunning,
+	}
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		current, err := tx.LeaseByID(lease.ID)
+		if err != nil {
+			return err
+		}
+		for next, ok := steps[current.State]; ok; next, ok = steps[current.State] {
+			if err := tx.TransitionLease(current.ID, current.State, next); err != nil {
+				return err
+			}
+			current.State = next
+		}
+		return nil
+	})
+}
+
+// Recorder returns the resource recorder for one lease. Each call it
+// makes commits its own transaction: a plan must be durable before the
+// create call runs, or the intent could not survive the crash it exists
+// for.
+//
+// The concrete type is returned rather than the capsule's interface. The
+// consumer declares that interface — capsule.ResourceRecorder — and Go
+// satisfies it structurally at the call site, so this package produces a
+// recorder without linking a container runtime to do it.
+func (m *Manager) Recorder(ctx context.Context, leaseID string) *intentRecorder {
+	return &intentRecorder{store: m.store, ctx: ctx, leaseID: leaseID}
+}
+
+type intentRecorder struct {
+	store   *store.Store
+	ctx     context.Context
+	leaseID string
+}
+
+func (r *intentRecorder) Plan(kind, role, name string) (int64, error) {
+	var id int64
+	err := r.store.Tx(r.ctx, func(tx *store.Tx) error {
+		var err error
+		id, err = tx.PlanResource(r.leaseID, store.ResourceKind(kind), role, name)
+		return err
+	})
+	return id, err
+}
+
+func (r *intentRecorder) Creating(intentID int64) error {
+	return r.store.Tx(r.ctx, func(tx *store.Tx) error {
+		return tx.MarkResourceCreating(intentID)
+	})
+}
+
+func (r *intentRecorder) Confirm(intentID int64, dockerID string) error {
+	return r.store.Tx(r.ctx, func(tx *store.Tx) error {
+		return tx.MarkResourcePresent(intentID, dockerID)
+	})
+}

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -1,0 +1,417 @@
+package lease
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// nopRemover stands in for the daemon on the removal side: absence is
+// success, exactly the contract the real client honours.
+type nopRemover struct{}
+
+func (nopRemover) RemoveOwnedContainer(context.Context, string, string, string) error { return nil }
+func (nopRemover) RemoveOwnedNetwork(context.Context, string, string, string) error   { return nil }
+func (nopRemover) RemoveOwnedVolume(context.Context, string, string, string) error    { return nil }
+
+// wedgedRemover fails every removal until healed — the daemon a
+// quarantined lease is waiting on.
+type wedgedRemover struct{ healed bool }
+
+func (w *wedgedRemover) fail() error {
+	if w.healed {
+		return nil
+	}
+	return errors.New("daemon wedged")
+}
+func (w *wedgedRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+	return w.fail()
+}
+func (w *wedgedRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+	return w.fail()
+}
+func (w *wedgedRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+	return w.fail()
+}
+
+type fixture struct {
+	t       *testing.T
+	m       *Manager
+	store   *store.Store
+	lease   store.Lease
+	attempt string
+}
+
+// newFixture builds one binding, one delivered workload and the lease
+// serving it — the state every lease-machine test starts from.
+func newFixture(t *testing.T, remove Remover) *fixture {
+	t.Helper()
+	st, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	f := &fixture{t: t, store: st,
+		m: NewManager(st, remove, slog.New(slog.NewTextHandler(io.Discard, nil)))}
+	f.tx(func(tx *store.Tx) error {
+		binding, err := tx.EnsureBinding("app", "github_actions",
+			"v1|repository|https://github.com/acme/app||runpool-standard")
+		if err != nil {
+			return err
+		}
+		if _, err := tx.RecordDelivery(binding, "msg-1", sha256.Sum256([]byte("payload")),
+			[]store.WorkloadRow{{SourceWorkloadKey: "job-1", TenantKey: "acme", ProjectKey: "app"}}); err != nil {
+			return err
+		}
+		ready, err := tx.ReadyAttempts(binding)
+		if err != nil {
+			return err
+		}
+		f.attempt = ready[0].ID
+		f.lease, err = tx.LeaseAttempt(f.attempt, binding, "standard")
+		return err
+	})
+	return f
+}
+
+func (f *fixture) tx(fn func(*store.Tx) error) {
+	f.t.Helper()
+	if err := f.store.Tx(f.t.Context(), fn); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// driveTo walks the lease to a target state through the real machine, so
+// a test never fabricates a state the product cannot produce.
+func (f *fixture) driveTo(target store.LeaseState) {
+	f.t.Helper()
+	paths := map[store.LeaseState][]store.LeaseState{
+		store.LeaseReserved:          {},
+		store.LeaseProvisioning:      {store.LeaseProvisioning},
+		store.LeaseRuntimeRegistered: {store.LeaseProvisioning, store.LeaseRuntimeRegistered},
+		store.LeaseWorkloadRunning: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning},
+		store.LeaseDraining: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining},
+		store.LeaseCleaning: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning},
+		store.LeaseQuarantined: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning,
+			store.LeaseQuarantined},
+	}
+	path, ok := paths[target]
+	if !ok {
+		f.t.Fatalf("no path defined to lease state %q", target)
+	}
+	f.tx(func(tx *store.Tx) error {
+		from := store.LeaseReserved
+		for _, to := range path {
+			if err := tx.TransitionLease(f.lease.ID, from, to); err != nil {
+				return err
+			}
+			from = to
+		}
+		return nil
+	})
+	if got := f.reload(); got.State != target {
+		f.t.Fatalf("wanted a lease in %q but it is %q; the test would assert nothing", target, got.State)
+	}
+}
+
+func (f *fixture) reload() store.Lease {
+	f.t.Helper()
+	var lease store.Lease
+	f.tx(func(tx *store.Tx) error {
+		var err error
+		lease, err = tx.LeaseByID(f.lease.ID)
+		return err
+	})
+	return lease
+}
+
+func (f *fixture) attemptState() store.Attempt {
+	f.t.Helper()
+	var a store.Attempt
+	f.tx(func(tx *store.Tx) error {
+		var err error
+		a, err = tx.Get(f.attempt)
+		return err
+	})
+	return a
+}
+
+func (f *fixture) recordEvidence(e store.Evidence) {
+	f.t.Helper()
+	if err := f.m.RecordEvidence(f.t.Context(), f.lease.ID, e); err != nil {
+		f.t.Fatal(err)
+	}
+}
+
+// Finalize commits release, cache-lane return and attempt disposition in
+// one transaction, deciding by what can be proven about execution. Work
+// that provably never began must return to the queue, observed execution
+// must settle with the observation as its resolution, and an unprovable
+// start outcome must be held for a person — visible, never silently
+// either of the others. A lease that is not cleaning refuses to
+// finalize, and the refusal leaves the attempt untouched: atomicity
+// means all of it or none of it.
+func TestFinalizeDisposesByEvidence(t *testing.T) {
+	cases := []struct {
+		name           string
+		evidence       store.Evidence
+		toState        store.LeaseState
+		startObs       assignment.ExecutionObservation
+		wantErr        bool
+		wantState      string
+		wantResolution string
+	}{
+		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, "", false, "settled", assignment.ResolutionCompletedObserved},
+		{"running observed", store.EvidenceRunningObserved, store.LeaseCleaning, "", false, "settled", assignment.ResolutionStartedObserved},
+		{"nothing was prepared", store.EvidenceNotStarted, store.LeaseCleaning, "", false, "ready", ""},
+		{"prepared but never authorized", store.EvidenceRuntimePrepared, store.LeaseCleaning, "", false, "ready", ""},
+		{"authorized and unprovable", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedAbsent, false, "manual_review", ""},
+		{"authorized and proven inert", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedCreated, false, "ready", ""},
+		{"lease not yet cleaning", store.EvidenceNotStarted, store.LeaseQuarantined, "", true, "leased", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t, nopRemover{})
+			f.driveTo(tc.toState)
+			f.recordEvidence(tc.evidence)
+
+			err := f.m.Finalize(t.Context(), f.lease.ID, tc.startObs)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Finalize error = %v; wantErr %v", err, tc.wantErr)
+			}
+
+			got := f.attemptState()
+			if got.State != tc.wantState {
+				t.Errorf("attempt state = %s; want %s", got.State, tc.wantState)
+			}
+			if tc.wantResolution != "" && got.Resolution != tc.wantResolution {
+				t.Errorf("resolution = %s; want %s", got.Resolution, tc.wantResolution)
+			}
+			if !tc.wantErr && f.reload().State != store.LeaseReleased {
+				t.Errorf("lease = %s; want released in the same commit", f.reload().State)
+			}
+		})
+	}
+}
+
+// The finalizing transaction is atomic: when any step inside it fails,
+// nothing commits — the lease stays cleaning and the attempt stays
+// leased, so reconciliation retries the whole ending instead of
+// observing half of one. The failure injected here is a resource record
+// that external cleanup never removed.
+func TestFinalizeIsAtomic(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	f.driveTo(store.LeaseCleaning)
+	f.recordEvidence(store.EvidenceExitObserved)
+
+	f.tx(func(tx *store.Tx) error {
+		id, err := tx.PlanResource(f.lease.ID, store.ResourceContainer, "runner", "runpool-runner-leftover")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "leftover")
+	})
+
+	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err == nil {
+		t.Fatal("finalizing with a surviving resource record succeeded")
+	}
+	if got := f.reload(); got.State != store.LeaseCleaning {
+		t.Errorf("lease = %s; want still cleaning — nothing may commit", got.State)
+	}
+	if got := f.attemptState(); got.State != "leased" {
+		t.Errorf("attempt = %s; want still leased — nothing may commit", got.State)
+	}
+}
+
+// Release walks a live lease all the way to released, removing every
+// owned object on the way and disposing of the attempt by evidence.
+func TestReleaseRemovesEverythingAndDisposes(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	f.driveTo(store.LeaseWorkloadRunning)
+	f.recordEvidence(store.EvidenceExitObserved)
+	f.tx(func(tx *store.Tx) error {
+		id, err := tx.PlanResource(f.lease.ID, store.ResourceContainer, "runner", "runpool-runner-1")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "runner-1")
+	})
+
+	if err := f.m.Release(t.Context(), f.lease.ID, store.LeaseWorkloadRunning); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.reload(); got.State != store.LeaseReleased {
+		t.Errorf("lease = %s; want released", got.State)
+	}
+	f.tx(func(tx *store.Tx) error {
+		intents, err := tx.Resources(f.lease.ID)
+		if err != nil {
+			return err
+		}
+		if len(intents) != 0 {
+			t.Errorf("intents = %d; every one must be forgotten before release commits", len(intents))
+		}
+		return nil
+	})
+	if got := f.attemptState(); got.State != "settled" {
+		t.Errorf("attempt = %s; want settled", got.State)
+	}
+}
+
+// A wedged daemon parks the lease in quarantine with backoff booked on
+// the intent, and the attempt stays unresolved — visible, waiting. The
+// lease keeps its credit precisely because its privileged containers may
+// still exist.
+func TestReleaseQuarantinesOnAWedgedDaemon(t *testing.T) {
+	remover := &wedgedRemover{}
+	f := newFixture(t, remover)
+	f.driveTo(store.LeaseWorkloadRunning)
+	f.tx(func(tx *store.Tx) error {
+		id, err := tx.PlanResource(f.lease.ID, store.ResourceContainer, "runner", "runpool-runner-wedge")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "wedge-1")
+	})
+
+	if err := f.m.Release(t.Context(), f.lease.ID, store.LeaseWorkloadRunning); err == nil {
+		t.Fatal("release with a wedged daemon succeeded")
+	}
+	if got := f.reload(); got.State != store.LeaseQuarantined {
+		t.Fatalf("lease = %s; want quarantined", got.State)
+	}
+	if got := f.attemptState(); got.State != "leased" {
+		t.Errorf("attempt = %s; want still leased — nothing was resolved", got.State)
+	}
+
+	// The intent carries a booked backoff, so the lease is not due yet.
+	due, err := f.m.IntentsDue(t.Context(), f.lease.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if due {
+		t.Error("a lease whose removal just failed is due immediately; the backoff was not booked")
+	}
+
+	// The daemon heals and the window elapses.
+	remover.healed = true
+	f.tx(func(tx *store.Tx) error {
+		intents, err := tx.Resources(f.lease.ID)
+		if err != nil {
+			return err
+		}
+		return tx.RecordResourceError(intents[0].ID, errors.New("previous failure"), time.Now().Add(-time.Second))
+	})
+	if due, err := f.m.IntentsDue(t.Context(), f.lease.ID); err != nil || !due {
+		t.Fatalf("after the backoff the lease must be due: due=%v, %v", due, err)
+	}
+	// A quarantined lease resumes through cleaning; moving it to failed
+	// again is the invalid transition that once aborted the retry.
+	if _, err := f.m.ToCleaning(t.Context(), f.lease.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.m.FinishCleaning(t.Context(), f.reload(), ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.reload(); got.State != store.LeaseReleased {
+		t.Errorf("lease = %s after the daemon healed; want released", got.State)
+	}
+}
+
+// The intent recorder is what makes a crash recoverable: the plan is
+// durable before the create call runs, in its own transaction, so it
+// survives the crash it exists for.
+func TestRecorderCommitsEachStepSeparately(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	rec := f.m.Recorder(t.Context(), f.lease.ID)
+
+	id, err := rec.Plan("container", "runner", "runpool-runner-x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.tx(func(tx *store.Tx) error {
+		intents, err := tx.Resources(f.lease.ID)
+		if err != nil {
+			return err
+		}
+		if len(intents) != 1 || intents[0].State != "planned" {
+			t.Fatalf("after Plan the store holds %+v; want one planned intent", intents)
+		}
+		return nil
+	})
+	if err := rec.Creating(id); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Confirm(id, "docker-abc"); err != nil {
+		t.Fatal(err)
+	}
+	f.tx(func(tx *store.Tx) error {
+		intents, err := tx.Resources(f.lease.ID)
+		if err != nil {
+			return err
+		}
+		if intents[0].State != "present" || intents[0].Handle() != "docker-abc" {
+			t.Errorf("confirmed intent = %s/%s; want present, addressed by id",
+				intents[0].State, intents[0].Handle())
+		}
+		return nil
+	})
+}
+
+// TestTheExhaustedBudgetHoldsTheAttemptForReview covers the manager's half
+// of the retry budget: the store refuses the fourth serving's requeue, and
+// this is where that refusal has to become a review instead of an error.
+// An error here fails Finalize's transaction, which rolls back the lease
+// release with it - so the credit is never freed and reconciliation
+// retries the same failing commit forever.
+func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+
+	// Serve and dispose through the real machine until the budget is
+	// spent. Each pass is one serving: drive to cleaning, finalize with
+	// retriable evidence, and the attempt returns to ready.
+	for serving := 1; ; serving++ {
+		f.driveTo(store.LeaseCleaning)
+		if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+			t.Fatalf("finalize serving %d: %v", serving, err)
+		}
+		var attempt store.Attempt
+		f.tx(func(tx *store.Tx) error {
+			var err error
+			attempt, err = tx.Get(f.attempt)
+			return err
+		})
+		if attempt.State == "manual_review" {
+			if attempt.ReviewReason != store.ReviewReasonRetryBudgetExhausted {
+				t.Fatalf("held for review as %q; want %q, so an operator knows the "+
+					"question is whether retrying will ever stop",
+					attempt.ReviewReason, store.ReviewReasonRetryBudgetExhausted)
+			}
+			return
+		}
+		if attempt.State != "ready" {
+			t.Fatalf("after serving %d the attempt is %q; want ready or manual_review", serving, attempt.State)
+		}
+		if serving > 5 {
+			t.Fatal("the budget never ended; a failure that repeats is retried without bound")
+		}
+		// The next serving.
+		f.tx(func(tx *store.Tx) error {
+			var err error
+			f.lease, err = tx.LeaseAttempt(f.attempt, attempt.BindingID, "standard")
+			return err
+		})
+	}
+}

--- a/scripts/drills/lifecycle.sh
+++ b/scripts/drills/lifecycle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# The lifecycle drills: install, backup, restore, upgrade (migration),
+# rollback (restore), and uninstall — executed against a real Docker
+# host, with the real controller image, so the runbook's procedures are
+# proven rather than described. Every drill asserts its outcome; a
+# procedure that cannot be verified is not a procedure.
+#
+# The drills need no GitHub credential. State is seeded by a small
+# first-party helper that opens the store the way the controller would;
+# everything else goes through the shipped CLI in the shipped image.
+#
+# Usage: scripts/drills/lifecycle.sh <ssh-host>
+#   RUNPOOL_CONTRACT_HOST  default for <ssh-host>
+cd "$(dirname "$0")/../.."
+host=${1:-${RUNPOOL_CONTRACT_HOST:-}}
+if [ -z "$host" ]; then
+  echo "usage: scripts/drills/lifecycle.sh <ssh-host>   (a Linux Docker host)" >&2
+  exit 2
+fi
+out=$(mktemp -d)
+trap 'rm -rf "$out"' EXIT
+
+echo "== cross-compile the seed helper (linux/amd64, CGO_ENABLED=0) =="
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$out/drill-seed" ./test/drills/seed
+
+echo "== ship the tree and the helper =="
+COPYFILE_DISABLE=1 git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$out/src.tgz" --null -T - 2>/dev/null
+remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-drills.XXXXXX')
+remote_dir_q=$(printf '%q' "$remote_dir")
+trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
+scp -q "$out/src.tgz" "$out/drill-seed" test/drills/remote-drills.sh "$host":"$remote_dir/"
+# shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
+ssh "$host" "bash '$remote_dir/remote-drills.sh' '$remote_dir'"

--- a/test/drills/remote-drills.sh
+++ b/test/drills/remote-drills.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Remote half of the lifecycle drills. Runs on the Docker host: builds
+# the controller image from the shipped tree, then walks install →
+# backup → wipe → restore → upgrade check → uninstall, asserting each
+# step. Everything it creates is named after this run and removed at
+# the end, success or failure.
+#
+# Usage: remote-drills.sh <dir>
+dir=${1:?usage: remote-drills.sh <dir with src.tgz and drill-seed>}
+run_id=$(basename "$dir" | tr -dc 'a-zA-Z0-9' | tail -c 8)
+vol="runpool-drill-state-$run_id"
+img="runpool:drill-$run_id"
+# Busybox for volume plumbing, digest-pinned like everything else.
+bb='busybox:1.36@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662'
+
+cleanup() {
+  docker volume rm "$vol" >/dev/null 2>&1 || true
+  docker rmi "$img" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mkdir -p "$dir/src"
+tar -xzf "$dir/src.tgz" -C "$dir/src" 2>/dev/null
+cd "$dir/src"
+
+echo "== drill: install =="
+docker build -q -f build/controller/Dockerfile -t "$img" . >/dev/null
+docker volume create "$vol" >/dev/null
+# The image runs and states its version. Doctor on an unconfigured
+# host must do two things at once: pass every host check, and still
+# exit non-zero naming the missing configuration — an all-green exit
+# with nothing configured would be a lie about readiness.
+docker run --rm "$img" version
+doctor_out=$(docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro "$img" doctor 2>&1) \
+  && { echo "install drill: doctor exited zero without a configuration"; exit 1; }
+echo "$doctor_out"
+if echo "$doctor_out" | grep -q '^fail'; then
+  echo "install drill: a host check failed on the reference host"; exit 1
+fi
+echo "$doctor_out" | grep -q 'RUNPOOL_GITHUB_URL' || {
+  echo "install drill: doctor did not name the missing configuration"; exit 1; }
+# Fail-closed proof: serve without a credential must refuse, not start.
+if docker run --rm -v "$vol":/var/lib/runpool/state "$img" serve >/dev/null 2>&1; then
+  echo "install drill: serve started without a credential"; exit 1
+fi
+echo "install: image runs, doctor passes, serve refuses without a credential"
+
+echo "== drill: seed state (stands in for a served instance) =="
+# The helper runs inside a container so the files carry the same
+# ownership the controller would give them.
+docker run --rm -v "$vol":/state -v "$dir/drill-seed":/drill-seed:ro "$bb" \
+  /drill-seed create /state > "$dir/instance-id"
+instance=$(cat "$dir/instance-id")
+echo "seeded instance $instance"
+
+echo "== drill: backup =="
+# The runbook's procedure verbatim: archive the state volume while no
+# controller runs. The singleton lock makes 'no controller' checkable.
+docker run --rm -v "$vol":/state:ro "$bb" tar -czf - -C /state . > "$dir/state-backup.tgz"
+[ -s "$dir/state-backup.tgz" ] || { echo "backup drill: empty archive"; exit 1; }
+# Non-empty is not the property that matters. A volume name that does not
+# exist is created on the spot by `docker run`, and an archive of that
+# empty directory is valid, non-empty and useless — silent until a
+# restore needs it. What has to be in there is the database.
+if ! tar -tzf "$dir/state-backup.tgz" | grep -q 'runpool\.db$'; then
+  echo "backup drill: the archive holds no state database:"
+  tar -tzf "$dir/state-backup.tgz" | sed 's/^/  /'
+  exit 1
+fi
+echo "backup: $(wc -c < "$dir/state-backup.tgz") bytes, database present"
+
+echo "== drill: disaster (wipe) and restore =="
+docker volume rm "$vol" >/dev/null
+docker volume create "$vol" >/dev/null
+docker run --rm -v "$vol":/state -i "$bb" tar -xzf - -C /state < "$dir/state-backup.tgz"
+restored=$(docker run --rm -v "$vol":/state -v "$dir/drill-seed":/drill-seed:ro "$bb" /drill-seed verify /state)
+if [ "$restored" != "$instance" ]; then
+  echo "restore drill: instance $restored after restore; want $instance"; exit 1
+fi
+# The CLI agrees: status reads the restored books. Captured before it is
+# trimmed: piping the command straight into head lets head close the pipe
+# first on a long report, which kills the writer with EPIPE and, under
+# pipefail, fails the drill for finishing its own output.
+status_report=$(docker run --rm -v "$vol":/var/lib/runpool/state -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  "$img" status)
+printf '%s\n' "$status_report" | head -3
+echo "restore: instance identity and audit marker survived"
+
+echo "== drill: upgrade (migration) and integrity =="
+# Pre-release, 'upgrade' is: the new binary opens existing state and
+# migrates forward; the seed helper (built from this same tree) does
+# exactly that on open, and verify proves the data survived migration.
+# Rollback for a failed upgrade is the restore above — down-migrations
+# exist, but restoring the pre-upgrade backup is the documented path.
+docker run --rm -v "$vol":/state -v "$dir/drill-seed":/drill-seed:ro "$bb" /drill-seed verify /state >/dev/null
+echo "upgrade: current schema opens the restored state and the marker survives"
+
+echo "== drill: uninstall =="
+# Uninstall must remove everything the instance owns — including a
+# labeled resource created out-of-band — and must refuse without the
+# instance id as confirmation.
+docker volume create --label io.runpool.managed=true --label "io.runpool.instance=$instance" \
+  --label io.runpool.role=cache-lane "runpool-cache-drill$run_id" >/dev/null
+if docker run --rm -v "$vol":/var/lib/runpool/state -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  "$img" uninstall --confirm=wrong-id >/dev/null 2>&1; then
+  echo "uninstall drill: accepted a wrong confirmation id"; exit 1
+fi
+docker run --rm -v "$vol":/var/lib/runpool/state -v /var/run/docker.sock:/var/run/docker.sock:ro \
+  "$img" uninstall "--confirm=$instance"
+left=$(docker volume ls -q --filter "label=io.runpool.instance=$instance")
+if [ -n "$left" ]; then
+  echo "uninstall drill: owned volumes left behind: $left"; exit 1
+fi
+echo "uninstall: refused the wrong id, removed the owned volume"
+
+echo
+echo "lifecycle drills passed: install, backup, restore, upgrade, uninstall"

--- a/test/drills/seed/main.go
+++ b/test/drills/seed/main.go
@@ -1,0 +1,64 @@
+// Command seed prepares a state directory for the lifecycle drills: it
+// opens the store the way the controller would — creating the instance
+// identity and migrating to the current schema — and leaves one audit
+// entry as a marker the drills can verify across backup, restore and
+// upgrade. It exists because every real path that creates state needs a
+// provider credential, and the drills must not.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+func main() {
+	if len(os.Args) != 3 || (os.Args[1] != "create" && os.Args[1] != "verify") {
+		fmt.Fprintln(os.Stderr, "usage: seed <create|verify> <state-dir>")
+		os.Exit(2)
+	}
+	mode, dir := os.Args[1], os.Args[2]
+
+	st, err := store.Open(dir)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "open:", err)
+		os.Exit(1)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	switch mode {
+	case "create":
+		if err := st.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordAudit("lifecycle-drill", "seed", "instance", "marker for backup/restore verification")
+		}); err != nil {
+			fmt.Fprintln(os.Stderr, "seed:", err)
+			os.Exit(1)
+		}
+		fmt.Println(st.InstanceID())
+	case "verify":
+		var found bool
+		if err := st.Tx(ctx, func(tx *store.Tx) error {
+			entries, err := tx.AuditTail(50)
+			if err != nil {
+				return err
+			}
+			for _, e := range entries {
+				if e.Actor == "lifecycle-drill" && e.Action == "seed" {
+					found = true
+				}
+			}
+			return nil
+		}); err != nil {
+			fmt.Fprintln(os.Stderr, "verify:", err)
+			os.Exit(1)
+		}
+		if !found {
+			fmt.Fprintln(os.Stderr, "verify: the seeded audit marker is gone; the state did not survive")
+			os.Exit(1)
+		}
+		fmt.Println(st.InstanceID())
+	}
+}


### PR DESCRIPTION
## What changes

`internal/lease` arrives: the lease state machine, the resource-intent
saga that drives every object a capsule created to absent, and the
terminal transaction that releases the credit, returns the cache lane and
records the attempt's disposition together. The lifecycle drills that
exercise it against a real host arrive with it.

## What was found

**Release and disposition must commit together.** They are two records of
one event. Committed separately, a crash between them leaves a credit
returned to the pool while the attempt is still open — so the controller
believes it has capacity it has not accounted for, and the attempt is
never settled. One transaction removes the window entirely.

**Cleanup must not depend on the provider.** The objects to remove are on
this host, and cleanup is most needed exactly when things have gone wrong
— which includes the provider being unreachable. A lease therefore holds
a binding id and nothing that requires a call to interpret. Telling the
provider about the runner is a separate concern with a separate failure
mode.

**Already-absent is success.** Cleanup runs after failures, restarts and
partial teardowns, so it routinely meets objects a previous pass already
removed. Treating absence as an error makes the second attempt fail on
precisely the work the first one completed, and the lease never reaches
terminal.

**Disposition cannot be read from the lease state.** The lease state says
how far cleanup got; the attempt's disposition says what the job did.
They are different questions, and a capsule that failed before the runner
started produces a fully cleaned lease and a job that never ran.
Deriving one from the other settles that attempt as if it had executed,
which is the difference between a retry and a lost job.

**Intents are durable.** A restart mid-cleanup has to resume rather than
rediscover, because rediscovery depends on the daemon still reporting
objects that a partial teardown may have already removed. The intents
recorded when the capsule was built are what make the sweep complete
after a crash.

## Evidence

Hermetic only in CI: the state machine, the saga's ordering and the
terminal transaction are covered by unit tests against a real SQLite
database in a temporary directory. The drills that kill a controller
mid-cleanup and confirm the next start finishes the sweep need a Docker
host and are dispatched by hand.

```text
hermetic only in CI — the lifecycle drills need a Docker host and were
not run here
```

## What would notice this regressing

`internal/lease`'s suite fails if release and disposition stop committing
in one transaction, if an already-absent object starts failing cleanup,
or if a disposition is derived from a lease state. The drills are what
would notice a crash mid-cleanup leaving objects behind, which no
hermetic test can observe.

## Risk, compatibility and operations

Trust boundary: none crossed directly. The package drives removals
through an interface the Docker adapter satisfies.

Ownership and cleanup: this is the cleanup path. Every object a capsule
creates is recorded as an intent when it is created, and the saga drives
each intent to absent, so nothing depends on the daemon still listing an
object for it to be removed.

Resource limits: the admission credit is released in the same transaction
that settles the attempt, so capacity accounting cannot drift from what
is actually running.

Failure behaviour: cleanup is idempotent and resumable. A lease that
cannot complete cleanup stays non-terminal and keeps holding its credit,
which is deliberate — releasing capacity for resources that still exist
would oversubscribe the host.

Credentials, networking, schema, migration: N/A — the schema this uses
already exists.

CLI, configuration, status API, deployment, rollback, runbook: N/A —
nothing imports this package yet.

## Changelog

```text
NONE
```
