### PR TITLE
feat(app): the controller

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,11 @@ jobs:
         run: |
           go tool sqlc diff
           go tool sqlc vet
+      - name: Verify the locked image digests have not drifted
+        # Only the registry half: that each locked tag still resolves to the
+        # digest recorded beside it. That the Dockerfiles build from those
+        # digests is hermetic, so internal/app carries it as a test.
+        run: scripts/verify/image-lock.sh
       - name: Verify the module is tidy
         run: |
           go mod tidy

--- a/build/images.lock.json
+++ b/build/images.lock.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "Runtime images Runpool creates containers from, pinned by digest.",
+    "A tag can move; a digest cannot, so a release always runs the images",
+    "it was tested against. The runner and dind pair is versioned together:",
+    "the runner's externals tree and the daemon it drives must match.",
+    "scripts/verify/image-lock.sh re-resolves each tag and fails when a",
+    "digest has drifted from what is recorded here."
+  ],
+  "resolved": "2026-08-15",
+  "platform": "linux/amd64",
+  "images": {
+    "runner": {
+      "ref": "ghcr.io/actions/actions-runner:2.336.0",
+      "digest": "sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda",
+      "upstream": "https://github.com/actions/runner/releases/tag/v2.336.0",
+      "note": "GitHub requires a runner with auto-update disabled to be updated within 30 days of a release."
+    },
+    "dind": {
+      "ref": "docker:29.7.2-dind",
+      "digest": "sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07",
+      "upstream": "https://hub.docker.com/_/docker",
+      "note": "Runs privileged inside the capsule; its data root is a fresh volume per job. Release qualification exercises this exact digest through the capsule candidate."
+    }
+  }
+}

--- a/docs/adrs/2026-08-14-scheduling-and-swap.md
+++ b/docs/adrs/2026-08-14-scheduling-and-swap.md
@@ -1,0 +1,57 @@
+# Scheduling uses explicit parallelism and provider-neutral resource units
+
+**Status:** accepted
+**Date:** 2026-08-14
+
+## Context
+
+A single Runpool instance can serve several targets through several resource
+tiers. Tier limits alone let each tier fill independently, which is useful on a
+dedicated host but can overstate the safe workload set on a shared Docker
+daemon. A host operator also needs configuration terms that describe product
+intent rather than Docker API representation.
+
+Docker calls CPU quota `NanoCPUs` and expresses `MemorySwap` as the combined
+memory-plus-swap limit. Those are adapter mechanics. Exposing them in the
+configuration makes a common request such as “allow 1 GiB of swap” require
+knowledge of Docker's arithmetic and creates ambiguity around zero and
+unlimited values.
+
+## Decision
+
+The configuration has two explicit scheduling levels:
+
+- `tiers[].parallelism` limits active leases for one resource tier;
+- optional `scheduling.parallelism` limits active leases across every target
+  and tier in the instance.
+
+Omitting the global field keeps tiers independent. Setting it constrains both
+provider capacity and local admission. Zero is invalid rather than overloaded
+to mean unlimited. An unreleased lease consumes capacity from durable
+reservation through cleanup or quarantine, and startup reconciliation adopts
+existing leases before admitting new work.
+
+The public resource envelope uses `cpu`, `memory`, `swap`, and `pids`. `memory`
+is the RAM hard limit and `swap` is additional swap. The Docker adapter derives
+its combined `MemorySwap` value as `memory + swap`; `swap: 0B` disables swap and
+Runpool never requests an unlimited value.
+
+Preflight uses the same scheduling contract. Without a global limit it budgets
+all tiers at full parallelism. With a global limit N it conservatively sums the
+N largest eligible envelopes independently for CPU, memory, and swap, then adds
+the host reserve. Configured swap also requires observable host capacity and
+Docker/cgroup enforcement.
+
+## Consequences
+
+- A shared 8 CPU, 16 GiB host can publish several selectable tiers while an
+  instance limit of one guarantees that only one lease consumes resources at a
+  time.
+- Provider announcements cannot accept more aggregate work than local
+  admission can serve under the configured global limit.
+- `runpool status` reports the scheduling mode, configured and effective
+  parallelism, active and available capacity, and per-tier accounting.
+- Changing an omitted global limit to a number is an intentional policy change,
+  not a backward-compatible default adjustment.
+- Swap is an emergency buffer, not ordinary capacity. Production guidance
+  recommends encrypted persistent swap where CI secrets may reach memory.

--- a/docs/adrs/2026-08-17-capsule-image-substitution.md
+++ b/docs/adrs/2026-08-17-capsule-image-substitution.md
@@ -1,0 +1,84 @@
+# An operator may name the capsule image, and the capsule declares its protocol
+
+**Status:** accepted
+**Date:** 2026-08-17
+
+A release binary refuses `RUNPOOL_CAPSULE_IMAGE` whenever its built-in
+capsule reference is digest-qualified (`internal/app/images.go`). The
+shipped capsule is the upstream runner image plus the dind binaries,
+`iptables`, `uidmap` and `iproute2` — not a toolchain image. A workload
+that needs a system package has no way to add one, and no configuration
+field names an alternative.
+
+## What the refusal protects, and what it does not
+
+It does not protect the host. The controller holds the host's Docker
+socket, which is host-root authority, and every capsule runs a
+privileged daemon. An operator who can configure Runpool can already
+run any image with any privileges directly against that socket.
+Refusing to launch their image removes a capability from Runpool
+without removing it from the operator.
+
+What the pin does protect is exactness: the controller launches the
+image it was built against, and the digest cannot move underneath it.
+That property survives an operator-supplied image as long as the
+substitute is named by digest too.
+
+What it also protects, and this one is real, is the meaning of a
+qualified release. The gates observe one capsule. A substituted capsule
+has not been through them.
+
+## What a capsule must be
+
+The capsule is not an arbitrary image. It is the other half of a control
+protocol:
+
+- `ENTRYPOINT` is the Runpool supervisor, which owns PID 1, boots the
+  inner daemon and drains on `SIGTERM`.
+- The supervisor answers three verbs over `docker exec` —
+  `deliver` (JIT bundle on stdin), `start` and `state`.
+- It writes the protocol version to `/run/runpool/protocol` on the
+  control tmpfs at boot.
+
+The version file exists and nothing reads it. A substituted image
+carrying an older supervisor would be launched, would answer some verbs
+and not others, and would fail as a job failure rather than as a
+configuration error.
+
+## Decision
+
+**A tier may name its capsule image**, as `tiers[].capsuleImage`, and the
+value must be digest-qualified. The tier already carries the shape of
+the workload — cpu, memory, swap, pids — and the image belongs to that
+shape. A target-wide field would not express a deployment whose heavy
+tier needs a toolchain the quick tier does not.
+
+`RUNPOOL_CAPSULE_IMAGE` keeps its current meaning for development
+builds and keeps its refusal against a digest-qualified release
+default. Configuration, not the environment, is where a deployment
+states an image.
+
+**The launcher reads `/run/runpool/protocol` before delivering.** A
+capsule whose version is not the one this controller speaks is destroyed
+and the lease resolved as a configuration failure, naming both versions.
+An image that is not a Runpool capsule at all fails the same check,
+because the file is absent.
+
+**The image contract is documented** as a base to build from: the
+published capsule is the base, an operator's image derives from it with
+`FROM`, and the supervisor, its entrypoint and the control tmpfs are the
+parts that may not be replaced.
+
+## Consequences
+
+- A deployment can add system packages, language toolchains or
+  preinstalled software to its jobs without a fork.
+- A substituted capsule is outside the configuration the release gates
+  observed. `runpool status` reports the image each binding launches, so
+  the deviation is visible rather than inferred, and the support
+  statement names it.
+- The version check turns a class of silent, per-job failures into one
+  refusal at launch with both versions in the message.
+- The protocol version becomes a compatibility surface: changing what
+  the supervisor accepts means changing the version, and a controller
+  refuses the pair it does not speak.

--- a/docs/adrs/2026-08-17-job-timeout.md
+++ b/docs/adrs/2026-08-17-job-timeout.md
@@ -1,0 +1,81 @@
+# The lease ceiling is a backstop, not the job's timeout
+
+**Status:** accepted
+**Date:** 2026-08-17
+
+`jobTimeout` is two hours, declared as a constant in `internal/app`, and
+it bounds the context that wraps a whole lease — both a lease this
+controller started and one it adopted at restart. Expiry cancels
+whatever that lease is doing, which in practice is the wait on the
+capsule, because every other step on the path is short.
+
+GitHub's own maximum for a job is 360 minutes. A workflow that sets
+nothing, or sets anything above two hours, is therefore killed by
+Runpool before its own provider would end it, and no document mentions a
+time limit at all.
+
+## The job's own timeout is not in the protocol
+
+The provider's job message carries the runner request id, the repository
+and owner, the job id, the workflow ref, the display name, the workflow
+run id, the event name, the requested labels and four timestamps. It
+does not carry `timeout-minutes`. There is no field to read and no
+second call that would return one: the timeout is enforced by the
+provider against the job, and Runpool is told about the job, not about
+its schedule.
+
+So the ceiling cannot be the job's timeout. The question is what else it
+should be.
+
+## What the ceiling is for
+
+The provider already ends a job at its own limit. When it does, the
+runner exits, the supervisor observes the exit, and the lease resolves
+through the normal path. The ceiling never fires in that case.
+
+It fires when the runner does not exit: a wedged process, a daemon that
+will not stop, a capsule that has lost the ability to report. Without it
+a lease holds its credit and its privileged container indefinitely.
+
+That makes it a backstop against a stuck capsule, and a backstop belongs
+**above** the largest legitimate run, not below it. Two hours is below
+the provider's own maximum, so today it truncates healthy jobs to
+protect against unhealthy ones.
+
+## Decision
+
+**The ceiling is configurable per tier and defaults to eight hours.**
+
+```yaml
+tiers:
+  - id: standard
+    jobTimeout: 8h
+```
+
+The provider's own maximum for a job is 360 minutes, which is six hours
+exactly — so six is not a margin, it is a tie, and the two timeouts would
+race. The provider's timeout is the one that resolves a healthy lease,
+and it still has to reach the runner, exit it and be observed here. Eight
+hours buys that sequence. A tier that knows its work is short may lower
+it and get its capacity back sooner.
+
+**Expiry is named.** The lease resolves with a reason that says the
+capsule exceeded the tier's ceiling, so the attempt's evidence
+distinguishes a Runpool backstop from a provider timeout and from a
+crash.
+
+**The value is documented** as what it is: a limit on how long Runpool
+waits for a capsule, not a limit on how long a job may run.
+
+## Consequences
+
+- A workflow within the provider's own limits is no longer ended by the
+  control plane.
+- A stuck capsule still cannot hold a credit forever, which is the
+  property the constant existed to provide.
+- The ceiling is per tier because the tier is where the workload's shape
+  is already declared; an instance-wide value would force the shortest
+  tier's tolerance onto the longest.
+- An adopted lease inherits the ceiling of the tier it belongs to, so a
+  restart does not extend or shorten a capsule's remaining tolerance
+  beyond what its tier declares.

--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -1,0 +1,482 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/allocator"
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/lease"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// These tests exercise the assignment machine across the app layer, not
+// only its SQLite primitives: what is acknowledged, what becomes a lease,
+// what survives a restart, and what happens when each step fails — a
+// message can be acknowledged in one layer while the work is lost in
+// another, and only a cross-layer test sees that.
+//
+// GitHub and Docker are absent by construction: deliveries enter through
+// the same persistence path production uses, and the loop's decisions
+// are driven through the launch seam and the durable store, which are
+// where the properties live.
+
+type harness struct {
+	t     *testing.T
+	srv   *Controller
+	bind  *binding
+	store *store.Store
+	// probe is the filesystem the disk monitor sees. A test states the
+	// facts it wants and the monitor decides from them.
+	probe *fakeProbe
+	// objects is the daemon inventory reconciliation works from.
+	objects *fakeObjects
+
+	mu       sync.Mutex
+	launched []string
+	leases   map[string]store.Lease // attempt id -> lease, captured at launch
+
+	msgSeq int
+}
+
+func newHarness(t *testing.T, parallelism int) *harness {
+	t.Helper()
+	st, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	return newHarnessOnStore(t, st, parallelism)
+}
+
+// newHarnessOnStore builds a controller over an existing database — the
+// restart path: the same binding identity resolves to the same rows.
+func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness {
+	t.Helper()
+	var bindingID int64
+	if err := st.Tx(context.Background(), func(tx *store.Tx) error {
+		var err error
+		bindingID, err = tx.EnsureBinding("app", "github_actions",
+			"v1|repository|https://github.com/acme/app||runpool-standard")
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &harness{t: t, store: st, leases: map[string]store.Lease{}}
+	b := &binding{
+		key:       "app/standard",
+		tier:      config.Tier{ID: "standard", Parallelism: parallelism},
+		bindingID: bindingID,
+		// These tests serve an existing binding; creating or adopting its
+		// scale set is the subject of its own test.
+		ensured: true,
+	}
+	h.bind = b
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cacheMgr := cache.New(st, nopVolumes{}, st.InstanceID())
+	h.objects = &fakeObjects{wedged: map[string]bool{}}
+	h.srv = &Controller{
+		log:       log,
+		store:     st,
+		objects:   h.objects,
+		leases:    lease.NewManager(st, nopRemover{}, log),
+		cache:     cacheMgr,
+		alloc:     allocator.New(),
+		bindings:  []*binding{b},
+		byBinding: map[int64]*binding{bindingID: b},
+	}
+	if err := h.srv.alloc.Register(b.tier.ID, b.key, parallelism); err != nil {
+		t.Fatal(err)
+	}
+	// The monitor is real, on a defaulted policy and a probe that reports
+	// room: admission consults the level on every delivery, and a nil
+	// monitor would make "no pressure" indistinguishable from "not wired".
+	monitorCfg := &config.Config{}
+	config.ApplyDefaults(monitorCfg)
+	h.probe = &fakeProbe{free: docker.FilesystemFree{FreeBytes: 1 << 40, FreeInodes: 1 << 20}}
+	h.srv.disk = newDiskMonitor(monitorCfg, log, st, h.probe, cacheMgr, h.srv.alloc, "probe-image")
+	// The default launch records the claim and leaves the lease running,
+	// so a test decides its outcome explicitly.
+	h.srv.launch = func(_ *binding, lease store.Lease) {
+		defer h.srv.wg.Done()
+		h.mu.Lock()
+		h.launched = append(h.launched, lease.AttemptID)
+		h.leases[lease.AttemptID] = lease
+		h.mu.Unlock()
+	}
+	return h
+}
+
+// deliverMsg persists one broker message through the production path.
+// The message id is explicit so a test can redeliver the same message.
+func (h *harness) deliverMsg(msgID int, workloads ...assignment.WorkloadAssignment) error {
+	_, err := h.srv.persistDelivery(h.t.Context(), h.bind, &githubactions.Message{
+		ID: msgID, Assigned: workloads,
+	})
+	return err
+}
+
+// deliver persists one fresh message.
+func (h *harness) deliver(workloads ...assignment.WorkloadAssignment) error {
+	h.msgSeq++
+	return h.deliverMsg(h.msgSeq, workloads...)
+}
+
+func (h *harness) serve() {
+	h.srv.scheduleReadyAttempts(h.t.Context(), h.bind)
+	h.srv.wg.Wait()
+}
+
+func (h *harness) launchedAttempts() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.launched...)
+}
+
+// useRemover rebuilds the lease manager over a faulted daemon, so a test
+// can drive the cleanup saga through removal failures.
+func (h *harness) useRemover(r lease.Remover) {
+	h.srv.leases = lease.NewManager(h.store, r, h.srv.log)
+}
+
+func (h *harness) recordEvidence(leaseID string, e store.Evidence) {
+	h.t.Helper()
+	if err := h.store.Tx(h.t.Context(), func(tx *store.Tx) error {
+		return tx.RecordEvidenceForLease(leaseID, e)
+	}); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+func (h *harness) inStore(fn func(*store.Tx) error) {
+	h.t.Helper()
+	if err := h.store.Tx(context.Background(), fn); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+// ready lists the binding's servable attempts.
+func (h *harness) ready() []store.Attempt {
+	h.t.Helper()
+	var out []store.Attempt
+	h.inStore(func(s *store.Tx) error {
+		var err error
+		out, err = s.ReadyAttempts(h.bind.bindingID)
+		return err
+	})
+	return out
+}
+
+// attemptByLease resolves the attempt a lease serves, or a zero Attempt
+// when disposition already detached it.
+func (h *harness) attemptByLease(leaseID string) store.Attempt {
+	h.t.Helper()
+	var out store.Attempt
+	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
+		a, err := tx.AttemptByLease(leaseID)
+		switch {
+		case err == nil:
+			out = a
+			return nil
+		case errors.Is(err, store.ErrNotFound):
+			return nil
+		default:
+			return err
+		}
+	}); err != nil {
+		h.t.Fatal(err)
+	}
+	return out
+}
+
+// resolveWithoutRuntime runs recovery for a lease whose capsule
+// no longer exists — the common crash shape these tests construct.
+func (h *harness) resolveWithoutRuntime(ctx context.Context, lease store.Lease) {
+	h.srv.resolveInterrupted(ctx, h.bind, lease, docker.OwnedContainer{}, false)
+}
+
+func demand(workloadKey, project string, run int64) assignment.WorkloadAssignment {
+	return assignment.WorkloadAssignment{
+		SourceWorkloadKey: workloadKey, TenantKey: "acme", ProjectKey: project, SourceRunID: run,
+	}
+}
+
+// nopRemover stands in for the daemon on the removal side: absence is
+// success, exactly the contract the real client honours.
+type nopRemover struct{}
+
+func (nopRemover) RemoveOwnedContainer(context.Context, string, string, string) error { return nil }
+func (nopRemover) RemoveOwnedNetwork(context.Context, string, string, string) error   { return nil }
+func (nopRemover) RemoveOwnedVolume(context.Context, string, string, string) error    { return nil }
+
+var errDaemon = errors.New("daemon unreachable")
+
+// fakeObjects stands in for the daemon's inventory. It records what was
+// removed and can refuse any of it by name, which is the half of
+// reconciliation that matters and the half a live daemon will not
+// perform on request: an object that does not die.
+type fakeObjects struct {
+	containers []docker.OwnedContainer
+	networks   []docker.OwnedResource
+	volumes    []docker.OwnedResource
+	// wedged names the objects whose removal fails, by id.
+	wedged map[string]bool
+	// listErr fails the container inventory, which is the failure a sweep
+	// must treat as fatal rather than as an empty daemon.
+	listErr error
+
+	removed []string
+}
+
+func (f *fakeObjects) ListOwnedContainers(context.Context, string) ([]docker.OwnedContainer, error) {
+	return f.containers, f.listErr
+}
+func (f *fakeObjects) ListOwnedNetworks(context.Context, string) ([]docker.OwnedResource, error) {
+	return f.networks, nil
+}
+func (f *fakeObjects) ListOwnedVolumes(context.Context, string) ([]docker.OwnedResource, error) {
+	return f.volumes, nil
+}
+func (f *fakeObjects) RemoveContainer(_ context.Context, id string) error { return f.remove(id) }
+func (f *fakeObjects) RemoveNetwork(_ context.Context, id string) error   { return f.remove(id) }
+func (f *fakeObjects) RemoveVolume(_ context.Context, name string) error  { return f.remove(name) }
+
+func (f *fakeObjects) remove(id string) error {
+	if f.wedged[id] {
+		return errors.New("object is wedged")
+	}
+	f.removed = append(f.removed, id)
+	return nil
+}
+
+// fakeProbe stands in for the daemon on the measurement side. Its whole
+// purpose is the states a real filesystem cannot be asked for on demand:
+// no bytes left, no inodes left, a probe that fails.
+type fakeProbe struct {
+	free     docker.FilesystemFree
+	usage    []docker.VolumeUsage
+	freeErr  error
+	usageErr error
+}
+
+func (f *fakeProbe) ProbeFilesystemFree(context.Context, string, string) (docker.FilesystemFree, error) {
+	return f.free, f.freeErr
+}
+
+func (f *fakeProbe) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+	return f.usage, f.usageErr
+}
+
+// nopVolumes stands in for the daemon on the cache side: every lane
+// volume exists and is owned. These tests exercise assignment, not
+// cache handling.
+type nopVolumes struct{}
+
+func (nopVolumes) EnsureOwnedVolume(context.Context, string, map[string]string) error { return nil }
+func (nopVolumes) OwnedIDByName(_ context.Context, _, name, _, _ string) (string, error) {
+	return name, nil
+}
+func (nopVolumes) RemoveVolume(context.Context, string) error { return nil }
+func (nopVolumes) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+	return nil, nil
+}
+
+// A message whose assignments cannot all be made durable must not be
+// acknowledged. Dropping the unrecordable one and acknowledging the rest
+// loses work silently, which is what the code did before.
+func TestUnidentifiableAssignmentFailsTheMessage(t *testing.T) {
+	h := newHarness(t, 2)
+
+	err := h.deliver(
+		demand("job-1", "app", 10),
+		demand("", "app", 11), // no identity
+	)
+	if err == nil {
+		t.Fatal("persisting succeeded despite an assignment with no identity; the message would be acknowledged")
+	}
+	if got := h.ready(); len(got) != 0 {
+		t.Errorf("a partial record was committed: %+v", got)
+	}
+}
+
+// Redelivery after a failed acknowledgement must not duplicate work, and
+// two jobs of one workflow run must both be served.
+func TestRedeliveryIsIdempotentAndMatrixJobsBothRun(t *testing.T) {
+	h := newHarness(t, 2)
+	linux, macos := demand("job-linux", "app", 99), demand("job-macos", "app", 99)
+
+	if err := h.deliverMsg(7, linux, macos); err != nil {
+		t.Fatal(err)
+	}
+	// The acknowledgement failed, so the broker sends the same message
+	// again, byte for byte.
+	if err := h.deliverMsg(7, linux, macos); err != nil {
+		t.Fatal(err)
+	}
+	h.serve()
+
+	if got := h.launchedAttempts(); len(got) != 2 {
+		t.Fatalf("launched %v; want both matrix jobs exactly once", got)
+	}
+	// Serving again must not launch anything: the work is in flight.
+	h.serve()
+	if got := h.launchedAttempts(); len(got) != 2 {
+		t.Errorf("serving twice launched %v", got)
+	}
+}
+
+// The admission credit budget gates launches; the attempt stays durable
+// and is served when a credit frees.
+func TestAttemptsWaitForACreditAndSurvive(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-a", "app", 1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.deliver(demand("job-b", "app", 2)); err != nil {
+		t.Fatal(err)
+	}
+	h.serve()
+
+	if got := h.launchedAttempts(); len(got) != 1 {
+		t.Fatalf("launched %v with one credit; want one", got)
+	}
+	if got := h.ready(); len(got) != 1 {
+		t.Errorf("the waiting attempt is not queued: %+v", got)
+	}
+}
+
+// The lease machine's own contracts — disposition by evidence, the
+// atomicity of the finalizing transaction, the cleanup saga's backoff —
+// live with the code that owns them, in internal/lease. What stays here
+// is what only the composition layer can exercise: the serving loop, the
+// provider-facing paths, and startup recovery across bindings.
+
+// A controller that dies with attempts recorded but unserved must resume
+// them, which is the whole point of persisting before the
+// acknowledgement. The restart is real: the database closes and reopens
+// from disk, and a fresh coordinator resolves the same binding identity
+// to the same rows.
+func TestReadyAttemptsResumeAfterRestart(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := newHarnessOnStore(t, st, 1)
+	if err := h.deliver(demand("job-crash", "app", 7)); err != nil {
+		t.Fatal(err)
+	}
+	// The process dies here: nothing was launched, and GitHub considers
+	// the message delivered.
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { reopened.Close() })
+	revived := newHarnessOnStore(t, reopened, 1)
+	revived.serve()
+	got := revived.launchedAttempts()
+	if len(got) != 1 {
+		t.Fatalf("after restart launched %v; want the recorded attempt", got)
+	}
+	if a := revived.attemptByLease(revived.leases[got[0]].ID); a.SourceWorkloadKey != "job-crash" {
+		t.Fatalf("launched workload = %q; want job-crash", a.SourceWorkloadKey)
+	}
+}
+
+// attemptState reloads one attempt by id, wherever its state moved.
+func attemptState(t *testing.T, h *harness, attemptID string) store.Attempt {
+	t.Helper()
+	var out store.Attempt
+	h.inStore(func(s *store.Tx) error {
+		a, err := s.Get(attemptID)
+		if err != nil {
+			return err
+		}
+		out = a
+		return nil
+	})
+	return out
+}
+
+// leaseFor claims the open attempt of a workload through the production
+// transaction, returning the lease and the attempt id.
+func leaseFor(t *testing.T, h *harness, workloadKey string) (store.Lease, string) {
+	t.Helper()
+	var lease store.Lease
+	var attemptID string
+	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
+		ready, err := tx.ReadyAttempts(h.bind.bindingID)
+		if err != nil {
+			return err
+		}
+		for _, a := range ready {
+			if a.SourceWorkloadKey != workloadKey {
+				continue
+			}
+			attemptID = a.ID
+			lease, err = tx.LeaseAttempt(a.ID, h.bind.bindingID, h.bind.tier.ID)
+			return err
+		}
+		t.Fatalf("no ready attempt for workload %q", workloadKey)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return lease, attemptID
+}
+
+func driveLeaseTo(t *testing.T, h *harness, leaseID string, target store.LeaseState) {
+	t.Helper()
+	// A lease starts reserved; every other state is reached by walking the
+	// real machine, so a test never fabricates a state the product cannot
+	// produce. Hand-written per-target paths silently left several states
+	// at reserved, which made a reconciliation test assert nothing.
+	paths := map[store.LeaseState][]store.LeaseState{
+		store.LeaseReserved:          {},
+		store.LeaseProvisioning:      {store.LeaseProvisioning},
+		store.LeaseRuntimeRegistered: {store.LeaseProvisioning, store.LeaseRuntimeRegistered},
+		store.LeaseWorkloadRunning:   {store.LeaseProvisioning, store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning},
+		store.LeaseDraining: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining},
+		store.LeaseCleaning: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning},
+		store.LeaseReleased: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning, store.LeaseReleased},
+		store.LeaseFailed: {store.LeaseProvisioning, store.LeaseFailed},
+		store.LeaseQuarantined: {store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+			store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning, store.LeaseQuarantined},
+	}
+	path, ok := paths[target]
+	if !ok {
+		t.Fatalf("no path defined to lease state %q", target)
+	}
+	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
+		from := store.LeaseReserved
+		for _, to := range path {
+			if err := tx.TransitionLease(leaseID, from, to); err != nil {
+				return err
+			}
+			from = to
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := reloadLease(t, h, leaseID); got.State != target {
+		t.Fatalf("wanted a lease in %q but it is %q; the test would assert nothing", target, got.State)
+	}
+}

