### PR TITLE
feat(doctor): what must be true before the controller serves

### DIFF
--- a/internal/doctor/capacity.go
+++ b/internal/doctor/capacity.go
@@ -1,0 +1,166 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// configuredSwap is the swap that will actually be requested on a container,
+// so it sums tier envelopes only. host.reserve.swap is capacity withheld from
+// scheduling and never reaches a container: counting it here would demand
+// cgroup swap accounting for a limit Runpool never sets. The host-total gate
+// in physicalCapacity does count the reserve, because that question is
+// whether the host has the swap, not whether Docker can cap it.
+func configuredSwap(cfg *config.Config) int64 {
+	if cfg == nil {
+		return 0
+	}
+	var total int64
+	for _, tier := range cfg.Tiers {
+		total += int64(tier.Resources.Swap)
+	}
+	return total
+}
+
+// checkCapacity reports scheduling policy and binding contention. More
+// bindings than tier parallelism is legal because they share credits, but a
+// silent binding may wait one discovery rotation before its first job is seen.
+func checkCapacity(cfg *config.Config) Result {
+	bindings := map[string]int{}
+	for _, target := range cfg.Targets {
+		for _, binding := range target.Tiers {
+			bindings[binding.TierID]++
+		}
+	}
+	total := 0
+	totalBindings := 0
+	var contended []string
+	for _, tier := range cfg.Tiers {
+		total += tier.Parallelism
+		totalBindings += bindings[tier.ID]
+		if n := bindings[tier.ID]; n > tier.Parallelism {
+			contended = append(contended, fmt.Sprintf("%s (parallelism %d, %d bindings)", tier.ID, tier.Parallelism, n))
+		}
+	}
+	if cfg.Scheduling.Parallelism != nil && totalBindings > *cfg.Scheduling.Parallelism {
+		contended = append(contended, fmt.Sprintf("instance (parallelism %d, %d bindings)",
+			*cfg.Scheduling.Parallelism, totalBindings))
+	}
+	detail := fmt.Sprintf("aggregate tier parallelism %d across %d tiers", total, len(cfg.Tiers))
+	if cfg.Scheduling.Parallelism != nil {
+		detail += fmt.Sprintf("; instance parallelism %d", *cfg.Scheduling.Parallelism)
+	} else {
+		detail += "; tiers are independent"
+	}
+	if len(contended) > 0 {
+		return Result{"capacity", Warn, detail + "; contended: " + strings.Join(contended, ", "),
+			"bindings share tier capacity and rotate discovery; raise tier parallelism if first-job latency matters"}
+	}
+	return Result{"capacity", Pass, detail, ""}
+}
+
+// checkPhysicalCapacity fails before admission when the worst workload set
+// plus the configured host reserve cannot fit on the daemon host.
+func checkPhysicalCapacity(ctx context.Context, cfg *config.Config, d *docker.Client) Result {
+	if d == nil {
+		return Result{"physical capacity", Fail, "daemon not connected", ""}
+	}
+	info, err := d.Info(ctx)
+	if err != nil {
+		return Result{"physical capacity", Fail, err.Error(), ""}
+	}
+	return physicalCapacity(cfg, info)
+}
+
+func physicalCapacity(cfg *config.Config, info docker.HostInfo) Result {
+	required := capacityRequirement(cfg)
+	needMem := saturatingAdd(required.memory, int64(cfg.Host.Reserve.Memory))
+	needCPU := saturatingAdd(required.nanoCPUs, int64(cfg.Host.Reserve.CPU))
+	needSwap := saturatingAdd(required.swap, int64(cfg.Host.Reserve.Swap))
+	hostCPU := int64(info.NCPU) * 1_000_000_000
+	detail := fmt.Sprintf("admitted workloads need %s memory, %s swap and %.1f CPU; reserve adds %s memory, %s swap and %.1f CPU; host has %s memory, %s swap and %d CPU",
+		config.ByteSize(required.memory), config.ByteSize(required.swap), float64(required.nanoCPUs)/1e9,
+		cfg.Host.Reserve.Memory, cfg.Host.Reserve.Swap, float64(cfg.Host.Reserve.CPU)/1e9,
+		config.ByteSize(info.MemTotalBytes), config.ByteSize(info.SwapTotalBytes), info.NCPU)
+	if needMem > info.MemTotalBytes {
+		return Result{"physical capacity", Fail, detail,
+			"the worst admitted workload set plus the host reserve exceeds host memory; lower parallelism, tier memory or the reserve"}
+	}
+	if needCPU > hostCPU {
+		return Result{"physical capacity", Fail, detail,
+			"the worst admitted workload set plus the host reserve exceeds host CPU; lower parallelism, tier cpu or the reserve"}
+	}
+	if needSwap > 0 && !info.SwapTotalKnown {
+		return Result{"physical capacity", Fail, detail,
+			"host swap capacity could not be read; use the local daemon and expose /proc/meminfo to the controller, or set every tier swap and host.reserve.swap to 0B"}
+	}
+	if needSwap > info.SwapTotalBytes {
+		return Result{"physical capacity", Fail, detail,
+			"the worst admitted workload set plus the host reserve exceeds host swap; provision encrypted swap or lower configured swap"}
+	}
+	return Result{"physical capacity", Pass, detail, ""}
+}
+
+type capacityNeeds struct {
+	memory   int64
+	swap     int64
+	nanoCPUs int64
+}
+
+// capacityRequirement calculates each resource dimension independently. With
+// a global limit, the most expensive N tier envelopes are the conservative
+// workload set for that dimension; without one, every tier may fill at once.
+func capacityRequirement(cfg *config.Config) capacityNeeds {
+	totalParallelism := 0
+	for _, tier := range cfg.Tiers {
+		totalParallelism += tier.Parallelism
+	}
+	limit := totalParallelism
+	if cfg.Scheduling.Parallelism != nil && *cfg.Scheduling.Parallelism < limit {
+		limit = *cfg.Scheduling.Parallelism
+	}
+	return capacityNeeds{
+		memory:   sumLargest(cfg.Tiers, limit, func(r config.Resources) int64 { return int64(r.Memory) }),
+		swap:     sumLargest(cfg.Tiers, limit, func(r config.Resources) int64 { return int64(r.Swap) }),
+		nanoCPUs: sumLargest(cfg.Tiers, limit, func(r config.Resources) int64 { return int64(r.CPU) }),
+	}
+}
+
+type weightedResource struct {
+	value int64
+	count int
+}
+
+func sumLargest(tiers []config.Tier, limit int, value func(config.Resources) int64) int64 {
+	values := make([]weightedResource, len(tiers))
+	for i, tier := range tiers {
+		values[i] = weightedResource{value: value(tier.Resources), count: tier.Parallelism}
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i].value > values[j].value })
+	var total int64
+	for _, candidate := range values {
+		count := min(candidate.count, limit)
+		if count <= 0 {
+			break
+		}
+		if candidate.value > 0 && int64(count) > (math.MaxInt64-total)/candidate.value {
+			return math.MaxInt64
+		}
+		total += candidate.value * int64(count)
+		limit -= count
+	}
+	return total
+}
+
+func saturatingAdd(a, b int64) int64 {
+	if b > math.MaxInt64-a {
+		return math.MaxInt64
+	}
+	return a + b
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,427 @@
+// Package doctor validates that a host can honour the capsule contract
+// before Runpool admits any work: the daemon's version, rootful mode,
+// cgroup v2 with the controllers the tier limits need, writable state
+// storage, and the configured credentials and targets.
+//
+// Every check reports pass, warn or fail with an actionable message.
+// A failed check closes admission — the design's rule that a host which
+// cannot meet the contract must fail before creating scale sets, not
+// midway through a job.
+package doctor
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/credential"
+	"github.com/rhobuild/runpool/internal/platform"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+type Status string
+
+const (
+	Pass Status = "pass"
+	Warn Status = "warn"
+	Fail Status = "fail"
+)
+
+// Result is one check's verdict. Detail states what was observed; Fix,
+// when set, says what the operator should do about it.
+type Result struct {
+	Name   string `json:"name"`
+	Status Status `json:"status"`
+	Detail string `json:"detail"`
+	Fix    string `json:"fix,omitempty"`
+}
+
+// Report is a whole doctor run.
+type Report struct {
+	Results []Result `json:"results"`
+}
+
+// OK reports whether every check passed or warned — the admission gate.
+func (r Report) OK() bool {
+	for _, res := range r.Results {
+		if res.Status == Fail {
+			return false
+		}
+	}
+	return true
+}
+
+func (r Report) String() string {
+	var b strings.Builder
+	for _, res := range r.Results {
+		fmt.Fprintf(&b, "%-4s %-22s %s\n", res.Status, res.Name, res.Detail)
+		if res.Fix != "" {
+			fmt.Fprintf(&b, "     %-22s → %s\n", "", res.Fix)
+		}
+	}
+	return b.String()
+}
+
+// Options are the paths and configuration a run checks against. Docker
+// may be nil, in which case the daemon checks report the connection
+// failure instead of panicking.
+type Options struct {
+	Config   *config.Config
+	Docker   *docker.Client
+	StateDir string
+	Environ  func(string) string
+	// NewCredentialProbe builds the probe for one target, from that
+	// target's URL and resolved token. A nil factory skips the live
+	// credential checks, which is what a caller wanting only local host
+	// validation asks for — the presence of a way to reach the provider
+	// is the switch, so there is no second flag to keep in step with it.
+	//
+	// It is a factory rather than a client because the provider is
+	// reached per target: each has its own URL and credential.
+	NewCredentialProbe func(configURL string, secret credential.Secret) (CredentialProbe, error)
+}
+
+// CredentialProbe proves one credential can reach one target's runner
+// group — the whole provider surface this package needs. Declaring it
+// here rather than importing an adapter is what keeps the doctor
+// provider-neutral, the same shape as networkProbeClient below.
+type CredentialProbe interface {
+	RunnerGroupID(ctx context.Context, group string) (int, error)
+	// ScaleSetID reports the provider's id for a scale set this instance
+	// would serve, and whether it exists yet. Not existing is not a
+	// finding: the controller creates it on its first serve.
+	ScaleSetID(ctx context.Context, group, name string) (int, bool, error)
+}
+
+// Run executes every check and returns the report. It never mutates
+// durable product state; the disposable probes it may create are labeled
+// and removed.
+func Run(ctx context.Context, opts Options) Report {
+	var r Report
+	add := func(res Result) { r.Results = append(r.Results, res) }
+
+	add(checkPlatform())
+	if opts.Config != nil {
+		add(checkHostTopology(opts.Config))
+	}
+	add(checkDaemon(ctx, opts.Docker))
+	add(checkIsolatedBridge(ctx, opts.Docker))
+	for _, res := range checkCgroups(ctx, opts.Docker, opts.Config) {
+		add(res)
+	}
+	// Cache lanes are daemon-side volumes now, so the daemon check above
+	// covers their storage; only the state directory is the
+	// controller's own filesystem concern.
+	add(checkStorage("state directory", opts.StateDir))
+	if opts.Config != nil {
+		add(checkCapacity(opts.Config))
+		add(checkPhysicalCapacity(ctx, opts.Config, opts.Docker))
+		if opts.NewCredentialProbe != nil {
+			for _, res := range checkCredentials(ctx, opts) {
+				add(res)
+			}
+		}
+	}
+	return r
+}
+
+func checkHostTopology(cfg *config.Config) Result {
+	switch cfg.Host.Topology {
+	case config.HostTopologySharedDaemon:
+		return Result{
+			Name:   "host topology",
+			Status: Warn,
+			Detail: "shared Docker daemon; Runpool reservations and ownership filters protect coexistence, not daemon compromise",
+			Fix:    "exclude Runpool-managed volumes from platform-wide prune and run only trusted private CI workflows on this host",
+		}
+	case config.HostTopologyDedicatedDaemon:
+		return Result{"host topology", Pass, "dedicated Docker daemon", ""}
+	default:
+		return Result{"host topology", Fail, "not configured", "set host.topology explicitly"}
+	}
+}
+
+func checkPlatform() Result {
+	if runtime.GOOS != "linux" {
+		return Result{"platform", Fail, runtime.GOOS + "/" + runtime.GOARCH + " cannot run Linux capsules",
+			"run the controller on a Linux host"}
+	}
+	return Result{"platform", Pass, runtime.GOOS + "/" + runtime.GOARCH, ""}
+}
+
+func checkDaemon(ctx context.Context, d *docker.Client) Result {
+	if d == nil {
+		return Result{"docker daemon", Fail, "not connected",
+			"mount the daemon socket at /var/run/docker.sock"}
+	}
+	info, err := d.Info(ctx)
+	if err != nil {
+		return Result{"docker daemon", Fail, err.Error(), "check the socket mount and daemon health"}
+	}
+	if info.Rootless {
+		return Result{"docker daemon", Fail, "rootless mode (engine " + info.ServerVersion + ")",
+			"V1 requires rootful Docker: privileged dind and cgroup limits differ under rootless"}
+	}
+	major := majorVersion(info.ServerVersion)
+	detail := fmt.Sprintf("engine %s, api %s, %s", info.ServerVersion, info.APIVersion, info.Architecture)
+	if major < platform.MinimumEngineMajor {
+		return Result{"docker daemon", Fail, detail,
+			fmt.Sprintf("upgrade to Docker Engine %d or newer", platform.MinimumEngineMajor)}
+	}
+	return Result{"docker daemon", Pass, detail, ""}
+}
+
+// checkIsolatedBridge proves the daemon actually provides the capability
+// the restricted profile depends on, rather than inferring it from a
+// version number. Engine 28 introduced the isolated bridge gateway mode,
+// but a version string is a claim: a backport, a patched build, a future
+// major that drops or renames the option, or a daemon whose network
+// driver is unavailable will all announce a sufficient version and then
+// refuse the network a capsule needs.
+//
+// The probe creates one disposable internal+isolated bridge, labeled as
+// managed so any sweep can recognise it, and removes it immediately. It
+// carries no containers and reserves nothing beyond a subnet for the
+// moment it exists. Failing here is the point: a host that cannot build
+// this network must be refused before it accepts work, not after a job
+// has already been assigned to it.
+type networkProbeClient interface {
+	CreateNetwork(context.Context, docker.NetworkSpec) (string, error)
+	RemoveNetwork(context.Context, string) error
+}
+
+func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
+	const name = "isolated bridge"
+	if d == nil {
+		return Result{name, Fail, "daemon not connected", ""}
+	}
+	suffix, err := probeSuffix()
+	if err != nil {
+		return Result{name, Fail, "cannot generate a unique probe name: " + err.Error(), "check the host random source"}
+	}
+	probe := "runpool-doctor-" + suffix
+	id, err := d.CreateNetwork(ctx, docker.NetworkSpec{
+		Name:     probe,
+		Internal: true,
+		Isolated: true,
+		Labels: map[string]string{
+			docker.LabelManaged:  "true",
+			docker.LabelInstance: "doctor",
+			docker.LabelKind:     "network",
+			docker.LabelRole:     "preflight-probe",
+		},
+	})
+	if err != nil {
+		cleanupErr := removeProbeNetwork(ctx, d, probe)
+		if cleanupErr != nil {
+			return Result{name, Fail,
+				"network creation was ambiguous and cleanup failed: " + errors.Join(err, cleanupErr).Error(),
+				"inspect and remove " + probe + " before retrying"}
+		}
+		return Result{name, Fail, "daemon refused an internal isolated bridge: " + err.Error(),
+			"the restricted network profile needs the Engine 28 isolated gateway mode; " +
+				"use a daemon that provides it, or accept unsafe-open-egress deliberately"}
+	}
+	if err := removeProbeNetwork(ctx, d, id); err != nil {
+		return Result{name, Fail,
+			"created, but the probe network could not be removed: " + err.Error(),
+			"remove " + probe + " manually"}
+	}
+	return Result{name, Pass, "internal isolated bridge created and removed", ""}
+}
+
+func removeProbeNetwork(ctx context.Context, d networkProbeClient, id string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	return d.RemoveNetwork(cleanupCtx, id)
+}
+
+// probeSuffix names one probe uniquely so two concurrent preflights do
+// not collide on the name, and so a leaked probe is traceable to a run.
+func probeSuffix() (string, error) {
+	b := make([]byte, 6)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func checkCgroups(ctx context.Context, d *docker.Client, cfg *config.Config) []Result {
+	if d == nil {
+		return []Result{{"cgroups", Fail, "daemon not connected", ""}}
+	}
+	info, err := d.Info(ctx)
+	if err != nil {
+		return []Result{{"cgroups", Fail, err.Error(), ""}}
+	}
+	var out []Result
+	switch {
+	case info.CgroupVersion != "2":
+		out = append(out, Result{"cgroups", Fail, "version " + info.CgroupVersion,
+			"V1 requires cgroup v2 for the tier CPU, memory and PID limits"})
+	case !capsule.KnownCgroupDriver(info.CgroupDriver):
+		// The parent cgroup's form is generated for the driver, and a
+		// driver this build cannot write a parent for produces no parent
+		// at all — so the capsule and its gateway would run under
+		// separate budgets and the tier would stop being their sum. It is
+		// silent at every later point, which is why it fails here.
+		out = append(out, Result{"cgroups", Fail,
+			"v2, driver " + info.CgroupDriver + ", which this build cannot address",
+			"the tier envelope needs one parent cgroup per lease, and its form is written for systemd or cgroupfs"})
+	default:
+		out = append(out, Result{"cgroups", Pass, "v2, driver " + info.CgroupDriver, ""})
+	}
+	// Without these controllers the tier envelope is advisory, which the
+	// resource contract does not allow.
+	if !info.MemoryLimit || !info.PidsLimit {
+		out = append(out, Result{"cgroup controllers", Fail,
+			fmt.Sprintf("memory=%v pids=%v", info.MemoryLimit, info.PidsLimit),
+			"enable the memory and pids controllers; tier limits cannot be enforced without them"})
+	} else {
+		out = append(out, Result{"cgroup controllers", Pass, "memory and pids enforceable", ""})
+	}
+	if configuredSwap(cfg) > 0 {
+		if !info.SwapLimit {
+			out = append(out, Result{"swap controller", Fail, "Docker cannot enforce memory swap limits",
+				"enable swap accounting for the cgroup v2 memory controller or set every configured swap value to 0B"})
+		} else {
+			out = append(out, Result{"swap controller", Pass, "memory swap limits enforceable", ""})
+		}
+	}
+	return out
+}
+
+// checkStorage proves the directory exists and is writable by actually
+// writing, since a read-only mount is the failure this must catch.
+func checkStorage(name, dir string) Result {
+	if dir == "" {
+		return Result{name, Fail, "not configured", ""}
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Result{name, Fail, err.Error(), "mount a writable volume at " + dir}
+	}
+	probe, err := os.CreateTemp(dir, ".runpool-write-probe-*")
+	if err != nil {
+		return Result{name, Fail, "not writable: " + err.Error(), "mount " + dir + " read-write"}
+	}
+	probeName := probe.Name()
+	if _, err := probe.WriteString("ok"); err != nil {
+		_ = probe.Close()
+		_ = os.Remove(probeName)
+		return Result{name, Fail, "write probe failed: " + err.Error(), "check free space and filesystem health at " + dir}
+	}
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(probeName)
+		return Result{name, Fail, "write probe close failed: " + err.Error(), "check filesystem health at " + dir}
+	}
+	if err := os.Remove(probeName); err != nil {
+		return Result{name, Fail, "write probe could not be removed: " + err.Error(), "remove " + probeName + " and check directory permissions"}
+	}
+	return Result{name, Pass, dir + " writable", ""}
+}
+
+// checkCredentials resolves each target's credential and proves the token
+// can reach the target's runner group — the permission failure operators
+// hit most, surfaced before any scale set is created.
+//
+// It names no provider. The caller supplies the probe, which is what lets
+// this package stay in the architecture test's core set alongside every
+// other domain package.
+func checkCredentials(ctx context.Context, opts Options) []Result {
+	creds := map[string]config.Credential{}
+	for _, c := range opts.Config.Credentials {
+		creds[c.ID] = c
+	}
+	var out []Result
+	for _, target := range opts.Config.Targets {
+		name := "target " + target.ID
+		ref, err := config.ParseTargetURL(target.URL)
+		if err != nil {
+			out = append(out, Result{name, Fail, err.Error(), ""})
+			continue
+		}
+		secret, err := credential.Resolve(opts.Environ, creds[target.CredentialID])
+		if err != nil {
+			out = append(out, Result{name, Fail, err.Error(), "provide the credential the target references"})
+			continue
+		}
+		probe, err := opts.NewCredentialProbe(ref.CanonicalURL, secret)
+		if err != nil {
+			out = append(out, Result{name, Fail, err.Error(), ""})
+			continue
+		}
+		group := target.RunnerGroup
+		if group == "" {
+			group = "default"
+		}
+		if _, err := probe.RunnerGroupID(ctx, group); err != nil {
+			out = append(out, Result{name, Fail, "cannot reach runner group " + group + ": " + err.Error(),
+				"the credential needs administration on the target (repository) or self-hosted runners (organization)"})
+			continue
+		}
+		out = append(out, Result{name, Pass,
+			fmt.Sprintf("%s scope, runner group %s reachable, authenticated as %s",
+				ref.Scope, group, describe(secret)), ""})
+		out = append(out, scaleSetResults(ctx, probe, target, group)...)
+	}
+	return out
+}
+
+func majorVersion(v string) int {
+	major, _, _ := strings.Cut(v, ".")
+	n := 0
+	for _, r := range major {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// scaleSetResults reports each scale set this target would serve, and the
+// label a workflow reaches it by.
+//
+// The label is the reason this check exists. A scale set is named in
+// configuration and matched by workflows, and nothing else an operator
+// can run says the two are the same string — so a workflow that names it
+// wrongly queues forever against an instance whose every other check
+// passes.
+func scaleSetResults(ctx context.Context, probe CredentialProbe, target config.Target, group string) []Result {
+	var out []Result
+	for _, tb := range target.Tiers {
+		name := "scale set " + tb.ScaleSetName
+		id, found, err := probe.ScaleSetID(ctx, group, tb.ScaleSetName)
+		switch {
+		case err != nil:
+			out = append(out, Result{name, Fail, err.Error(),
+				"the credential reached the runner group but not its scale sets"})
+		case found:
+			out = append(out, Result{name, Pass,
+				fmt.Sprintf("id %d; workflows reach it with runs-on: %s", id, tb.ScaleSetName), ""})
+		default:
+			out = append(out, Result{name, Pass,
+				fmt.Sprintf("not created yet; serve creates it, and workflows reach it with runs-on: %s",
+					tb.ScaleSetName), ""})
+		}
+	}
+	return out
+}
+
+// describe names what a credential authenticates as, without naming what
+// it is. An operator debugging a permission answer needs to know which
+// identity was refused; nothing about the value helps them.
+func describe(secret credential.Secret) string {
+	if secret.App != nil {
+		return fmt.Sprintf("app installation %d", secret.App.InstallationID)
+	}
+	return "a personal access token"
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,589 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/credential"
+	"github.com/rhobuild/runpool/internal/platform"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+func TestReportOK(t *testing.T) {
+	cases := map[string]struct {
+		results []Result
+		want    bool
+	}{
+		"all pass":       {[]Result{{Status: Pass}, {Status: Pass}}, true},
+		"warn tolerated": {[]Result{{Status: Pass}, {Status: Warn}}, true},
+		"one fail":       {[]Result{{Status: Pass}, {Status: Fail}}, false},
+		"empty":          {nil, true},
+	}
+	for name, tc := range cases {
+		if got := (Report{Results: tc.results}).OK(); got != tc.want {
+			t.Errorf("%s: OK() = %v; want %v", name, got, tc.want)
+		}
+	}
+}
+
+func TestCheckHostTopology(t *testing.T) {
+	shared := &config.Config{Host: config.Host{Topology: config.HostTopologySharedDaemon}}
+	if got := checkHostTopology(shared); got.Status != Warn || !strings.Contains(got.Detail, "shared") || got.Fix == "" {
+		t.Fatalf("shared topology = %+v; want an actionable warning", got)
+	}
+	dedicated := &config.Config{Host: config.Host{Topology: config.HostTopologyDedicatedDaemon}}
+	if got := checkHostTopology(dedicated); got.Status != Pass {
+		t.Fatalf("dedicated topology = %+v; want pass", got)
+	}
+}
+
+func TestCheckStorage(t *testing.T) {
+	dir := t.TempDir()
+	if res := checkStorage("state", filepath.Join(dir, "created")); res.Status != Pass {
+		t.Errorf("writable dir = %+v; want pass", res)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, "created"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("storage probe left %d files behind", len(entries))
+	}
+	if res := checkStorage("state", ""); res.Status != Fail {
+		t.Errorf("unset dir = %+v; want fail", res)
+	}
+
+	// A read-only mount is the failure this check exists for, so it must
+	// be caught by writing, not by stat.
+	readonly := filepath.Join(dir, "readonly")
+	if err := os.Mkdir(readonly, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permissions do not deny writes")
+	}
+	res := checkStorage("cache", readonly)
+	if res.Status != Fail {
+		t.Errorf("read-only dir = %+v; want fail", res)
+	}
+}
+
+func TestCheckCapacity(t *testing.T) {
+	cfg := &config.Config{
+		Targets: []config.Target{
+			{ID: "a", Tiers: []config.TierBinding{{TierID: "std"}}},
+			{ID: "b", Tiers: []config.TierBinding{{TierID: "std"}}},
+		},
+		Tiers: []config.Tier{{ID: "std", Parallelism: 2}},
+	}
+	if res := checkCapacity(cfg); res.Status != Pass {
+		t.Errorf("two bindings with parallelism two = %+v; want pass", res)
+	}
+
+	// More bindings than parallelism is legal under credits — they share the
+	// tier and take turns at discovery — but it costs first-job
+	// latency, so the operator is told rather than stopped.
+	cfg.Tiers[0].Parallelism = 1
+	res := checkCapacity(cfg)
+	if res.Status != Warn {
+		t.Fatalf("two bindings with parallelism one = %+v; want warn, not a failure", res)
+	}
+	if res.Fix == "" {
+		t.Error("a contended capacity check must tell the operator what it costs")
+	}
+}
+
+// TestPhysicalCapacity: full tiers plus the reserve must fit in what
+// the daemon reports, and the failure names which resource ran out.
+func TestPhysicalCapacity(t *testing.T) {
+	cfg := &config.Config{
+		Tiers: []config.Tier{{ID: "std", Parallelism: 4, Resources: config.Resources{
+			Memory: 2 << 30, CPU: 2_000_000_000,
+		}}},
+	}
+	cfg.Host.Reserve.Memory = 2 << 30
+	cfg.Host.Reserve.CPU = 1_000_000_000
+	host := docker.HostInfo{NCPU: 12, MemTotalBytes: 16 << 30, SwapTotalKnown: true}
+
+	// 4x2GiB + 2GiB = 10GiB of 16; 4x2 + 1 = 9 of 12 CPUs.
+	if res := physicalCapacity(cfg, host); res.Status != Pass {
+		t.Errorf("fitting config = %+v; want pass", res)
+	}
+
+	tight := host
+	tight.MemTotalBytes = 8 << 30
+	if res := physicalCapacity(cfg, tight); res.Status != Fail || !strings.Contains(res.Fix, "memory") {
+		t.Errorf("over-committed memory = %+v; want fail naming memory", res)
+	}
+
+	tight = host
+	tight.NCPU = 8
+	if res := physicalCapacity(cfg, tight); res.Status != Fail || !strings.Contains(res.Fix, "CPU") {
+		t.Errorf("over-committed cpu = %+v; want fail naming CPU", res)
+	}
+}
+
+func TestPhysicalCapacityUsesGlobalWorstCase(t *testing.T) {
+	one := 1
+	cfg := &config.Config{
+		Scheduling: config.Scheduling{Parallelism: &one},
+		Tiers: []config.Tier{
+			{ID: "small", Parallelism: 1, Resources: config.Resources{Memory: 4 << 30, Swap: 512 << 20, CPU: 2e9}},
+			{ID: "large", Parallelism: 1, Resources: config.Resources{Memory: 10 << 30, Swap: 2 << 30, CPU: 6e9}},
+		},
+		Host: config.Host{Reserve: config.Reserve{Memory: 5 << 30, Swap: 2 << 30, CPU: 2e9}},
+	}
+	host := docker.HostInfo{
+		NCPU: 8, MemTotalBytes: 16 << 30, SwapTotalBytes: 4 << 30, SwapTotalKnown: true,
+	}
+	if res := physicalCapacity(cfg, host); res.Status != Pass {
+		t.Fatalf("global parallelism one should budget the largest tier, not their sum: %+v", res)
+	}
+
+	cfg.Scheduling.Parallelism = nil
+	if res := physicalCapacity(cfg, host); res.Status != Fail {
+		t.Fatalf("independent tiers should budget both envelopes: %+v", res)
+	}
+}
+
+func TestPhysicalCapacityRequiresKnownSufficientSwap(t *testing.T) {
+	cfg := &config.Config{Tiers: []config.Tier{{
+		ID: "std", Parallelism: 1,
+		Resources: config.Resources{Memory: 1 << 30, Swap: 1 << 30, CPU: 1e9},
+	}}}
+	host := docker.HostInfo{NCPU: 2, MemTotalBytes: 4 << 30}
+	if res := physicalCapacity(cfg, host); res.Status != Fail || !strings.Contains(res.Fix, "could not be read") {
+		t.Fatalf("unknown swap = %+v; want fail", res)
+	}
+	host.SwapTotalKnown = true
+	host.SwapTotalBytes = 512 << 20
+	if res := physicalCapacity(cfg, host); res.Status != Fail || !strings.Contains(res.Fix, "exceeds host swap") {
+		t.Fatalf("insufficient swap = %+v; want fail", res)
+	}
+}
+
+// TestSwapGatesKeyOnDifferentQuestions pins the split the two swap checks
+// deliberately make. A host reserve is capacity withheld from scheduling: it
+// never reaches a container, so it must not demand cgroup swap accounting —
+// but it does have to exist on the host.
+func TestSwapGatesKeyOnDifferentQuestions(t *testing.T) {
+	cfg := &config.Config{
+		Tiers: []config.Tier{{
+			ID: "std", Parallelism: 1,
+			Resources: config.Resources{Memory: 1 << 30, Swap: 0, CPU: 1e9},
+		}},
+		Host: config.Host{Reserve: config.Reserve{Swap: 2 << 30}},
+	}
+
+	// No tier asks for swap, so Docker is never asked to cap it.
+	if got := configuredSwap(cfg); got != 0 {
+		t.Errorf("configuredSwap = %d with reserve-only swap; the cgroup gate must not fire", got)
+	}
+
+	// The host still has to own the swap the reserve withholds.
+	host := docker.HostInfo{NCPU: 2, MemTotalBytes: 4 << 30, SwapTotalKnown: true, SwapTotalBytes: 1 << 30}
+	if res := physicalCapacity(cfg, host); res.Status != Fail || !strings.Contains(res.Fix, "exceeds host swap") {
+		t.Fatalf("reserve larger than host swap = %+v; want fail", res)
+	}
+	host.SwapTotalBytes = 4 << 30
+	if res := physicalCapacity(cfg, host); res.Status != Pass {
+		t.Fatalf("reserve within host swap = %+v; want pass", res)
+	}
+
+	// A tier that does ask for swap turns the cgroup gate on.
+	cfg.Tiers[0].Resources.Swap = 1 << 30
+	if got := configuredSwap(cfg); got != 1<<30 {
+		t.Errorf("configuredSwap = %d; want the tier envelope", got)
+	}
+}
+
+func TestMajorVersion(t *testing.T) {
+	cases := map[string]int{
+		"28.5.0":         28,
+		"27.0.3":         27,
+		"28":             28,
+		"":               0,
+		"v28.5":          0, // not a bare number: treated as unknown, which fails closed
+		"garbage":        0,
+		"28.5.0-ce+meta": 28,
+	}
+	for in, want := range cases {
+		if got := majorVersion(in); got != want {
+			t.Errorf("majorVersion(%q) = %d; want %d", in, got, want)
+		}
+	}
+}
+
+// TestEngineVersionGuardIsAFloorNotAWindow. The release-qualification
+// reference names the host that produced a release's evidence; it is not a
+// runtime constraint. A guard that turned one qualified patch into an equality
+// would refuse daemons that run Runpool correctly, and a guard with a
+// ceiling would refuse every future major sight unseen. Below the floor
+// fails because the isolated gateway mode does not exist there; at or
+// above it, the capability probe decides, not the number.
+func TestEngineVersionGuardIsAFloorNotAWindow(t *testing.T) {
+	for _, tc := range []struct {
+		version   string
+		wantAdmit bool
+		why       string
+	}{
+		{"27.5.1", false, "the isolated bridge gateway mode does not exist before Engine 28"},
+		{"28.0.0", true, "the compatibility floor itself is admitted"},
+		{"28.5.0", true, "a compatible Engine 28 patch is admitted"},
+		{"28.9.9", true, "a later 28 patch is not a drift to refuse"},
+		{"29.0.0", true, "a newer major is admitted; the capability probe decides"},
+		{"30.1.2", true, "no ceiling exists, so no future major is refused for its number"},
+		{"", false, "an unreadable version fails closed"},
+		{"garbage", false, "an unparseable version fails closed"},
+	} {
+		admitted := majorVersion(tc.version) >= platform.MinimumEngineMajor
+		if admitted != tc.wantAdmit {
+			t.Errorf("engine %q admitted=%v; want %v — %s", tc.version, admitted, tc.wantAdmit, tc.why)
+		}
+	}
+}
+
+// TestIsolatedBridgeProbeFailsClosedWithoutADaemon: the capability check
+// is an admission gate, so an unusable daemon is a failure rather than a
+// silently skipped check.
+func TestIsolatedBridgeProbeFailsClosedWithoutADaemon(t *testing.T) {
+	res := checkIsolatedBridge(t.Context(), nil)
+	if res.Status != Fail {
+		t.Errorf("probe without a daemon = %s; want fail", res.Status)
+	}
+}
+
+// TestProbeNamesAreUnique keeps two concurrent preflights on one host
+// from colliding on the probe network's name.
+func TestProbeNamesAreUnique(t *testing.T) {
+	seen := map[string]bool{}
+	for range 64 {
+		s, err := probeSuffix()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s == "" {
+			t.Fatal("probe suffix is empty; the probe network would be unnamed")
+		}
+		if seen[s] {
+			t.Fatalf("probe suffix %q repeated; concurrent preflights would collide", s)
+		}
+		seen[s] = true
+	}
+}
+
+type fakeNetworkProbe struct {
+	createErr    error
+	removeErr    error
+	cancel       context.CancelFunc
+	created      docker.NetworkSpec
+	removed      string
+	removeCalls  int
+	removeCtxErr error
+}
+
+func (f *fakeNetworkProbe) CreateNetwork(_ context.Context, spec docker.NetworkSpec) (string, error) {
+	f.created = spec
+	if f.cancel != nil {
+		f.cancel()
+	}
+	return "probe-id", f.createErr
+}
+
+func (f *fakeNetworkProbe) RemoveNetwork(ctx context.Context, id string) error {
+	f.removeCalls++
+	f.removed = id
+	f.removeCtxErr = ctx.Err()
+	return f.removeErr
+}
+
+func TestIsolatedBridgeProbeLifecycle(t *testing.T) {
+	t.Run("create failure", func(t *testing.T) {
+		probe := &fakeNetworkProbe{createErr: errors.New("unsupported")}
+		if got := checkIsolatedBridge(t.Context(), probe); got.Status != Fail {
+			t.Fatalf("status = %s; want fail", got.Status)
+		}
+		if probe.removeCalls != 1 {
+			t.Fatalf("ambiguous create cleanup called %d times; want 1", probe.removeCalls)
+		}
+	})
+
+	t.Run("cleanup survives caller cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		probe := &fakeNetworkProbe{cancel: cancel}
+		if got := checkIsolatedBridge(ctx, probe); got.Status != Pass {
+			t.Fatalf("result = %+v; want pass", got)
+		}
+		if probe.removeCalls != 1 {
+			t.Fatalf("remove calls = %d; want 1", probe.removeCalls)
+		}
+		if err := probe.removeCtxErr; err != nil {
+			t.Fatalf("cleanup inherited cancellation: %v", err)
+		}
+		if !probe.created.Internal || !probe.created.Isolated {
+			t.Fatalf("probe network = %+v; want internal and isolated", probe.created)
+		}
+		if probe.created.Labels[docker.LabelRole] != "preflight-probe" {
+			t.Fatalf("probe role = %q; want preflight-probe", probe.created.Labels[docker.LabelRole])
+		}
+		if probe.removed != "probe-id" {
+			t.Fatalf("removed %q; want the created network id", probe.removed)
+		}
+	})
+
+	t.Run("cleanup failure closes admission", func(t *testing.T) {
+		probe := &fakeNetworkProbe{removeErr: errors.New("busy")}
+		if got := checkIsolatedBridge(t.Context(), probe); got.Status != Fail {
+			t.Fatalf("result = %+v; want fail", got)
+		}
+	})
+}
+
+// fakeProbe answers as the provider would. It records the group it was
+// asked for, because "" defaulting to "default" is a rule the operator
+// never sees stated anywhere else.
+type fakeProbe struct {
+	asked string
+	id    int
+	err   error
+	// sets are the scale sets the provider already holds, by name. A name
+	// absent here is one the provider does not have yet, which is the
+	// ordinary state before the first serve.
+	sets    map[string]int
+	setsErr error
+}
+
+func (f *fakeProbe) RunnerGroupID(_ context.Context, group string) (int, error) {
+	f.asked = group
+	return f.id, f.err
+}
+
+func (f *fakeProbe) ScaleSetID(_ context.Context, _, name string) (int, bool, error) {
+	if f.setsErr != nil {
+		return 0, false, f.setsErr
+	}
+	id, ok := f.sets[name]
+	return id, ok, nil
+}
+
+// TestCheckCredentials is the check that needs a provider, and the reason
+// the provider arrives as a factory the caller supplies. Every outcome an
+// operator can hit is reachable without a network: the token missing, the
+// client refusing to be built, and the permission failure that is the
+// most common of all — a credential that authenticates but cannot see the
+// runner group.
+func TestCheckCredentials(t *testing.T) {
+	cfg := &config.Config{
+		Credentials: []config.Credential{{ID: "gh", TokenEnv: "TOKEN"}},
+		Targets: []config.Target{
+			{ID: "app", URL: "https://github.com/acme/app", CredentialID: "gh"},
+		},
+	}
+	environ := func(k string) string {
+		if k == "TOKEN" {
+			return "t0ken"
+		}
+		return ""
+	}
+
+	t.Run("reachable", func(t *testing.T) {
+		probe := &fakeProbe{id: 7}
+		res := checkCredentials(t.Context(), Options{
+			Config: cfg, Environ: environ,
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) { return probe, nil },
+		})
+		if len(res) != 1 || res[0].Status != Pass {
+			t.Fatalf("results = %+v; want one pass", res)
+		}
+		if probe.asked != "default" {
+			t.Errorf("asked for runner group %q; an unset group means default", probe.asked)
+		}
+		if !strings.Contains(res[0].Detail, "repository") {
+			t.Errorf("detail %q does not name the scope it proved", res[0].Detail)
+		}
+	})
+
+	t.Run("group unreachable", func(t *testing.T) {
+		res := checkCredentials(t.Context(), Options{
+			Config: cfg, Environ: environ,
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) {
+				return &fakeProbe{err: errors.New("404 not found")}, nil
+			},
+		})
+		if len(res) != 1 || res[0].Status != Fail {
+			t.Fatalf("results = %+v; want one failure", res)
+		}
+		if !strings.Contains(res[0].Fix, "administration") {
+			t.Errorf("fix %q does not say what permission is missing", res[0].Fix)
+		}
+	})
+
+	t.Run("named group is honoured", func(t *testing.T) {
+		withGroup := *cfg
+		withGroup.Targets = []config.Target{
+			{ID: "org", URL: "https://github.com/acme", CredentialID: "gh", RunnerGroup: "isolated"},
+		}
+		probe := &fakeProbe{id: 3}
+		checkCredentials(t.Context(), Options{
+			Config: &withGroup, Environ: environ,
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) { return probe, nil },
+		})
+		if probe.asked != "isolated" {
+			t.Errorf("asked for runner group %q; want the configured one", probe.asked)
+		}
+	})
+
+	t.Run("token missing", func(t *testing.T) {
+		res := checkCredentials(t.Context(), Options{
+			Config: cfg, Environ: func(string) string { return "" },
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) {
+				t.Error("the provider was reached without a credential")
+				return nil, nil
+			},
+		})
+		if len(res) != 1 || res[0].Status != Fail {
+			t.Fatalf("results = %+v; want one failure", res)
+		}
+	})
+
+	t.Run("client refuses to be built", func(t *testing.T) {
+		res := checkCredentials(t.Context(), Options{
+			Config: cfg, Environ: environ,
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) {
+				return nil, errors.New("bad base url")
+			},
+		})
+		if len(res) != 1 || res[0].Status != Fail {
+			t.Fatalf("results = %+v; want one failure", res)
+		}
+	})
+}
+
+// TestCheckCredentialsNamesTheRunsOnLabel: a scale set is named in
+// configuration and matched by a workflow's runs-on, and nothing else an
+// operator can run says the two are the same string. A workflow that
+// names it wrongly queues forever against an instance whose every other
+// check passes, so the check that proves the credential also states the
+// label.
+func TestCheckCredentialsNamesTheRunsOnLabel(t *testing.T) {
+	cfg := &config.Config{
+		Credentials: []config.Credential{{ID: "gh", TokenEnv: "TOKEN"}},
+		Targets: []config.Target{{
+			ID: "app", URL: "https://github.com/acme/app", CredentialID: "gh",
+			Tiers: []config.TierBinding{
+				{TierID: "standard", ScaleSetName: "runpool-standard"},
+				{TierID: "heavy", ScaleSetName: "runpool-heavy"},
+			},
+		}},
+	}
+	environ := func(k string) string {
+		if k == "TOKEN" {
+			return "t0ken"
+		}
+		return ""
+	}
+	run := func(p *fakeProbe) []Result {
+		return checkCredentials(t.Context(), Options{
+			Config: cfg, Environ: environ,
+			NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) { return p, nil },
+		})
+	}
+
+	t.Run("one already exists, one does not", func(t *testing.T) {
+		res := run(&fakeProbe{id: 7, sets: map[string]int{"runpool-standard": 42}})
+		if len(res) != 3 {
+			t.Fatalf("results = %+v; want the credential plus one per tier", res)
+		}
+		for _, r := range res {
+			if r.Status != Pass {
+				t.Errorf("%s is %v: %s", r.Name, r.Status, r.Detail)
+			}
+		}
+		if !strings.Contains(res[1].Detail, "id 42") ||
+			!strings.Contains(res[1].Detail, "runs-on: runpool-standard") {
+			t.Errorf("existing set reads %q", res[1].Detail)
+		}
+		// A set that does not exist yet is not a finding, and the label is
+		// what the operator came for either way.
+		if !strings.Contains(res[2].Detail, "not created yet") ||
+			!strings.Contains(res[2].Detail, "runs-on: runpool-heavy") {
+			t.Errorf("absent set reads %q", res[2].Detail)
+		}
+	})
+
+	t.Run("the provider refuses the scale set read", func(t *testing.T) {
+		res := run(&fakeProbe{id: 7, setsErr: errors.New("403 Forbidden")})
+		if len(res) != 3 {
+			t.Fatalf("results = %+v; want the credential plus one per tier", res)
+		}
+		if res[0].Status != Pass {
+			t.Errorf("the runner group check should still pass: %+v", res[0])
+		}
+		for _, r := range res[1:] {
+			if r.Status != Fail || !strings.Contains(r.Detail, "403") {
+				t.Errorf("%s = %+v; want the refusal reported", r.Name, r)
+			}
+		}
+	})
+}
+
+// TestCheckCredentialsNamesTheIdentity: a permission answer is about an
+// identity, and a deployment can now authenticate as two different kinds.
+// An operator reading "the runner group is unreachable" needs to know
+// which identity was refused; nothing about the secret itself helps them.
+func TestCheckCredentialsNamesTheIdentity(t *testing.T) {
+	for name, tc := range map[string]struct {
+		credential config.Credential
+		environ    func(string) string
+		want       string
+	}{
+		"a personal access token": {
+			credential: config.Credential{ID: "gh", TokenEnv: "TOKEN"},
+			environ:    func(k string) string { return map[string]string{"TOKEN": "t0ken"}[k] },
+			want:       "a personal access token",
+		},
+		"an app installation": {
+			credential: config.Credential{
+				ID: "gh", Type: config.CredentialTypeGitHubApp,
+				ClientID: "Iv1.a", InstallationID: 987, PrivateKeyEnv: "KEY",
+			},
+			environ: func(k string) string {
+				return map[string]string{"KEY": "-----BEGIN RSA PRIVATE KEY-----\nk\n-----END RSA PRIVATE KEY-----"}[k]
+			},
+			want: "app installation 987",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var handed credential.Secret
+			res := checkCredentials(t.Context(), Options{
+				Config: &config.Config{
+					Credentials: []config.Credential{tc.credential},
+					Targets: []config.Target{
+						{ID: "app", URL: "https://github.com/acme/app", CredentialID: "gh"},
+					},
+				},
+				Environ: tc.environ,
+				NewCredentialProbe: func(_ string, s credential.Secret) (CredentialProbe, error) {
+					handed = s
+					return &fakeProbe{id: 7}, nil
+				},
+			})
+			if len(res) != 1 || res[0].Status != Pass {
+				t.Fatalf("results = %+v; want one pass", res)
+			}
+			if !strings.Contains(res[0].Detail, tc.want) {
+				t.Errorf("detail = %q, want it to name %q", res[0].Detail, tc.want)
+			}
+			// The probe is handed the credential whole: an app that
+			// resolved to a token would authenticate as the wrong thing.
+			if (tc.credential.Type == config.CredentialTypeGitHubApp) != (handed.App != nil) {
+				t.Errorf("probe was handed %+v for a %q credential", handed, tc.credential.Type)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

`internal/doctor` arrives: the preflight checks that decide whether a
host may serve. It covers the Docker daemon's version and rootful mode,
cgroup v2 and the controllers tier limits require, writable state
storage, and live verification of every configured credential and target.

## What was found

**The check must happen before scale sets exist.** Once a scale set is
created the provider can assign work to it, and an assignment taken by a
host that cannot run it is a job that fails after being consumed. Closing
admission on a failed check is what keeps a misconfigured host from
taking work it will lose.

**cgroup v2 with specific controllers, not cgroups in general.** A tier
declares CPU and memory limits, and those are applied through controllers
that may be absent even when cgroup v2 is mounted. Checking for the
version alone would pass a host where the limit silently does nothing —
and a limit that silently does nothing is worse than one that fails,
because the tier's guarantee becomes fiction while every dashboard says
it holds.

**Rootless is refused rather than warned about.** The capsule needs a
privileged daemon; rootless cannot provide it, and continuing produces a
failure inside somebody's job instead of at startup.

**A credential is verified by using it.** Parsing proves the shape, not
the authority. The check makes a real call so an expired token, a
revoked App installation or a host that does not serve the protocol is
reported as what it is — with an error naming the credential — instead of
surfacing later as an unexplained failure to create a scale set.

**Every result carries an action.** A check that reports a problem
without saying what to do leaves the operator to reverse-engineer the
requirement from a symptom, which is exactly the situation the check
existed to prevent.

## Evidence

Hermetic only in CI. The checks that need a daemon or a provider are
covered by their own contract suites; the classification logic — which
result closes admission, which warns — is unit-tested here.

```text
hermetic only — the daemon and credential checks require a host and a
provider, and neither was contacted in this run
```

## What would notice this regressing

`internal/doctor`'s suite fails if a failing check stops closing
admission, if a missing cgroup controller is downgraded to a warning, or
if rootless mode is accepted. A check that stopped making a real call for
credentials would show up as a credential test that no longer needs a
provider.

## Risk, compatibility and operations

Trust boundary: the credential check resolves and uses secret material.
It passes the value only to the provider client and never logs, stores or
places it in an error.

Failure behaviour: fails closed. A host that cannot be verified does not
serve.

Networking: outbound HTTPS to each configured target during the
credential check.

Ownership and cleanup: the state-storage check writes and removes a probe
file with a random name, so it cannot collide with real state and leaves
nothing behind.

Resource limits: this is where the host's ability to enforce a tier's
limits is established, before any tier is advertised.

CLI, configuration, status API, schema, migration, deployment, rollback,
runbook: N/A — nothing imports this package yet. The command that
exposes it lands later.

## Changelog

```text
NONE
```