--- a/internal/app/attribution_test.go
+++ b/internal/app/attribution_test.go
@@ -1,0 +1,293 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// nameRuntime attaches a runner name to a lease, the way provisioning
+// does once the capsule's runner is registered.
+func nameRuntime(t *testing.T, h *harness, lease store.Lease, runtimeName string) {
+	t.Helper()
+	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
+		return tx.SetLeaseRuntimeName(lease.ID, runtimeName)
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// eventsOf lists an attempt's recorded lifecycle.
+func eventsOf(t *testing.T, h *harness, attemptID string) []string {
+	t.Helper()
+	var kinds []string
+	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
+		events, err := tx.Events(attemptID)
+		if err != nil {
+			return err
+		}
+		for _, e := range events {
+			kinds = append(kinds, e.Kind)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return kinds
+}
+
+func contains(kinds []string, want string) bool {
+	for _, k := range kinds {
+		if k == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestExecutionIsRecordedAgainstTheWorkloadThatRan is the correctness of
+// the evidence model.
+//
+// A runner is minted against a scale set, not a job, so the provider can
+// hand a runner this instance provisioned for one workload a different
+// one entirely — which is exactly what happens when an assignment lapses
+// and its job is requeued under a new identity. Correlating the
+// observation by the runner's name answers "which attempt was this runner
+// provisioned for", and records the execution against an attempt that
+// never ran.
+//
+// The event names its own workload. That is the attempt whose evidence
+// this is.
+func TestExecutionIsRecordedAgainstTheWorkloadThatRan(t *testing.T) {
+	h := newHarness(t, 2)
+
+	if err := h.deliver(demand("job-lapsed", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.deliver(demand("job-requeued", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+
+	// The runner exists for the first workload; the second is still
+	// waiting. This is the shape a requeue leaves behind.
+	lapsedLease, lapsedAttempt := leaseFor(t, h, "job-lapsed")
+	nameRuntime(t, h, lapsedLease, "runpool-ghost")
+
+	var requeuedAttempt string
+	for _, a := range h.ready() {
+		if a.SourceWorkloadKey == "job-requeued" {
+			requeuedAttempt = a.ID
+		}
+	}
+	if requeuedAttempt == "" {
+		t.Fatal("the requeued workload has no attempt to be evidence for")
+	}
+
+	// The provider reports the requeued workload running, on the runner
+	// minted for the lapsed one.
+	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
+		ID: 901,
+		Started: []assignment.WorkloadLifecycleEvent{{
+			Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-requeued",
+			RuntimeName: "runpool-ghost",
+		}},
+	})
+
+	if !contains(eventsOf(t, h, requeuedAttempt), "running_observed") {
+		t.Error("the workload that ran has no record of running; its evidence went elsewhere")
+	}
+	if contains(eventsOf(t, h, lapsedAttempt), "running_observed") {
+		t.Error("the lapsed workload is recorded as running; it never ran, and its " +
+			"attempt now claims an execution that belongs to another job")
+	}
+}
+
+// TestAnObservationWithNoAttemptFallsBackToTheRunner. A workload this
+// instance never recorded, or whose attempt already settled, still has a
+// runner — and the observation is worth keeping against the attempt that
+// runner serves rather than dropped.
+func TestAnObservationWithNoAttemptFallsBackToTheRunner(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-known", "app", 71)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, "job-known")
+	nameRuntime(t, h, lease, "runpool-known")
+
+	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
+		ID: 902,
+		Started: []assignment.WorkloadLifecycleEvent{{
+			Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-never-seen",
+			RuntimeName: "runpool-known",
+		}},
+	})
+
+	if !contains(eventsOf(t, h, attemptID), "running_observed") {
+		t.Error("an observation naming an unknown workload was dropped; the runner it " +
+			"names is this instance's, and the attempt it serves is the best answer left")
+	}
+}
+
+// TestALateObservationStaysWithTheAttemptThatRanIt is the other half of
+// the correlation rule, and the case where answering by workload alone
+// gets it wrong.
+//
+// A requeue delivers the same workload again, so the delivery path
+// supersedes the open attempt and opens a successor for it. Both attempts
+// name that one workload, and only the first one ever had a runner. An
+// observation of that first run can still arrive afterwards — a session
+// replaced mid-flight replays every message it never acknowledged — and
+// answering "which attempt is open for this workload" hands it the
+// successor, which has started nothing.
+//
+// The runner is what tells them apart: its lease belongs to an attempt
+// for this same workload, so the report is of that attempt's run.
+func TestALateObservationStaysWithTheAttemptThatRanIt(t *testing.T) {
+	h := newHarness(t, 2)
+
+	if err := h.deliver(demand("job-requeued", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	firstLease, firstAttempt := leaseFor(t, h, "job-requeued")
+	nameRuntime(t, h, firstLease, "runpool-first")
+	driveLeaseTo(t, h, firstLease.ID, store.LeaseReleased)
+
+	// The requeue: the same workload arrives again, superseding the
+	// attempt that holds the runner.
+	if err := h.deliver(demand("job-requeued", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	var successor string
+	for _, a := range h.ready() {
+		if a.SourceWorkloadKey == "job-requeued" {
+			successor = a.ID
+		}
+	}
+	if successor == "" || successor == firstAttempt {
+		t.Fatalf("the requeue left no successor attempt (got %q against the first %q); "+
+			"this case needs two attempts for one workload", successor, firstAttempt)
+	}
+
+	// The delayed report of the first run.
+	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
+		ID: 902,
+		Completed: []assignment.WorkloadLifecycleEvent{{
+			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-requeued",
+			RuntimeName: "runpool-first", Result: "succeeded",
+		}},
+	})
+
+	if !contains(eventsOf(t, h, firstAttempt), "exit_observed") {
+		t.Error("the attempt whose runner produced the observation has no record of it")
+	}
+	if contains(eventsOf(t, h, successor), "exit_observed") {
+		t.Error("the successor is recorded as having exited; it holds no lease and has " +
+			"started nothing, so an operator reading its trail is told a run happened")
+	}
+}
+
+// TestALateCancellationDoesNotCloseTheSuccessor. A cancellation is an
+// observation like any other, and it has to reach the attempt the
+// observation was correlated to. Resolving the workload's open attempt on
+// its own gives a second, independent answer, and after a requeue that
+// answer is the successor: the run being cancelled is the one that came
+// before it, and closing the successor destroys work the provider has
+// just handed to this instance and is still waiting on.
+func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
+	h := newHarness(t, 2)
+
+	if err := h.deliver(demand("job-requeued", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	firstLease, firstAttempt := leaseFor(t, h, "job-requeued")
+	nameRuntime(t, h, firstLease, "runpool-first")
+	driveLeaseTo(t, h, firstLease.ID, store.LeaseReleased)
+
+	if err := h.deliver(demand("job-requeued", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	var successor string
+	for _, a := range h.ready() {
+		if a.SourceWorkloadKey == "job-requeued" {
+			successor = a.ID
+		}
+	}
+	if successor == "" || successor == firstAttempt {
+		t.Fatalf("the requeue left no successor attempt (got %q against the first %q)",
+			successor, firstAttempt)
+	}
+
+	// The provider cancels the run that preceded the requeue.
+	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
+		ID: 903,
+		Completed: []assignment.WorkloadLifecycleEvent{{
+			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-requeued",
+			RuntimeName: "runpool-first", Result: "canceled",
+		}},
+	})
+
+	if !contains(eventsOf(t, h, firstAttempt), "remote_canceled") {
+		t.Error("the cancellation never reached the attempt whose run it ends; " +
+			"dropping late cancellations entirely would also leave the successor alone")
+	}
+	var after store.Attempt
+	h.inStore(func(tx *store.Tx) error {
+		var err error
+		after, err = tx.Get(successor)
+		return err
+	})
+	if after.State != "ready" {
+		t.Errorf("the successor is %q/%q; it was never cancelled, and closing it "+
+			"destroys work the provider is still waiting for a runner on",
+			after.State, after.Resolution)
+	}
+}
+
+// TestASecondServingsHintsAreNotSwallowed. attempt_events dedupes on an
+// idempotency key, and the provider's lifecycle hints used a fixed one
+// per attempt. An attempt is served once per runtime now, so the second
+// serving's hints read as replays of the first and vanished - the trail
+// showed one start and one exit stitched across two different runners.
+func TestASecondServingsHintsAreNotSwallowed(t *testing.T) {
+	h := newHarness(t, 2)
+	if err := h.deliver(demand("job-retried", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	firstLease, attemptID := leaseFor(t, h, "job-retried")
+	nameRuntime(t, h, firstLease, "runpool-first")
+
+	hint := func(runtime string) {
+		h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
+			ID: 910,
+			Started: []assignment.WorkloadLifecycleEvent{{
+				Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-retried",
+				RuntimeName: runtime,
+			}},
+		})
+	}
+	hint("runpool-first")
+
+	// The first serving ends without proof and the attempt is served
+	// again by a new runtime.
+	driveLeaseTo(t, h, firstLease.ID, store.LeaseReleased)
+	h.inStore(func(tx *store.Tx) error { return tx.Requeue(attemptID) })
+	secondLease, _ := leaseFor(t, h, "job-retried")
+	nameRuntime(t, h, secondLease, "runpool-second")
+	hint("runpool-second")
+
+	events := eventsOf(t, h, attemptID)
+	got := 0
+	for _, kind := range events {
+		if kind == "running_observed" {
+			got++
+		}
+	}
+	if got != 2 {
+		t.Errorf("running_observed recorded %d times for two servings; want 2 - a "+
+			"fixed idempotency key swallows the second serving's hint as a replay "+
+			"of the first (trail: %v)", got, events)
+	}
+}

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -1,0 +1,262 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/credential"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// buildBindings resolves every configured (target, tier) pair into a
+// binding registered with the allocator. One GitHub client per target;
+// tokens are resolved once.
+//
+// It reaches no provider. Startup reconciliation needs every binding in
+// hand to adopt a running capsule or resolve an interrupted lease, so a
+// binding must exist before the first provider call rather than as its
+// result. Creating-or-adopting the scale set is the binding's own loop's
+// first act, where a failure is retried instead of ending the process.
+func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, environ func(string) string) error {
+	tiers := make(map[string]config.Tier, len(cfg.Tiers))
+	for _, t := range cfg.Tiers {
+		tiers[t.ID] = t
+	}
+	creds := make(map[string]config.Credential, len(cfg.Credentials))
+	for _, c := range cfg.Credentials {
+		creds[c.ID] = c
+	}
+
+	for _, target := range cfg.Targets {
+		ref, err := config.ParseTargetURL(target.URL)
+		if err != nil {
+			return err
+		}
+		secret, err := credential.Resolve(environ, creds[target.CredentialID])
+		if err != nil {
+			return err
+		}
+		gh, err := githubactions.NewClient(githubactions.ClientConfig{
+			ConfigURL:  ref.CanonicalURL,
+			Credential: secret,
+			Version:    cfg.Instance.Name,
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, tb := range target.Tiers {
+			tier := tiers[tb.TierID]
+
+			// The neutral binding row comes first: it keys the delivery,
+			// attempt and lease machinery. Its source key is a versioned
+			// encoding of the provider identity, never an ambiguous
+			// concatenation.
+			sourceBindingKey := fmt.Sprintf("v1|%s|%s|%s|%s",
+				ref.Scope, ref.CanonicalURL, target.RunnerGroup, tb.ScaleSetName)
+			var bindingID, knownSetID int64
+			if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+				var err error
+				if bindingID, err = tx.EnsureBinding(target.ID, "github_actions", sourceBindingKey); err != nil {
+					return err
+				}
+				// The scale set id recorded against this binding is the
+				// proof of ownership that lets an existing set be adopted.
+				// Without it, a set that merely shares the name is a
+				// stranger's.
+				knownSetID, err = tx.GitHubScaleSetID(bindingID)
+				return err
+			}); err != nil {
+				return err
+			}
+			b := &binding{
+				key:    target.ID + "/" + tier.ID,
+				target: target,
+				tier:   tier,
+				ref:    ref,
+				gh:     gh,
+				jit:    gh,
+				sets:   gh,
+				// The recorded id is what lets the loop adopt the set it
+				// created on an earlier start instead of refusing a
+				// stranger's set of the same name. Zero means this binding
+				// has never had one.
+				scaleSetID:   int(knownSetID),
+				scaleSetName: tb.ScaleSetName,
+				bindingID:    bindingID,
+				// Only a repository-scoped binding may bind a persistent
+				// cache: an organization runner is not bound to the job
+				// whose demand created it, so it could execute any
+				// repository's job against another repository's cache.
+				cacheEnabled: ref.Scope == config.ScopeRepository && target.Cache.Enabled,
+				generation:   target.Cache.Generation,
+				maxLanes:     laneCeiling(cfg, tier),
+				capsuleImage: tierCapsuleImage(tier, s.shippedCapsuleImage),
+			}
+			if err := s.alloc.Register(tier.ID, b.key, tier.Parallelism); err != nil {
+				return err
+			}
+			s.bindings = append(s.bindings, b)
+			s.byBinding[bindingID] = b
+		}
+	}
+	if len(s.bindings) == 0 {
+		return errors.New("no bindings configured")
+	}
+	return nil
+}
+
+// ensureScaleSet creates or adopts this binding's scale set and records
+// the provider's own id against it. It runs from the binding's loop, so a
+// provider that is unreachable costs this binding its turn rather than
+// costing the process its startup: the capsules other bindings adopted
+// keep running, and their exits are still observed.
+func (s *Controller) ensureScaleSet(ctx context.Context, b *binding) error {
+	// Creating a set at the provider and writing its id here are two
+	// steps, and the gap between them is where the process can die. The
+	// name is therefore written down first, as an intention: a row with
+	// no id says this binding asked for this name and does not yet know
+	// what it got. Without it, a crash in that gap leaves a set the
+	// provider has and this instance cannot account for, and every later
+	// start refuses to adopt it — correctly, because a set that merely
+	// shares a name is a stranger's. The intention is what tells the two
+	// apart.
+	var intended bool
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		_, recorded, err := tx.GitHubScaleSet(b.bindingID)
+		if err != nil {
+			return err
+		}
+		intended = recorded
+		if recorded {
+			return nil
+		}
+		return tx.RecordGitHubBindingMetadata(b.bindingID, string(b.ref.Scope),
+			b.ref.CanonicalURL, b.target.RunnerGroup, b.scaleSetName, 0)
+	}); err != nil {
+		return err
+	}
+
+	set, err := b.sets.EnsureScaleSet(ctx, b.target.RunnerGroup, b.scaleSetName, b.scaleSetID, intended)
+	if err != nil {
+		return err
+	}
+	// The id is written on a context that outlives this one: the set now
+	// exists, and a shutdown arriving here would otherwise discard the
+	// only record of which one, leaving the next start to adopt it
+	// through the intention above rather than by knowing its id.
+	record, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := s.store.Tx(record, func(tx *store.Tx) error {
+		return tx.RecordGitHubBindingMetadata(b.bindingID, string(b.ref.Scope),
+			b.ref.CanonicalURL, b.target.RunnerGroup, b.scaleSetName, int64(set.ID))
+	}); err != nil {
+		return err
+	}
+	b.scaleSetID = set.ID
+	b.ensured = true
+	s.log.Info("scale set ready", "binding", b.key, "name", b.scaleSetName,
+		"id", set.ID, "adopted", set.Adopted, "scope", string(b.ref.Scope))
+	return nil
+}
+
+// laneCeiling is the real concurrency ceiling for one tier: its own
+// parallelism, capped by the instance-wide limit when that is tighter.
+// Sizing cache lanes off the tier alone would provision a lane for every
+// lease the tier could theoretically hold, which a global limit forbids.
+func laneCeiling(cfg *config.Config, tier config.Tier) int {
+	if cfg.Scheduling.Parallelism == nil {
+		return tier.Parallelism
+	}
+	return min(tier.Parallelism, *cfg.Scheduling.Parallelism)
+}
+
+// contactHeartbeat is the longest a recorded reach may go unrefreshed
+// while nothing about it changes. What the record answers is "how long
+// has this been so", so a state that persists is written on a heartbeat
+// rather than on every observation of it — the loop's own pace is the
+// broker's long poll, but a broker that answers at once would otherwise
+// turn a reporting field into a write per iteration, on a database whose
+// single connection every lease transition also needs.
+const contactHeartbeat = 15 * time.Second
+
+// recordProviderContact marks this binding as reaching its provider.
+//
+// Failing to record it is not worth interrupting serving for: the record
+// exists so an operator can see a binding that reaches nothing, and a
+// binding that cannot write is one whose store is already reporting for
+// itself.
+func (s *Controller) recordProviderContact(ctx context.Context, b *binding) {
+	// Cancelled on the way out of a shutdown, where a store write would
+	// fail for that reason alone and say nothing about the provider.
+	if ctx.Err() != nil {
+		return
+	}
+	now := time.Now()
+	// A transition is always written; a state that has not changed waits
+	// out the heartbeat. Recovering from a failure is a transition, which
+	// is why the failure path clears the pacing rather than leaving a
+	// recovery to wait.
+	if b.reaching && now.Sub(b.lastContactWrite) < contactHeartbeat {
+		return
+	}
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.RecordProviderContact(b.bindingID, now)
+	}); err != nil {
+		s.log.Warn("cannot record provider contact", "binding", b.key, "error", err)
+		return
+	}
+	b.lastContactWrite = now
+	b.reaching = true
+}
+
+// recordProviderFailure records what this binding currently cannot do
+// with its provider.
+//
+// A failure is written whenever it is new or different, and otherwise on
+// the same heartbeat as a success: what an operator needs is what is
+// wrong and how long it has been wrong, and neither answer improves by
+// rewriting the same sentence every five seconds.
+func (s *Controller) recordProviderFailure(ctx context.Context, b *binding, cause error) {
+	if ctx.Err() != nil {
+		return
+	}
+	now, reason := time.Now(), cause.Error()
+	if b.reaching || reason != b.lastFailure || now.Sub(b.lastContactWrite) >= contactHeartbeat {
+		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordProviderFailure(b.bindingID, now, reason)
+		}); err != nil {
+			s.log.Warn("cannot record provider failure", "binding", b.key, "error", err)
+			return
+		}
+		b.lastContactWrite = now
+	}
+	b.reaching = false
+	b.lastFailure = reason
+}
+
+// tierCapsuleImage is what one tier's jobs run in. A configured image
+// replaces the shipped one for that tier alone; the controller already
+// holds the host's daemon, so an operator naming their own capsule adds
+// nothing they could not already do, and the digest the validator
+// requires keeps the launch as exact as the shipped pin.
+func tierCapsuleImage(tier config.Tier, shipped string) string {
+	if tier.CapsuleImage != "" {
+		return tier.CapsuleImage
+	}
+	return shipped
+}
+
+// firstOf keeps the first moment of a run of like events: the second and
+// later ones are the same episode, and its age is what decides whether it
+// is still ordinary.
+func firstOf(existing, now time.Time) time.Time {
+	if existing.IsZero() {
+		return now
+	}
+	return existing
+}

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -1,0 +1,336 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// flakyScaleSets fails a fixed number of times before it succeeds, which
+// is what an unreachable provider looks like from the loop.
+type flakyScaleSets struct {
+	failures int32
+	calls    atomic.Int32
+}
+
+func (f *flakyScaleSets) EnsureScaleSet(context.Context, string, string, int, bool) (githubactions.ScaleSet, error) {
+	if f.calls.Add(1) <= f.failures {
+		return githubactions.ScaleSet{}, errors.New("provider unreachable")
+	}
+	return githubactions.ScaleSet{ID: 77}, nil
+}
+
+// A provider that cannot be reached costs the binding its turn, not the
+// process its startup: the loop retries the scale set until it exists,
+// which is what lets startup reconciliation run before any provider call.
+func TestAnUnreachableProviderDoesNotEndTheLoop(t *testing.T) {
+	h := newHarness(t, 1)
+	h.bind.ref = config.TargetRef{
+		Scope:        config.ScopeRepository,
+		Owner:        "acme",
+		Repository:   "app",
+		CanonicalURL: "https://github.com/acme/app",
+	}
+	h.bind.ensured = false
+	h.bind.scaleSetID = 0
+	sets := &flakyScaleSets{failures: 2}
+	h.bind.sets = sets
+	h.srv.pollBackoff = time.Millisecond
+	// The broker stays unreachable too, so the loop is exercised in the
+	// state this test is about: connected to nothing, still running.
+	// Reaching the session open is the loop's own statement that the
+	// scale set is ready: it is the step after ensure. Waiting for the
+	// second attempt rather than the first is what makes the failure of
+	// the first one already recorded by the time this reads the store.
+	var once sync.Once
+	var attempts atomic.Int32
+	failing := make(chan struct{})
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		if attempts.Add(1) >= 2 {
+			once.Do(func() { close(failing) })
+		}
+		return nil, errors.New("broker unreachable")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		h.srv.loop(ctx, h.bind)
+	}()
+
+	select {
+	case <-failing:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-stopped
+		t.Fatalf("the loop gave up after %d attempts", sets.calls.Load())
+	}
+	cancel()
+	<-stopped
+
+	if got := sets.calls.Load(); got != 3 {
+		t.Errorf("ensure attempts = %d, want 3 (two failures then the success)", got)
+	}
+	if !h.bind.ensured {
+		t.Error("the binding is not marked ensured after the provider answered")
+	}
+	if h.bind.scaleSetID != 77 {
+		t.Errorf("scaleSetID = %d, want the id the provider returned", h.bind.scaleSetID)
+	}
+
+	// The same run is what a reporting command reads: the scale set was
+	// reached, and the broker behind it is what is failing now.
+	var contact store.ProviderContact
+	if err := h.srv.store.Tx(t.Context(), func(tx *store.Tx) error {
+		contacts, err := tx.ProviderContacts()
+		contact = contacts[h.bind.bindingID]
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if contact.LastContact.IsZero() {
+		t.Error("the successful ensure recorded no contact")
+	}
+	if contact.LastError == "" {
+		t.Error("the unreachable broker recorded no failure")
+	}
+	if contact.LastContact.After(contact.LastErrorAt) {
+		t.Errorf("failure at %v predates contact at %v; the binding would read as healthy",
+			contact.LastErrorAt, contact.LastContact)
+	}
+}
+
+// TestAnUnreachableProviderDoesNotSpendTheQueue is the regression test
+// for a startup outage consuming every queued attempt's retry budget.
+//
+// Draining a ready attempt mints a JIT credential against this binding's
+// scale set, so it is not local work and cannot run before the set is
+// confirmed. When it did, a restart that met an unreachable provider
+// leased each queued attempt against an unconfirmed id, failed, and spent
+// one of its three servings per pass — holding the whole queue for a
+// person within seconds, for an outage that would have passed.
+func TestAnUnreachableProviderDoesNotSpendTheQueue(t *testing.T) {
+	h := newHarness(t, 4)
+	h.bind.ref = config.TargetRef{
+		Scope: config.ScopeRepository, Owner: "acme", Repository: "app",
+		CanonicalURL: "https://github.com/acme/app",
+	}
+	if err := h.deliver(
+		assignment.WorkloadAssignment{SourceWorkloadKey: "job-1"},
+		assignment.WorkloadAssignment{SourceWorkloadKey: "job-2"},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(h.ready()); got != 2 {
+		t.Fatalf("queued %d attempts, want 2", got)
+	}
+
+	// The provider is unreachable for the whole run, which is the outage
+	// this is about.
+	var attempts atomic.Int32
+	tried := make(chan struct{})
+	var once sync.Once
+	h.bind.ensured = false
+	h.bind.sets = &refusingScaleSets{calls: &attempts, reached: func() {
+		once.Do(func() { close(tried) })
+	}}
+	h.srv.pollBackoff = time.Millisecond
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		return nil, errors.New("broker unreachable")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		h.srv.loop(ctx, h.bind)
+	}()
+	<-tried
+	// Long enough for many passes: the defect spent a serving per pass.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-stopped
+
+	if attempts.Load() < 2 {
+		t.Fatalf("the loop tried the provider %d times; the test needs it to keep retrying", attempts.Load())
+	}
+	if got := len(h.ready()); got != 2 {
+		t.Errorf("%d attempts still queued, want 2: the outage spent them", got)
+	}
+	if launched := h.launchedAttempts(); len(launched) != 0 {
+		t.Errorf("launched %v against an unconfirmed scale set", launched)
+	}
+}
+
+type refusingScaleSets struct {
+	calls   *atomic.Int32
+	reached func()
+}
+
+func (r *refusingScaleSets) EnsureScaleSet(context.Context, string, string, int, bool) (githubactions.ScaleSet, error) {
+	r.calls.Add(1)
+	r.reached()
+	return githubactions.ScaleSet{}, errors.New("provider unreachable")
+}
+
+// TestProviderReachIsWrittenOnTransition: the record answers what is
+// wrong and how long it has been wrong. Rewriting the same sentence every
+// pass answers neither, and each write takes the store's only connection
+// ahead of the lease transitions that need it.
+func TestProviderReachIsWrittenOnTransition(t *testing.T) {
+	h := newHarness(t, 1)
+	h.bind.ref = config.TargetRef{
+		Scope: config.ScopeRepository, Owner: "acme", Repository: "app",
+		CanonicalURL: "https://github.com/acme/app",
+	}
+	ctx := t.Context()
+	read := func() store.ProviderContact {
+		t.Helper()
+		var c store.ProviderContact
+		if err := h.srv.store.Tx(ctx, func(tx *store.Tx) error {
+			all, err := tx.ProviderContacts()
+			c = all[h.bind.bindingID]
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+
+	same := errors.New("provider unreachable")
+	h.srv.recordProviderFailure(ctx, h.bind, same)
+	first := read()
+	if first.LastError != same.Error() {
+		t.Fatalf("first failure not recorded: %+v", first)
+	}
+
+	// The same failure again: nothing changed, so the recorded moment must
+	// not move — it is what dates the outage. The pause is what makes
+	// "did not write" observable at all, since the only evidence of a
+	// write is a moment that moved.
+	time.Sleep(5 * time.Millisecond)
+	h.srv.recordProviderFailure(ctx, h.bind, same)
+	if again := read(); !again.LastErrorAt.Equal(first.LastErrorAt) {
+		t.Errorf("a repeated failure moved its own start from %v to %v",
+			first.LastErrorAt, again.LastErrorAt)
+	}
+
+	// A different failure is a transition and is written at once.
+	time.Sleep(5 * time.Millisecond)
+	h.srv.recordProviderFailure(ctx, h.bind, errors.New("401 Unauthorized"))
+	if got := read(); got.LastError != "401 Unauthorized" {
+		t.Errorf("a changed failure was not recorded: %+v", got)
+	}
+
+	// Recovery is a transition too, and must not wait out the heartbeat.
+	h.srv.recordProviderContact(ctx, h.bind)
+	got := read()
+	if got.LastError != "" {
+		t.Errorf("recovery left the failure in place: %+v", got)
+	}
+	if got.LastContact.IsZero() {
+		t.Error("recovery recorded no contact")
+	}
+}
+
+// TestACrashBetweenCreatingAndRecordingConverges: creating a scale set at
+// the provider and writing down its id are two steps. A process that dies
+// between them leaves a set the provider has and this instance cannot
+// account for, and a set that merely shares a name is a stranger's — so
+// every later start correctly refused to adopt it and the binding never
+// served again.
+//
+// The intention is what tells the two apart, and it is only honoured when
+// it was actually recorded.
+func TestACrashBetweenCreatingAndRecordingConverges(t *testing.T) {
+	for name, tc := range map[string]struct {
+		seedIntent   bool
+		wantIntended bool
+	}{
+		"a binding that never asked for this name":  {false, false},
+		"a binding killed after it created the set": {true, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t, 1)
+			h.bind.ref = config.TargetRef{
+				Scope: config.ScopeRepository, Owner: "acme", Repository: "app",
+				CanonicalURL: "https://github.com/acme/app",
+			}
+			h.bind.ensured = false
+			h.bind.scaleSetID = 0
+
+			if tc.seedIntent {
+				// Exactly what the first pass leaves behind when it dies
+				// between the provider call and the record: the name
+				// written down, and no id.
+				h.inStore(func(tx *store.Tx) error {
+					return tx.RecordGitHubBindingMetadata(h.bind.bindingID,
+						string(h.bind.ref.Scope), h.bind.ref.CanonicalURL,
+						h.bind.target.RunnerGroup, h.bind.scaleSetName, 0)
+				})
+			}
+
+			// The set exists at the provider from the moment the call
+			// returns, so the name has to be written down before it: that
+			// is the whole of what makes the crash recoverable.
+			var namedBeforeTheCall bool
+			sets := &recordingScaleSets{id: 42, duringCall: func() {
+				h.inStore(func(tx *store.Tx) error {
+					_, recorded, err := tx.GitHubScaleSet(h.bind.bindingID)
+					namedBeforeTheCall = recorded
+					return err
+				})
+			}}
+			h.bind.sets = sets
+			if err := h.srv.ensureScaleSet(t.Context(), h.bind); err != nil {
+				t.Fatalf("ensureScaleSet: %v", err)
+			}
+			if sets.lastIntended != tc.wantIntended {
+				t.Errorf("intended = %v, want %v: a real provider decides whether to adopt on this",
+					sets.lastIntended, tc.wantIntended)
+			}
+			if !namedBeforeTheCall {
+				t.Error("the provider was asked to create a name this binding had not written down")
+			}
+			if h.bind.scaleSetID != 42 || !h.bind.ensured {
+				t.Errorf("binding did not converge: id=%d ensured=%v", h.bind.scaleSetID, h.bind.ensured)
+			}
+			// And the id is recorded, so the next start needs no
+			// intention at all.
+			var recorded int64
+			h.inStore(func(tx *store.Tx) error {
+				var err error
+				recorded, err = tx.GitHubScaleSetID(h.bind.bindingID)
+				return err
+			})
+			if recorded != 42 {
+				t.Errorf("recorded id = %d, want 42", recorded)
+			}
+		})
+	}
+}
+
+type recordingScaleSets struct {
+	id           int
+	lastIntended bool
+	// duringCall runs while the provider call is in flight, which is the
+	// only moment that can show what was written down before it.
+	duringCall func()
+}
+
+func (r *recordingScaleSets) EnsureScaleSet(_ context.Context, _, _ string, _ int, intended bool) (githubactions.ScaleSet, error) {
+	r.lastIntended = intended
+	if r.duringCall != nil {
+		r.duringCall()
+	}
+	return githubactions.ScaleSet{ID: r.id}, nil
+}

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -1,0 +1,119 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// TestPreparationIsBoundedSeparatelyFromTheJob: a tier's ceiling is the
+// wait for a job the provider owns. Bounding preparation with it too made
+// the validator's own floor unreachable — the capsule's readiness budget
+// alone outlasts the lowest ceiling a tier may configure — and any expiry
+// surfaced as whichever preparation step it happened to land in.
+func TestPreparationIsBoundedSeparatelyFromTheJob(t *testing.T) {
+	floor := time.Duration(config.MinJobTimeout)
+	if capsulePrepTimeout <= floor {
+		t.Errorf("preparation is bounded at %s and a tier may configure a ceiling of %s; "+
+			"the two must not be the same budget", capsulePrepTimeout, floor)
+	}
+	// The readiness wait is one step inside preparation, so a budget that
+	// does not clear it cannot be the budget for the whole of it.
+	if capsulePrepTimeout <= 90*time.Second {
+		t.Errorf("preparation is bounded at %s, which does not clear the capsule's own readiness budget",
+			capsulePrepTimeout)
+	}
+}
+
+// TestRemainingCeilingIsNotRestartedByAdoption: the ceiling bounds a
+// capsule that stopped reporting. Handing an adopted capsule a fresh full
+// budget on every restart is how that bound stops bounding anything.
+func TestRemainingCeilingIsNotRestartedByAdoption(t *testing.T) {
+	ceiling := config.Duration(4 * time.Hour)
+	tier := config.Tier{ID: "standard", JobTimeout: &ceiling}
+
+	if got := remainingCeiling(tier, time.Time{}); got != 4*time.Hour {
+		t.Errorf("a lease with no recorded start waits %s, want the whole ceiling", got)
+	}
+	if got := remainingCeiling(tier, time.Now().Add(-time.Hour)); got > 3*time.Hour {
+		t.Errorf("a lease an hour old waits %s, want at most the three hours it has left", got)
+	}
+	// Past the ceiling, a short grace rather than zero: the wait has to
+	// resolve through the ordinary path, not expire before it begins.
+	got := remainingCeiling(tier, time.Now().Add(-5*time.Hour))
+	if got <= 0 {
+		t.Errorf("a lease past its ceiling waits %s; it would expire before observing anything", got)
+	}
+	if got > time.Minute {
+		t.Errorf("a lease past its ceiling waits %s, want only a grace", got)
+	}
+}
+
+// TestTheTierImageReachesTheCapsuleOnly: tiers[].capsuleImage lets a
+// deployment add tools to the container its jobs run in. The per-lease
+// egress gateway is not that container — it is the one that applies the
+// policy confining them — and it once read the same field, so extending a
+// tier's jobs silently replaced the enforcement with the operator's own
+// build.
+//
+// The gateway's image is no longer something a launch can name: it
+// belongs to the launcher, which the controller builds from the image
+// this build ships. What is left to assert here is the other half — that
+// the tier's image reaches the capsule and stops there.
+func TestTheTierImageReachesTheCapsuleOnly(t *testing.T) {
+	const operators = "ghcr.io/acme/capsule@sha256:" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+
+	h := newHarness(t, 1)
+	h.bind.capsuleImage = operators
+	h.bind.tier = config.Tier{ID: "standard", Parallelism: 1, CapsuleImage: operators}
+
+	caps := &fakeCapsule{}
+	runFaulted(t, h, caps, &fakeRegistry{}, &fakeWaiter{}, "job-1")
+
+	spec := caps.spec
+	if spec.CapsuleImage != operators {
+		t.Errorf("the job runs %q, want the tier's image", spec.CapsuleImage)
+	}
+
+}
+
+// TestAnIncompatibleCapsuleIsHeldNotRetried: a capsule that does not
+// speak this controller's protocol will not start speaking it on the next
+// attempt. Retrying it spends one of the attempt's three servings
+// discovering the same fact, three times per job, and then holds it for a
+// reason that names the budget rather than the image.
+func TestAnIncompatibleCapsuleIsHeldNotRetried(t *testing.T) {
+	h := newHarness(t, 1)
+	caps := &fakeCapsule{prepareErr: fmt.Errorf("%w: it speaks control protocol \"0\"",
+		capsule.ErrIncompatibleImage)}
+	lease, _ := runFaulted(t, h, caps, &fakeRegistry{}, &fakeWaiter{}, "job-1")
+
+	attempt := h.attemptByLease(lease.ID)
+	if attempt.State != "manual_review" {
+		t.Fatalf("attempt state = %q, want it held rather than requeued", attempt.State)
+	}
+	if attempt.ReviewReason != store.ReviewReasonIncompatibleCapsule {
+		t.Errorf("held as %q, want the image named", attempt.ReviewReason)
+	}
+}
+
+// And an ordinary preparation failure is still a retry: the budget is
+// there for transients, and holding every one of them would turn a failed
+// image pull into a person's problem.
+func TestAnOrdinaryPreparationFailureStillRetries(t *testing.T) {
+	h := newHarness(t, 1)
+	caps := &fakeCapsule{prepareErr: errors.New("image pull failed")}
+	lease, _ := runFaulted(t, h, caps, &fakeRegistry{}, &fakeWaiter{}, "job-1")
+
+	attempt := h.attemptByLease(lease.ID)
+	if attempt.State == "manual_review" {
+		t.Errorf("a transient preparation failure was held as %q", attempt.ReviewReason)
+	}
+}

--- a/internal/app/capsule_image_test.go
+++ b/internal/app/capsule_image_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// TestTierCapsuleImage: a tier's own image replaces the shipped one for
+// that tier alone, and a tier that names none runs what the build ships.
+func TestTierCapsuleImage(t *testing.T) {
+	const shipped = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"1111111111111111111111111111111111111111111111111111111111111111"
+	const operators = "ghcr.io/acme/capsule@sha256:" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+
+	if got := tierCapsuleImage(config.Tier{ID: "standard"}, shipped); got != shipped {
+		t.Errorf("a tier naming no image runs %q, want the shipped capsule", got)
+	}
+	if got := tierCapsuleImage(config.Tier{ID: "heavy", CapsuleImage: operators}, shipped); got != operators {
+		t.Errorf("a tier naming an image runs %q, want its own", got)
+	}
+}

--- a/internal/app/credits_test.go
+++ b/internal/app/credits_test.go
@@ -1,0 +1,138 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/allocator"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/disk"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestCreditsRebuildFromAdoptedCapsules: after a restart the allocator
+// starts empty, and reconciliation is what puts the credits back. A
+// capsule found running holds its credit again, so the pool does not
+// advertise capacity the host is already using.
+func TestCreditsRebuildFromAdoptedCapsules(t *testing.T) {
+	a := allocator.New()
+	for _, key := range []string{"a", "b"} {
+		if err := a.Register("std", key, 2); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Fresh process: nothing is known yet, so both credits look free.
+	if got := sumAdvertised(a); got > 2 {
+		t.Fatalf("sum(advertised) = %d before reconciliation; want at most 2", got)
+	}
+
+	// Reconciliation finds two capsules still running for a.
+	a.Adopt("a")
+	a.Adopt("a")
+
+	if got := a.Advertised("a"); got != 2 {
+		t.Errorf("a advertised %d; want the 2 capsules it is running", got)
+	}
+	if got := a.Advertised("b"); got != 0 {
+		t.Errorf("b advertised %d; the pool's credits are all held", got)
+	}
+	if got := sumAdvertised(a); got != 2 {
+		t.Errorf("sum(advertised) = %d; want exactly the 2 capacity units", got)
+	}
+	if a.TryReserve("b") {
+		t.Error("b took a credit the host does not have")
+	}
+}
+
+// TestPressureWithholdsCredit: the disk monitor's verdict reaches the
+// broker through the allocator. An emergency stops new capacity being
+// announced; recovery restores it.
+func TestPressureWithholdsCredit(t *testing.T) {
+	h := newHarness(t, 2)
+	h.srv.alloc.SetAssignedDemand(h.bind.key, 2)
+
+	if got := h.srv.alloc.Advertised(h.bind.key); got == 0 {
+		t.Fatal("a binding with demand and free capacity must advertise")
+	}
+
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.SetPressure(store.PressureInfo{Level: disk.SoftEmergency.String()})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.srv.disk.resume(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.srv.alloc.Advertised(h.bind.key); got != 0 {
+		t.Errorf("advertised %d under a soft emergency; want 0 new capacity", got)
+	}
+
+	h.srv.alloc.Hold(false)
+	if got := h.srv.alloc.Advertised(h.bind.key); got != 2 {
+		t.Errorf("advertised %d after recovery; want the demand back", got)
+	}
+}
+
+// TestSilentBindingIsFoundByRotation is the trapdoor at the level that
+// matters: several bindings share one tier, none has demand, and the
+// rotation must reach each of them — otherwise the one with a queued
+// job never learns it exists.
+func TestSilentBindingIsFoundByRotation(t *testing.T) {
+	a := allocator.New()
+	keys := []string{"repo-a", "repo-b", "repo-c", "repo-d"}
+	for _, k := range keys {
+		if err := a.Register("std", k, 2); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seen := map[string]bool{}
+	for range len(keys) {
+		for _, k := range keys {
+			if a.Advertised(k) > 0 {
+				seen[k] = true
+			}
+		}
+		if got := sumAdvertised(a); got > 2 {
+			t.Fatalf("sum(advertised) = %d during rotation; want at most 2", got)
+		}
+		a.Rotate()
+	}
+	for _, k := range keys {
+		if !seen[k] {
+			t.Errorf("binding %q was never offered the discovery credit; it would stay blind", k)
+		}
+	}
+}
+
+func sumAdvertised(a *allocator.Allocator) int {
+	total := 0
+	for _, v := range a.AdvertisedAll("std") {
+		total += v
+	}
+	return total
+}
+
+// TestLaneCeilingFollowsTheTighterLimit: cache lanes are sized off how many
+// leases can actually run at once. A tier that could hold four is held to one
+// by an instance-wide limit, and provisioning four lanes for it would reserve
+// disk for leases that can never exist.
+func TestLaneCeilingFollowsTheTighterLimit(t *testing.T) {
+	tier := config.Tier{ID: "std", Parallelism: 4}
+
+	independent := &config.Config{}
+	if got := laneCeiling(independent, tier); got != 4 {
+		t.Errorf("lane ceiling = %d with independent tiers; want the tier's own 4", got)
+	}
+
+	one := 1
+	global := &config.Config{Scheduling: config.Scheduling{Parallelism: &one}}
+	if got := laneCeiling(global, tier); got != 1 {
+		t.Errorf("lane ceiling = %d under an instance limit of one; want 1", got)
+	}
+
+	// A global limit looser than the tier does not raise the tier's own cap.
+	ten := 10
+	loose := &config.Config{Scheduling: config.Scheduling{Parallelism: &ten}}
+	if got := laneCeiling(loose, tier); got != 4 {
+		t.Errorf("lane ceiling = %d under a looser instance limit; want the tier's 4", got)
+	}
+}

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -1,0 +1,660 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// loop is one binding's demand cycle: announce the allocator's credit,
+// translate what the broker committed, and queue it. Messages are
+// hints; the state store carries the truth.
+//
+// The announcement is a whole number of credits, which may be zero. A
+// binding announcing zero is silent, not blind: the tier's rotating
+// discovery credit reaches it within one pass of the pool.
+func (s *Controller) loop(ctx context.Context, b *binding) {
+	failures := 0
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		// The scale set is ensured before anything reads its id.
+		//
+		// A provider that cannot be reached here leaves the binding where
+		// an unreachable broker leaves it: retrying, while the capsules it
+		// already owns run to completion. What must not happen is serving
+		// past it. Draining a ready attempt is not local work — it mints a
+		// JIT credential against this scale set — so an attempt served
+		// before the id is confirmed is served against an id read from the
+		// store, which is proof of ownership and not proof that the set
+		// still exists. Each such attempt fails and spends one of its
+		// servings, so a provider outage at startup would hold a whole
+		// queue for review rather than waiting the outage out.
+		//
+		// Ensuring first is also what makes the id safe to publish: it is
+		// written here, on this goroutine, before any capsule goroutine
+		// that reads it exists.
+		if !b.ensured {
+			if err := s.ensureScaleSet(ctx, b); err == nil {
+				s.recordProviderContact(ctx, b)
+			} else {
+				if ctx.Err() != nil {
+					return
+				}
+				s.log.Error("cannot create or adopt the scale set; the binding keeps retrying",
+					"binding", b.key, "name", b.scaleSetName, "error", err)
+				s.recordProviderFailure(ctx, b, err)
+				select {
+				case <-time.After(s.backoff()):
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+		}
+
+		// Local work drains whether or not the broker is reachable, so
+		// this runs before the session is required — and after the scale
+		// set, which it needs.
+		s.scheduleReadyAttempts(ctx, b)
+
+		if b.session == nil {
+			if err := s.openSession(ctx, b); err == nil {
+				b.conflictSince = time.Time{}
+				s.recordProviderContact(ctx, b)
+			} else {
+				if ctx.Err() != nil {
+					return
+				}
+				// A conflict here is this binding's own previous session,
+				// which the broker holds until it expires by inactivity -
+				// the close that gave it up is expected to fail. It is
+				// the ordinary shape of this path, so it waits at the
+				// conflict's own interval and does not report an error
+				// indistinguishable from a revoked credential.
+				wait := s.backoff()
+				if githubactions.IsSessionConflict(err) {
+					wait = sessionConflictBackoff
+					if s.conflictBackoff != 0 {
+						wait = s.conflictBackoff
+					}
+					// Ordinary on a restart, so it is not reported as a
+					// failure to reach the provider — the provider is
+					// answering. It stops being ordinary once it outlasts
+					// the inactivity the broker expires a session on, and
+					// past that the binding serves nothing for a reason
+					// nothing else would carry.
+					b.conflictSince = firstOf(b.conflictSince, time.Now())
+					if held := time.Since(b.conflictSince); held > sessionConflictGrace {
+						s.log.Error("the broker has held this binding's session past the point it expires by inactivity",
+							"binding", b.key, "held", held.Round(time.Second))
+						s.recordProviderFailure(ctx, b, err)
+					} else {
+						s.log.Info("the broker still holds this binding's previous session; waiting for it to expire",
+							"binding", b.key)
+					}
+				} else {
+					s.log.Error("cannot open a message session; the binding keeps retrying",
+						"binding", b.key, "error", err)
+					s.recordProviderFailure(ctx, b, err)
+				}
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					return
+				}
+				continue
+			}
+		}
+		s.announce(b)
+
+		msg, err := b.session.Receive(ctx)
+		if err == nil {
+			s.recordProviderContact(ctx, b)
+		} else {
+			if ctx.Err() != nil {
+				return
+			}
+			failures++
+			s.log.Error("receive failed; retrying", "binding", b.key,
+				"consecutive_failures", failures, "error", err)
+			s.recordProviderFailure(ctx, b, err)
+			failures = s.discardSpentSession(ctx, b, failures)
+			select {
+			case <-time.After(s.backoff()):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		if msg == nil {
+			// An empty long-poll is one full cycle with nothing to do,
+			// which is exactly when the discovery credit should move on
+			// to the next silent binding.
+			failures = 0
+			s.alloc.Rotate()
+			continue
+		}
+		if msg.AcquireError == nil {
+			failures = 0
+		} else {
+			// The offers return to the broker's queue, so nothing is
+			// lost yet. It counts against the session all the same: a
+			// handle whose token refresh has failed answers this call
+			// and the poll differently, so a session that keeps failing
+			// it while polls succeed would otherwise never be replaced,
+			// and the binding would collect offers it can never turn
+			// into work forever.
+			failures++
+			s.log.Error("cannot acquire the jobs this session was offered",
+				"binding", b.key, "consecutive_failures", failures, "error", msg.AcquireError)
+			// The poll that carried this succeeded and was recorded as
+			// contact, so without saying so a binding that can never turn
+			// an offer into work reports as reaching its provider.
+			s.recordProviderFailure(ctx, b, msg.AcquireError)
+			if failures = s.discardSpentSession(ctx, b, failures); b.session == nil {
+				// Nothing more goes through a handle that has been given
+				// up, and the acknowledgement below is one of those
+				// things. The message stays unacknowledged, so the
+				// replacement's cursor replays it and its assignments are
+				// recorded then.
+				continue
+			}
+		}
+		if len(msg.StrandedGrants) > 0 {
+			// The broker granted a request this session cannot land: the
+			// job is claimed there with nothing here to run it, and no
+			// pass on this side can find it again. Nothing to do but say
+			// so, loudly enough that it is not discovered as a job that
+			// silently never ran.
+			s.log.Error("the broker granted jobs this session cannot account for",
+				"binding", b.key, "requests", msg.StrandedGrants)
+		}
+
+		// Persist before acknowledging. GitHub hands an assignment over
+		// once, so a crash after acknowledgement and before the record
+		// exists would strand the job with no runner and no local trace.
+		// Recording is idempotent, so a redelivered message after a
+		// failed acknowledgement changes nothing.
+		delivery, err := s.persistDelivery(ctx, b, msg)
+		if err != nil {
+			s.log.Error("cannot persist the delivery; leaving it for redelivery",
+				"binding", b.key, "error", err)
+			select {
+			case <-time.After(s.backoff()):
+			case <-ctx.Done():
+				return
+			}
+			continue
+		}
+		advanced := s.acknowledgeDelivery(ctx, b, delivery, msg.ID)
+
+		if msg.Statistics != nil {
+			// TotalAssignedJobs is the upstream scaling signal: what
+			// GitHub has committed to this scale set. Availables are
+			// offers that only become demand once acquired, and counting
+			// them would overstate what this binding owes.
+			s.alloc.SetAssignedDemand(b.key, msg.Statistics.Assigned)
+		}
+		s.recordLifecycleEvents(ctx, b, msg)
+
+		s.scheduleReadyAttempts(ctx, b)
+
+		if !advanced {
+			// The cursor did not move, so the next poll is answered with
+			// this same message immediately. Everything the message
+			// carries is processed above either way - a cancellation
+			// hint riding in a wedged redelivery still has to land - and
+			// the wait is what keeps a binding that cannot advance from
+			// becoming an unthrottled call rate against the provider.
+			select {
+			case <-time.After(s.backoff()):
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// acknowledgeDelivery drives the durable ack state machine around the
+// one network call. The in-flight mark commits before the call, an
+// unambiguous success commits confirmed, and anything else commits
+// uncertain: the broker's redelivery plus idempotent persistence is
+// what converges an uncertain acknowledgement, so no outcome is guessed.
+// It reports whether the cursor moved. It does not on two paths - a
+// delivery already confirmed, and an acknowledgement that failed - and on
+// both of them the next poll returns this same message with no long-poll
+// delay, so the caller has to wait rather than spin.
+func (s *Controller) acknowledgeDelivery(ctx context.Context, b *binding, deliveryID int64, messageID int) bool {
+	var proceed bool
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		proceed, err = tx.AckRequested(deliveryID)
+		return err
+	}); err != nil {
+		s.log.Error("cannot mark the acknowledgement in flight; leaving the message for redelivery",
+			"binding", b.key, "error", err)
+		return false
+	}
+	if !proceed {
+		// Only a confirmed delivery is excluded now: the broker already
+		// knows. A delivery left `requested` by a crash was never
+		// acknowledged, so it is retried rather than skipped.
+		//
+		// Reaching this means the broker sent a delivery this binding had
+		// already acknowledged, which it has no reason to do — the
+		// acknowledgement is what removes it. Saying so is what turns a
+		// binding that has quietly stopped advancing into something with
+		// a line explaining it.
+		s.log.Warn("the broker redelivered a message this binding already acknowledged; "+
+			"the cursor cannot advance past it",
+			"binding", b.key, "message", messageID, "delivery", deliveryID)
+		return false
+	}
+
+	ackErr := b.session.Acknowledge(ctx, messageID)
+
+	// The outcome is recorded on a context detached from the poll: the
+	// observation must survive a shutdown that arrives mid-cycle.
+	rctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := s.store.Tx(rctx, func(tx *store.Tx) error {
+		if ackErr == nil {
+			return tx.AckConfirmed(deliveryID)
+		}
+		return tx.AckUncertain(deliveryID)
+	}); err != nil {
+		s.log.Error("cannot record the acknowledgement outcome", "binding", b.key, "error", err)
+	}
+	if ackErr != nil {
+		s.log.Warn("acknowledgement failed; the message will be redelivered",
+			"binding", b.key, "error", ackErr)
+		return false
+	}
+	return true
+}
+
+// persistDelivery makes one broker message durable: the delivery, its
+// attempts and the adapter's observed identifiers commit together, and
+// only a committed delivery may be acknowledged. A workload with no
+// identity fails the whole message — dropping one and acknowledging the
+// rest loses it silently, while an unacknowledged message is
+// redelivered, which is visible and recoverable.
+//
+// A workload that already holds an open attempt is a reassignment
+// racing its predecessor. A predecessor that is still ready never
+// consumed anything and is superseded in the same transaction; one that
+// got further resolves through its own lifecycle first, and this
+// message simply stays unacknowledged until it has — never are two
+// attempts of one workload live together.
+func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githubactions.Message) (int64, error) {
+	// Everything this message hands over: what the broker assigned plus
+	// what the session acquired from its availables.
+	admitted := make([]assignment.WorkloadAssignment, 0, len(msg.Assigned)+len(msg.Acquired))
+	admitted = append(admitted, msg.Assigned...)
+	admitted = append(admitted, msg.Acquired...)
+	for _, a := range admitted {
+		if err := a.Validate(); err != nil {
+			return 0, err
+		}
+	}
+	key := assignment.DeliveryKey(b.scaleSetID, msg.ID)
+	// The fingerprint covers the broker's own payload only. It exists to
+	// catch the provider sending different content under a stable key, and
+	// an acquisition is not the provider changing anything — what it grants
+	// depends on who else asked, so including it made the fingerprint vary
+	// between redeliveries of one message id. That read as unrecoverable
+	// drift, failed the persist, left the message unacknowledged, and
+	// because the queue is ordered it blocked the binding permanently.
+	fingerprint := assignment.Fingerprint(msg.Assigned)
+	workloads := make([]store.WorkloadRow, len(admitted))
+	for i, a := range admitted {
+		workloads[i] = store.WorkloadRow{
+			SourceWorkloadKey: a.SourceWorkloadKey,
+			TenantKey:         a.TenantKey,
+			ProjectKey:        a.ProjectKey,
+		}
+	}
+
+	var deliveryID int64
+	err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		delivery, err := tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
+		if errors.Is(err, store.ErrOpenAttemptExists) {
+			// Supersede a ready predecessor and record again, in this
+			// same transaction. Anything beyond ready is left to resolve
+			// itself; the error propagates and the message waits as a
+			// redelivery.
+			for _, a := range admitted {
+				serr := tx.SupersedeOpenAttempt(b.bindingID, a.SourceWorkloadKey, assignment.ResolutionSuperseded)
+				if serr != nil && !errors.Is(serr, store.ErrNotFound) {
+					return serr
+				}
+			}
+			delivery, err = tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
+		}
+		if err != nil {
+			return err
+		}
+		deliveryID = delivery.ID
+
+		// The provider's identifiers ride along per attempt, in the
+		// adapter-owned metadata table. Zero request ids are stored as
+		// observed — they are diagnostics, never identity.
+		attempts, err := tx.AttemptsOfDelivery(delivery.ID)
+		if err != nil {
+			return err
+		}
+		byKey := make(map[string]assignment.WorkloadAssignment, len(admitted))
+		for _, a := range admitted {
+			byKey[a.SourceWorkloadKey] = a
+		}
+		for _, attempt := range attempts {
+			a, ok := byKey[attempt.SourceWorkloadKey]
+			if !ok {
+				continue
+			}
+			if err := tx.RecordGitHubAttemptMetadata(attempt.ID,
+				a.SourceWorkloadKey, a.SourceRequestID, a.SourceRunID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return deliveryID, nil
+}
+
+// recordLifecycleEvents persists the provider's started/completed
+// observations against the attempt they belong to.
+func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg *githubactions.Message) {
+	// One correlation per event, and everything the event causes acts on
+	// what it resolved. Cancelling by workload key instead was a second,
+	// independent answer to the same question: after a requeue it named
+	// the successor, so a late cancellation of the run that preceded it
+	// closed work that had just been handed to this instance.
+	record := func(ev assignment.WorkloadLifecycleEvent, kind, idempotency string, cancel bool) {
+		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+			attemptID, err := s.attemptForObservation(tx, b, ev)
+			if err != nil || attemptID == "" {
+				return err
+			}
+			if cancel {
+				// The cancellation and the event it explains commit
+				// together, so no row is closed without the trail that
+				// says what closed it.
+				if err := s.cancelIfReady(tx, attemptID); err != nil {
+					return err
+				}
+			}
+			return tx.RecordEvent(attemptID, idempotency, kind)
+		}); err != nil {
+			s.log.Error("cannot record a lifecycle event",
+				"binding", b.key, "workload", ev.SourceWorkloadKey, "error", err)
+		}
+	}
+	// The hint keys carry the runtime, as cleanup's carry the lease: an
+	// attempt is served once per runtime, and a fixed key would swallow a
+	// second serving's hints as replays of the first. The cancellation
+	// key stays fixed on purpose - it is the same key CancelReady writes,
+	// which is what keeps the pair one event, and a cancellation ends the
+	// attempt rather than one serving of it.
+	for _, ev := range msg.Started {
+		s.log.Info("workload started",
+			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName)
+		record(ev, "running_observed", "remote_running_observed:"+ev.RuntimeName, false)
+	}
+	for _, ev := range msg.Completed {
+		s.log.Info("workload completed (hint)",
+			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName, "result", ev.Result)
+		kind, idempotency := "exit_observed", "remote_exit_observed:"+ev.RuntimeName
+		if ev.Result == "canceled" {
+			kind, idempotency = "remote_canceled", "remote_canceled"
+		}
+		record(ev, kind, idempotency, ev.Result == "canceled")
+	}
+}
+
+// cancelIfReady closes the attempt the cancellation was correlated to,
+// when it has not begun serving: a provider cancellation of unstarted
+// work needs no runtime, no drain and no review. An attempt past ready is
+// running work - its cancellation is the drain path's business, so the
+// row is left alone and only the event is recorded.
+//
+// It runs in the caller's transaction, on the attempt the caller
+// resolved. Resolving one of its own is how a cancellation of a run that
+// has already been superseded reached the successor instead.
+func (s *Controller) cancelIfReady(tx *store.Tx, attemptID string) error {
+	err := tx.CancelReady(attemptID, assignment.ResolutionRemoteCanceled)
+	if errors.Is(err, store.ErrConflict) {
+		return nil // nothing ready to cancel; running work drains instead
+	}
+	return err
+}
+
+// scheduleReadyAttempts claims ready attempts while admission has capacity.
+// The queue is the store, not memory, so a restart resumes
+// exactly where this left off, and the claim is a compare-and-swap only
+// one caller can win.
+func (s *Controller) scheduleReadyAttempts(ctx context.Context, b *binding) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// The disk-pressure admission gate. Ready attempts are durable and
+	// lose nothing by waiting; what an emergency must never do is stack
+	// more work onto a filesystem that is running out. The monitor logs
+	// the closure once, at the transition — not here, every pass.
+	if s.currentPressure().AdmissionClosed() {
+		return
+	}
+
+	var ready []store.Attempt
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		ready, err = tx.ReadyAttempts(b.bindingID)
+		return err
+	}); err != nil {
+		s.log.Error("cannot read the ready attempts", "binding", b.key, "error", err)
+		return
+	}
+
+	for _, attempt := range ready {
+		if !s.alloc.TryReserve(b.key) {
+			return // admission is full; the attempt stays durable and waits
+		}
+		lease, err := s.createLease(ctx, b, attempt)
+		if err != nil {
+			s.alloc.Release(b.key)
+			if errors.Is(err, store.ErrConflict) {
+				continue // another pass claimed it; nothing is lost
+			}
+			s.log.Error("lease creation failed", "binding", b.key, "error", err)
+			continue
+		}
+		// Claim before the goroutine exists. The lease is already committed
+		// and `reserved` is a live state, so between this commit and
+		// runCapsule's own claim the periodic reconciler could see it as
+		// ownerless and tear down a job that is starting.
+		s.claimLease(lease.ID)
+		s.wg.Add(1)
+		go s.launch(b, lease)
+	}
+}
+
+// announce tells the broker this binding's current credit, and logs the
+// tier's whole accounting when the number changes. A binding announcing
+// zero is the question an operator will ask about, and the answer —
+// who holds the discovery credit, who has demand, who is running — is
+// only meaningful as the pool's state, not the binding's.
+// backoff is the pause between failed polls. Held on the controller so a
+// test can exercise the failure run without waiting out real seconds.
+func (s *Controller) backoff() time.Duration {
+	if s.pollBackoff > 0 {
+		return s.pollBackoff
+	}
+	return pollBackoff
+}
+
+// attemptForObservation resolves which attempt an observation is
+// evidence of.
+//
+// The event names the workload it is about, and that is the answer
+// wherever this instance still holds an attempt for it. Correlating by
+// the runtime's name instead answers a different question — which attempt
+// the runner was provisioned for — and the two are the same thing only
+// while nothing has been requeued. A runner is minted against a scale
+// set, not a job, so a runner provisioned for one workload can be handed
+// another; recorded by runtime name, that execution lands on the attempt
+// that never ran, and the attempt's evidence is confidently wrong.
+//
+// The runtime name stays as the fallback. An observation about a workload
+// this instance never recorded, or whose attempt is already settled, is
+// still worth keeping against the attempt whose lease owns that runner.
+func (s *Controller) attemptForObservation(tx *store.Tx, b *binding, ev assignment.WorkloadLifecycleEvent) (string, error) {
+	attempt, err := tx.OpenAttemptByWorkload(b.bindingID, ev.SourceWorkloadKey)
+	switch {
+	case err == nil:
+		if ev.RuntimeName == "" {
+			return attempt.ID, nil
+		}
+		ranBy, rerr := tx.AttemptOfRuntimeName(ev.RuntimeName)
+		switch {
+		case errors.Is(rerr, store.ErrNotFound):
+			return attempt.ID, nil // a foreign runtime, or one never named
+		case rerr != nil:
+			return "", rerr
+		case ranBy == attempt.ID:
+			return attempt.ID, nil
+		}
+
+		// The runner ran for some other attempt. Which one separates the
+		// two ways that happens.
+		provisioned, perr := tx.Get(ranBy)
+		switch {
+		case errors.Is(perr, store.ErrNotFound):
+			// The books no longer hold the attempt this runner ran for,
+			// so nothing establishes that the workloads differ - and
+			// that is the one case where the comparison cannot be made.
+			// Booking it against the open attempt on an unknown is the
+			// mis-attribution this whole branch exists to avoid.
+			s.log.Warn("an observation names a runtime whose attempt is gone; it is not recorded",
+				"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName)
+			return "", nil
+		case perr != nil:
+			return "", perr
+		case provisioned.SourceWorkloadKey == ev.SourceWorkloadKey:
+			// Same workload, earlier attempt: a report of the run that
+			// attempt made, arriving after a requeue opened this one in
+			// its place. The open attempt has started nothing, and
+			// writing an execution against it would say otherwise.
+			return ranBy, nil
+		}
+
+		// Different workloads, so the provider handed this workload to a
+		// runner minted for another. The runner is fungible and the
+		// workload is not: the event's own workload is the subject.
+		s.log.Warn("a runner is executing a workload it was not provisioned for",
+			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName,
+			"attempt", attempt.ID, "runner_of_attempt", ranBy)
+		return attempt.ID, nil
+	case !errors.Is(err, store.ErrNotFound):
+		return "", err
+	}
+
+	if ev.RuntimeName == "" {
+		return "", nil
+	}
+	ranBy, err := tx.AttemptOfRuntimeName(ev.RuntimeName)
+	if errors.Is(err, store.ErrNotFound) {
+		return "", nil // no lease of ours; a foreign runtime
+	}
+	if err != nil {
+		return "", err
+	}
+	return ranBy, nil
+}
+
+// discardSpentSession gives up a session once a run of failures says the
+// handle itself is what is broken, and reports the failure count the
+// caller carries on with.
+//
+// The upstream client refreshes an expired session by itself, and when
+// that refresh fails it leaves the handle dead: every later call fails
+// the same way, for as long as the process runs, while the process itself
+// stays healthy. Retrying a dead handle is not recovery, so a run of
+// failures costs the session rather than the binding.
+//
+// The binding is left without a session rather than holding a spent one.
+// A handle this reached is unusable whether or not the close succeeded,
+// and leaving it in place is what would have the loop poll and announce
+// through it, and shutdown close it a second time and report a broker
+// still holding a session nobody holds.
+func (s *Controller) discardSpentSession(ctx context.Context, b *binding, failures int) int {
+	if failures < receiveFailuresBeforeReopen || b.newSession == nil {
+		return failures
+	}
+	cctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := b.session.Close(cctx); err != nil {
+		// Expected on the path that brought us here: the session the
+		// broker holds is the one that stopped answering.
+		s.log.Warn("cannot close the failing message session", "binding", b.key, "error", err)
+	}
+	b.session = nil
+	return 0
+}
+
+// openSession gives the binding a session and publishes the backlog it
+// opened with, which is what Serve does for the first one. Without that
+// the allocator keeps the dead session's last demand figure, and a
+// binding recorded at zero demand is one the free credit is never shared
+// with - so the queue it is holding never drains.
+//
+// The message cursor resets with the session. That costs a redelivery of
+// whatever was not acknowledged, which is free: recording a delivery is
+// idempotent on its natural key, and an unacknowledged message was going
+// to be redelivered anyway.
+func (s *Controller) openSession(ctx context.Context, b *binding) error {
+	session, err := b.newSession(ctx)
+	if err != nil {
+		return err
+	}
+	b.session = session
+	initial := session.Initial()
+	if initial == nil {
+		// The broker opened the session without statistics, so there is
+		// no figure to publish and the allocator keeps the last one it
+		// was told. Printing a zero here would be reporting an
+		// observation nobody made.
+		s.log.Warn("message session opened without statistics; assigned demand is unchanged",
+			"binding", b.key)
+		return nil
+	}
+	s.alloc.SetAssignedDemand(b.key, initial.Assigned)
+	s.log.Warn("message session opened", "binding", b.key, "assigned_backlog", initial.Assigned)
+	return nil
+}
+
+func (s *Controller) announce(b *binding) {
+	credit := s.alloc.Advertised(b.key)
+	b.session.SetCapacity(credit)
+	if credit == b.lastAdvertised {
+		return
+	}
+	b.lastAdvertised = credit
+	parallelism, rows := s.alloc.PoolReport(b.tier.ID)
+	total := 0
+	for _, r := range rows {
+		total += r.Advertised
+	}
+	s.log.Info("advertised capacity changed", "binding", b.key, "advertised", credit,
+		"tier", b.tier.ID, "tier_parallelism", parallelism, "tier_advertised", total,
+		"discovery", s.alloc.DiscoveryHolder(b.tier.ID), "instance_capacity", s.alloc.CapacityReport(),
+		"credits", rows)
+}

--- a/internal/app/durability_test.go
+++ b/internal/app/durability_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Permanent regressions for the durable assignment machine. Each names
+// the window it covers, because each is a way the machine loses or
+// duplicates work that no unit of SQLite behaviour on its own reveals.
+
+// TestLateRedeliveryDoesNotRecreateWork covers the window between a
+// failed acknowledgement and the broker's redelivery. The job ran to
+// completion; when the same message arrives again, the settled attempt
+// under the same delivery is what recognises it, and no second capsule
+// starts.
+func TestLateRedeliveryDoesNotRecreateWork(t *testing.T) {
+	h := newHarness(t, 1)
+	probe := demand("probe-job", "app", 42)
+
+	if err := h.deliverMsg(42, probe); err != nil {
+		t.Fatal(err)
+	}
+	// The acknowledgement fails here; the broker will send it again.
+	lease, attemptID := leaseFor(t, h, "probe-job")
+	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
+	h.recordEvidence(lease.ID, store.EvidenceExitObserved)
+	if err := h.srv.leases.Finalize(t.Context(), lease.ID, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// The redelivery arrives after the job has finished.
+	if err := h.deliverMsg(42, probe); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.ready(); len(got) != 0 {
+		t.Errorf("a completed job was queued again by a late redelivery: %+v", got)
+	}
+	if got := attemptState(t, h, attemptID); got.State != "settled" || got.Resolution != assignment.ResolutionCompletedObserved {
+		t.Errorf("attempt = %s/%s; want settled/completed_observed", got.State, got.Resolution)
+	}
+}
+
+// TestInterruptedLeaseReturnsItsAttempt covers a crash after the lease
+// exists but before the runner ran. Startup releases the lease, but if
+// the attempt stayed leased to it, the work is neither running nor
+// queued: it is invisible, and GitHub will not send it again.
+func TestInterruptedLeaseReturnsItsAttempt(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("probe-restart", "app", 43)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "probe-restart")
+
+	// Startup finds a reserved lease with no runner.
+	h.resolveWithoutRuntime(t.Context(), lease)
+
+	if got := h.ready(); len(got) != 1 {
+		t.Fatalf("the attempt did not return to the queue: %+v", got)
+	}
+}
+
+// TestFailedAndQuarantinedLeasesReachReleased covers recovery from the
+// two states that were once sent through a transition they cannot make:
+// failed -> failed and quarantined -> failed are both invalid, so
+// cleanup returned before touching anything.
+func TestFailedAndQuarantinedLeasesReachReleased(t *testing.T) {
+	for _, from := range []store.LeaseState{store.LeaseFailed, store.LeaseQuarantined} {
+		t.Run(string(from), func(t *testing.T) {
+			h := newHarness(t, 1)
+			if err := h.deliver(demand("probe-"+string(from), "app", 44)); err != nil {
+				t.Fatal(err)
+			}
+			lease, _ := leaseFor(t, h, "probe-"+string(from))
+			driveLeaseTo(t, h, lease.ID, from)
+
+			h.resolveWithoutRuntime(t.Context(), lease)
+
+			final := reloadLease(t, h, lease.ID)
+			if final.State != store.LeaseReleased {
+				t.Errorf("a %s lease stayed %s; recovery never ran its cleanup", from, final.State)
+			}
+		})
+	}
+}
+
+func reloadLease(t *testing.T, h *harness, leaseID string) store.Lease {
+	t.Helper()
+	var lease store.Lease
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		var err error
+		lease, err = tx.LeaseByID(leaseID)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return lease
+}

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -1,0 +1,483 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// The Start fault matrix: every way the launch orchestration can fail,
+// driven through the real runCapsule with the capsule, registry and
+// waiter seams faulted. The invariant across the whole table is that no
+// combination produces a false "executed" — an attempt settles only
+// when execution was observed, returns to ready only when a start
+// provably never took effect, and is held for a person whenever neither
+// can be shown.
+
+type fakeCapsule struct {
+	prepareErr error
+	startErr   error
+	obs        assignment.ExecutionObservation
+	obsErr     error
+	// spec is what the controller asked for, which is the only place the
+	// image decisions are observable.
+	spec capsule.Spec
+}
+
+func (f *fakeCapsule) Prepare(_ context.Context, spec capsule.Spec, rec capsule.ResourceRecorder) (capsule.PreparedRuntime, error) {
+	f.spec = spec
+	if f.prepareErr != nil {
+		return capsule.PreparedRuntime{}, f.prepareErr
+	}
+	// A successful preparation records its objects the way the real one
+	// does — plan, creating, confirm — so the finalizing transaction has
+	// real intents to verify and remove.
+	id, err := rec.Plan("container", "runner", "runpool-runner-fake")
+	if err != nil {
+		return capsule.PreparedRuntime{}, err
+	}
+	if err := rec.Creating(id); err != nil {
+		return capsule.PreparedRuntime{}, err
+	}
+	if err := rec.Confirm(id, "fake-runner"); err != nil {
+		return capsule.PreparedRuntime{}, err
+	}
+	return capsule.PreparedRuntime{RuntimeID: "fake-runner"}, nil
+}
+
+func (f *fakeCapsule) Start(context.Context, capsule.PreparedRuntime) error { return f.startErr }
+
+func (f *fakeCapsule) InspectExecution(context.Context, capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
+	return f.obs, f.obsErr
+}
+
+type fakeRegistry struct{ jitErr error }
+
+func (f *fakeRegistry) GenerateJITConfig(context.Context, int, string, string) (githubactions.JITConfig, error) {
+	if f.jitErr != nil {
+		return githubactions.JITConfig{}, f.jitErr
+	}
+	return githubactions.JITConfig{RunnerID: 5, RunnerName: "fake", Encoded: "fake-jit"}, nil
+}
+
+func (f *fakeRegistry) RemoveRunner(context.Context, int) error { return nil }
+
+type fakeWaiter struct {
+	exit    int64
+	waitErr error
+}
+
+func (f *fakeWaiter) WaitExit(context.Context, string) (int64, error) { return f.exit, f.waitErr }
+func (f *fakeWaiter) TailLogs(context.Context, string, int) (string, error) {
+	return "", nil
+}
+
+// runFaulted claims one attempt and drives runCapsule synchronously
+// against the given fakes.
+func runFaulted(t *testing.T, h *harness, caps *fakeCapsule, reg *fakeRegistry, wait *fakeWaiter, workload string) (store.Lease, string) {
+	t.Helper()
+	h.srv.caps = caps
+	h.srv.wait = wait
+	h.bind.jit = reg
+	if err := h.deliver(demand(workload, "app", 60)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, workload)
+	h.srv.wg.Add(1)
+	h.srv.runCapsule(h.bind, lease)
+	return lease, attemptID
+}
+
+func TestStartFaultMatrix(t *testing.T) {
+	boom := errors.New("injected failure")
+	cases := []struct {
+		name    string
+		caps    *fakeCapsule
+		reg     *fakeRegistry
+		wait    *fakeWaiter
+		want    string // attempt state afterwards
+		wantRes string // attempt resolution, when settled
+	}{
+		{
+			// The credential could not be minted: nothing was prepared,
+			// nothing could have run.
+			name: "jit generation fails",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{jitErr: boom}, wait: &fakeWaiter{},
+			want: "ready",
+		},
+		{
+			// Preparation died building the capsule: by construction no
+			// start was possible.
+			name: "prepare fails",
+			caps: &fakeCapsule{prepareErr: boom}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
+			want: "ready",
+		},
+		{
+			// Start errored and the daemon shows the container never left
+			// created: the one provable requeue past the authorization.
+			name: "start error, runtime proven inert",
+			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedCreated}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
+			want: "ready",
+		},
+		{
+			// Start errored but the container ran and exited: the error
+			// was noise, the execution was real.
+			name: "start error, runtime ran and exited",
+			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedExited}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
+			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+		},
+		{
+			// Start errored but the container is running: continue as if
+			// the start succeeded, await it, settle on its exit.
+			name: "start error, runtime running",
+			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedRunning}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 0},
+			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+		},
+		{
+			// Start errored and the container is gone: nothing can be
+			// proven in either direction, so a person decides.
+			name: "start error, runtime absent",
+			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedAbsent}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
+			want: "manual_review",
+		},
+		{
+			// Start errored and the daemon cannot be asked: same ruling.
+			name: "start error, daemon unavailable",
+			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedUnavailable, obsErr: boom}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
+			want: "manual_review",
+		},
+		{
+			// The runner started and the daemon was lost mid-run: running
+			// was observed, so the attempt settles as exactly that.
+			name: "wait fails after a clean start",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{waitErr: boom},
+			want: "settled", wantRes: assignment.ResolutionStartedObserved,
+		},
+		{
+			// A non-zero exit is the job's business, not the machine's:
+			// the runner ran and completed.
+			name: "runner exits non-zero",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 7},
+			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+		},
+		{
+			name: "happy path",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 0},
+			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t, 1)
+			lease, attemptID := runFaulted(t, h, tc.caps, tc.reg, tc.wait, "job-fault")
+
+			got := attemptState(t, h, attemptID)
+			if got.State != tc.want {
+				t.Errorf("attempt = %s; want %s", got.State, tc.want)
+			}
+			if tc.wantRes != "" && got.Resolution != tc.wantRes {
+				t.Errorf("resolution = %s; want %s", got.Resolution, tc.wantRes)
+			}
+			// No combination may leave the lease holding its credit: every
+			// path ends terminal, whatever became of the attempt.
+			if final := reloadLease(t, h, lease.ID); final.State != store.LeaseReleased {
+				t.Errorf("lease ended %s; want released", final.State)
+			}
+			// The invariant the atomic ending exists for: after any
+			// normal path, no attempt is left open under a finished
+			// lease. The reconciler's sweep should never find one.
+			h.inStore(func(s *store.Tx) error {
+				stranded, err := s.StrandedAttempts()
+				if err != nil {
+					return err
+				}
+				if len(stranded) != 0 {
+					t.Errorf("stranded attempts = %d after a normal path; release and "+
+						"disposition came apart", len(stranded))
+				}
+				return nil
+			})
+		})
+	}
+}
+
+// The operator's two decisions over held work, with their audit trail.
+// Retry is only offered because the operator verified externally that
+// the workload never executed; settle is the safe reading when it
+// cannot be ruled out.
+func TestOperatorResolvesHeldAttempts(t *testing.T) {
+	boom := errors.New("injected failure")
+	for _, decision := range []string{"retry", "settle"} {
+		t.Run(decision, func(t *testing.T) {
+			h := newHarness(t, 1)
+			// An unprovable start outcome puts the attempt in review.
+			_, attemptID := runFaulted(t, h,
+				&fakeCapsule{startErr: boom, obs: assignment.ObservedAbsent},
+				&fakeRegistry{}, &fakeWaiter{}, "job-held")
+			if got := attemptState(t, h, attemptID); got.State != "manual_review" {
+				t.Fatalf("attempt = %s; want manual_review", got.State)
+			}
+
+			h.inStore(func(s *store.Tx) error {
+				if decision == "retry" {
+					return s.ResolveReviewToReady(attemptID, "provider shows the job never started", "matias")
+				}
+				return s.ResolveReviewToSettled(attemptID, assignment.ResolutionMayHaveExecuted,
+					"cannot rule out execution", "matias")
+			})
+
+			got := attemptState(t, h, attemptID)
+			switch decision {
+			case "retry":
+				if got.State != "ready" {
+					t.Errorf("attempt = %s; want ready", got.State)
+				}
+				if len(h.ready()) != 1 {
+					t.Error("a retried attempt is not servable")
+				}
+			case "settle":
+				if got.State != "settled" || got.Resolution != assignment.ResolutionMayHaveExecuted {
+					t.Errorf("attempt = %s/%s; want settled/%s", got.State, got.Resolution, assignment.ResolutionMayHaveExecuted)
+				}
+			}
+			if got.ReviewedBy != "matias" {
+				t.Errorf("reviewed_by = %q; every resolution names its actor", got.ReviewedBy)
+			}
+			// The decision and its reason are in the lifecycle, where an
+			// audit reads them back.
+			var sawResolution bool
+			h.inStore(func(s *store.Tx) error {
+				events, err := s.Events(attemptID)
+				if err != nil {
+					return err
+				}
+				for _, ev := range events {
+					if ev.Kind == "operator_resolved" && ev.Detail != "{}" {
+						sawResolution = true
+					}
+				}
+				return nil
+			})
+			if !sawResolution {
+				t.Error("no operator_resolved event with detail; the audit trail is missing")
+			}
+		})
+	}
+}
+
+// faultyRemover fails removals until healed — a wedged daemon the
+// periodic reconciler must outlast.
+type faultyRemover struct {
+	healed bool
+}
+
+func (f *faultyRemover) fail() error {
+	if f.healed {
+		return nil
+	}
+	return errors.New("daemon wedged")
+}
+func (f *faultyRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+	return f.fail()
+}
+func (f *faultyRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+	return f.fail()
+}
+func (f *faultyRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+	return f.fail()
+}
+
+// The periodic reconciler converges a quarantined lease without a
+// restart: the wedged removal parks the lease and books backoff on the
+// intent; the pass respects the backoff while it lasts, and once the
+// daemon heals and the window elapses, one pass drives the whole ending
+// — removal, release, disposition.
+func TestPeriodicReconcileConvergesQuarantine(t *testing.T) {
+	h := newHarness(t, 1)
+	remover := &faultyRemover{}
+	h.useRemover(remover)
+	if err := h.deliver(demand("job-wedged", "app", 80)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attempt := leaseFor(t, h, "job-wedged")
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		id, err := tx.PlanResource(lease.ID, store.ResourceContainer, "runner", "runpool-runner-wedge")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "wedge-1")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The removal fails: the lease parks in quarantine with backoff
+	// booked on the intent, and the attempt stays leased — unresolved,
+	// visible, waiting.
+	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err == nil {
+		t.Fatal("recoverCapsuleFailure with a wedged daemon succeeded")
+	}
+	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseQuarantined {
+		t.Fatalf("lease = %s; want quarantined", got.State)
+	}
+
+	// The backoff has not elapsed: a periodic pass must not retry yet.
+	h.srv.retryStranded(t.Context())
+	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseQuarantined {
+		t.Fatalf("a pass inside the backoff window touched the lease: %s", got.State)
+	}
+
+	// The daemon heals and the backoff elapses.
+	remover.healed = true
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		intents, err := tx.Resources(lease.ID)
+		if err != nil {
+			return err
+		}
+		return tx.RecordResourceError(intents[0].ID, errors.New("previous failure"), time.Now().Add(-time.Second))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h.srv.retryStranded(t.Context())
+
+	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
+		t.Errorf("lease = %s after the periodic pass; want released", got.State)
+	}
+	if got := attemptState(t, h, attempt); got.State != "ready" {
+		t.Errorf("attempt = %s; want ready — nothing was ever authorized", got.State)
+	}
+}
+
+// A provider cancellation closes unstarted work and nothing else: the
+// ready attempt cancels, while an attempt already serving is left to
+// its own lifecycle — a cancellation aimed at old work must never touch
+// a live capsule.
+func TestRemoteCancellationClosesOnlyReadyWork(t *testing.T) {
+	h := newHarness(t, 2)
+	if err := h.deliver(demand("job-idle", "app", 70)); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.deliver(demand("job-busy", "app", 71)); err != nil {
+		t.Fatal(err)
+	}
+	_, busyAttempt := leaseFor(t, h, "job-busy") // now leased, not ready
+
+	cancelled := &githubactions.Message{ID: 900, Completed: []assignment.WorkloadLifecycleEvent{
+		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-idle", Result: "canceled"},
+		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-busy", Result: "canceled"},
+	}}
+	s := h.srv
+	s.recordLifecycleEvents(t.Context(), h.bind, cancelled)
+
+	idle := h.ready()
+	if len(idle) != 0 {
+		t.Errorf("a cancelled ready attempt is still servable: %+v", idle)
+	}
+	if got := attemptState(t, h, busyAttempt); got.State != "leased" {
+		t.Errorf("a serving attempt was touched by a remote cancellation: %s", got.State)
+	}
+}
+
+// TestPeriodicReconcileConvergesAStrandedCleaningLease is the credit-leak
+// guard. Quarantine is not the only way an owner stops: a failed
+// finalization leaves the lease in `cleaning` with no goroutine driving it.
+// The old pass listed quarantined leases only, so such a lease held its
+// admission credit until the process restarted — the tier permanently
+// admitting one less than its parallelism.
+func TestPeriodicReconcileConvergesAStrandedCleaningLease(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-stranded", "app", 80)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attempt := leaseFor(t, h, "job-stranded")
+
+	// Park the lease in cleaning with nobody driving it, which is where a
+	// failed Finalize leaves it, and take the credit its owner held.
+	if _, err := h.srv.leases.ToCleaning(t.Context(), lease.ID); err != nil {
+		t.Fatal(err)
+	}
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseCleaning {
+		t.Fatalf("lease = %s; want cleaning", got)
+	}
+	h.srv.alloc.Adopt(h.bind.key)
+	if h.srv.alloc.TryReserve(h.bind.key) {
+		t.Fatal("the stranded lease should be holding the tier's only credit")
+	}
+
+	h.srv.retryStranded(t.Context())
+
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseReleased {
+		t.Errorf("stranded cleaning lease = %s after a periodic pass; want released", got)
+	}
+	if !h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the stranded lease's admission credit was never returned")
+	}
+	if got := attemptState(t, h, attempt); got.State == "leased" {
+		t.Error("the attempt was left leased to a lease that no longer exists")
+	}
+}
+
+// A lease a goroutine is still driving is not stranded, and the periodic
+// pass must not touch it — two owners each concluding it is done would
+// release the same admission credit twice and oversubscribe the host.
+func TestPeriodicReconcileSkipsOwnedLeases(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-owned", "app", 80)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-owned")
+
+	if !h.srv.claimLease(lease.ID) {
+		t.Fatal("the lease should be claimable")
+	}
+	defer h.srv.releaseLease(lease.ID)
+
+	before := reloadLease(t, h, lease.ID).State
+	h.srv.retryStranded(t.Context())
+	if got := reloadLease(t, h, lease.ID).State; got != before {
+		t.Errorf("a claimed lease moved %s -> %s; the pass must leave owned leases alone", before, got)
+	}
+}
+
+// TestPeriodicReconcileSpareAJobBeingLaunched closes the window the
+// ownership claim opened. createLease commits a lease in `reserved` — a
+// live state the periodic pass now lists — and the goroutine that drives
+// it starts afterwards. If the claim were taken inside that goroutine, a
+// pass landing in between would find the lease ownerless and drive it
+// through recoverCapsuleFailure: the capsule, its network and its volume
+// destroyed under a job that was starting, and its admission credit
+// released twice.
+func TestPeriodicReconcileSpareAJobBeingLaunched(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-launching", "app", 80)); err != nil {
+		t.Fatal(err)
+	}
+	h.serve()
+
+	launched := h.launchedAttempts()
+	if len(launched) != 1 {
+		t.Fatalf("launched %v; want exactly one attempt", launched)
+	}
+	h.mu.Lock()
+	lease := h.leases[launched[0]]
+	h.mu.Unlock()
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseReserved {
+		t.Fatalf("lease = %s; the harness launch leaves it reserved", got)
+	}
+
+	h.srv.retryStranded(t.Context())
+
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseReserved {
+		t.Errorf("the periodic pass drove a lease being launched: %s -> %s",
+			store.LeaseReserved, got)
+	}
+	if h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the launching lease's admission credit was released out from under it")
+	}
+}

--- a/internal/app/images.go
+++ b/internal/app/images.go
@@ -1,0 +1,93 @@
+package app
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// The reviewed image lock travels inside the binary, so a controller
+// cannot be pointed at images it was not tested against by editing a file
+// next to it. A digest-qualified reference is what actually runs: a tag
+// can move, and the dind payload runs privileged.
+//
+//go:embed images.lock.json
+var imageLockJSON []byte
+
+type imageLock struct {
+	Images map[string]struct {
+		Ref    string `json:"ref"`
+		Digest string `json:"digest"`
+	} `json:"images"`
+}
+
+// capsuleImage resolves the outer capsule image the controller creates.
+// A release binary carries the exact digest that passed release qualification;
+// an environment value cannot replace it. Development builds may use an
+// explicit local image through RUNPOOL_CAPSULE_IMAGE.
+//
+// The runner and dind lock entries remain the build inputs of that
+// image — build/capsule/Dockerfile copies its halves from exactly those
+// digests — so the lock still reviews everything privileged that runs.
+func capsuleImage(environ func(string) string, buildDefault string) (string, error) {
+	if buildDefault == "" {
+		buildDefault = "runpool-capsule:dev"
+	}
+	override := environ("RUNPOOL_CAPSULE_IMAGE")
+	if config.IsDigestQualifiedImage(buildDefault) {
+		if override != "" && override != buildDefault {
+			return "", fmt.Errorf("RUNPOOL_CAPSULE_IMAGE cannot override the release capsule %q", buildDefault)
+		}
+		return buildDefault, nil
+	}
+	if buildDefault != "runpool-capsule:dev" {
+		return "", fmt.Errorf("release capsule image %q is not digest-qualified", buildDefault)
+	}
+	if override != "" {
+		return override, nil
+	}
+	return buildDefault, nil
+}
+
+// buildInputImages returns the digest-qualified runner and dind
+// references the capsule image is built from. A malformed or incomplete
+// lock is fatal: building from unverified bytes that later run
+// privileged is worse than not building.
+func buildInputImages() (runner, dind string, err error) {
+	var lock imageLock
+	if err := json.Unmarshal(imageLockJSON, &lock); err != nil {
+		return "", "", fmt.Errorf("image lock: %w", err)
+	}
+	runner, err = pinned(lock, "runner")
+	if err != nil {
+		return "", "", err
+	}
+	dind, err = pinned(lock, "dind")
+	return runner, dind, err
+}
+
+// pinned turns "repo:tag" plus a digest into "repo@digest": the tag is
+// discarded, so nothing resolves through a mutable name.
+func pinned(lock imageLock, name string) (string, error) {
+	entry, ok := lock.Images[name]
+	if !ok {
+		return "", fmt.Errorf("image lock has no %q entry", name)
+	}
+	if entry.Digest == "" || entry.Ref == "" {
+		return "", fmt.Errorf("image lock entry %q is incomplete", name)
+	}
+	repo := entry.Ref
+	// Strip the tag, keeping any registry port (host:5000/image:tag).
+	for i := len(repo) - 1; i >= 0; i-- {
+		if repo[i] == ':' {
+			repo = repo[:i]
+			break
+		}
+		if repo[i] == '/' {
+			break
+		}
+	}
+	return repo + "@" + entry.Digest, nil
+}

--- a/internal/app/images.lock.json
+++ b/internal/app/images.lock.json
@@ -1,0 +1,26 @@
+{
+  "$comment": [
+    "Runtime images Runpool creates containers from, pinned by digest.",
+    "A tag can move; a digest cannot, so a release always runs the images",
+    "it was tested against. The runner and dind pair is versioned together:",
+    "the runner's externals tree and the daemon it drives must match.",
+    "scripts/verify/image-lock.sh re-resolves each tag and fails when a",
+    "digest has drifted from what is recorded here."
+  ],
+  "resolved": "2026-08-15",
+  "platform": "linux/amd64",
+  "images": {
+    "runner": {
+      "ref": "ghcr.io/actions/actions-runner:2.336.0",
+      "digest": "sha256:0cfdcc701ce933c6d243c6b0b2da767366dc9f2e99961d4c3754b0b78084cdda",
+      "upstream": "https://github.com/actions/runner/releases/tag/v2.336.0",
+      "note": "GitHub requires a runner with auto-update disabled to be updated within 30 days of a release."
+    },
+    "dind": {
+      "ref": "docker:29.7.2-dind",
+      "digest": "sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07",
+      "upstream": "https://hub.docker.com/_/docker",
+      "note": "Runs privileged inside the capsule; its data root is a fresh volume per job. Release qualification exercises this exact digest through the capsule candidate."
+    }
+  }
+}

--- a/internal/app/images_lock_test.go
+++ b/internal/app/images_lock_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The embedded lock is what the controller executes; the reviewed lock
+// under build/ is what humans audit. If they diverge, the review applied
+// to bytes that do not run. Byte equality, not structural equality: two
+// JSON documents can be structurally equal while only one of them was
+// reviewed.
+func TestEmbeddedImageLockMatchesTheReviewedCopy(t *testing.T) {
+	reviewed, err := os.ReadFile("../../build/images.lock.json")
+	if err != nil {
+		t.Fatalf("read the reviewed lock: %v", err)
+	}
+	if !bytes.Equal(reviewed, imageLockJSON) {
+		t.Error("internal/app/images.lock.json differs from build/images.lock.json; " +
+			"the embedded copy is what runs, so the reviewed copy must be identical")
+	}
+}
+
+// The lock records the privileged payload a capsule runs, but the capsule is
+// built from the FROM lines in its Dockerfile. Nothing else compares the two:
+// the verify script re-resolves the lock against its registry and never opens
+// a Dockerfile, so a dependency update that moves one and not the other keeps
+// every check green while the reviewed document stops describing what runs.
+func TestLockedImagesAreWhatTheCapsuleIsBuiltFrom(t *testing.T) {
+	dockerfile, err := os.ReadFile("../../build/capsule/Dockerfile")
+	if err != nil {
+		t.Fatalf("read the capsule Dockerfile: %v", err)
+	}
+	var lock imageLock
+	if err := json.Unmarshal(imageLockJSON, &lock); err != nil {
+		t.Fatalf("parse the image lock: %v", err)
+	}
+	if len(lock.Images) == 0 {
+		t.Fatal("the image lock is empty, so this proves nothing")
+	}
+	for name, entry := range lock.Images {
+		want := entry.Ref + "@" + entry.Digest
+		if !strings.Contains(string(dockerfile), want) {
+			t.Errorf("build/capsule/Dockerfile does not build from the locked %s image %q; "+
+				"the lock is the reviewed record of what runs privileged, so a Dockerfile "+
+				"that names other bytes makes that record false", name, want)
+		}
+	}
+}
+
+// Development may select a local capsule image. A release carries the
+// qualified digest and refuses a runtime replacement.
+func TestCapsuleImageResolution(t *testing.T) {
+	fromEnv := func(k string) string {
+		if k == "RUNPOOL_CAPSULE_IMAGE" {
+			return "runpool-capsule:local-test"
+		}
+		return ""
+	}
+	img, err := capsuleImage(fromEnv, "runpool-capsule:dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img != "runpool-capsule:local-test" {
+		t.Errorf("with the override set, image = %q; want the override", img)
+	}
+	img, err = capsuleImage(func(string) string { return "" }, "runpool-capsule:dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if img != "runpool-capsule:dev" {
+		t.Errorf("without override or lock entry, image = %q; want the dev tag", img)
+	}
+
+	release := "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	img, err = capsuleImage(func(string) string { return release }, release)
+	if err != nil || img != release {
+		t.Fatalf("release image = %q, %v; want stamped digest", img, err)
+	}
+	if _, err := capsuleImage(fromEnv, release); err == nil {
+		t.Fatal("a runtime override replaced the release capsule image")
+	}
+	if _, err := capsuleImage(func(string) string { return "" }, "ghcr.io/rhobuild/runpool/capsule:v1"); err == nil {
+		t.Fatal("a mutable release capsule reference was accepted")
+	}
+}

--- a/internal/app/images_test.go
+++ b/internal/app/images_test.go
@@ -1,0 +1,55 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildInputImagesArePinned: what feeds the capsule image build
+// must resolve through an immutable digest, never a tag that can move
+// under a privileged payload.
+func TestBuildInputImagesArePinned(t *testing.T) {
+	runner, dind, err := buildInputImages()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, ref := range map[string]string{"runner": runner, "dind": dind} {
+		if !strings.Contains(ref, "@sha256:") {
+			t.Errorf("%s image %q is not digest-qualified", name, ref)
+		}
+		if strings.Contains(strings.TrimPrefix(ref, "ghcr.io/"), ":") &&
+			!strings.Contains(ref, "@") {
+			t.Errorf("%s image %q still carries a tag", name, ref)
+		}
+	}
+	if !strings.HasPrefix(runner, "ghcr.io/actions/actions-runner@") {
+		t.Errorf("runner reference lost its repository: %q", runner)
+	}
+	if !strings.HasPrefix(dind, "docker@") {
+		t.Errorf("dind reference lost its repository: %q", dind)
+	}
+}
+
+func TestPinnedStripsTagKeepsRegistryPort(t *testing.T) {
+	lock := imageLock{Images: map[string]struct {
+		Ref    string `json:"ref"`
+		Digest string `json:"digest"`
+	}{
+		"a": {Ref: "registry.example:5000/team/img:1.2.3", Digest: "sha256:abc"},
+		"b": {Ref: "img:tag", Digest: "sha256:def"},
+		"c": {Ref: "img", Digest: ""},
+	}}
+	got, err := pinned(lock, "a")
+	if err != nil || got != "registry.example:5000/team/img@sha256:abc" {
+		t.Errorf("registry port case = %q, %v", got, err)
+	}
+	if got, err := pinned(lock, "b"); err != nil || got != "img@sha256:def" {
+		t.Errorf("plain tag case = %q, %v", got, err)
+	}
+	if _, err := pinned(lock, "c"); err == nil {
+		t.Error("an entry without a digest must be rejected, not run unpinned")
+	}
+	if _, err := pinned(lock, "missing"); err == nil {
+		t.Error("a missing entry must be rejected")
+	}
+}

--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -1,0 +1,27 @@
+package app
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+func newLogger(cfg config.LogConfig) *slog.Logger {
+	var level slog.Level
+	switch cfg.Level {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	default:
+		level = slog.LevelInfo
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	if cfg.Format == config.LogFormatText {
+		return slog.New(slog.NewTextHandler(os.Stderr, opts))
+	}
+	return slog.New(slog.NewJSONHandler(os.Stderr, opts))
+}

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -1,0 +1,239 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/disk"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// The disk monitor measures once a minute. Pressure moves at the speed
+// jobs write, and a probe container per pass is the cost; tighter would
+// buy noise, looser would let a runaway job outrun the soft floor.
+const monitorInterval = time.Minute
+
+// diskProbe is the slice of the daemon a pressure verdict is made of.
+// Defined here because the consumer owns its interfaces, and narrow
+// because that is what lets a test present a filesystem with no room
+// left — the one state the daemon cannot be asked to be in.
+type diskProbe interface {
+	ProbeFilesystemFree(ctx context.Context, image, instanceID string) (docker.FilesystemFree, error)
+	OwnedVolumeUsage(ctx context.Context, instanceID string) ([]docker.VolumeUsage, error)
+}
+
+// admissionGate is the half of the credit pool a verdict acts on.
+// Capacity that will not be served must not be announced, or the broker
+// assigns work that then waits on a full disk.
+type admissionGate interface{ Hold(bool) }
+
+// diskPolicy is the configured pressure policy, captured once at start.
+type diskPolicy struct {
+	thresholds disk.Thresholds
+	ttl        time.Duration
+}
+
+func diskPolicyFrom(cfg *config.Config) diskPolicy {
+	g := cfg.Cache.Global
+	return diskPolicy{
+		thresholds: disk.Thresholds{
+			MaxManagedBytes:  int64(g.MaxManagedBytes),
+			HighPct:          g.HighWatermarkPercent,
+			LowPct:           g.LowWatermarkPercent,
+			SoftFreeBytes:    int64(g.SoftEmergencyFreeBytes),
+			HardFreeBytes:    int64(g.HardEmergencyFreeBytes),
+			ReserveFreeBytes: int64(cfg.Host.Reserve.FreeDisk),
+		},
+		ttl: time.Duration(cfg.Cache.Defaults.UnusedTTL),
+	}
+}
+
+// diskMonitor owns the pressure level: it measures the filesystem,
+// decides the level, persists it, closes admission when the level says
+// so and collects cache lanes when the level obliges.
+//
+// The controller keeps only a read of the level in force, because every
+// delivery consults it before admitting work. Everything that moves the
+// level lives here.
+type diskMonitor struct {
+	log        *slog.Logger
+	store      *store.Store
+	probe      diskProbe
+	lanes      *cache.LaneManager
+	gate       admissionGate
+	probeImage string
+	policy     diskPolicy
+
+	// level is the pressure in force. Read on the admission path from
+	// another goroutine, so it is atomic rather than guarded.
+	level atomic.Int32
+}
+
+func newDiskMonitor(cfg *config.Config, log *slog.Logger, st *store.Store, probe diskProbe,
+	lanes *cache.LaneManager, gate admissionGate, probeImage string) *diskMonitor {
+	return &diskMonitor{
+		log: log, store: st, probe: probe, lanes: lanes, gate: gate,
+		probeImage: probeImage, policy: diskPolicyFrom(cfg),
+	}
+}
+
+func (m *diskMonitor) current() disk.Level { return disk.Level(m.level.Load()) }
+
+// resume loads the persisted level so a restart resumes the emergency
+// that was in force instead of admitting into it. It must run before any
+// binding serves, because it is what holds the credit pool shut.
+func (m *diskMonitor) resume(ctx context.Context) error {
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		p, err := tx.Pressure()
+		if err != nil || p == nil {
+			return err
+		}
+		level, err := disk.ParseLevel(p.Level)
+		if err != nil {
+			return err
+		}
+		m.level.Store(int32(level))
+		m.gate.Hold(level.AdmissionClosed())
+		if level != disk.Normal {
+			m.log.Warn("resuming under disk pressure", "level", level.String())
+		}
+		return nil
+	})
+}
+
+// run is the pressure loop: measure, decide, persist, act.
+func (m *diskMonitor) run(ctx context.Context) {
+	ticker := time.NewTicker(monitorInterval)
+	defer ticker.Stop()
+	for {
+		m.pass(ctx)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// pass runs one measurement. A failed measurement changes nothing: the
+// level in force stays in force, because losing the probe must not
+// reopen an admission an emergency closed.
+func (m *diskMonitor) pass(ctx context.Context) {
+	facts, err := m.measure(ctx)
+	if err != nil {
+		m.log.Warn("disk measurement failed; keeping the current pressure level",
+			"level", m.current().String(), "error", err)
+		return
+	}
+
+	prev := m.current()
+	next := disk.Next(prev, facts, m.policy.thresholds)
+	m.level.Store(int32(next))
+	// Credit follows admission: capacity that will not be served must
+	// not be announced, or the broker assigns work that then waits on a
+	// full disk. Running capsules keep their credit either way.
+	m.gate.Hold(next.AdmissionClosed())
+
+	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
+		if err := tx.SetPressure(store.PressureInfo{
+			Level:        next.String(),
+			FreeBytes:    facts.FreeBytes,
+			FreeInodes:   facts.FreeInodes,
+			ManagedBytes: facts.ManagedBytes,
+		}); err != nil {
+			return err
+		}
+		if next != prev {
+			return tx.RecordAudit("disk-monitor", "pressure_"+next.String(), "host",
+				fmt.Sprintf("was=%s free_bytes=%d managed_bytes=%d", prev, facts.FreeBytes, facts.ManagedBytes))
+		}
+		return nil
+	}); err != nil {
+		m.log.Error("cannot persist the pressure verdict", "error", err)
+	}
+
+	if next != prev {
+		logf := m.log.Info
+		if next >= disk.SoftEmergency || prev >= disk.SoftEmergency {
+			logf = m.log.Warn
+		}
+		if next == disk.HardEmergency {
+			// The alert: fail closed and say so as loudly as a log can.
+			logf = m.log.Error
+		}
+		logf("disk pressure changed", "from", prev.String(), "to", next.String(),
+			"free_bytes", facts.FreeBytes, "managed_bytes", facts.ManagedBytes,
+			"admission", map[bool]string{true: "closed", false: "open"}[next.AdmissionClosed()])
+	}
+
+	if next.WantsGC() {
+		m.collectGarbage(ctx, next)
+	}
+}
+
+// measure probes the daemon's filesystem from inside it and weighs this
+// instance's cache lanes.
+func (m *diskMonitor) measure(ctx context.Context) (disk.Facts, error) {
+	free, err := m.probe.ProbeFilesystemFree(ctx, m.probeImage, m.store.InstanceID())
+	if err != nil {
+		return disk.Facts{}, fmt.Errorf("filesystem probe: %w", err)
+	}
+	usage, err := m.probe.OwnedVolumeUsage(ctx, m.store.InstanceID())
+	if err != nil {
+		return disk.Facts{}, fmt.Errorf("volume usage: %w", err)
+	}
+	var managed int64
+	for _, u := range usage {
+		if u.Labels[docker.LabelRole] == cache.RoleCacheLane && u.Size > 0 {
+			managed += u.Size
+		}
+	}
+	return disk.Facts{
+		FreeBytes:    free.FreeBytes,
+		FreeInodes:   free.FreeInodes,
+		ManagedBytes: managed,
+	}, nil
+}
+
+// collectGarbage runs the pass the level obliges: at high pressure,
+// down to the low watermark; in a soft emergency, every free lane.
+// Failures are logged and retried by the next pass.
+func (m *diskMonitor) collectGarbage(ctx context.Context, level disk.Level) {
+	opts := cache.GCOptions{
+		TTL: m.policy.ttl,
+		TargetBytes: cache.GCTarget(m.policy.thresholds.MaxManagedBytes,
+			m.policy.thresholds.LowPct),
+		AllFree: level.Aggressive(),
+		Now:     time.Now(),
+	}
+	plan, err := m.lanes.PlanGC(ctx, opts)
+	if err != nil {
+		m.log.Error("gc planning failed", "error", err)
+		return
+	}
+	if len(plan.Evictions) == 0 {
+		return
+	}
+	res, err := m.lanes.RunGC(ctx, plan, "disk-monitor")
+	if err != nil {
+		m.log.Error("gc failed", "error", err)
+		return
+	}
+	m.log.Info("gc pass", "level", level.String(), "applied", res.Applied,
+		"skipped", res.Skipped, "failed", len(res.Failed),
+		"managed_bytes", plan.ManagedBytes, "kept_bytes", plan.KeptBytes)
+	for _, ferr := range res.Failed {
+		m.log.Warn("gc eviction failed; the next pass retries", "error", ferr)
+	}
+}
+
+// currentPressure is the level in force, which every delivery consults
+// before admitting work. It is the whole of the monitor the controller
+// takes part in.
+func (s *Controller) currentPressure() disk.Level { return s.disk.current() }

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -1,0 +1,173 @@
+package app
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"slices"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/disk"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestMeasureWeighsOnlyThisInstancesLanes: the managed figure is what the
+// watermark passes work against, so anything counted into it that a
+// collection cannot evict makes the monitor chase a number it cannot
+// move. Only cache lanes are evictable, and a volume whose size the
+// daemon could not compute counts as zero rather than as a guess.
+func TestMeasureWeighsOnlyThisInstancesLanes(t *testing.T) {
+	h := newHarness(t, 1)
+	h.probe.free = docker.FilesystemFree{FreeBytes: 500, FreeInodes: 90}
+	h.probe.usage = []docker.VolumeUsage{
+		{Name: "lane-a", Size: 100, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
+		{Name: "lane-b", Size: 40, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
+		{Name: "workspace", Size: 9000, Labels: map[string]string{docker.LabelRole: "workspace"}},
+		{Name: "unmeasured", Size: -1, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
+	}
+
+	facts, err := h.srv.disk.measure(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if facts.ManagedBytes != 140 {
+		t.Errorf("managed = %d; want only the two measured lanes, 140", facts.ManagedBytes)
+	}
+	if facts.FreeBytes != 500 || facts.FreeInodes != 90 {
+		t.Errorf("facts = %+v; want the probe's own figures", facts)
+	}
+}
+
+// TestAFailedMeasurementKeepsTheLevelInForce. Losing the probe must not
+// reopen an admission an emergency closed: the daemon being unreachable
+// is not evidence that the disk drained.
+func TestAFailedMeasurementKeepsTheLevelInForce(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.disk.level.Store(int32(disk.HardEmergency))
+	h.probe.freeErr = errors.New("daemon unreachable")
+
+	h.srv.disk.pass(t.Context())
+
+	if got := h.srv.currentPressure(); got != disk.HardEmergency {
+		t.Errorf("level after a failed pass = %s; want the one already in force", got)
+	}
+}
+
+// TestPassClosesAdmissionAndPersistsIt drives the whole verdict on a
+// filesystem with nothing left — the state a real daemon cannot be asked
+// for. Three things have to happen together, and each covers a different
+// failure: the credit pool closes so the broker is not handed work that
+// will wait, the level is persisted so a restart resumes into it rather
+// than admitting, and the change is audited.
+func TestPassClosesAdmissionAndPersistsIt(t *testing.T) {
+	h := newHarness(t, 1)
+	h.probe.free = docker.FilesystemFree{FreeBytes: 0, FreeInodes: 0}
+
+	h.srv.disk.pass(t.Context())
+
+	level := h.srv.currentPressure()
+	if !level.AdmissionClosed() {
+		t.Fatalf("level on a full filesystem = %s; admission must be closed", level)
+	}
+	h.inStore(func(tx *store.Tx) error {
+		p, err := tx.Pressure()
+		if err != nil {
+			return err
+		}
+		if p == nil || p.Level != level.String() {
+			t.Errorf("persisted pressure = %+v; want %s, or a restart admits into an emergency", p, level)
+		}
+		return nil
+	})
+
+	// And the level survives a fresh monitor over the same store.
+	resumed := newDiskMonitor(defaultedConfig(t), h.srv.log, h.store, h.probe,
+		h.srv.cache, h.srv.alloc, "probe-image")
+	if err := resumed.resume(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if got := resumed.current(); got != level {
+		t.Errorf("resumed level = %s; want %s", got, level)
+	}
+}
+
+// TestDiskPolicyFromReadsTheConfiguredThresholds: the policy is captured
+// once at start, so a field read from the wrong place is a threshold that
+// silently never applies.
+func TestDiskPolicyFromReadsTheConfiguredThresholds(t *testing.T) {
+	cfg := defaultedConfig(t)
+	cfg.Cache.Global.MaxManagedBytes = 1 << 30
+	cfg.Cache.Global.HighWatermarkPercent = 85
+	cfg.Cache.Global.LowWatermarkPercent = 60
+	cfg.Host.Reserve.FreeDisk = 1 << 20
+
+	p := diskPolicyFrom(cfg)
+	if p.thresholds.MaxManagedBytes != 1<<30 || p.thresholds.HighPct != 85 || p.thresholds.LowPct != 60 {
+		t.Errorf("thresholds = %+v; want the configured watermarks", p.thresholds)
+	}
+	if p.thresholds.ReserveFreeBytes != 1<<20 {
+		t.Errorf("reserve = %d; the host reserve is what the emergency floor is raised to",
+			p.thresholds.ReserveFreeBytes)
+	}
+	if p.ttl != time.Duration(cfg.Cache.Defaults.UnusedTTL) {
+		t.Errorf("ttl = %s; want the configured lane TTL", p.ttl)
+	}
+}
+
+func defaultedConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := &config.Config{}
+	config.ApplyDefaults(cfg)
+	return cfg
+}
+
+// TestCollectGarbageRunsWhatTheLevelObliges: high pressure works the
+// managed total down to the low watermark, a soft emergency takes every
+// free lane. The two are one formula apart and the level is the only
+// input that distinguishes them.
+func TestCollectGarbageRunsWhatTheLevelObliges(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.disk.policy = diskPolicy{
+		thresholds: disk.Thresholds{MaxManagedBytes: 1000, LowPct: 60},
+	}
+	// No lanes exist, so a pass plans nothing and returns without
+	// touching the daemon; what is under test is that both levels reach
+	// the planner at all rather than one of them silently doing nothing.
+	for _, level := range []disk.Level{disk.High, disk.SoftEmergency} {
+		h.srv.disk.collectGarbage(t.Context(), level)
+	}
+	if got := cache.GCTarget(1000, 60); got != 600 {
+		t.Errorf("high pressure target = %d; want the low watermark, 600", got)
+	}
+	if !disk.SoftEmergency.Aggressive() || disk.High.Aggressive() {
+		t.Error("only a soft emergency asks for every free lane")
+	}
+}
+
+// TestRediscoverClosesEveryGatewayWhenDiscoveryFails. The policy in force
+// is not a safe fallback, only an older one: a network that appeared
+// since it was computed is reachable and there is no way to tell. So a
+// discovery that cannot be trusted closes every gateway rather than
+// relaying under a set that cannot be shown to be current.
+func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
+	d := &fakeSandboxDaemon{
+		uplinkID:     "up-1",
+		uplinkSubnet: "172.30.0.0/24",
+		probeOut:     "", // saw nothing: the deny set cannot be trusted
+		containers: []docker.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
+			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
+		},
+	}
+	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
+
+	n.rediscover(t.Context())
+
+	if !slices.Equal(d.removed, []string{"gw-1", "gw-2"}) {
+		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removed)
+	}
+}

--- a/internal/app/pressure_test.go
+++ b/internal/app/pressure_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/disk"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestAdmissionClosesUnderPressure: in an emergency no new capsule
+// starts, and the work is not lost — the attempts stay durable and are
+// served the moment pressure releases. High pressure, by contrast,
+// garbage collects but keeps admitting.
+func TestAdmissionClosesUnderPressure(t *testing.T) {
+	h := newHarness(t, 2)
+
+	if err := h.deliver(demand("job-1", "p1", 1)); err != nil {
+		t.Fatal(err)
+	}
+
+	h.srv.disk.level.Store(int32(disk.SoftEmergency))
+	h.serve()
+	if got := h.launchedAttempts(); len(got) != 0 {
+		t.Fatalf("launched %v under soft emergency; admission must be closed", got)
+	}
+
+	h.srv.disk.level.Store(int32(disk.HardEmergency))
+	h.serve()
+	if got := h.launchedAttempts(); len(got) != 0 {
+		t.Fatalf("launched %v under hard emergency; admission must be closed", got)
+	}
+
+	h.srv.disk.level.Store(int32(disk.High))
+	h.serve()
+	if got := h.launchedAttempts(); len(got) != 1 {
+		t.Fatalf("launched %v at high pressure; want the queued attempt served", got)
+	}
+}
+
+// TestPressureResumesFromTheStore: an emergency declared before a crash
+// is still in force after the restart — the monitor's persisted verdict
+// is the level a fresh process admits under, not an optimistic normal.
+func TestPressureResumesFromTheStore(t *testing.T) {
+	h := newHarness(t, 1)
+
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.SetPressure(store.PressureInfo{Level: disk.SoftEmergency.String()})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.srv.disk.resume(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.srv.currentPressure(); got != disk.SoftEmergency {
+		t.Fatalf("resumed level = %s; want soft_emergency", got)
+	}
+
+	if err := h.deliver(demand("job-1", "p1", 1)); err != nil {
+		t.Fatal(err)
+	}
+	h.serve()
+	if got := h.launchedAttempts(); len(got) != 0 {
+		t.Fatalf("launched %v; a restart must not reopen a closed admission", got)
+	}
+}

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -1,0 +1,533 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// reconcile aligns the books with the daemon at startup, across every
+// binding. A lease whose capsule still runs is adopted, awaited
+// and cleaned; every other live lease is released, and the resource
+// sweep then removes any owned Docker object — registered or orphaned
+// from a crash between create and record — that no adopted lease needs.
+// Foreign objects are never touched: the instance label is the boundary.
+func (s *Controller) reconcile(ctx context.Context) error {
+	containers, err := s.objects.ListOwnedContainers(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+
+	var live []store.Lease
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		live, err = tx.LeasesInStates(store.LiveLeaseStates...)
+		if err != nil {
+			return err
+		}
+		// Release and disposition commit together, so this should always
+		// be empty. It is swept anyway because an invariant nothing
+		// checks is an assumption: a released lease whose attempt is
+		// still open sits outside every working set, invisible to each
+		// later startup. Pulling it back in by the attempt keeps the set
+		// bounded by unresolved work rather than by every job ever run.
+		stranded, err := tx.StrandedAttempts()
+		if err != nil {
+			return err
+		}
+		for _, a := range stranded {
+			lease, err := tx.LeaseByAttempt(a.ID)
+			if err != nil {
+				return err
+			}
+			live = append(live, lease)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	if n := len(live); n > 0 {
+		s.log.Info("reconciling interrupted leases", "count", n)
+	}
+
+	runnerByLease := make(map[string]docker.OwnedContainer, len(containers))
+	for _, c := range containers {
+		if c.Role == capsule.RoleCapsule {
+			runnerByLease[c.LeaseID] = c
+		}
+	}
+
+	adopted := make(map[string]bool)
+	for _, lease := range live {
+		b := s.byBinding[lease.BindingID] // may be nil if the target was removed
+		// Adoption means "this lease is still executing; wait it out".
+		// A lease already past draining is not executing — it is being
+		// unwound, and adopting it would run WalkToRunning and then a
+		// release guarded on `workload_running`, which conflicts and
+		// returns before any cleanup. The lease would then hold its credit
+		// and its privileged container forever, because being marked
+		// adopted also exempts it from the orphan sweep.
+		if runner, ok := runnerByLease[lease.ID]; ok && runner.Running && b != nil && adoptable(lease.State) {
+			s.log.Info("adopting running capsule", "binding", b.key, "lease", lease.ID)
+			s.reportAdoption(b, s.alloc.Adopt(b.key))
+			s.adopt(b, lease, runner.ID)
+			adopted[lease.ID] = true
+			continue
+		}
+		// Every nonterminal lease holds a credit until it is resolved, even
+		// with no runner left: its resources may still exist, and the
+		// resolution below can end in quarantine, which keeps consuming
+		// capacity until cleanup succeeds.
+		if b != nil {
+			s.reportAdoption(b, s.alloc.Adopt(b.key))
+			defer s.releaseCreditIfDone(b, lease.ID)
+		}
+		runner, hasRunner := runnerByLease[lease.ID]
+		s.resolveInterrupted(ctx, b, lease, runner, hasRunner)
+	}
+
+	return s.sweepOrphans(ctx, adopted)
+}
+
+// reportAdoption says when a restart has left the instance holding more
+// than its budget. Adoption never refuses — the capsule is running and its
+// resources are committed — so the books simply record what is true, and
+// the pool stays over its limit until those leases release. It converges
+// on its own; what it must not do is converge silently, because until it
+// does the advertised total exceeds parallelism and no other line explains
+// why.
+//
+// Both limits are named when both exist, because either can be the one
+// breached: a tier inside its own parallelism can still put the instance
+// past the limit every tier shares. With independent tiers the instance
+// figure is left out — the report's fallback is a sum, not a limit anyone
+// configured, and printing it beside a warning invites reading it as one.
+func (s *Controller) reportAdoption(b *binding, overBudget bool) {
+	if !overBudget {
+		return
+	}
+	fields := []any{"binding", b.key, "tier", b.tier.ID, "tier_parallelism", b.tier.Parallelism}
+	if report := s.alloc.CapacityReport(); report.Global {
+		fields = append(fields,
+			"instance_active", report.Active, "instance_parallelism", report.Parallelism)
+	}
+	s.log.Warn("adopted past the budget; capacity stays over its limit until these leases release",
+		fields...)
+}
+
+// resolveInterrupted brings one lease with no adoptable runner to a
+// terminal state and disposes of its attempt. Cleanup depends on where
+// the crash left the lease — transitions valid from `provisioning` are
+// invalid from `cleaning` — while the disposition depends only on what
+// can be proven about execution:
+//
+//   - still setting up (reserved through workload_running) or already
+//     failed/quarantined: release the lease, then dispose;
+//   - already unwinding (draining, cleaning): resume the release, then
+//     dispose;
+//   - already released with its attempt still open: nothing to clean,
+//     only the disposition runs.
+func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease store.Lease, runner docker.OwnedContainer, hasRunner bool) {
+	// Recovery bookkeeping runs detached from the caller's context.
+	// Reconciliation happens at startup, where a shutdown can cancel
+	// mid-pass, and releasing a lease while failing to requeue its
+	// attempt leaves that attempt attached to a lease that no longer
+	// exists — invisible to every query, retried by nothing. The release
+	// already survived cancellation; the requeue must too, or the pair
+	// is not a recovery at all.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	evidence, err := s.leases.EvidenceOf(ctx, lease)
+	if err != nil {
+		s.log.Error("cannot read the attempt's evidence; leaving the lease for the next pass",
+			"lease", lease.ID, "error", err)
+		return
+	}
+	log := s.log.With("lease", lease.ID,
+		"state", string(lease.State), "evidence", string(evidence))
+
+	// The observation is taken before any cleanup: the container is the
+	// only proof of whether an authorized start took effect, and the
+	// release below destroys it.
+	obs := assignment.ObservedAbsent
+	if evidence == store.EvidenceStartAuthorized && hasRunner {
+		var err error
+		obs, err = s.caps.InspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: runner.ID})
+		if err != nil {
+			log.Error("cannot observe the runtime of an ambiguous start", "error", err)
+		}
+	}
+
+	// An exited runtime observed here refines the evidence before any
+	// path destroys the container that proves it: the finalizing
+	// transaction then settles from evidence alone.
+	if obs == assignment.ObservedExited && evidence == store.EvidenceStartAuthorized {
+		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordEvidence(lease.AttemptID, store.EvidenceExitObserved)
+		}); err != nil {
+			log.Error("cannot record the observed exit", "error", err)
+		} else {
+			evidence = store.EvidenceExitObserved
+		}
+	}
+
+	switch lease.State {
+	case store.LeaseDraining, store.LeaseCleaning:
+		// Resume the interrupted release: external cleanup, then the
+		// finalizing transaction disposes of the attempt atomically.
+		log.Info("resuming an interrupted release")
+		if err := s.leases.FinishCleaning(ctx, lease, obs); err != nil {
+			log.Error("resuming the release failed; the lease stays quarantined", "error", err)
+			s.leases.Quarantine(lease.ID)
+		}
+
+	case store.LeaseReleased:
+		// The invariant sweep found a released lease whose attempt is
+		// still open. Release and disposition commit together, so this
+		// should be unreachable; reaching it means something violated
+		// that, and the disposition is the only thing left to run.
+		log.Warn("disposing of an attempt left open by a released lease")
+		s.leases.DisposeStranded(ctx, lease, evidence, obs)
+
+	case store.LeaseReserved, store.LeaseProvisioning,
+		store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning,
+		store.LeaseFailed, store.LeaseQuarantined:
+		// recoverCapsuleFailure finishes with the same finalizing
+		// transaction, so release and disposition cannot come apart.
+		log.Info("releasing an interrupted lease")
+		if err := s.recoverCapsuleFailure(b, lease.ID, obs); err != nil {
+			log.Error("recovery could not resolve the lease; reconciliation will retry", "error", err)
+		}
+
+	default:
+		log.Warn("no recovery defined for this state; leaving it for an operator")
+	}
+}
+
+func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string) {
+	// Claimed here rather than inside the goroutine, so no pass can see the
+	// lease as ownerless in the gap before it is scheduled.
+	s.claimLease(lease.ID)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		defer s.releaseLease(lease.ID)
+		defer s.releaseCreditIfDone(b, lease.ID)
+		// What is left of this lease's ceiling, not a fresh one: a capsule
+		// that stopped reporting is exactly what the ceiling bounds, and
+		// restarting the clock on every controller restart would let it
+		// hold its credit indefinitely.
+		ctx, cancel := context.WithTimeout(context.Background(),
+			remainingCeiling(b.tier, lease.CreatedAt))
+		defer cancel()
+		// Through the same seam the ordinary launch awaits its runner:
+		// an adopted capsule is a capsule, and one of the two paths
+		// reaching around it is how they come to behave differently.
+		if _, err := s.wait.WaitExit(ctx, runnerContainer); err != nil {
+			s.log.Error("adopted capsule wait failed", "lease", lease.ID, "error", err)
+			if err := s.recoverCapsuleFailure(b, lease.ID, ""); err != nil {
+				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
+					"lease", lease.ID, "error", err)
+			}
+			return
+		}
+		// The adopted capsule was awaited to its exit. Recording the
+		// observation is what lets the finalizing transaction settle the
+		// attempt from evidence, like any other completed run.
+		if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
+			s.log.Error("cannot record the adopted capsule's exit", "lease", lease.ID, "error", err)
+		}
+		if err := s.leases.WalkToRunning(ctx, lease); err != nil {
+			s.log.Error("adopted capsule state repair failed", "lease", lease.ID, "error", err)
+		}
+		if err := s.leases.Release(ctx, lease.ID, store.LeaseWorkloadRunning); err != nil {
+			s.log.Error("adopted capsule cleanup failed", "lease", lease.ID, "error", err)
+			return
+		}
+		s.log.Info("adopted capsule released", "binding", b.key, "lease", lease.ID)
+	}()
+}
+
+// sweepOrphans removes every owned Docker resource whose lease is not
+// among the adopted ones — released leases' registered resources and any
+// object stranded by a crash between creation and recording — in
+// dependency order: containers, then networks, then volumes.
+//
+// Three kinds of failure, three answers.
+//
+// One object that will not die does not stop the controller. A single
+// wedged container — a dind in uninterruptible sleep, a volume held by a
+// stale mount — used to abort startup entirely with no retry, while the
+// per-lease intent saga books exponential backoff for exactly the same
+// work. Startup was strictly less resilient than steady state. Those
+// failures are counted and reported instead: the object keeps its
+// ownership labels, and sweepPeriodically runs this again on the
+// reconcile interval — so "the next sweep" is a real event and not "the
+// next restart".
+//
+// Listing is fatal, because a sweep that cannot see the daemon has
+// proven nothing and must not report an empty inventory as a clean one.
+//
+// Forgetting the record is fatal too, and for a different reason: it
+// fails only when the store is unreachable, and everything the rest of
+// this pass would do needs the same store. Aborting loses nothing —
+// startup fails loudly, and the periodic caller logs and comes back in
+// under a minute.
+//
+// What that abort does not undo is the object already removed from the
+// daemon whose record did not go with it. That intent row is beyond
+// every retry there is: the sweep works from what the daemon still
+// lists, the stranded-lease pass works from live leases and this one is
+// released, and retention refuses a lease that still owns an intent —
+// deliberately, so the leak stays visible in `status` rather than being
+// quietly forgotten.
+func (s *Controller) sweepOrphans(ctx context.Context, keep map[string]bool) error {
+	wedged := 0
+	fail := func(kind, name string, err error) {
+		wedged++
+		s.log.Error("cannot sweep an orphan; it stays labelled for the next pass",
+			"kind", kind, "id", name, "error", err)
+	}
+
+	containers, err := s.objects.ListOwnedContainers(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+	for _, c := range containers {
+		if keep[c.LeaseID] {
+			continue
+		}
+		if c.HelperInFlight() {
+			continue
+		}
+		s.log.Info("sweeping orphan container", "name", c.Name, "lease", c.LeaseID)
+		if err := s.objects.RemoveContainer(ctx, c.ID); err != nil {
+			fail("container", c.Name, err)
+			continue
+		}
+		// The durable record goes with the object it described. Removing
+		// one without the other leaves the daemon and the books
+		// disagreeing, and the foreign key then blocks the lease from
+		// ever being purged.
+		if err := s.leases.ForgetResource(ctx, c.LeaseID, c.ID); err != nil {
+			return err
+		}
+	}
+	networks, err := s.objects.ListOwnedNetworks(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+	for _, n := range networks {
+		if keep[n.LeaseID] {
+			continue
+		}
+		if n.InstanceInfrastructure() {
+			continue
+		}
+		if err := s.objects.RemoveNetwork(ctx, n.ID); err != nil {
+			fail("network", n.ID, err)
+			continue
+		}
+		if err := s.leases.ForgetResource(ctx, n.LeaseID, n.ID); err != nil {
+			return err
+		}
+	}
+	volumes, err := s.objects.ListOwnedVolumes(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+	for _, v := range volumes {
+		if keep[v.LeaseID] {
+			continue
+		}
+		if v.InstanceInfrastructure() {
+			continue
+		}
+		if err := s.objects.RemoveVolume(ctx, v.ID); err != nil {
+			fail("volume", v.ID, err)
+			continue
+		}
+		if err := s.leases.ForgetResource(ctx, v.LeaseID, v.ID); err != nil {
+			return err
+		}
+	}
+	if wedged > 0 {
+		s.log.Warn("some orphans could not be swept; they keep their labels and are retried next pass",
+			"count", wedged)
+	}
+	return nil
+}
+
+// periodicReconcile retries what the serving paths gave up on, without
+// waiting for a restart. Its working set is every live lease no goroutine
+// owns — quarantine is the common case, but it is not the only way an
+// owner stops: a failed finalization parks a lease in `cleaning`, and a
+// failed transition leaves one wherever it was. Those are just as
+// ownerless, and they hold an admission credit until something resolves
+// them, so narrowing the set to quarantine leaked capacity until restart.
+// Ownership, not state, is what makes a lease this pass's business.
+// Each retry honours the backoff booked on the lease's intents, so one
+// wedged object paces its own attempts instead of hammering the daemon;
+// and each pass is bounded, because an unbounded sweep is how a
+// reconciler becomes the load it was meant to absorb.
+func (s *Controller) periodicReconcile(ctx context.Context) {
+	const base = 45 * time.Second
+	for {
+		wait := base + time.Duration(rand.Int64N(int64(base/3)))
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(wait):
+		}
+		s.retryStranded(ctx)
+		s.sweepPeriodically(ctx)
+		s.prunePeriodically(ctx)
+	}
+}
+
+// prunePeriodically forgets the record of finished leases past the
+// configured window. Bounded per pass like its neighbours: the books grow
+// with every job the host runs, and a sweep that tried to catch up in one
+// go would be the load it exists to prevent.
+//
+// It writes one audit row per pass, not one per lease. RunGC records
+// each eviction because a volume is an object an operator can look at; a
+// pass that forgets five thousand rows would flood the one table nothing
+// ever prunes.
+func (s *Controller) prunePeriodically(ctx context.Context) {
+	if s.leaseHistory <= 0 {
+		return // keep every lease record; the operator asked for it
+	}
+	const perPass = 500
+	before := time.Now().Add(-s.leaseHistory)
+	var pruned int
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		pruned, err = tx.PruneLeaseHistory(before, perPass)
+		if err != nil || pruned == 0 {
+			return err
+		}
+		return tx.RecordAudit("retention", "retention_prune", "capsule_leases",
+			fmt.Sprintf("pruned=%d older_than=%s", pruned, s.leaseHistory))
+	}); err != nil {
+		s.log.Error("retention pass failed", "error", err)
+		return
+	}
+	if pruned > 0 {
+		s.log.Info("pruned lease history", "leases", pruned, "older_than", s.leaseHistory.String())
+	}
+}
+
+// sweepPeriodically is the retry the startup sweep's failures depend on.
+// sweepOrphans logs and continues rather than aborting the controller, but
+// it used to run only at startup — so "the next pass finds it again" meant
+// "the next restart", and a wedged privileged container leaked for the life
+// of the process behind a warning.
+//
+// Everything with a live lease is kept, which is stricter than the startup
+// sweep needs to be and is the right default here: a lease still in the
+// machine is either being driven by a goroutine or about to be resolved by
+// retryStranded, and in both cases its objects are that owner's to remove.
+// What is left is a genuine orphan — an object whose lease is released or
+// gone entirely.
+func (s *Controller) sweepPeriodically(ctx context.Context) {
+	var live []store.Lease
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		live, err = tx.LeasesInStates(store.LiveLeaseStates...)
+		return err
+	}); err != nil {
+		s.log.Error("periodic sweep cannot list live leases", "error", err)
+		return
+	}
+	keep := make(map[string]bool, len(live))
+	for _, lease := range live {
+		keep[lease.ID] = true
+	}
+	if err := s.sweepOrphans(ctx, keep); err != nil {
+		s.log.Error("periodic sweep failed", "error", err)
+	}
+}
+
+// retryStranded drives one bounded pass over live leases nobody owns.
+// ToCleaning begins from the lease's actual state, so the same recovery
+// resolves a lease from anywhere in the machine; what must not happen is
+// touching one a goroutine is still driving, which is what the claim is
+// for. A lease that fails to claim is not stranded — it has an owner.
+func (s *Controller) retryStranded(ctx context.Context) {
+	var live []store.Lease
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		live, err = tx.LeasesInStates(store.LiveLeaseStates...)
+		return err
+	}); err != nil {
+		s.log.Error("periodic reconcile cannot list live leases", "error", err)
+		return
+	}
+	const perPass = 8
+	stranded, retried, converged := 0, 0, 0
+	for _, lease := range live {
+		if retried >= perPass {
+			break
+		}
+		if !s.claimLease(lease.ID) {
+			continue // a goroutine is driving it; not this pass's business
+		}
+		stranded++
+		func() {
+			// Deferred so a panic cannot leak the claim. A leaked claim
+			// makes the lease invisible to every later pass, which is the
+			// leak this whole mechanism exists to prevent.
+			defer s.releaseLease(lease.ID)
+			s.resolveStranded(ctx, lease, &retried, &converged)
+		}()
+	}
+	if retried > 0 {
+		s.log.Info("periodic reconcile pass",
+			"stranded", stranded, "retried", retried, "converged", converged)
+	}
+}
+
+// resolveStranded is one claimed lease's recovery, split out so the claim
+// is released on every path out.
+func (s *Controller) resolveStranded(ctx context.Context, lease store.Lease, retried, converged *int) {
+	due, err := s.leases.IntentsDue(ctx, lease.ID)
+	if err != nil {
+		s.log.Error("periodic reconcile cannot read intents", "lease", lease.ID, "error", err)
+		return
+	}
+	if !due {
+		return // its backoff has not elapsed; let it breathe
+	}
+	*retried++
+	b := s.byBinding[lease.BindingID] // may be nil if the target was removed
+	if err := s.recoverCapsuleFailure(b, lease.ID, ""); err != nil {
+		s.log.Warn("stranded lease still unresolved",
+			"lease", lease.ID, "state", string(lease.State), "error", err)
+		return
+	}
+	*converged++
+	if b != nil {
+		s.releaseCreditIfDone(b, lease.ID)
+	}
+}
+
+// adoptable reports whether a lease found with a running capsule can be
+// awaited rather than unwound. Everything up to `workload_running` is a
+// job still in flight; `draining` onward is a release already under way,
+// and resolveInterrupted is what knows how to finish one.
+func adoptable(state store.LeaseState) bool {
+	switch state {
+	case store.LeaseReserved, store.LeaseProvisioning,
+		store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Startup recovery tests execute the real reconciler against durable leases
+// in SQLite and assert the resulting lease and attempt states.
+
+// reachableEvidence lists, per capsule state, the evidence values a
+// crash can actually leave together with it. Preparation and start
+// authorization happen while the lease is runtime_registered, and the
+// running/exit observations from workload_running onward; failure states
+// are reachable from any point, so they combine with everything.
+func reachableEvidence(s store.LeaseState) []store.Evidence {
+	all := []store.Evidence{
+		store.EvidenceNotStarted, store.EvidenceRuntimePrepared,
+		store.EvidenceStartAuthorized, store.EvidenceRunningObserved,
+		store.EvidenceExitObserved,
+	}
+	switch s {
+	case store.LeaseReserved, store.LeaseProvisioning:
+		return all[:1] // nothing is prepared before registration
+	case store.LeaseWorkloadRunning:
+		// The transition to workload_running happens once a start
+		// succeeded; authorized-only is possible when recording the
+		// running observation failed and the loop continued.
+		return all[2:]
+	default:
+		return all
+	}
+}
+
+// TestRecoveryMatrix is the cartesian product of capsule states and the
+// evidence reachable with them. Two properties hold across the whole
+// matrix, and they are deliberately independent:
+//
+//   - cleanup: every lease ends released, whatever state the crash left,
+//     because a lease that cannot be resolved holds its credit forever;
+//   - disposition: what becomes of the attempt follows the evidence
+//     alone — requeued when nothing was authorized, settled with the
+//     observation as its resolution when execution was seen, held for
+//     review when a start was authorized and no runtime remains to
+//     prove its outcome.
+func TestRecoveryMatrix(t *testing.T) {
+	states := []store.LeaseState{
+		store.LeaseReserved, store.LeaseProvisioning, store.LeaseRuntimeRegistered,
+		store.LeaseWorkloadRunning, store.LeaseDraining, store.LeaseCleaning,
+		store.LeaseFailed, store.LeaseQuarantined, store.LeaseReleased,
+	}
+	for _, from := range states {
+		for _, evidence := range reachableEvidence(from) {
+			t.Run(string(from)+"/"+string(evidence), func(t *testing.T) {
+				h := newHarness(t, 1)
+				workload := "job-" + string(from) + "-" + string(evidence)
+				if err := h.deliver(demand(workload, "app", 2)); err != nil {
+					t.Fatal(err)
+				}
+				lease, attemptID := leaseFor(t, h, workload)
+				driveLeaseTo(t, h, lease.ID, from)
+				h.recordEvidence(lease.ID, evidence)
+
+				h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+
+				if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
+					t.Errorf("a %s lease ended %s; it still holds its credit", from, got.State)
+				}
+
+				var wantState, wantResolution string
+				switch evidence {
+				case store.EvidenceNotStarted, store.EvidenceRuntimePrepared:
+					wantState = "ready"
+				case store.EvidenceStartAuthorized:
+					wantState = "manual_review" // no runtime remains; nothing can be proven
+				case store.EvidenceRunningObserved:
+					wantState, wantResolution = "settled", assignment.ResolutionStartedObserved
+				default:
+					wantState, wantResolution = "settled", assignment.ResolutionCompletedObserved
+				}
+				got := attemptState(t, h, attemptID)
+				if got.State != wantState {
+					t.Errorf("attempt = %s from %s with %s; want %s", got.State, from, evidence, wantState)
+				}
+				if wantResolution != "" && got.Resolution != wantResolution {
+					t.Errorf("resolution = %s from %s with %s; want %s", got.Resolution, from, evidence, wantResolution)
+				}
+			})
+		}
+	}
+}
+
+// TestCapsuleFailureRecoverySurvivesAMissingBinding: a lease whose
+// target is no longer configured reaches recoverCapsuleFailure with a
+// nil binding, which must not panic — it happens during startup, where
+// a panic takes down recovery for every other lease with it.
+func TestCapsuleFailureRecoverySurvivesAMissingBinding(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-orphan", "app", 3)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-orphan")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("recoverCapsuleFailure panicked with a missing binding: %v", r)
+		}
+	}()
+	if err := h.srv.recoverCapsuleFailure(nil, lease.ID, ""); err != nil {
+		t.Fatalf("recoverCapsuleFailure with a missing binding: %v", err)
+	}
+}
+
+// TestAdoptableStopsAtDraining: adoption means "still executing, wait it
+// out". Past draining the lease is being unwound, and adopting one would
+// walk it to running and then attempt a release guarded on
+// workload_running — a state conflict that returns before any cleanup,
+// leaving the credit held and the privileged container exempt from the
+// orphan sweep for the life of the process.
+func TestAdoptableStopsAtDraining(t *testing.T) {
+	for state, want := range map[store.LeaseState]bool{
+		store.LeaseReserved:          true,
+		store.LeaseProvisioning:      true,
+		store.LeaseRuntimeRegistered: true,
+		store.LeaseWorkloadRunning:   true,
+		store.LeaseDraining:          false,
+		store.LeaseCleaning:          false,
+		store.LeaseFailed:            false,
+		store.LeaseQuarantined:       false,
+		store.LeaseReleased:          false,
+	} {
+		if got := adoptable(state); got != want {
+			t.Errorf("adoptable(%s) = %v; want %v", state, got, want)
+		}
+	}
+}
+
+// TestPrunePeriodicallyHonoursTheWindow covers the wiring, not the
+// predicate: the SQL is proved in internal/store, where a lease can be
+// aged. What only this layer can show is that the window reaches the
+// pass at all — zero means the operator asked for every record to be
+// kept and nothing runs, and a live window does not touch work that just
+// finished.
+func TestPrunePeriodicallyHonoursTheWindow(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-1", "p1", 1)); err != nil {
+		t.Fatal(err)
+	}
+	h.serve()
+	launched := h.launchedAttempts()
+	if len(launched) != 1 {
+		t.Fatalf("launched %v; want one", launched)
+	}
+	lease := h.leases[launched[0]]
+	h.inStore(func(tx *store.Tx) error {
+		for _, step := range [][2]store.LeaseState{
+			{store.LeaseReserved, store.LeaseProvisioning},
+			{store.LeaseProvisioning, store.LeaseRuntimeRegistered},
+			{store.LeaseRuntimeRegistered, store.LeaseDraining},
+			{store.LeaseDraining, store.LeaseCleaning},
+			{store.LeaseCleaning, store.LeaseReleased},
+		} {
+			if err := tx.TransitionLease(lease.ID, step[0], step[1]); err != nil {
+				return err
+			}
+		}
+		return tx.Settle(lease.AttemptID, "leased", "completed_observed")
+	})
+
+	for _, window := range []time.Duration{0, 24 * time.Hour} {
+		h.srv.leaseHistory = window
+		h.srv.prunePeriodically(h.t.Context())
+		h.inStore(func(tx *store.Tx) error {
+			if _, err := tx.LeaseByID(lease.ID); err != nil {
+				t.Errorf("a %s window forgot a lease that finished a moment ago: %v", window, err)
+			}
+			return nil
+		})
+	}
+}

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -1,0 +1,440 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Regressions for the ways an assignment can be lost — as opposed to
+// run twice, the failure the design guarded first. None of them is
+// visible from the outside: the controller reports a clean release
+// while the work never happens. They shared one root: identity keyed on
+// the job id alone, and recovery inferred from the lease state a crash
+// happened to leave behind rather than from what execution was
+// observed.
+
+// A lease that reached failed without ever provisioning a runner
+// carried no execution. Cleanup state is not execution evidence: this
+// attempt was never consumed, so it belongs back in the queue.
+func TestFailedBeforeAnyRunnerRequeuesItsAttempt(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-prerun", "app", 40)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-prerun")
+	// reserved -> provisioning -> failed: no runner was ever registered,
+	// so nothing can have executed.
+	driveLeaseTo(t, h, lease.ID, store.LeaseFailed)
+
+	h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+
+	ready := h.ready()
+	if len(ready) != 1 {
+		t.Fatalf("ready attempts = %d; want 1 — a lease that failed before "+
+			"provisioning a runner never consumed its delivery, and settling it "+
+			"drops the job with no trace", len(ready))
+	}
+
+	// Servable means the scheduler leases it again. Asserting only that it
+	// is back in the queue left the second serving untested, and it could
+	// not happen: the attempt already held a lease, and one per attempt
+	// was all the schema allowed.
+	h.srv.scheduleReadyAttempts(t.Context(), h.bind)
+	if got := len(h.ready()); got != 0 {
+		t.Fatalf("%d attempts still ready after a scheduling pass; the requeued "+
+			"attempt was not served again, so it waits at the head of a queue "+
+			"nothing drains", got)
+	}
+	var second store.Lease
+	h.inStore(func(tx *store.Tx) error {
+		var err error
+		second, err = tx.LeaseByAttempt(ready[0].ID)
+		return err
+	})
+	if second.ID == lease.ID {
+		t.Error("the second serving reused the first lease; each serving is its own")
+	}
+}
+
+// Reconciliation runs at startup, where a shutdown can cancel the
+// context mid-pass. Releasing the lease and requeueing its attempt are
+// one recovery: if the release survives cancellation but the requeue
+// does not, the attempt stays leased to a lease that no longer exists
+// and no query will ever return it again.
+func TestRequeueSurvivesACancelledReconciliation(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-cancelled", "app", 41)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-cancelled")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	h.resolveWithoutRuntime(ctx, reloadLease(t, h, lease.ID))
+
+	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
+		t.Fatalf("lease ended %s; the release itself is expected to survive cancellation", got.State)
+	}
+	if got := len(h.ready()); got != 1 {
+		t.Errorf("ready attempts = %d; want 1 — the lease was released but its "+
+			"attempt stayed leased to it, so the job is now invisible to "+
+			"every query and is never retried", got)
+	}
+}
+
+// GitHub can cancel an assignment and reassign the same workflow job up
+// to three times. Each reassignment arrives as a new delivery. The
+// settled predecessor must not hide the new attempt, and the new
+// attempt must carry its own observed identifiers.
+func TestReassignmentOfASettledJobIsServable(t *testing.T) {
+	h := newHarness(t, 1)
+
+	first := demand("job-reassigned", "app", 42)
+	first.SourceRequestID = 201
+	if err := h.deliverMsg(1, first); err != nil {
+		t.Fatal(err)
+	}
+	// The first attempt runs and settles: a redelivery of *that*
+	// delivery must never start a second capsule, and does not here.
+	lease, attemptID := leaseFor(t, h, "job-reassigned")
+	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
+	h.recordEvidence(lease.ID, store.EvidenceExitObserved)
+	if err := h.srv.leases.Finalize(t.Context(), lease.ID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(h.ready()); got != 0 {
+		t.Fatalf("a settled attempt is still servable (%d); the tombstone is not holding", got)
+	}
+
+	// GitHub cancels and reassigns the same job: same workload key, new
+	// message, new request id. This is work that has never run.
+	second := demand("job-reassigned", "app", 42)
+	second.SourceRequestID = 202
+	if err := h.deliverMsg(2, second); err != nil {
+		t.Fatal(err)
+	}
+
+	ready := h.ready()
+	if len(ready) != 1 {
+		t.Fatalf("ready attempts = %d; want 1 — a reassignment is a new attempt, "+
+			"and deduplicating on the workload key alone hides it behind the "+
+			"attempt that already completed", len(ready))
+	}
+	if ready[0].SourceWorkloadKey != "job-reassigned" || ready[0].ID == attemptID {
+		t.Errorf("servable attempt = %+v; want a fresh attempt of the same workload", ready[0])
+	}
+}
+
+// A reassignment can also race a predecessor that was assigned but
+// never served. The predecessor consumed nothing, so it is superseded
+// in the same transaction that records the new delivery — never do two
+// attempts of one workload serve together.
+func TestReassignmentSupersedesAReadyPredecessor(t *testing.T) {
+	h := newHarness(t, 1)
+
+	if err := h.deliverMsg(1, demand("job-raced", "app", 43)); err != nil {
+		t.Fatal(err)
+	}
+	old := h.ready()[0]
+
+	if err := h.deliverMsg(2, demand("job-raced", "app", 43)); err != nil {
+		t.Fatal(err)
+	}
+
+	ready := h.ready()
+	if len(ready) != 1 || ready[0].ID == old.ID {
+		t.Fatalf("ready = %+v; want exactly the new attempt", ready)
+	}
+	if got := attemptState(t, h, old.ID); got.State != "superseded" || got.Resolution != assignment.ResolutionSuperseded {
+		t.Errorf("predecessor = %s/%s; want superseded/%s", got.State, got.Resolution, assignment.ResolutionSuperseded)
+	}
+}
+
+// Each of the following is a distinct way for an attempt to be resolved
+// as if its job had run, or to stop being visible at all, while the
+// controller reports success.
+
+// A capsule is a network, five volumes, a daemon, a container and a
+// credential before anything is asked to start. Recording a start at the
+// top of that stretch means every failure inside it — a volume, the
+// daemon, the JIT delivery — reads as work that may have executed, and
+// the job is settled instead of retried.
+func TestPreparationFailureLeavesTheAttemptServable(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-prepare", "app", 50)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-prepare")
+	driveLeaseTo(t, h, lease.ID, store.LeaseRuntimeRegistered)
+	// The capsule was built; no start was ever authorized.
+	h.recordEvidence(lease.ID, store.EvidenceRuntimePrepared)
+
+	h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+
+	if got := len(h.ready()); got != 1 {
+		t.Errorf("ready attempts = %d; want 1 — a capsule that was prepared but "+
+			"never authorized to start consumed no delivery", got)
+	}
+}
+
+// recoverCapsuleFailure can carry a lease from provisioning to failed and on to
+// cleaning without a runner ever existing, so "this far along" says
+// nothing about execution. Cleanup removes resources; it must not decide
+// what became of the work.
+func TestCleaningDoesNotDecideExecution(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-cleaning", "app", 51)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-cleaning")
+	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
+	h.recordEvidence(lease.ID, store.EvidenceNotStarted)
+
+	h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+
+	if got := len(h.ready()); got != 1 {
+		t.Errorf("ready attempts = %d; want 1 — a lease reaches cleaning from "+
+			"recoverCapsuleFailure too, and settling every lease this far along as executed "+
+			"drops the jobs that never ran", got)
+	}
+}
+
+// Releasing a lease and disposing of its attempt are two commits. A
+// crash in between leaves the attempt leased to a lease that is
+// terminal, and therefore outside every working set the next startup
+// builds: no query returns it and nothing ever retries it.
+func TestAttemptStrandedOnAReleasedLeaseIsRecovered(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-stranded", "app", 52)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-stranded")
+	driveLeaseTo(t, h, lease.ID, store.LeaseReleased)
+	h.recordEvidence(lease.ID, store.EvidenceNotStarted)
+
+	// This is the reachable state: the lease is released, the attempt
+	// still leased to it, and nothing disposed of it.
+	var stranded int
+	h.inStore(func(s *store.Tx) error {
+		attempts, err := s.StrandedAttempts()
+		if err != nil {
+			return err
+		}
+		stranded = len(attempts)
+		return nil
+	})
+	if stranded != 1 {
+		t.Fatalf("the invariant sweep found %d stranded attempts; want 1 — an attempt "+
+			"leased to a released lease is invisible to every other query", stranded)
+	}
+
+	h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+
+	if got := len(h.ready()); got != 1 {
+		t.Errorf("ready attempts = %d; want 1 — recovery did not dispose of an "+
+			"attempt left behind by a crash between the two commits", got)
+	}
+}
+
+// RecordEvidence must reject values outside the monotonic evidence model.
+func TestRecordEvidenceClassifiesEveryOutcome(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-observe", "app", 53)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-observe")
+
+	record := func(id string, e store.Evidence) error {
+		return h.store.Tx(t.Context(), func(tx *store.Tx) error {
+			return tx.RecordEvidenceForLease(id, e)
+		})
+	}
+
+	if err := record(lease.ID, store.Evidence("definitely-not-a-value")); !errors.Is(err, store.ErrInvalidExecutionObservation) {
+		t.Errorf("an unknown value returned %v; want ErrInvalidExecutionObservation — "+
+			"a silent no-op tells the caller something was recorded when nothing was", err)
+	}
+	if err := record("no-such-lease", store.EvidenceRunningObserved); err == nil {
+		t.Error("recording against a missing lease succeeded; the target's absence was swallowed")
+	}
+
+	if err := record(lease.ID, store.EvidenceRunningObserved); err != nil {
+		t.Fatalf("recording a running observation: %v", err)
+	}
+	// Re-observing the same fact is not a fault.
+	if err := record(lease.ID, store.EvidenceRunningObserved); err != nil {
+		t.Errorf("repeating an identical observation returned %v; want explicit idempotent success", err)
+	}
+	// A slower writer cannot unmake an observation.
+	if err := record(lease.ID, store.EvidenceRuntimePrepared); !errors.Is(err, store.ErrObservationConflict) {
+		t.Errorf("a backwards write returned %v; want ErrObservationConflict — a runner "+
+			"that was seen running cannot become one that never started", err)
+	}
+	if got := h.attemptByLease(lease.ID); got.Evidence != store.EvidenceRunningObserved {
+		t.Errorf("evidence = %s after the rejected writes; want running_observed untouched", got.Evidence)
+	}
+}
+
+// TestRedeliveryToleratesADifferentAcquisition is the binding-wedge guard.
+// A message's availables are acquired by a separate call whose result
+// depends on who else asked, so two deliveries of one message id can
+// legitimately carry different acquired sets. Folding those into the
+// fingerprint made that read as the provider changing a payload under a
+// stable key: RecordDelivery returned contract drift, persistDelivery
+// failed, the message was never acknowledged, and because the queue is
+// ordered nothing behind it was ever served again.
+func TestRedeliveryToleratesADifferentAcquisition(t *testing.T) {
+	h := newHarness(t, 2)
+
+	// First arrival: the broker assigned one job and the session acquired
+	// one available.
+	first := &githubactions.Message{
+		ID:       7,
+		Assigned: []assignment.WorkloadAssignment{demand("job-assigned", "app", 80)},
+		Acquired: []assignment.WorkloadAssignment{demand("job-acquired-a", "app", 81)},
+	}
+	if _, err := h.srv.persistDelivery(t.Context(), h.bind, first); err != nil {
+		t.Fatalf("first delivery: %v", err)
+	}
+
+	// Redelivery of the same message id: the acknowledgement was lost, and
+	// this time the acquisition granted a different job.
+	second := &githubactions.Message{
+		ID:       7,
+		Assigned: []assignment.WorkloadAssignment{demand("job-assigned", "app", 80)},
+		Acquired: []assignment.WorkloadAssignment{demand("job-acquired-b", "app", 82)},
+	}
+	if _, err := h.srv.persistDelivery(t.Context(), h.bind, second); err != nil {
+		t.Fatalf("a redelivery with a different acquisition wedged the binding: %v", err)
+	}
+
+	// The broker's own payload is still what identity is checked against,
+	// so a message id whose assigned set changed is still refused.
+	drifted := &githubactions.Message{
+		ID:       7,
+		Assigned: []assignment.WorkloadAssignment{demand("job-different", "app", 99)},
+	}
+	if _, err := h.srv.persistDelivery(t.Context(), h.bind, drifted); err == nil {
+		t.Error("a changed assigned set was accepted; contract drift is no longer detected")
+	}
+}
+
+// TestAWedgedRedeliveryStillLandsItsHints. A message the binding already
+// acknowledged can come back anyway - the wedge the acknowledgement Warn
+// describes - and the loop throttles rather than spinning on it. What the
+// throttle must not do is skip the message's content: a cancellation hint
+// riding in the redelivery has to land, or the wedged binding keeps
+// serving, and burning a capsule on, a job the provider already cancelled.
+func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+
+	// One lane, already busy: the loop schedules before it receives, and
+	// a free lane would lease the attempt before the hint could reach it.
+	// A cancellation matters exactly while the attempt is still waiting.
+	// The credit is taken through the allocator, which is what the
+	// scheduler actually consults.
+	if !h.srv.alloc.TryReserve(h.bind.key) {
+		t.Fatal("the lane was never occupied")
+	}
+
+	// A confirmed delivery: recorded, acknowledged, cursor past it.
+	msg := &githubactions.Message{
+		ID:       41,
+		Assigned: []assignment.WorkloadAssignment{demand("job-cancelled-upstream", "app", 41)},
+	}
+	delivery, err := h.srv.persistDelivery(t.Context(), h.bind, msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.inStore(func(tx *store.Tx) error {
+		if _, err := tx.AckRequested(delivery); err != nil {
+			return err
+		}
+		return tx.AckConfirmed(delivery)
+	})
+
+	// The broker sends it again, now carrying the cancellation. One full
+	// loop iteration: the session hands over exactly this message, then
+	// blocks.
+	msg.Completed = []assignment.WorkloadLifecycleEvent{{
+		Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-cancelled-upstream",
+		Result: "canceled",
+	}}
+	redelivery := &replaySession{msg: msg, drained: make(chan struct{})}
+	h.bind.session = redelivery
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	select {
+	case <-redelivery.drained:
+	case <-time.After(10 * time.Second):
+		t.Error("the loop never consumed the redelivered message")
+	}
+	cancel()
+	<-done
+
+	// The state, not the queue: an attempt can also leave ready by being
+	// leased, which is exactly the outcome the hint exists to prevent.
+	var attempt store.Attempt
+	h.inStore(func(tx *store.Tx) error {
+		open, err := tx.OpenAttemptByWorkload(h.bind.bindingID, "job-cancelled-upstream")
+		if err == nil {
+			attempt = open
+			return nil
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+		// Settled, then: fetch it through its delivery.
+		attempts, aerr := tx.AttemptsOfDelivery(delivery)
+		if aerr != nil {
+			return aerr
+		}
+		attempt = attempts[0]
+		return nil
+	})
+	if attempt.State != "canceled" || attempt.Resolution != assignment.ResolutionRemoteCanceled {
+		t.Errorf("the attempt is %q/%q; want canceled/remote_canceled - the hint in the "+
+			"wedged redelivery never landed, and the binding will burn a capsule on a "+
+			"job the provider already cancelled", attempt.State, attempt.Resolution)
+	}
+}
+
+// replaySession hands over one message once, then blocks: the shape of a
+// broker stuck redelivering something already acknowledged.
+type replaySession struct {
+	mu      sync.Mutex
+	msg     *githubactions.Message
+	served  bool
+	drained chan struct{}
+}
+
+func (s *replaySession) Receive(ctx context.Context) (*githubactions.Message, error) {
+	s.mu.Lock()
+	first := !s.served
+	s.served = true
+	s.mu.Unlock()
+	if first {
+		return s.msg, nil
+	}
+	close(s.drained)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *replaySession) Acknowledge(context.Context, int) error { return nil }
+func (s *replaySession) SetCapacity(int)                        {}
+func (s *replaySession) Initial() *githubactions.Statistics     { return nil }
+func (s *replaySession) Close(context.Context) error            { return nil }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -1,0 +1,398 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// createLease takes an admission credit for one ready attempt. The lease and the
+// attempt's claim commit together, so the two can never disagree about
+// whether a workload is being served.
+func (s *Controller) createLease(ctx context.Context, b *binding, attempt store.Attempt) (store.Lease, error) {
+	var lease store.Lease
+	err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		lease, err = tx.LeaseAttempt(attempt.ID, b.bindingID, b.tier.ID)
+		return err
+	})
+	if err != nil {
+		return store.Lease{}, err
+	}
+	s.log.Info("lease reserved", "binding", b.key, "lease", lease.ID,
+		"project", attempt.TenantKey+"/"+attempt.ProjectKey, "attempt", attempt.ID)
+	return lease, nil
+}
+
+// advanceAttempt walks the attempt machine one edge, best-effort: the
+// walk is what an operator watches, while disposition rests on evidence
+// and the terminal transitions, so a conflict is logged rather than
+// fatal.
+func (s *Controller) advanceAttempt(ctx context.Context, attemptID, from, to string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.Advance(attemptID, from, to)
+	}); err != nil {
+		s.log.Warn("attempt did not advance", "attempt", attemptID,
+			"from", from, "to", to, "error", err)
+	}
+}
+
+// runCapsule drives one lease through the machine on its own context:
+// cancelling serve stops admission, not a running job — drain waits, and
+// whatever outlives the drain window is adopted on the next start.
+func (s *Controller) runCapsule(b *binding, lease store.Lease) {
+	defer s.wg.Done()
+	attemptID := lease.AttemptID
+	// startObs carries the classification of an ambiguous start into the
+	// finalizing transaction. It lives in memory because it is taken
+	// before cleanup destroys the container that proves it; after a
+	// crash, recovery re-takes the same observation from the daemon.
+	var startObs assignment.ExecutionObservation
+	// The scheduler claims the lease before this goroutine is started, so
+	// the claim is unbroken from the moment the lease row exists. Claiming
+	// again is a no-op that covers a direct caller; releasing is registered
+	// before the credit defer, so it runs after it.
+	s.claimLease(lease.ID)
+	defer s.releaseLease(lease.ID)
+	// The credit is released by whoever reaches `released` — not here.
+	// A lease that ends quarantined still owns privileged containers,
+	// networks and volumes, so releasing its capacity would admit work
+	// the host cannot actually run.
+	defer s.releaseCreditIfDone(b, lease.ID)
+	// The lease's own context outlives every step: cleanup and the
+	// failure paths need one that is not the step's.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log := s.log.With("binding", b.key, "lease", lease.ID)
+
+	// Preparation and execution are bounded separately because they are
+	// bounded for different reasons. Getting a capsule to the point of
+	// running is this instance's own work — pull, boot, protocol, deliver
+	// — and it either finishes in a known time or something is wrong
+	// here. Waiting for the job is the provider's business, and the
+	// tier's ceiling is the backstop for a capsule that stops reporting.
+	// Wrapping both in the ceiling made its floor unreachable: a tier
+	// configured at the lowest value the validator accepts would expire
+	// inside the capsule's readiness budget, and the expiry would surface
+	// as whichever preparation step it landed in.
+	prepCtx, cancelPrep := context.WithTimeout(ctx, capsulePrepTimeout)
+	defer cancelPrep()
+
+	if err := s.leases.Transition(ctx, lease.ID, store.LeaseReserved, store.LeaseProvisioning); err != nil {
+		log.Error("transition failed", "error", err)
+		return
+	}
+
+	runnerName := "runpool-" + shortID(lease.ID)
+	jit, err := b.jit.GenerateJITConfig(prepCtx, b.scaleSetID, runnerName, workFolder)
+	if err != nil {
+		log.Error("jit generation failed", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	// The runtime's name is the lease's correlation handle; the runner id
+	// GitHub assigned is the adapter's, and lands in the attempt's
+	// metadata table where deregistration reads it back.
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		if err := tx.SetLeaseRuntimeName(lease.ID, jit.RunnerName); err != nil {
+			return err
+		}
+		if err := tx.RecordGitHubRunnerID(attemptID, int64(jit.RunnerID)); err != nil {
+			return err
+		}
+		return tx.TransitionLease(lease.ID, store.LeaseProvisioning, store.LeaseRuntimeRegistered)
+	}); err != nil {
+		log.Error("registering runner in state failed", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+
+	// A repository-scoped binding leases an exclusive cache lane; the
+	// lane is freed by lease teardown, so it survives a crash and is
+	// reclaimed on the next reconciliation.
+	var cacheMount capsule.CacheMount
+	if b.cacheEnabled {
+		loc, ok, err := s.cache.Acquire(prepCtx, b.ref.CanonicalURL, b.generation, lease.ID, b.maxLanes)
+		switch {
+		case err != nil:
+			log.Warn("cache lane unavailable; running without cache", "error", err)
+		case ok:
+			cacheMount = capsule.CacheMount{Volume: loc.Volume}
+			log.Info("cache lane leased",
+				"project_id", loc.ProjectID, "generation", loc.Generation, "lane_id", loc.LaneID,
+				"volume", loc.Volume)
+		}
+	}
+
+	recorder := s.leases.Recorder(ctx, lease.ID)
+	s.advanceAttempt(ctx, attemptID, "leased", "preparing")
+	sandbox, err := s.netSandbox.forLaunch(prepCtx)
+	if err != nil {
+		log.Error("network sandbox refresh failed", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	prepared, err := s.caps.Prepare(prepCtx, capsule.Spec{
+		LeaseID:      lease.ID,
+		InstanceID:   s.store.InstanceID(),
+		AttemptID:    attemptID,
+		TargetID:     b.target.ID,
+		TierID:       b.tier.ID,
+		CapsuleImage: b.capsuleImage,
+		JITConfig:    jit.Encoded,
+		Resources:    b.tier.Resources,
+		Cache:        cacheMount,
+		Sandbox:      sandbox,
+		CgroupDriver: s.cgroupDriver,
+	}, recorder)
+	if err != nil {
+		// Nothing was asked to run, so the assignment stays servable —
+		// unless the image itself is the answer. A capsule that does not
+		// speak this controller's protocol will not start speaking it on
+		// the next attempt, so retrying spends the budget discovering the
+		// same fact three times per job. That one is held with its reason
+		// named, and the tier's image is the thing to change.
+		log.Error("capsule preparation failed", "error", err)
+		if errors.Is(err, capsule.ErrIncompatibleImage) {
+			s.leases.HoldAttempt(ctx, lease.ID, store.ReviewReasonIncompatibleCapsule)
+		}
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	// Recorded after the preparation exists — evidence names what
+	// happened, never what was about to be attempted.
+	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceRuntimePrepared); err != nil {
+		log.Error("cannot record that the runtime is prepared", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	s.advanceAttempt(ctx, attemptID, "preparing", "prepared")
+	// The authorization is durable immediately before the one effect
+	// that can begin execution, so the ambiguous window is exactly one
+	// Docker request wide and a crash inside it is classified by
+	// inspecting the runtime, never by guessing.
+	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceStartAuthorized); err != nil {
+		log.Error("cannot record the start authorization", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	s.advanceAttempt(ctx, attemptID, "prepared", "starting")
+	if startErr := s.caps.Start(prepCtx, prepared); startErr != nil {
+		// A failed Start call does not prove no start: the request may
+		// have taken effect before the error. Classify from the daemon
+		// now, before any cleanup can destroy the answer.
+		obs, ierr := s.caps.InspectExecution(ctx, prepared)
+		if ierr != nil {
+			log.Error("start outcome cannot be observed", "start_error", startErr, "inspect_error", ierr)
+		}
+		startObs = obs
+		switch obs {
+		case assignment.ObservedRunning:
+			log.Warn("start reported an error but the runtime is running; continuing", "error", startErr)
+		case assignment.ObservedExited:
+			log.Warn("start reported an error but the runtime ran and exited", "error", startErr)
+			if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
+				log.Error("cannot record the observed exit", "error", err)
+			}
+			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			return
+		case assignment.ObservedCreated:
+			log.Info("the runtime was never started; the assignment stays servable", "error", startErr)
+			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			return
+		default:
+			// Absent or unavailable: neither retry nor settlement can be
+			// justified, so the finalizing transaction holds the
+			// assignment for a person.
+			log.Error("start outcome is unobservable; the assignment needs an operator",
+				"observation", string(obs), "error", startErr)
+			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			return
+		}
+	}
+	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceRunningObserved); err != nil {
+		log.Error("cannot record that the runner is running", "error", err)
+	}
+	s.advanceAttempt(ctx, attemptID, "starting", "running")
+	if err := s.leases.Transition(ctx, lease.ID, store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning); err != nil {
+		log.Error("transition to running failed", "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	runnerContainer := prepared.RuntimeID
+	log.Info("capsule running", "runner", jit.RunnerName, "container", shortID(runnerContainer))
+
+	// From here the tier's ceiling governs, and only here: this is the
+	// wait for work the provider owns, and the ceiling is the backstop
+	// for a capsule that stops reporting rather than a limit on the job.
+	// An adopted capsule spends what its lease has left of the same
+	// budget, so a restart neither extends nor restarts it.
+	waitCtx, cancelWait := context.WithTimeout(ctx, remainingCeiling(b.tier, lease.CreatedAt))
+	defer cancelWait()
+	exit, err := s.wait.WaitExit(waitCtx, runnerContainer)
+	if err == nil {
+		if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
+			log.Error("cannot record that the runner completed", "error", err)
+		}
+	}
+	if err != nil {
+		// The ceiling and a broken wait unwind the same way, and only one
+		// of them is a decision this instance made. Saying which is the
+		// difference between an operator raising a tier's ceiling and one
+		// hunting a capsule that never failed.
+		if errors.Is(waitCtx.Err(), context.DeadlineExceeded) {
+			log.Error("capsule exceeded the tier's job ceiling; it is being destroyed",
+				"tier", b.tier.ID, "ceiling", b.tier.Ceiling())
+		} else {
+			log.Error("waiting on runner failed", "error", err)
+		}
+		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		return
+	}
+	if exit != 0 {
+		tail, _ := s.wait.TailLogs(ctx, runnerContainer, 40)
+		log.Warn("runner exited non-zero", "exit", exit, "log_tail", tail)
+	} else {
+		log.Info("runner exited cleanly")
+	}
+
+	if err := s.leases.Release(ctx, lease.ID, store.LeaseWorkloadRunning); err != nil {
+		log.Error("cleanup failed; lease quarantined", "error", err)
+		return
+	}
+	log.Info("lease released")
+}
+
+// shortID trims an id for log lines, tolerating ids shorter than the
+// display width — test fixtures and future id formats included.
+func shortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+// releaseCreditIfDone returns the binding's admission credit only when the lease has
+// reached its terminal state. A quarantined or otherwise stuck lease
+// keeps consuming capacity until reconciliation or cleanup resolves it.
+func (s *Controller) releaseCreditIfDone(b *binding, leaseID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	var lease store.Lease
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		lease, err = tx.LeaseByID(leaseID)
+		return err
+	}); err != nil {
+		// The lease cannot be read, so its disposition is unknown; holding
+		// the credit is the safe reading of an unknown.
+		s.log.Error("cannot confirm lease disposition; holding its credit", "lease", leaseID, "error", err)
+		return
+	}
+	if !lease.State.Terminal() {
+		s.log.Warn("lease did not reach released; its credit stays held",
+			"lease", leaseID, "state", string(lease.State))
+		return
+	}
+	s.alloc.Release(b.key)
+}
+
+// recoverCapsuleFailure walks a lease to released through the failure path: external
+// cleanup while the lease is cleaning, then the single finalizing
+// transaction that also disposes of the attempt. A removal failure
+// parks the lease in quarantined and reports it — the caller learns the
+// lease is unresolved instead of assuming otherwise.
+// b may be nil when the lease belongs to a target no longer configured:
+// its Docker resources still need removing, and logging must not
+// dereference it — a panic here takes down startup reconciliation for
+// every other lease.
+func (s *Controller) recoverCapsuleFailure(b *binding, leaseID string, startObs assignment.ExecutionObservation) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	bindingKey := "(unconfigured)"
+	if b != nil {
+		bindingKey = b.key
+	}
+	log := s.log.With("binding", bindingKey, "lease", leaseID)
+
+	was, err := s.leases.ToCleaning(ctx, leaseID)
+	if err != nil {
+		log.Error("failure transition failed", "error", err)
+		return err
+	}
+
+	// The runner id lives in the adapter's metadata for the attempt this
+	// lease serves; a binding of another provider has none, and zero
+	// means there is nothing to deregister. Reaching for it is this
+	// layer's job precisely because the lease machine must not know a
+	// provider exists.
+	var runnerGitHubID int64
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		runnerGitHubID, err = tx.GitHubRunnerID(was.AttemptID)
+		return err
+	}); err != nil {
+		log.Warn("cannot read the registered runner id; skipping deregistration", "error", err)
+	}
+
+	// b is nil for a lease whose target is no longer configured: clean
+	// its Docker resources, but there is no client to deregister the
+	// runner with — GitHub expires an unseen ephemeral runner on its own.
+	if runnerGitHubID != 0 && b != nil {
+		switch err := b.jit.RemoveRunner(ctx, int(runnerGitHubID)); {
+		case err == nil:
+		case errors.Is(err, githubactions.ErrRunnerNotFound):
+			// Already gone, which is what cleanup wanted.
+			log.Debug("the runner registration was already removed", "runner", runnerGitHubID)
+		case errors.Is(err, githubactions.ErrJobStillRunning):
+			// The provider still holds this runner busy, so the
+			// registration outlives the capsule that carried it and
+			// counts against the scale set until the provider expires it.
+			log.Warn("the provider refuses to deregister a runner it still considers busy; "+
+				"the registration is leaked until it expires there",
+				"runner", runnerGitHubID, "error", err)
+		default:
+			log.Warn("removing registered runner", "runner", runnerGitHubID, "error", err)
+		}
+	}
+
+	if err := s.leases.RemoveResources(ctx, leaseID); err != nil {
+		log.Error("failure cleanup failed; lease quarantined", "error", err)
+		s.leases.Quarantine(leaseID)
+		return err
+	}
+	if err := s.leases.Finalize(ctx, leaseID, startObs); err != nil {
+		log.Error("failure finalization failed; the lease stays cleaning for reconciliation", "error", err)
+		return err
+	}
+	return nil
+}
+
+// remainingCeiling is what is left of a lease's tier ceiling.
+//
+// The ceiling bounds how long this instance waits for one capsule, and a
+// capsule adopted after a restart has already spent part of it. Measuring
+// from the lease's own start is what keeps a restart from handing a
+// wedged capsule a fresh full budget — the failure mode the ceiling
+// exists to bound would otherwise be extended by every restart. A lease
+// already past its ceiling gets a short grace rather than zero, so the
+// wait resolves through the ordinary path instead of expiring before it
+// begins.
+func remainingCeiling(tier config.Tier, createdAt time.Time) time.Duration {
+	const grace = time.Minute
+	if createdAt.IsZero() {
+		return tier.Ceiling()
+	}
+	if left := tier.Ceiling() - time.Since(createdAt); left > grace {
+		return left
+	}
+	return grace
+}

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -1,0 +1,492 @@
+package app
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// sandboxNetworks is what computing an egress policy needs from the
+// daemon: the instance uplink, its subnet, every subnet the daemon knows
+// and a probe container to look at the host with.
+type sandboxNetworks interface {
+	EnsureOwnedNetwork(ctx context.Context, spec docker.NetworkSpec) (string, error)
+	NetworkSubnet(ctx context.Context, id string) (string, error)
+	AllNetworkSubnets(ctx context.Context) ([]string, error)
+	RunTask(ctx context.Context, spec docker.ContainerSpec) (int64, string, error)
+}
+
+// sandboxGateways is what installing one needs: find the gateways, hand
+// each the new sets, and remove the ones that will not take them.
+type sandboxGateways interface {
+	ListOwnedContainers(ctx context.Context, instanceID string) ([]docker.OwnedContainer, error)
+	Exec(ctx context.Context, id string, cmd []string) (int, string, error)
+	ExecWithInput(ctx context.Context, id string, cmd []string, input []byte) (int, string, error)
+	RemoveContainer(ctx context.Context, id string) error
+}
+
+// sandboxDaemon is both halves, which one *docker.Client satisfies. They
+// are named apart because they are two jobs, and because a fake for one
+// can embed the other and leave it unimplemented.
+type sandboxDaemon interface {
+	sandboxNetworks
+	sandboxGateways
+}
+
+// sandboxState owns the current restricted-network snapshot. Capsule
+// launches receive deep copies, so a rediscovery cannot mutate policy while
+// a concurrent launch is serializing it. refreshMu also serializes the
+// external discovery/reload operation: policy changes must be applied in the
+// same order in which they are observed.
+type sandboxState struct {
+	mu        sync.RWMutex
+	refreshMu sync.Mutex
+	current   *capsule.Sandbox
+}
+
+func newSandboxState(initial *capsule.Sandbox) *sandboxState {
+	return &sandboxState{current: cloneSandbox(initial)}
+}
+
+func (s *sandboxState) snapshot() *capsule.Sandbox {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return cloneSandbox(s.current)
+}
+
+func (s *sandboxState) replace(next *capsule.Sandbox) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.current = cloneSandbox(next)
+}
+
+func cloneSandbox(in *capsule.Sandbox) *capsule.Sandbox {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	out.Allow = append([]string(nil), in.Allow...)
+	out.Deny = append([]string(nil), in.Deny...)
+	return &out
+}
+
+// networkSandbox owns the restricted profile's egress policy: it
+// computes the deny set from the host, keeps the snapshot capsule
+// launches are cut from, and installs changes into the running gateways.
+//
+// A nil *networkSandbox is the unsafe-open-egress profile — there is no
+// policy to maintain — and every method here answers for that, so the
+// serving paths ask without first asking whether there is anything to
+// ask.
+type networkSandbox struct {
+	log        *slog.Logger
+	daemon     sandboxDaemon
+	instanceID string
+	probeImage string
+	// allow and denies are the operator's own two lists, read once. They
+	// extend the discovered set rather than replacing anything in it, and
+	// they are kept so a rediscovery rebuilds the policy with them still
+	// in place.
+	allow  []string
+	denies []string
+
+	state *sandboxState
+}
+
+// newNetworkSandbox assembles the initial policy and fails closed. Any
+// gap in the deny set is a hole in every capsule's egress, so serve does
+// not start without a complete one.
+func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon, instanceID, probeImage string,
+	cfg *config.Config, log *slog.Logger) (*networkSandbox, error) {
+	n := &networkSandbox{
+		log: log, daemon: daemon, instanceID: instanceID, probeImage: probeImage,
+	}
+	for _, c := range cfg.Network.AllowPrivateCIDRs {
+		n.allow = append(n.allow, c.String())
+	}
+	for _, c := range cfg.Network.DenyCIDRs {
+		n.denies = append(n.denies, c.String())
+	}
+	initial, err := n.build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	n.state = newSandboxState(initial)
+	log.Info("network sandbox ready", "uplink_subnet", initial.UplinkSubnet,
+		"deny", len(initial.Deny), "allow", len(initial.Allow))
+	return n, nil
+}
+
+// build assembles the sandbox input: the instance uplink (created or
+// adopted under proven ownership) and the deny-set snapshot — host
+// interface networks discovered through a short-lived host-namespace
+// probe, every Docker subnet the daemon knows, the baseline ranges, and
+// the uplink itself.
+func (n *networkSandbox) build(ctx context.Context) (*capsule.Sandbox, error) {
+	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, docker.NetworkSpec{
+		Name: "runpool-uplink-" + n.instanceID[:8],
+		Labels: map[string]string{
+			docker.LabelManaged:  "true",
+			docker.LabelInstance: n.instanceID,
+			docker.LabelRole:     capsule.RoleUplink,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("uplink network: %w", err)
+	}
+	uplinkSubnet, err := n.daemon.NetworkSubnet(ctx, uplinkID)
+	if err != nil {
+		return nil, fmt.Errorf("uplink subnet: %w", err)
+	}
+	hostCIDRs, err := n.discoverHostCIDRs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("host discovery: %w", err)
+	}
+	dockerSubnets, err := n.daemon.AllNetworkSubnets(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("docker subnets: %w", err)
+	}
+	return &capsule.Sandbox{
+		UplinkNetworkID: uplinkID,
+		UplinkSubnet:    uplinkSubnet,
+		Allow:           n.allow,
+		Deny:            egress.BuildDeny(uplinkSubnet, hostCIDRs, append(dockerSubnets, n.denies...)),
+	}, nil
+}
+
+// rediscoverInterval is how often the deny set is recomputed against
+// the host. Networks appear when someone starts an unrelated stack;
+// the cost of noticing late is a hole that stays open until then, and
+// the cost of noticing often is one probe container.
+const rediscoverInterval = 5 * time.Minute
+
+// PolicyChange classifies what a rediscovered deny set does to the one
+// in force. The distinction decides what a failure to install it costs.
+type PolicyChange int
+
+const (
+	// PolicyUnchanged: nothing to install.
+	PolicyUnchanged PolicyChange = iota
+	// PolicyRestriction: the new set denies everything the old one did
+	// and more. Until it is installed, a capsule can reach an address
+	// that should now be denied, so failing to install it is a security
+	// failure, not a delay.
+	PolicyRestriction
+	// PolicyRelaxation: the new set denies strictly less. Failing to
+	// install it costs a job some reachability and nothing else, so
+	// established work is preserved.
+	PolicyRelaxation
+	// PolicyMixed: it both adds and removes denies. It carries a
+	// restriction, so it is treated as one.
+	PolicyMixed
+)
+
+func (c PolicyChange) String() string {
+	switch c {
+	case PolicyUnchanged:
+		return "unchanged"
+	case PolicyRestriction:
+		return "restriction"
+	case PolicyRelaxation:
+		return "relaxation"
+	case PolicyMixed:
+		return "mixed"
+	}
+	return "unknown"
+}
+
+// restricts reports whether the change adds any deny — the property
+// that makes a failed install unsafe rather than merely stale.
+func (c PolicyChange) restricts() bool { return c == PolicyRestriction || c == PolicyMixed }
+
+// ClassifyPolicy compares two deny sets as sets of prefixes.
+//
+// The comparison is textual on purpose: the deny sets are built by one
+// function from discovered facts, so a range that is still denied is
+// still denied by the same prefix string. Treating "10.0.0.0/8 became
+// 10.0.0.0/9" as anything other than a change would require a
+// containment analysis whose mistakes would all point the wrong way.
+func ClassifyPolicy(inForce, next []string) PolicyChange {
+	had := make(map[string]bool, len(inForce))
+	for _, c := range inForce {
+		had[c] = true
+	}
+	has := make(map[string]bool, len(next))
+	for _, c := range next {
+		has[c] = true
+	}
+	var added, removed bool
+	for c := range has {
+		if !had[c] {
+			added = true
+		}
+	}
+	for c := range had {
+		if !has[c] {
+			removed = true
+		}
+	}
+	switch {
+	case added && removed:
+		return PolicyMixed
+	case added:
+		return PolicyRestriction
+	case removed:
+		return PolicyRelaxation
+	default:
+		return PolicyUnchanged
+	}
+}
+
+// watch repeats discovery and installs what it finds.
+//
+// The old policy is not a safe fallback. It is merely older: if a host
+// interface or a Docker network appeared since it was computed, the
+// capsules running under it can reach an address that should now be
+// denied. So a failure is classified by what it leaves reachable —
+// a restriction that cannot be installed closes the affected gateway to
+// everything, and discovery that cannot be trusted at all does the same
+// for every gateway, because an undiscovered subnet is indistinguishable
+// from one that was never there.
+func (n *networkSandbox) watch(ctx context.Context) {
+	if n == nil {
+		return // unsafe-open-egress: there is no policy to maintain
+	}
+	ticker := time.NewTicker(rediscoverInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		n.rediscover(ctx)
+	}
+}
+
+// forLaunch re-proves the instance uplink and the complete deny set
+// immediately before a capsule is admitted. This makes an idle uplink removed
+// by a platform cleanup recoverable, and it prevents a shared daemon's newly
+// created networks from remaining reachable until the periodic refresh.
+func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error) {
+	if n == nil {
+		return nil, nil
+	}
+	if err := n.refresh(ctx); err != nil {
+		return nil, err
+	}
+	return n.state.snapshot(), nil
+}
+
+func (n *networkSandbox) refresh(ctx context.Context) error {
+	n.state.refreshMu.Lock()
+	defer n.state.refreshMu.Unlock()
+	next, err := n.build(ctx)
+	if err != nil {
+		return err
+	}
+	n.applyPolicy(ctx, next)
+	return nil
+}
+
+// rediscover is one pass, separated so a test can drive it directly.
+func (n *networkSandbox) rediscover(ctx context.Context) {
+	err := n.refresh(ctx)
+	if err == nil {
+		return
+	}
+
+	// Discovery failed. The environment may have grown a network this
+	// policy does not deny, and there is no way to tell — so every
+	// gateway closes rather than relaying under a set that cannot be
+	// shown to be current.
+	n.log.Error("sandbox rediscovery failed; closing every gateway to all egress", "error", err)
+	if err := n.closeGateways(ctx); err != nil {
+		n.log.Error("could not close every gateway after a failed rediscovery", "error", err)
+	}
+}
+
+// applyPolicy installs a rediscovered set, and decides what a failure
+// costs from what the change was.
+func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox) {
+	previous := n.state.snapshot()
+	change := ClassifyPolicy(previous.Deny, next.Deny)
+	uplinkChanged := previous.UplinkNetworkID != next.UplinkNetworkID
+	if change == PolicyUnchanged && !uplinkChanged {
+		return
+	}
+	n.log.Info("egress policy changed", "change", change.String(),
+		"was", len(previous.Deny), "now", len(next.Deny), "uplink_recreated", uplinkChanged)
+	n.state.replace(next)
+
+	failed, err := n.reloadGateways(ctx, next.Allow, next.Deny)
+	if err != nil {
+		n.log.Error("could not enumerate gateways to reload", "error", err)
+	}
+	if len(failed) == 0 {
+		return
+	}
+	if !change.restricts() {
+		// A relaxation that did not land leaves the capsule with the
+		// stricter policy it started under. Its work continues.
+		n.log.Warn("some gateways kept the previous, stricter policy",
+			"gateways", len(failed), "change", change.String())
+		return
+	}
+	// A restriction that did not land leaves a capsule able to reach
+	// something the policy now denies. Close those gateways.
+	n.log.Error("a restriction could not be installed; closing the affected gateways",
+		"gateways", len(failed))
+	for _, id := range failed {
+		if err := n.closeGateway(ctx, id); err != nil {
+			n.log.Error("a gateway could not be closed and may still relay a denied address",
+				"container", id, "error", err)
+		}
+	}
+}
+
+// reloadGateways hands the new sets to every running gateway this
+// instance owns. A gateway that cannot be reloaded is reported, not
+// worked around. It returns the ids of the gateways that did not take
+// the new policy, so the caller can decide what that costs from what
+// the change was.
+func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []string) (failed []string, err error) {
+	containers, err := n.daemon.ListOwnedContainers(ctx, n.instanceID)
+	if err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(egress.Policy{Allow: allow, Deny: deny})
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range containers {
+		if c.Role != capsule.RoleGateway || !c.Running {
+			continue
+		}
+		code, out, err := n.daemon.ExecWithInput(ctx, c.ID,
+			[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
+		if err != nil || code != 0 {
+			failed = append(failed, c.ID)
+			n.log.Error("gateway policy reload failed", "container", c.Name, "exit", code, "error", err, "output", out)
+			continue
+		}
+		n.log.Info("gateway policy reloaded", "container", c.Name)
+	}
+	return failed, nil
+}
+
+// closeGateway revokes a live gateway's egress: every destination
+// denied, in the kernel ruleset and in the relay's own check.
+//
+// Closing the policy is not enough on its own — an established tunnel
+// is already through the check — so the gateway is stopped afterwards,
+// which takes its connections with it. A capsule whose gateway is gone
+// has no egress at all, which is the state this is trying to reach.
+func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) error {
+	code, out, err := n.daemon.Exec(ctx, containerID,
+		[]string{capsule.SupervisorPath, "gateway-deny-all"})
+	if err != nil || code != 0 {
+		// The policy could not be closed from inside; removing the
+		// container is the remaining way to stop it relaying.
+		n.log.Error("gateway deny-all failed; removing the gateway",
+			"container", containerID, "exit", code, "error", err, "output", out)
+	}
+	return n.daemon.RemoveContainer(ctx, containerID)
+}
+
+// closeGateways closes every live gateway this instance owns.
+func (n *networkSandbox) closeGateways(ctx context.Context) error {
+	containers, err := n.daemon.ListOwnedContainers(ctx, n.instanceID)
+	if err != nil {
+		return err
+	}
+	var failures int
+	for _, c := range containers {
+		if c.Role != capsule.RoleGateway || !c.Running {
+			continue
+		}
+		if err := n.closeGateway(ctx, c.ID); err != nil {
+			failures++
+			n.log.Error("a gateway could not be closed", "container", c.Name, "error", err)
+		}
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d gateway(s) could not be closed", failures)
+	}
+	return nil
+}
+
+// discoverHostCIDRs enumerates the host's global IPv4 networks with a
+// short-lived probe in the host network namespace: read-only, no
+// capabilities, no socket, no volumes — it looks and reports. An empty
+// answer is a failure, not a finding: a host has interfaces, and a
+// deny set built from a blind probe would allow what it cannot see.
+func (n *networkSandbox) discoverHostCIDRs(ctx context.Context) ([]string, error) {
+	nonce := make([]byte, 4)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	code, out, err := n.daemon.RunTask(ctx, docker.ContainerSpec{
+		Name:        "runpool-" + n.instanceID[:8] + "-hostnet-probe-" + hex.EncodeToString(nonce),
+		Image:       n.probeImage,
+		Entrypoint:  []string{"/bin/sh", "-c"},
+		Cmd:         []string{"ip -o -4 addr show scope global"},
+		NetworkMode: "host",
+		Labels: map[string]string{
+			docker.LabelManaged:  "true",
+			docker.LabelInstance: n.instanceID,
+			docker.LabelRole:     "probe",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, fmt.Errorf("host probe exited %d: %s", code, out)
+	}
+	cidrs, err := parseHostCIDRs(out)
+	if err != nil {
+		return nil, err
+	}
+	if len(cidrs) == 0 {
+		return nil, fmt.Errorf("host probe saw no global IPv4 networks; refusing a blind deny set")
+	}
+	return cidrs, nil
+}
+
+// parseHostCIDRs reads `ip -o -4 addr show` one-line output: the field
+// after "inet" is address/prefix, masked here to the network.
+func parseHostCIDRs(out string) ([]string, error) {
+	seen := map[string]bool{}
+	var cidrs []string
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		for i, f := range fields {
+			if f != "inet" || i+1 >= len(fields) {
+				continue
+			}
+			prefix, err := netip.ParsePrefix(fields[i+1])
+			if err != nil {
+				return nil, fmt.Errorf("host probe line %q: %w", line, err)
+			}
+			network := prefix.Masked().String()
+			if !seen[network] {
+				seen[network] = true
+				cidrs = append(cidrs, network)
+			}
+		}
+	}
+	return cidrs, nil
+}

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -1,0 +1,335 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+func TestSandboxStateSnapshotsAreIndependent(t *testing.T) {
+	original := &capsule.Sandbox{
+		UplinkNetworkID: "uplink-1",
+		UplinkSubnet:    "172.20.0.0/16",
+		Allow:           []string{"203.0.113.0/24"},
+		Deny:            []string{"10.0.0.0/8"},
+	}
+	state := newSandboxState(original)
+
+	original.Deny[0] = "changed-outside"
+	first := state.snapshot()
+	first.Allow[0] = "changed-snapshot"
+	if got := state.snapshot(); !reflect.DeepEqual(got.Allow, []string{"203.0.113.0/24"}) ||
+		!reflect.DeepEqual(got.Deny, []string{"10.0.0.0/8"}) {
+		t.Fatalf("sandbox state was aliased across owners: %+v", got)
+	}
+
+	state.replace(&capsule.Sandbox{UplinkNetworkID: "uplink-2", Deny: []string{"192.168.0.0/16"}})
+	if got := state.snapshot(); got.UplinkNetworkID != "uplink-2" || !reflect.DeepEqual(got.Deny, []string{"192.168.0.0/16"}) {
+		t.Fatalf("replacement snapshot = %+v", got)
+	}
+}
+
+// TestClassifyPolicy is what decides whether a failed reload is a delay
+// or a security failure. A change that adds a deny leaves capsules able
+// to reach something that should now be blocked until it lands; one
+// that only removes denies costs reachability and nothing else.
+func TestClassifyPolicy(t *testing.T) {
+	base := []string{"10.0.0.0/8", "192.168.0.0/16"}
+
+	cases := []struct {
+		name      string
+		inForce   []string
+		next      []string
+		want      PolicyChange
+		restricts bool
+	}{
+		{"identical", base, []string{"192.168.0.0/16", "10.0.0.0/8"}, PolicyUnchanged, false},
+		{"a new docker network appeared", base, append(append([]string{}, base...), "172.30.0.0/16"), PolicyRestriction, true},
+		{"a host network went away", base, []string{"10.0.0.0/8"}, PolicyRelaxation, false},
+		{"one replaced by another", base, []string{"10.0.0.0/8", "172.30.0.0/16"}, PolicyMixed, true},
+		{"everything went away", base, nil, PolicyRelaxation, false},
+		{"from nothing", nil, base, PolicyRestriction, true},
+	}
+	for _, tc := range cases {
+		got := ClassifyPolicy(tc.inForce, tc.next)
+		if got != tc.want {
+			t.Errorf("%s: classified %s; want %s", tc.name, got, tc.want)
+		}
+		if got.restricts() != tc.restricts {
+			t.Errorf("%s: restricts() = %v; want %v", tc.name, got.restricts(), tc.restricts)
+		}
+	}
+}
+
+// TestPolicyChangeNamesItself keeps the log readable: an operator
+// reading "change=restriction" learns why their capsule was closed.
+func TestPolicyChangeNamesItself(t *testing.T) {
+	for _, c := range []PolicyChange{PolicyUnchanged, PolicyRestriction, PolicyRelaxation, PolicyMixed} {
+		if c.String() == "unknown" {
+			t.Errorf("PolicyChange(%d) has no name", c)
+		}
+	}
+}
+
+// fakeSandboxDaemon answers for both halves of the daemon the sandbox
+// uses. Its point is the states that decide the design: a probe that sees
+// nothing, and a gateway that refuses the policy it is handed.
+type fakeSandboxDaemon struct {
+	uplinkID     string
+	uplinkSubnet string
+	subnets      []string
+	probeOut     string
+	probeErr     error
+
+	containers []docker.OwnedContainer
+	// refuse names the containers whose exec fails, which is how a
+	// gateway that will not take a new policy is expressed.
+	refuse   map[string]bool
+	reloaded []string
+	denied   []string
+	removed  []string
+}
+
+func (f *fakeSandboxDaemon) EnsureOwnedNetwork(context.Context, docker.NetworkSpec) (string, error) {
+	return f.uplinkID, nil
+}
+func (f *fakeSandboxDaemon) NetworkSubnet(context.Context, string) (string, error) {
+	return f.uplinkSubnet, nil
+}
+func (f *fakeSandboxDaemon) AllNetworkSubnets(context.Context) ([]string, error) {
+	return f.subnets, nil
+}
+func (f *fakeSandboxDaemon) RunTask(context.Context, docker.ContainerSpec) (int64, string, error) {
+	return 0, f.probeOut, f.probeErr
+}
+func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, string) ([]docker.OwnedContainer, error) {
+	return f.containers, nil
+}
+func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, _ []string) (int, string, error) {
+	f.denied = append(f.denied, id)
+	if f.refuse[id] {
+		return 1, "refused", nil
+	}
+	return 0, "", nil
+}
+func (f *fakeSandboxDaemon) ExecWithInput(_ context.Context, id string, _ []string, _ []byte) (int, string, error) {
+	if f.refuse[id] {
+		return 1, "refused", nil
+	}
+	f.reloaded = append(f.reloaded, id)
+	return 0, "", nil
+}
+func (f *fakeSandboxDaemon) RemoveContainer(_ context.Context, id string) error {
+	f.removed = append(f.removed, id)
+	return nil
+}
+
+func newTestSandbox(t *testing.T, daemon sandboxDaemon, inForce *capsule.Sandbox) *networkSandbox {
+	t.Helper()
+	return &networkSandbox{
+		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		daemon:     daemon,
+		instanceID: "instance-0001",
+		probeImage: "probe",
+		state:      newSandboxState(inForce),
+	}
+}
+
+// TestParseHostCIDRs reads what the probe actually prints. Each address
+// is masked to its network, because the deny set is about ranges and an
+// interface address would deny one host of them.
+func TestParseHostCIDRs(t *testing.T) {
+	out := `1: lo    inet 127.0.0.1/8 scope host lo
+2: eth0    inet 10.0.5.37/24 brd 10.0.5.255 scope global eth0
+3: eth1    inet 10.0.5.99/24 brd 10.0.5.255 scope global eth1
+4: docker0    inet 172.17.0.1/16 scope global docker0`
+	got, err := parseHostCIDRs(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"127.0.0.0/8", "10.0.5.0/24", "172.17.0.0/16"}
+	if !slices.Equal(got, want) {
+		t.Errorf("parseHostCIDRs = %v; want networks, deduplicated, in order: %v", got, want)
+	}
+
+	if _, err := parseHostCIDRs("7: eth0    inet not-an-address scope global"); err == nil {
+		t.Error("an unparseable line was accepted; a deny set must not be built from a line nobody read")
+	}
+	if got, err := parseHostCIDRs(""); err != nil || len(got) != 0 {
+		t.Errorf("empty output = (%v, %v); it is the caller that decides emptiness is fatal", got, err)
+	}
+}
+
+// TestBuildRefusesABlindDenySet: a probe that reports no global network
+// has not proved the host has none, and a deny set built from it would
+// allow every range it could not see. Failing closed is the only safe
+// reading, and it is why serve does not start.
+func TestBuildRefusesABlindDenySet(t *testing.T) {
+	// `ip ... scope global` filters, so a probe that saw nothing prints
+	// nothing. Scope is not re-checked here — the command is the filter.
+	n := newTestSandbox(t, &fakeSandboxDaemon{
+		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: "",
+	}, nil)
+	if _, err := n.build(t.Context()); err == nil {
+		t.Fatal("a sandbox was built from a probe that saw no global network")
+	}
+}
+
+// TestBuildDeniesEverythingItDiscovered: the uplink, the host's networks,
+// every subnet the daemon knows and the operator's own list all have to
+// reach the deny set. Any one of them missing is a hole in every
+// capsule's egress, which is why this fails serve rather than warning.
+func TestBuildDeniesEverythingItDiscovered(t *testing.T) {
+	n := newTestSandbox(t, &fakeSandboxDaemon{
+		uplinkID:     "up-1",
+		uplinkSubnet: "172.30.0.0/24",
+		subnets:      []string{"172.18.0.0/16"},
+		probeOut:     "2: eth0    inet 192.0.2.10/24 scope global eth0",
+	}, nil)
+	n.denies = []string{"203.0.113.0/24"}
+	n.allow = []string{"10.9.0.0/16"}
+
+	sb, err := n.build(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sb.UplinkNetworkID != "up-1" || sb.UplinkSubnet != "172.30.0.0/24" {
+		t.Errorf("uplink = %s %s; want the one it ensured", sb.UplinkNetworkID, sb.UplinkSubnet)
+	}
+	for _, want := range []string{"172.30.0.0/24", "192.0.2.0/24", "172.18.0.0/16", "203.0.113.0/24"} {
+		if !slices.Contains(sb.Deny, want) {
+			t.Errorf("deny set is missing %s: %v", want, sb.Deny)
+		}
+	}
+	if !slices.Equal(sb.Allow, []string{"10.9.0.0/16"}) {
+		t.Errorf("allow = %v; want the operator's list", sb.Allow)
+	}
+}
+
+// TestApplyPolicyCostsWhatTheChangeWas is the asymmetry the whole
+// classification exists for. A restriction that did not install leaves a
+// capsule able to reach what the policy now denies, so those gateways are
+// closed. A relaxation that did not install leaves it under the stricter
+// policy it started with, so its work continues.
+func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
+	gateways := []docker.OwnedContainer{
+		{ID: "gw-ok", Name: "gw-ok", Role: capsule.RoleGateway, Running: true},
+		{ID: "gw-bad", Name: "gw-bad", Role: capsule.RoleGateway, Running: true},
+		{ID: "gw-stopped", Name: "gw-stopped", Role: capsule.RoleGateway},
+		{ID: "runner", Name: "runner", Role: capsule.RoleCapsule, Running: true},
+	}
+	inForce := &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}}
+
+	t.Run("a restriction that did not land closes the gateway", func(t *testing.T) {
+		d := &fakeSandboxDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
+		n := newTestSandbox(t, d, inForce)
+		n.applyPolicy(t.Context(), &capsule.Sandbox{
+			UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		})
+		if !slices.Equal(d.reloaded, []string{"gw-ok"}) {
+			t.Errorf("reloaded %v; only running gateways take a policy", d.reloaded)
+		}
+		if !slices.Equal(d.removed, []string{"gw-bad"}) {
+			t.Errorf("removed %v; the gateway that refused a restriction must be closed", d.removed)
+		}
+	})
+
+	t.Run("a relaxation that did not land leaves the work running", func(t *testing.T) {
+		d := &fakeSandboxDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
+		n := newTestSandbox(t, d, inForce)
+		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1"})
+		if len(d.removed) != 0 {
+			t.Errorf("removed %v; a gateway keeping a stricter policy is not a danger", d.removed)
+		}
+	})
+
+	t.Run("nothing changed installs nothing", func(t *testing.T) {
+		d := &fakeSandboxDaemon{containers: gateways}
+		n := newTestSandbox(t, d, inForce)
+		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}})
+		if len(d.reloaded)+len(d.removed) != 0 {
+			t.Errorf("an unchanged policy touched %v / %v", d.reloaded, d.removed)
+		}
+	})
+
+	t.Run("a recreated uplink is a change even with the same deny set", func(t *testing.T) {
+		d := &fakeSandboxDaemon{containers: gateways}
+		n := newTestSandbox(t, d, inForce)
+		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-2", Deny: []string{"10.0.0.0/8"}})
+		if !slices.Equal(d.reloaded, []string{"gw-ok", "gw-bad"}) {
+			t.Errorf("reloaded %v; a new uplink has to reach every gateway", d.reloaded)
+		}
+	})
+}
+
+// TestCloseGatewaysRemovesEvenWhatWillNotDeny: an established tunnel is
+// already past the relay's check, so closing the policy from inside is
+// not enough on its own. The container goes either way.
+func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
+	d := &fakeSandboxDaemon{
+		containers: []docker.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
+			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
+			{ID: "runner", Role: capsule.RoleCapsule, Running: true},
+		},
+		refuse: map[string]bool{"gw-2": true},
+	}
+	n := newTestSandbox(t, d, &capsule.Sandbox{})
+	if err := n.closeGateways(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(d.removed, []string{"gw-1", "gw-2"}) {
+		t.Errorf("removed %v; a gateway that refuses deny-all still has to stop relaying", d.removed)
+	}
+}
+
+// A nil sandbox is the unsafe-open-egress profile, and every serving path
+// asks it the same questions.
+func TestANilSandboxIsTheOpenProfile(t *testing.T) {
+	var n *networkSandbox
+	sb, err := n.forLaunch(t.Context())
+	if sb != nil || err != nil {
+		t.Errorf("forLaunch on the open profile = (%v, %v); want no policy and no error", sb, err)
+	}
+	n.watch(t.Context()) // returns rather than ticking forever
+}
+
+// TestNewNetworkSandboxFailsServeClosed. The constructor is where the
+// first policy is computed, and serve does not start without a complete
+// one: a capsule launched under a partial deny set can reach what the
+// profile promises it cannot, and there is no later pass that would
+// notice.
+func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cfg := &config.Config{}
+	config.ApplyDefaults(cfg)
+
+	blind := &fakeSandboxDaemon{uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: ""}
+	if _, err := newNetworkSandbox(t.Context(), blind, "instance-0001", "probe", cfg, log); err == nil {
+		t.Error("serve would have started on a deny set built from a probe that saw nothing")
+	}
+
+	seeing := &fakeSandboxDaemon{
+		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24",
+		probeOut: "2: eth0    inet 192.0.2.10/24 scope global eth0",
+	}
+	n, err := newNetworkSandbox(t.Context(), seeing, "instance-0001", "probe", cfg, log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The snapshot a launch is cut from is in force from the start.
+	sb, err := n.forLaunch(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sb == nil || sb.UplinkNetworkID != "up-1" {
+		t.Errorf("the first launch would get %+v; want the policy just built", sb)
+	}
+}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -1,0 +1,510 @@
+// Package app owns the controller's process lifecycle: wiring
+// configuration, state, GitHub and Docker into the serve loops, and
+// shutting the whole thing down in order. Business rules live in the
+// packages it composes.
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/allocator"
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/doctor"
+	"github.com/rhobuild/runpool/internal/lease"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+const (
+	workFolder = "_work"
+	// drainTimeout bounds the wait for capsule goroutines at shutdown. A
+	// capsule running a job outlives any window worth waiting — that is
+	// what adoption on the next start is for — so this is sized to be
+	// spent, and to leave the deployment's stop grace period enough room
+	// afterwards to close every message session. A window that outlasts
+	// that grace period is never reached: the platform sends SIGKILL
+	// first, the sessions stay open, and the next start waits each one
+	// out as a conflict.
+	drainTimeout = 60 * time.Second
+	pollBackoff  = 5 * time.Second
+
+	// capsulePrepTimeout bounds getting a capsule to the point of running:
+	// minting a credential, acquiring a lane, building the sandbox,
+	// pulling and booting the image, and handing over the credential.
+	// That is this instance's own work against its own daemon, so it
+	// either finishes in a knowable time or something here is wrong. It
+	// is deliberately generous — a cold image pull is the slow step — and
+	// deliberately not the tier's ceiling, which answers a different
+	// question about a different party.
+	capsulePrepTimeout = 15 * time.Minute
+
+	// receiveFailuresBeforeReopen is how many consecutive polls may fail
+	// before the binding stops trusting its session. The upstream client
+	// refreshes an expired session itself and leaves the handle dead when
+	// that refresh fails, so a run of identical failures is the shape a
+	// dead session takes. Three keeps a transient 5xx from costing a
+	// session while still recovering within a minute.
+	receiveFailuresBeforeReopen = 3
+
+	// A session left by a crashed controller lingers in the broker until
+	// it expires by inactivity; the successor already holds the local
+	// lock, so the loop waits it out rather than giving up on the binding.
+	sessionConflictBackoff = 10 * time.Second
+	// sessionConflictGrace is how long a broker may hold a predecessor's
+	// session before the wait stops being ordinary. The broker expires a
+	// session by inactivity well inside this, so past it the binding is
+	// serving nothing for a reason no report would otherwise carry.
+	sessionConflictGrace = 5 * time.Minute
+)
+
+type Options struct {
+	Version      string
+	CapsuleImage string
+	StateDir     string
+	Environ      func(string) string
+}
+
+// binding is one (target, tier) pair: its own scale set and session.
+// The admission credit budget and advertised capacity are shared through
+// the allocator, keyed by binding. Deduplication needs no memory here:
+// delivery and attempt identity live in the store, and claiming an
+// attempt is a compare-and-swap only one caller can win.
+type binding struct {
+	key    string
+	target config.Target
+	tier   config.Tier
+	ref    config.TargetRef
+	gh     *githubactions.Client
+	// jit is the serving-time slice of gh, split out so the fault matrix
+	// can mint credentials and deregister runners without a provider.
+	jit runnerRegistry
+	// sets is the startup slice of gh, split out for the same reason.
+	sets scaleSetRegistry
+	// scaleSetID is the provider's own id for this binding's scale set,
+	// held in memory for the session and JIT calls. bindingID is what the
+	// attempt and lease machinery keys on; this reaches the store in one
+	// place only, inside the opaque delivery key, because a delivery id
+	// is unique per queue rather than per binding and the binding
+	// outlives the queue.
+	scaleSetID int
+	// scaleSetName is the provider-side name the loop creates or adopts
+	// under. It is configuration rather than provider state, so it is
+	// known before any call.
+	scaleSetName string
+	// ensured records that this process has created-or-adopted the scale
+	// set. It starts false on every start, including a restart that read
+	// scaleSetID from the store: the recorded id is proof of ownership,
+	// not proof that the set still exists or still refuses runner
+	// self-update. Owned by the binding's own loop.
+	ensured bool
+	// lastContactWrite paces the recorded successes. Owned by the
+	// binding's own loop, like ensured above.
+	lastContactWrite time.Time
+	// reaching is what the store was last told about this binding's reach,
+	// and lastFailure the reason it was last told about. Together they
+	// make a write a transition rather than a repetition. Owned by the
+	// binding's own loop.
+	reaching    bool
+	lastFailure string
+	// conflictSince is when this binding's current run of broker session
+	// conflicts began, zero while it holds none. A conflict is the
+	// ordinary shape of a restart; one that outlasts the inactivity the
+	// broker expires a session on is not, and only elapsed time tells the
+	// two apart. Owned by the binding's own loop.
+	conflictSince time.Time
+	bindingID     int64
+	cacheEnabled  bool
+	generation    string
+	// capsuleImage is what this binding launches: its tier's image where
+	// one is configured, and the image this build ships otherwise. It is
+	// resolved once, per binding, so the launch path never re-decides it.
+	capsuleImage string
+	// maxLanes is the most leases this binding's tier can run at once, which
+	// is what bounds the cache lanes one project may hold. It is the tier's
+	// parallelism capped by the instance-wide limit, because a lane per
+	// possible tier lease overcounts when a global limit is the tighter one.
+	maxLanes int
+
+	session providerSession
+	// newSession builds a session for this binding, in one attempt. The
+	// loop's own backoff is the retry: a broker still holding this
+	// binding's session is holding the one this process just closed, not
+	// a predecessor's, and waiting that out in place would stall the loop
+	// for as long as the broker takes. Held as a closure so the loop can
+	// recover without knowing what a session is made of, and so a test
+	// can hand it one that fails.
+	newSession func(ctx context.Context) (providerSession, error)
+
+	// lastAdvertised is what this binding announced last, so the credit
+	// accounting is logged when it changes rather than every poll.
+	// Owned by the binding's own loop.
+	lastAdvertised int
+
+	// mu serialises scheduling passes per binding, so one poll's serve
+	// loop finishes deciding before the next begins.
+	mu sync.Mutex
+}
+
+// Serve runs the controller until ctx is cancelled, then drains.
+func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
+	log := newLogger(cfg.Observability.Log)
+	log.Info("host topology selected", "topology", cfg.Host.Topology,
+		"reserve_cpu", cfg.Host.Reserve.CPU.String(),
+		"reserve_memory", cfg.Host.Reserve.Memory.String(),
+		"reserve_swap", cfg.Host.Reserve.Swap.String(),
+		"reserve_free_disk", cfg.Host.Reserve.FreeDisk.String())
+
+	// The network profile decides the capsule topology. The restricted
+	// profile builds its sandbox below, once the daemon is connected;
+	// unsafe-open must keep being an explicit, logged choice.
+	if cfg.Network.Profile == config.NetworkProfileUnsafeOpen {
+		log.Warn("network profile is unsafe-open-egress: capsules reach whatever this host reaches, including the LAN and host services")
+	}
+
+	capsuleImg, err := capsuleImage(opts.Environ, opts.CapsuleImage)
+	if err != nil {
+		return err
+	}
+	// The build inputs stay verified even though the controller no
+	// longer runs them directly: the capsule image is built from exactly
+	// these digests, and refusing to start on a broken lock is what
+	// keeps that reviewable.
+	if _, _, err := buildInputImages(); err != nil {
+		return err
+	}
+	log.Info("capsule image", "image", capsuleImg)
+
+	lock, err := store.TryAcquire(opts.StateDir)
+	if err != nil {
+		if errors.Is(err, store.ErrLockHeld) {
+			return fmt.Errorf("%w; only one controller may use a state directory", err)
+		}
+		return err
+	}
+	defer lock.Release()
+
+	st, err := store.Open(opts.StateDir, store.WithRetryBudget(cfg.Scheduling.RetryBudget))
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+	log = log.With("instance", st.InstanceID()[:8])
+
+	dock, err := docker.New(ctx)
+	if err != nil {
+		return err
+	}
+	defer dock.Close()
+	dock.OnCleanupError(func(name string, err error) {
+		// The ownership labels guarantee a later sweep finds it, but a
+		// helper that outlives its task is worth seeing now.
+		log.Warn("a setup helper could not be removed", "container", name, "error", err)
+	})
+
+	// The daemon's own facts, read once. The cgroup driver decides the
+	// form of every lease's parent cgroup, and the daemon rejects the
+	// wrong form — so it is read from the host rather than assumed.
+	hostInfo, err := dock.Info(ctx)
+	if err != nil {
+		return fmt.Errorf("read daemon facts: %w", err)
+	}
+
+	// The host contract is checked before anything is created on GitHub:
+	// a host that cannot honour it must fail here, not midway through a
+	// job. Live credential checks are left to `runpool doctor`, so a
+	// transient API failure never blocks a restart with running capsules.
+	report := doctor.Run(ctx, doctor.Options{
+		Config:   cfg,
+		Docker:   dock,
+		StateDir: opts.StateDir,
+		Environ:  opts.Environ,
+	})
+	for _, res := range report.Results {
+		switch res.Status {
+		case doctor.Fail:
+			log.Error("doctor", "check", res.Name, "detail", res.Detail, "fix", res.Fix)
+		case doctor.Warn:
+			log.Warn("doctor", "check", res.Name, "detail", res.Detail, "fix", res.Fix)
+		default:
+			log.Debug("doctor", "check", res.Name, "detail", res.Detail)
+		}
+	}
+	if !report.OK() {
+		return errors.New("host does not meet the runtime contract; run `runpool doctor` for the full report")
+	}
+
+	// The restricted profile's sandbox: uplink and deny-set snapshot,
+	// assembled before any binding exists. A discovery failure fails
+	// serve closed — a capsule must never launch with a partial policy.
+	var netSandbox *networkSandbox
+	if cfg.Network.Profile == config.NetworkProfilePublicInternetOnly {
+		netSandbox, err = newNetworkSandbox(ctx, dock, st.InstanceID(), capsuleImg, cfg, log)
+		if err != nil {
+			return fmt.Errorf("network sandbox: %w", err)
+		}
+	}
+
+	// Cache lanes are daemon-side named volumes, so there is nothing to
+	// resolve about how this controller is deployed: the same volume is
+	// the same object from a container or from the host, which is
+	// independent of where the controller process is mounted.
+	cacheMgr := cache.New(st, dock, st.InstanceID())
+
+	s := &Controller{
+		log:                 log,
+		shippedCapsuleImage: capsuleImg,
+		store:               st,
+		objects:             dock,
+		caps:                capsule.NewLauncher(dock, capsuleImg),
+		wait:                dock,
+		leases:              lease.NewManager(st, dock, log),
+		cache:               cacheMgr,
+		alloc:               newAllocator(cfg),
+		leaseHistory:        cfg.Retention.Window(),
+		netSandbox:          netSandbox,
+		cgroupDriver:        hostInfo.CgroupDriver,
+		byBinding:           map[int64]*binding{},
+	}
+	s.disk = newDiskMonitor(cfg, log, st, dock, cacheMgr, s.alloc, capsuleImg)
+	// Before any binding serves: resuming an emergency is what holds the
+	// credit pool shut, and admitting into one is the failure it prevents.
+	if err := s.disk.resume(ctx); err != nil {
+		return fmt.Errorf("resume disk pressure: %w", err)
+	}
+	s.launch = func(b *binding, lease store.Lease) { s.runCapsule(b, lease) }
+	if err := s.buildBindings(ctx, cfg, opts.Environ); err != nil {
+		return err
+	}
+
+	if err := s.reconcile(ctx); err != nil {
+		return fmt.Errorf("startup reconciliation: %w", err)
+	}
+
+	owner := "runpool-" + st.InstanceID()[:8]
+	for _, b := range s.bindings {
+		b.newSession = func(ctx context.Context) (providerSession, error) {
+			return b.gh.OpenSession(ctx, b.scaleSetID, owner)
+		}
+		defer func(b *binding) {
+			// A session the broker still holds is one the next start has
+			// to wait out, and it reports that wait as a predecessor's
+			// crash. Saying so here is what tells the two apart.
+			if b.session == nil {
+				return // never opened, or discarded by the loop
+			}
+			cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			if err := b.session.Close(cctx); err != nil {
+				log.Warn("cannot close the message session; the broker holds it until it "+
+					"expires and the next start waits that out",
+					"binding", b.key, "error", err)
+			}
+		}(b)
+	}
+
+	var loops sync.WaitGroup
+	loops.Add(1)
+	go func() {
+		defer loops.Done()
+		s.periodicReconcile(ctx)
+	}()
+	loops.Add(1)
+	go func() {
+		defer loops.Done()
+		s.disk.run(ctx)
+	}()
+	loops.Add(1)
+	go func() {
+		defer loops.Done()
+		s.netSandbox.watch(ctx)
+	}()
+	for _, b := range s.bindings {
+		loops.Add(1)
+		go func(b *binding) {
+			defer loops.Done()
+			s.loop(ctx, b)
+		}(b)
+	}
+	loops.Wait()
+	return s.drain()
+}
+
+func newAllocator(cfg *config.Config) *allocator.Allocator {
+	if cfg.Scheduling.Parallelism == nil {
+		return allocator.New()
+	}
+	return allocator.NewWithGlobalParallelism(*cfg.Scheduling.Parallelism)
+}
+
+// capsuleRuntime is what serving needs from the capsule layer, defined
+// here because the consumer owns its interfaces. The fault matrix
+// depends on this seam: preparation, start and inspection failures are
+// exactly the outcomes Docker cannot be asked to produce on demand.
+type capsuleRuntime interface {
+	Prepare(ctx context.Context, spec capsule.Spec, rec capsule.ResourceRecorder) (capsule.PreparedRuntime, error)
+	Start(ctx context.Context, prepared capsule.PreparedRuntime) error
+	InspectExecution(ctx context.Context, prepared capsule.PreparedRuntime) (assignment.ExecutionObservation, error)
+}
+
+// runtimeWaiter is the slice of the Docker client the serving loop
+// awaits runners through.
+type runtimeWaiter interface {
+	WaitExit(ctx context.Context, id string) (int64, error)
+	TailLogs(ctx context.Context, id string, lines int) (string, error)
+}
+
+// runnerRegistry is what a binding needs from its provider client while
+// serving: mint one JIT credential, deregister one runner.
+type runnerRegistry interface {
+	GenerateJITConfig(ctx context.Context, scaleSetID int, runnerName, workFolder string) (githubactions.JITConfig, error)
+	RemoveRunner(ctx context.Context, id int) error
+}
+
+// scaleSetRegistry is what a binding needs from its provider client
+// before serving: create or adopt its scale set. Declared here, like the
+// seam above, because the loop has to get its failure right — an
+// unreachable provider is a retry, not the end of the process — and that
+// is only testable against a registry that fails on demand.
+type scaleSetRegistry interface {
+	EnsureScaleSet(ctx context.Context, groupName, name string, knownID int, intended bool) (githubactions.ScaleSet, error)
+}
+
+// providerSession is the message session as the serving loop uses it.
+//
+// Declared here, like the seams above, because what the loop has to get
+// right is the session failing: the upstream client refreshes an expired
+// session by itself, and when that refresh fails it leaves the handle
+// dead. Polling a dead handle is indistinguishable from a quiet provider
+// unless the loop can be shown one.
+type providerSession interface {
+	Receive(ctx context.Context) (*githubactions.Message, error)
+	Acknowledge(ctx context.Context, messageID int) error
+	SetCapacity(n int)
+	Initial() *githubactions.Statistics
+	Close(ctx context.Context) error
+}
+
+// ownedObjects is what reconciliation needs from the daemon: the
+// inventory of everything this instance labelled, and the removal of one
+// of them. Nothing here creates.
+//
+// Narrow, and declared by the consumer, for the same reason as the
+// seams above: what reconciliation has to get right is the daemon
+// refusing — a container that will not die, an inventory that cannot be
+// read — and a live daemon cannot be asked for those on demand. Held as
+// this interface rather than the client itself, the whole startup and
+// sweep path becomes reachable from a test.
+type ownedObjects interface {
+	ListOwnedContainers(ctx context.Context, instanceID string) ([]docker.OwnedContainer, error)
+	ListOwnedNetworks(ctx context.Context, instanceID string) ([]docker.OwnedResource, error)
+	ListOwnedVolumes(ctx context.Context, instanceID string) ([]docker.OwnedResource, error)
+	RemoveContainer(ctx context.Context, id string) error
+	RemoveNetwork(ctx context.Context, id string) error
+	RemoveVolume(ctx context.Context, name string) error
+}
+
+// Controller is the running instance: it owns the durable store, the
+// daemon connection, the credit pool and the loops that keep them
+// agreeing with each other. One process, one state directory, one
+// Controller — the singleton lock enforces it.
+type Controller struct {
+	log *slog.Logger
+	// shippedCapsuleImage is the capsule this build carries. A binding
+	// launches its own resolved image; this is what a tier falls back to,
+	// and what the disk monitor probes with.
+	shippedCapsuleImage string
+	// pollBackoff is the pause between failed polls; zero means the
+	// package default. It exists so the session-recovery path is
+	// reachable from a test without waiting out real seconds.
+	pollBackoff time.Duration
+	// conflictBackoff overrides sessionConflictBackoff for the loop's
+	// reopen path; zero means the package default. Held for the same
+	// reason as pollBackoff: ten seconds is not something a test waits.
+	conflictBackoff time.Duration
+	store           *store.Store
+	// objects is the daemon as reconciliation sees it: an inventory and
+	// a way to remove from it. Creating capsules goes through caps, and
+	// awaiting them through wait.
+	objects ownedObjects
+	caps    capsuleRuntime
+	wait    runtimeWaiter
+	// leases owns the lease machine and the cleanup saga. Everything
+	// about ending a capsule's life lives there; the controller decides
+	// when, and who has to be told.
+	leases *lease.Manager
+	cache  *cache.LaneManager
+	alloc  *allocator.Allocator
+
+	// inFlight holds the id of every lease a goroutine is currently
+	// driving. It is what tells the periodic reconciler which live leases
+	// are stranded — nobody's — and which are simply being worked on, and
+	// it is the mutual exclusion that keeps two owners from releasing the
+	// same admission credit twice.
+	inFlight sync.Map
+
+	// disk owns the pressure level and everything that moves it. The
+	// controller reads the level in force on the admission path and does
+	// not otherwise take part.
+	disk *diskMonitor
+
+	// leaseHistory is how long a finished lease's record is kept; zero
+	// keeps every one. Captured at construction rather than read back out
+	// of the configuration, because the only *config.Config the
+	// controller holds belongs to the network sandbox.
+	leaseHistory time.Duration
+
+	// netSandbox owns the restricted profile's egress policy: the deny
+	// set, the snapshot each launch is cut from, and the installs into
+	// running gateways. Nil is the explicit unsafe-open-egress profile,
+	// which its own methods answer for.
+	netSandbox *networkSandbox
+
+	// cgroupDriver is the daemon's driver, read once at startup. It
+	// decides the form of a lease's parent cgroup, and the daemon
+	// rejects the wrong form outright.
+	cgroupDriver string
+
+	bindings  []*binding
+	byBinding map[int64]*binding // store binding id -> binding
+
+	// launch runs one served attempt. Production points it at
+	// runCapsule; tests replace it to drive the assignment machine
+	// through failures Docker and GitHub cannot be asked to produce.
+	launch func(b *binding, lease store.Lease)
+
+	wg sync.WaitGroup // capsule goroutines, for drain
+}
+
+func (s *Controller) drain() error {
+	s.log.Info("draining")
+	done := make(chan struct{})
+	go func() { s.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		s.log.Info("drained cleanly")
+		return nil
+	case <-time.After(drainTimeout):
+		s.log.Warn("drain window elapsed; live capsules will be adopted on next start")
+		return nil
+	}
+}
+
+// claimLease takes ownership of a lease's recovery. It reports false when
+// another goroutine already holds it, which is what keeps the periodic
+// reconciler off a lease that is still being driven — and keeps two owners
+// from each concluding the lease is done and releasing its credit.
+func (s *Controller) claimLease(leaseID string) bool {
+	_, loaded := s.inFlight.LoadOrStore(leaseID, struct{}{})
+	return !loaded
+}
+
+func (s *Controller) releaseLease(leaseID string) { s.inFlight.Delete(leaseID) }

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -1,0 +1,409 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+)
+
+// stubSession is a message session a test can break on purpose. The
+// upstream client refreshes an expired session by itself, so the failure
+// this stands in for is the one after that refresh has already failed:
+// a handle that answers every poll the same way, forever.
+type stubSession struct {
+	mu       sync.Mutex
+	receives int
+	closes   int
+
+	// fail is returned from every Receive. When block is set, Receive
+	// waits for cancellation instead — the shape of a session that works.
+	// offerErr answers every poll with a message the session could not
+	// turn into work: the poll succeeded, the acquisition did not.
+	fail     error
+	block    bool
+	offerErr error
+
+	// backlog is what this session reports it opened holding.
+	backlog *githubactions.Statistics
+
+	// polled closes on the first Receive. Waiting on it is what proves
+	// the binding is holding this session and not merely that a
+	// replacement was built.
+	polled chan struct{}
+	once   sync.Once
+}
+
+func (s *stubSession) Receive(ctx context.Context) (*githubactions.Message, error) {
+	s.mu.Lock()
+	s.receives++
+	s.mu.Unlock()
+	if s.polled != nil {
+		s.once.Do(func() { close(s.polled) })
+	}
+	if s.offerErr != nil {
+		// A fresh id per poll, as the broker sends: reusing one makes the
+		// delivery a repeat the store already knows, which returns before
+		// the session is touched and hides everything downstream of it.
+		s.mu.Lock()
+		id := s.receives
+		s.mu.Unlock()
+		return &githubactions.Message{ID: id, AcquireError: s.offerErr}, nil
+	}
+	if s.block {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, s.fail
+}
+
+func (s *stubSession) Acknowledge(context.Context, int) error { return nil }
+func (s *stubSession) SetCapacity(int)                        {}
+func (s *stubSession) Initial() *githubactions.Statistics     { return s.backlog }
+
+func (s *stubSession) Close(context.Context) error {
+	s.mu.Lock()
+	s.closes++
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *stubSession) counts() (receives, closes int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.receives, s.closes
+}
+
+// TestARepeatedlyFailingSessionIsReplaced is the recovery a dead session
+// needs. A refresh the upstream client could not complete leaves the
+// handle unusable, and every later poll fails identically — so retrying
+// the same handle is not recovery, it is a binding that has stopped
+// working while the process reports itself healthy.
+func TestARepeatedlyFailingSessionIsReplaced(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+
+	broken := &stubSession{fail: errors.New("session id does not exist")}
+	replacement := &stubSession{block: true, polled: make(chan struct{})}
+
+	h.bind.session = broken
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		return replacement, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+
+	// Waiting for the replacement to be polled, not merely built: the
+	// binding has recovered only once it is the one being asked.
+	select {
+	case <-replacement.polled:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-done
+		receives, _ := broken.counts()
+		t.Fatalf("the binding still polled the dead session after %d failures; a dead "+
+			"handle retried forever is a binding that stopped serving in silence", receives)
+	}
+
+	cancel()
+	<-done
+
+	receives, closes := broken.counts()
+	if receives < receiveFailuresBeforeReopen {
+		t.Errorf("the session was replaced after %d failures; want at least %d, or a "+
+			"single transient failure costs a session", receives, receiveFailuresBeforeReopen)
+	}
+	if closes != 1 {
+		t.Errorf("the failing session was closed %d times; want exactly 1 — a session the "+
+			"broker still holds is one the next start has to wait out", closes)
+	}
+}
+
+// TestASessionThatRecoversIsNotReplaced keeps the previous test from
+// passing for the wrong reason: a transient failure must cost a retry,
+// not a session.
+//
+// It runs three failure runs, each one short of the threshold, separated
+// by a poll that succeeds - once empty, once carrying a message. Those
+// are the two shapes a healthy cycle takes and each has its own reset, so
+// dropping either one lets a later run reach the threshold and replace a
+// session that was only ever unlucky.
+func TestASessionThatRecoversIsNotReplaced(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+
+	const shortOfThreshold = receiveFailuresBeforeReopen - 1
+	if shortOfThreshold < 1 {
+		t.Fatalf("receiveFailuresBeforeReopen is %d; a run shorter than the threshold "+
+			"needs at least one failure to be a run at all", receiveFailuresBeforeReopen)
+	}
+	flaky := &intermittentSession{
+		failuresPerRun: shortOfThreshold,
+		settled:        make(chan struct{}),
+	}
+	h.bind.session = flaky
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		t.Error("a session that recovered between runs was replaced anyway")
+		return &stubSession{block: true}, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	select {
+	case <-flaky.settled:
+	case <-time.After(10 * time.Second):
+		t.Error("the flaky session never got through both failure runs")
+	}
+	cancel()
+	<-done
+}
+
+// intermittentSession fails in runs, recovering between them. Each
+// recovery is a different shape of healthy cycle: an empty long poll,
+// then a message that carries nothing to acquire.
+type intermittentSession struct {
+	mu             sync.Mutex
+	seen           int
+	failuresPerRun int
+
+	// settled closes once every run and both recoveries are behind it -
+	// the point at which a counter that missed either reset would have
+	// replaced this session.
+	settled chan struct{}
+	once    sync.Once
+}
+
+func (s *intermittentSession) Receive(ctx context.Context) (*githubactions.Message, error) {
+	s.mu.Lock()
+	s.seen++
+	n, perRun := s.seen, s.failuresPerRun
+	s.mu.Unlock()
+
+	switch {
+	case n <= perRun:
+		return nil, errors.New("transient")
+	case n == perRun+1:
+		return nil, nil // the empty long poll
+	case n <= 2*perRun+1:
+		return nil, errors.New("transient")
+	case n == 2*perRun+2:
+		return &githubactions.Message{ID: n}, nil // a message, nothing to acquire
+	case n <= 3*perRun+2:
+		return nil, errors.New("transient")
+	}
+	s.once.Do(func() { close(s.settled) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *intermittentSession) Acknowledge(context.Context, int) error { return nil }
+func (s *intermittentSession) SetCapacity(int)                        {}
+func (s *intermittentSession) Initial() *githubactions.Statistics     { return nil }
+func (s *intermittentSession) Close(context.Context) error            { return nil }
+
+// TestAFailedReopenDoesNotKeepTheDeadSession. Recovery can fail: the
+// broker is unreachable, or still holds the session that was just closed.
+// What must not survive that is the handle itself. Left in place it is
+// polled and announced through for another full run of failures, and
+// shutdown closes it a second time and reports a broker holding a session
+// nobody holds — which is how a false alarm is manufactured out of an
+// orderly stop.
+func TestAFailedReopenDoesNotKeepTheDeadSession(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+
+	dead := &stubSession{fail: errors.New("session id does not exist")}
+	replacement := &stubSession{block: true, polled: make(chan struct{})}
+
+	var attempts int
+	h.bind.session = dead
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, errors.New("the broker still holds this session")
+		}
+		return replacement, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+
+	select {
+	case <-replacement.polled:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("the binding never recovered across repeated reopen failures")
+	}
+	cancel()
+	<-done
+
+	receives, closes := dead.counts()
+	if receives != receiveFailuresBeforeReopen {
+		t.Errorf("the dead session was polled %d times; want exactly %d — after the run "+
+			"that gave it up, nothing may reach it again", receives, receiveFailuresBeforeReopen)
+	}
+	if closes != 1 {
+		t.Errorf("the dead session was closed %d times; want exactly 1, or shutdown "+
+			"reports a broker holding a session nobody holds", closes)
+	}
+	if attempts != 3 {
+		t.Errorf("the binding made %d open attempts; want 3 — a failed open must be "+
+			"retried by the loop, not counted as recovery", attempts)
+	}
+}
+
+// TestASessionThatCannotAcquireIsReplaced. A poll and an acquisition go
+// through the same handle and the same token refresh, so a session whose
+// refresh has failed can keep answering polls while failing every
+// acquisition. Counted only as a log line, that binding collects offers
+// it can never turn into work for as long as the process runs.
+func TestASessionThatCannotAcquireIsReplaced(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+
+	cannotAcquire := &stubSession{offerErr: errors.New("acquire 1 offered jobs: 401")}
+	replacement := &stubSession{block: true, polled: make(chan struct{})}
+
+	h.bind.session = cannotAcquire
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		return replacement, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+
+	select {
+	case <-replacement.polled:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-done
+		receives, _ := cannotAcquire.counts()
+		t.Fatalf("the binding kept the session that failed %d acquisitions; a handle that "+
+			"can never acquire is one that has stopped serving", receives)
+	}
+	cancel()
+	<-done
+}
+
+// TestAReopenedSessionPublishesItsBacklog. Serve feeds the first
+// session's assigned backlog to the allocator before any loop runs, so a
+// binding with waiting work is not outbid by an idle one. A replacement
+// carries its own backlog and must do the same: left at the dead
+// session's last figure, a binding recorded at zero demand is one the
+// free credit is never shared with, and the queue it is holding never
+// drains.
+func TestAReopenedSessionPublishesItsBacklog(t *testing.T) {
+	h := newHarness(t, 4)
+	h.srv.pollBackoff = time.Millisecond
+
+	// A second binding in the same pool, holding demand of its own. The
+	// credit is water-filled by demand, so the recovered binding only
+	// out-advertises this one if its replacement's backlog was published;
+	// at zero demand it is left with the discovery credit, which this
+	// one's demand of 1 matches.
+	const rival = "other/standard"
+	if err := h.srv.alloc.Register(h.bind.tier.ID, rival, 4); err != nil {
+		t.Fatal(err)
+	}
+	h.srv.alloc.SetAssignedDemand(rival, 1)
+	h.srv.alloc.SetAssignedDemand(h.bind.key, 0)
+
+	dead := &stubSession{fail: errors.New("session id does not exist")}
+	replacement := &stubSession{
+		block:   true,
+		polled:  make(chan struct{}),
+		backlog: &githubactions.Statistics{Assigned: 3},
+	}
+
+	h.bind.session = dead
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		return replacement, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	select {
+	case <-replacement.polled:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("the binding never recovered")
+	}
+	cancel()
+	<-done
+
+	recovered, other := h.srv.alloc.Advertised(h.bind.key), h.srv.alloc.Advertised(rival)
+	if recovered <= other {
+		t.Errorf("the recovered binding advertises %d against a rival's %d; its "+
+			"replacement session's assigned backlog never reached the allocator",
+			recovered, other)
+	}
+}
+
+// TestAReopenConflictWaitsAtItsOwnInterval. The broker holding this
+// binding's previous session is the expected shape of the reopen path -
+// the close that gave it up fails there by design - so the loop must
+// recognise the conflict and wait at the conflict's interval rather than
+// hammering the generic retry. The generic backoff is set prohibitively
+// high: if the conflict branch stops being taken, recovery blows the
+// test's deadline instead of passing by accident.
+func TestAReopenConflictWaitsAtItsOwnInterval(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Hour
+	h.srv.conflictBackoff = time.Millisecond
+
+	replacement := &stubSession{block: true, polled: make(chan struct{})}
+
+	// No session at all: the loop's first act is the open, which is the
+	// state a discarded session leaves behind.
+	var attempts int
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, errors.New(`the session "abc" already exists, status="409 Conflict"`)
+		}
+		return replacement, nil
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	select {
+	case <-replacement.polled:
+	case <-time.After(10 * time.Second):
+		cancel()
+		<-done
+		t.Fatal("the binding never recovered through the conflict; the reopen is not " +
+			"recognising a 409 and is waiting out the generic backoff instead")
+	}
+	cancel()
+	<-done
+}

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -1,0 +1,100 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestReconcileAdoptsWhatIsStillRunning. A restart finds leases the
+// crashed process left behind, and the whole question is which of them
+// are still doing work. One with a running capsule is adopted and awaited
+// — its job is alive and killing it would lose the run. One whose capsule
+// is gone is resolved and released, because nothing will finish it.
+//
+// Adoption also claims the lease before its goroutine exists: a periodic
+// pass that saw it ownerless in that window would tear down a capsule
+// that is still running.
+func TestReconcileAdoptsWhatIsStillRunning(t *testing.T) {
+	h := newHarness(t, 2)
+	if err := h.deliver(demand("job-alive", "p1", 1), demand("job-dead", "p1", 2)); err != nil {
+		t.Fatal(err)
+	}
+	alive, _ := leaseFor(t, h, "job-alive")
+	dead, _ := leaseFor(t, h, "job-dead")
+	for _, l := range []store.Lease{alive, dead} {
+		h.inStore(func(tx *store.Tx) error {
+			return tx.TransitionLease(l.ID, store.LeaseReserved, store.LeaseProvisioning)
+		})
+	}
+
+	h.objects.containers = []docker.OwnedContainer{
+		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: alive.ID, Running: true},
+	}
+	h.srv.caps = &fakeCapsule{obs: assignment.ObservedAbsent}
+	h.srv.wait = &fakeWaiter{}
+
+	if err := h.srv.reconcile(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	h.srv.wg.Wait()
+
+	// The adopted lease was awaited to its exit and then released; the
+	// one with no capsule was resolved without ever being awaited.
+	if got := reloadLease(t, h, alive.ID); got.State != store.LeaseReleased {
+		t.Errorf("the adopted lease is %s; want released once its capsule exited", got.State)
+	}
+	if got := reloadLease(t, h, dead.ID); !got.State.Terminal() {
+		t.Errorf("a lease with no capsule left is %s; nothing will ever finish it", got.State)
+	}
+	// Its container is not swept: adoption is what exempts it, and
+	// sweeping a running capsule's objects is the failure that matters.
+	for _, id := range h.objects.removed {
+		if id == "runner-alive" {
+			t.Error("the sweep removed the container of a capsule it had just adopted")
+		}
+	}
+}
+
+// TestReconcileFailsWhenTheDaemonCannotBeRead: startup that cannot see
+// the daemon has proven nothing about what is running, and continuing
+// would mean deciding every lease's fate against an inventory that was
+// never read.
+func TestReconcileFailsWhenTheDaemonCannotBeRead(t *testing.T) {
+	h := newHarness(t, 1)
+	h.objects.listErr = errDaemon
+
+	if err := h.srv.reconcile(t.Context()); err == nil {
+		t.Error("reconciliation succeeded without reading the daemon")
+	}
+}
+
+// TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn. The periodic sweep runs
+// beside live work, so its keep set is the live leases plus the ones a
+// goroutine currently owns. A lease in flight whose objects were swept
+// would have its capsule destroyed underneath it.
+func TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-1", "p1", 1)); err != nil {
+		t.Fatal(err)
+	}
+	live, _ := leaseFor(t, h, "job-1")
+	h.objects.containers = []docker.OwnedContainer{
+		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: live.ID, Running: true},
+		{ID: "runner-orphan", Role: capsule.RoleCapsule, LeaseID: "lse-vanished"},
+	}
+
+	h.srv.sweepPeriodically(t.Context())
+
+	for _, id := range h.objects.removed {
+		if id == "runner-live" {
+			t.Fatal("the periodic sweep removed a live lease's capsule")
+		}
+	}
+	if len(h.objects.removed) != 1 || h.objects.removed[0] != "runner-orphan" {
+		t.Errorf("swept %v; want the object of the lease that no longer exists", h.objects.removed)
+	}
+}

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -1,0 +1,75 @@
+package app
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// TestSweepOrphansSparesWhatIsNotGarbage drives the sweep at its own call
+// site, which is where its mistakes are destructive. Four rules meet
+// here, and each one protects something different from being deleted:
+// an adopted lease's objects are in use, a helper still measuring is the
+// instance's own, persistent infrastructure carries no lease on purpose,
+// and everything else is what a sweep exists to collect.
+func TestSweepOrphansSparesWhatIsNotGarbage(t *testing.T) {
+	h := newHarness(t, 1)
+	h.objects.containers = []docker.OwnedContainer{
+		{ID: "runner-live", Role: "capsule", LeaseID: "lse-adopted", Running: true},
+		{ID: "runner-done", Role: "capsule", LeaseID: "lse-gone"},
+		{ID: "probe-running", Role: "probe", Running: true},
+		{ID: "probe-leaked", Role: "probe"},
+	}
+	h.objects.networks = []docker.OwnedResource{
+		{ID: "uplink", Role: "uplink"},
+		{ID: "net-gone", Role: "capsule-net", LeaseID: "lse-gone"},
+	}
+	h.objects.volumes = []docker.OwnedResource{
+		{ID: "lane", Role: "cache-lane"},
+		{ID: "vol-gone", Role: "dind-data", LeaseID: "lse-gone"},
+	}
+
+	if err := h.srv.sweepOrphans(t.Context(), map[string]bool{"lse-adopted": true}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"runner-done", "probe-leaked", "net-gone", "vol-gone"}
+	if !slices.Equal(h.objects.removed, want) {
+		t.Errorf("swept %v;\nwant only lease garbage and a leaked helper, in dependency order: %v",
+			h.objects.removed, want)
+	}
+}
+
+// TestSweepOrphansSurvivesAnObjectThatWillNotDie: one wedged object used
+// to abort startup with no retry, while the per-lease intent saga books
+// backoff for the very same work. The pass now counts it and keeps
+// going, so the objects behind it are still collected and the next sweep
+// finds the survivor by its labels.
+func TestSweepOrphansSurvivesAnObjectThatWillNotDie(t *testing.T) {
+	h := newHarness(t, 1)
+	h.objects.containers = []docker.OwnedContainer{{ID: "wedged", Role: "capsule", LeaseID: "lse-gone"}}
+	h.objects.networks = []docker.OwnedResource{{ID: "net-gone", Role: "capsule-net", LeaseID: "lse-gone"}}
+	h.objects.volumes = []docker.OwnedResource{{ID: "vol-gone", Role: "dind-data", LeaseID: "lse-gone"}}
+	h.objects.wedged["wedged"] = true
+
+	if err := h.srv.sweepOrphans(t.Context(), nil); err != nil {
+		t.Fatalf("one object that would not die failed the whole pass: %v", err)
+	}
+	if !slices.Equal(h.objects.removed, []string{"net-gone", "vol-gone"}) {
+		t.Errorf("swept %v; the limbs after the wedged object must still run", h.objects.removed)
+	}
+}
+
+// TestSweepOrphansFailsOnAnUnreadableInventory: a sweep that cannot see
+// the daemon has proven nothing, and reporting an empty inventory as a
+// clean one is how it would delete nothing and claim success.
+func TestSweepOrphansFailsOnAnUnreadableInventory(t *testing.T) {
+	h := newHarness(t, 1)
+	h.objects.listErr = errors.New("daemon unreachable")
+
+	if err := h.srv.sweepOrphans(t.Context(), nil); err == nil {
+		t.Error("an unreadable inventory was reported as nothing to sweep")
+	}
+}

--- a/scripts/verify/image-lock.sh
+++ b/scripts/verify/image-lock.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Re-resolve every tag in the image lock against its registry and fail if
+# a digest has drifted. The lock is what the controller executes, so
+# drift means the privileged payload changed under a name already
+# reviewed. Needs network and `docker buildx`; the hermetic half — the
+# embedded copy matching the reviewed copy — is a Go test
+# (internal/app/images_lock_test.go) and runs with the ordinary suite.
+#
+# Usage: scripts/verify/image-lock.sh
+cd "$(dirname "$0")/../.."
+lock=build/images.lock.json
+status=0
+
+names=$(python3 -c 'import json,sys; print(" ".join(json.load(open(sys.argv[1]))["images"]))' "$lock")
+for name in $names; do
+  ref=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["images"][sys.argv[2]]["ref"])' "$lock" "$name")
+  want=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["images"][sys.argv[2]]["digest"])' "$lock" "$name")
+  if ! got=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '"'); then
+    echo "FAIL  $name ($ref): registry unreachable, so the digest could not be verified"
+    status=1
+    continue
+  fi
+  if [ "$got" = "$want" ]; then
+    echo "ok    $name $ref"
+  else
+    echo "FAIL  $name $ref: lock says $want, registry says $got"
+    status=1
+  fi
+done
+exit $status


### PR DESCRIPTION
## What changes

`internal/app` arrives: the controller process. It composes the packages
already present into the delivery loop, the runtime that drives a
capsule, the reconciler that adopts and cleans what it finds at startup,
the disk monitor, and an ordered shutdown. The reviewed image lock and
the registry-drift check arrive with it.

## What was found

**Ordering inside the binding loop is load-bearing.** Scheduling ready
attempts before the scale set is ensured advertises capacity for
something that may not exist, and the provider will assign work against
it. Ensuring first means capacity is only ever announced for a scale set
that is there to receive it.

**A session conflict at restart is not a provider failure.** One session
per scale set is the provider's rule, and the previous process's session
survives the process. A restart therefore meets a conflict as a matter of
course, and recording it as a failed provider contact marks a healthy
deployment unreachable on every restart — which then suppresses the very
work it was restarting to do. It is treated as expected until it outlasts
a grace period, and recorded as a failure only after that.

**The scale-set id is written as an intention before the call.** If the
provider creates the scale set and the controller dies before recording
the id, the next start has no record of an object that exists and creates
a second one. Writing the intention first, and the real id afterwards
under a context that survives cancellation, means the recovery path has
something to find.

**The ceiling was below the provider's own maximum.** A two-hour limit on
a lease, against a provider maximum of 360 minutes, ends healthy jobs
that the provider would have allowed. The job message carries no
`timeout-minutes` field and there is no second call that returns one, so
the ceiling cannot be the job's timeout — it can only be a backstop
against a capsule that stops reporting. A backstop belongs above the
largest legitimate run: it defaults to eight hours and is per tier,
because the tier is where the workload's shape is already declared.

**Six hours would have been a tie, not a margin.** The provider's maximum
is 360 minutes, which is six hours exactly, so the two timeouts would
race and the winner would decide whether a job read as a provider timeout
or a Runpool backstop. Eight hours leaves room for the provider's
timeout to reach the runner, exit it, and be observed here.

**An incompatible capsule image is held for review.** Retrying cannot
resolve a protocol mismatch, and spending the retry budget on it replaces
a precise cause with a generic exhaustion.

**The two copies of the image lock must be identical bytes.** The
embedded copy is what the controller executes; the copy under `build/` is
what a person audits. Structural equality is not enough — two JSON
documents can be structurally equal while only one of them was reviewed.
A second test reads the capsule Dockerfile and requires every locked
`ref@digest` to appear in it, because the verification script re-resolves
the lock against its registry and never opens a Dockerfile: an update
that moved one and not the other would leave every check green while the
reviewed record stopped describing the privileged payload.

## Evidence

The hermetic suite runs in CI and covers the loop ordering, the session
conflict grace, the credit accounting, the reconciler's adoption paths,
disk pressure and the lock parity. The registry half of the lock check
ran here against the live registries.

```text
scripts/verify/image-lock.sh
ok    runner ghcr.io/actions/actions-runner:2.336.0
ok    dind docker:29.7.2-dind
```

## What would notice this regressing

`internal/app`'s suite fails if ready attempts are scheduled before the
scale set is ensured, if a session conflict is recorded as a provider
failure before the grace period elapses, if the scale-set intention stops
being written before the provider call, or if an incompatible capsule
image is retried instead of held. `TestEmbeddedImageLockMatchesTheReviewedCopy`
fails on any divergence between the two copies, and
`TestLockedImagesAreWhatTheCapsuleIsBuiltFrom` fails if the Dockerfile
stops building from the locked digests.

## Risk, compatibility and operations

Trust boundary: the controller holds the host's Docker socket, which
confers host-root authority, and it creates privileged capsules. This
change composes the existing boundaries; it does not widen any.

Credentials: resolved per call through the credential package and passed
to provider clients. Nothing is cached in state or written to a log.

Ownership and cleanup: the reconciler adopts what a previous process left
and drives orphans to removal, which is what makes a restart safe rather
than merely survivable.

Resource limits: admission credits are enforced here, and the per-tier
ceiling now defaults to eight hours instead of a fixed two.

Failure behaviour: an unreachable provider suppresses new work but does
not disturb running capsules; disk pressure closes admission before it
closes anything else.

Deployment and rollback: the ceiling is configurable per tier, so a
deployment that wants the old bound sets `jobTimeout: 2h`.

CLI, status API, runbook: N/A here — the command surface lands next.

Schema, migration: N/A — the schema this uses already exists.

Constrains what the code may do later, so the records arrive with it:
[the lease ceiling is a backstop above the provider's own maximum](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-17-job-timeout.md),
[a tier may name its capsule, and the capsule declares its protocol](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-17-capsule-image-substitution.md),
and [scheduling and swap semantics](https://github.com/rhobuild/runpool/blob/main/docs/adrs/2026-08-14-scheduling-and-swap.md).

## Changelog

```text
NONE
```
