### PR TITLE
feat(command): the command line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,10 @@ jobs:
         run: |
           go tool sqlc diff
           go tool sqlc vet
+      - name: Verify generated CLI documentation is current
+        run: |
+          go generate ./internal/command/...
+          git diff --exit-code docs/reference/cli
       - name: Verify the locked image digests have not drifted
         # Only the registry half: that each locked tag still resolves to the
         # digest recorded beside it. That the Dockerfiles build from those
@@ -100,6 +104,18 @@ jobs:
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
+      - name: Build the release binaries
+        # Static and cross-built for the platforms a release ships, so a
+        # build tag or a cgo dependency that only breaks elsewhere
+        # breaks here instead.
+        run: |
+          CGO_ENABLED=0 go build -trimpath -o /tmp/runpool ./cmd/runpool
+          for target in linux/amd64 linux/arm64 darwin/arm64; do
+            GOOS=${target%/*} GOARCH=${target#*/} CGO_ENABLED=0 \
+              go build -trimpath -o /dev/null ./cmd/runpool ./cmd/capsule-supervisor
+          done
+      - name: Verify the configuration examples still validate
+        run: /tmp/runpool config validate --file internal/config/testdata/example.yaml
 
   lint:
     name: workflows, scripts and containers

--- a/cmd/runpool/main.go
+++ b/cmd/runpool/main.go
@@ -1,0 +1,23 @@
+// Command runpool is the Runpool controller and operations CLI.
+package main
+
+import (
+	"os"
+
+	"github.com/rhobuild/runpool/internal/command"
+)
+
+// version is stamped by the release build; "dev" identifies local builds.
+var version = "dev"
+
+// capsuleImage is the immutable capsule artifact paired with this
+// controller. Development builds use a local tag; release builds stamp a
+// digest-qualified registry reference after that image is release-qualified.
+var capsuleImage = "runpool-capsule:dev"
+
+func main() {
+	os.Exit(command.Run(os.Args[1:], command.BuildInfo{
+		Version:      version,
+		CapsuleImage: capsuleImage,
+	}))
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,52 @@
+# CLI reference
+
+Generated from the command tree itself — `go generate ./internal/command/...`
+— so it cannot drift from what the binary does. Every page below is the
+same help text `runpool <command> --help` prints.
+
+| Command | What it does |
+| --- | --- |
+| [runpool](cli/runpool.md) | The root command and the global picture |
+| [version](cli/runpool_version.md) | Build version; `--json` adds commit, build time, toolchain, capsule digest and qualification reference |
+| [serve](cli/runpool_serve.md) | Run the controller |
+| [doctor](cli/runpool_doctor.md) | Check the host, storage and credentials |
+| [healthcheck](cli/runpool_healthcheck.md) | Container liveness and readiness probe |
+| [status](cli/runpool_status.md) | What this instance owns, and whether the books agree with the daemon |
+| [attempts](cli/runpool_attempts.md) | The work held for a person: [list](cli/runpool_attempts_list.md), [inspect](cli/runpool_attempts_inspect.md), [resolve](cli/runpool_attempts_resolve.md) |
+| [gc](cli/runpool_gc.md) | Collect cache lanes and finished lease records |
+| [cleanup](cli/runpool_cleanup.md) | Remove resources no live lease needs |
+| [uninstall](cli/runpool_uninstall.md) | Remove everything this instance owns |
+| [config](cli/runpool_config.md) | [validate](cli/runpool_config_validate.md) and [effective](cli/runpool_config_effective.md) |
+
+## Conventions the whole tree keeps
+
+**Exit codes.** `0` success, `1` an operational failure, `2` a usage
+error. A script can branch on the difference: `2` means the invocation
+was wrong, `1` means the world was.
+
+**Destructive commands preview by default.** `cleanup`, `gc` and
+`uninstall` print what they would do and change nothing until `--apply`
+(or, for `uninstall`, `--confirm=<instance-id>`). A wrong instance id
+is refused rather than approximated.
+
+**Usage is printed for a parse failure, never for an operational one.**
+If `uninstall` fails against a live daemon you get the error, not the
+flag list.
+
+**JSON output uses `snake_case` and always emits arrays for collections**
+— an empty one is `[]`, never `null`. A command asked for `--json`
+answers with a document in every case it can reach, including the one
+before this instance has ever run.
+
+**One document is a versioned contract**: `status --json` carries an
+`api_version` and is specified in [the status API
+reference](status-api.md). The other `--json` outputs — `version`,
+`doctor`, `attempts list` and `attempts inspect` — are reports rather
+than contracts. They carry no version, and a consumer parsing them should
+expect fields to be added.
+
+## Completions
+
+`go generate ./internal/command/...` writes bash, zsh and fish
+completions to `dist/completions/`. They are generated, not committed:
+a release publishes them, and a working tree regenerates them.

--- a/docs/reference/cli/runpool.md
+++ b/docs/reference/cli/runpool.md
@@ -1,0 +1,31 @@
+## runpool
+
+Docker-native autoscaling for ephemeral GitHub Actions runners
+
+### Synopsis
+
+Runpool coordinates GitHub Actions scale-set demand against a finite
+pool of per-job execution capsules on one Docker host.
+
+```
+runpool [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for runpool
+```
+
+### SEE ALSO
+
+* [runpool attempts](runpool_attempts.md)	 - The work held for a person, and how to decide it
+* [runpool cleanup](runpool_cleanup.md)	 - Remove resources no live lease needs (dry run by default)
+* [runpool config](runpool_config.md)	 - Validate and inspect the configuration
+* [runpool doctor](runpool_doctor.md)	 - Check the host, storage and credentials
+* [runpool gc](runpool_gc.md)	 - Collect cache lanes and finished lease records (dry run by default)
+* [runpool healthcheck](runpool_healthcheck.md)	 - Container health probe
+* [runpool serve](runpool_serve.md)	 - Run the controller (configuration from the environment)
+* [runpool status](runpool_status.md)	 - What this instance owns, and whether the books agree with the daemon
+* [runpool uninstall](runpool_uninstall.md)	 - Remove everything this instance owns
+* [runpool version](runpool_version.md)	 - Print the build version

--- a/docs/reference/cli/runpool_attempts.md
+++ b/docs/reference/cli/runpool_attempts.md
@@ -1,0 +1,20 @@
+## runpool attempts
+
+The work held for a person, and how to decide it
+
+```
+runpool attempts [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for attempts
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners
+* [runpool attempts inspect](runpool_attempts_inspect.md)	 - Show one attempt and its lifecycle events
+* [runpool attempts list](runpool_attempts_list.md)	 - List attempts waiting for a decision
+* [runpool attempts resolve](runpool_attempts_resolve.md)	 - Decide a held attempt (preview by default)

--- a/docs/reference/cli/runpool_attempts_inspect.md
+++ b/docs/reference/cli/runpool_attempts_inspect.md
@@ -1,0 +1,18 @@
+## runpool attempts inspect
+
+Show one attempt and its lifecycle events
+
+```
+runpool attempts inspect <attempt-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for inspect
+      --json   emit the attempt as JSON
+```
+
+### SEE ALSO
+
+* [runpool attempts](runpool_attempts.md)	 - The work held for a person, and how to decide it

--- a/docs/reference/cli/runpool_attempts_list.md
+++ b/docs/reference/cli/runpool_attempts_list.md
@@ -1,0 +1,19 @@
+## runpool attempts list
+
+List attempts waiting for a decision
+
+```
+runpool attempts list [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for list
+      --json           emit the list as JSON
+      --state string   attempt state to list: manual-review or ready (default "manual-review")
+```
+
+### SEE ALSO
+
+* [runpool attempts](runpool_attempts.md)	 - The work held for a person, and how to decide it

--- a/docs/reference/cli/runpool_attempts_resolve.md
+++ b/docs/reference/cli/runpool_attempts_resolve.md
@@ -1,0 +1,35 @@
+## runpool attempts resolve
+
+Decide a held attempt (preview by default)
+
+### Synopsis
+
+Decides work Runpool could not decide alone.
+
+--retry returns the attempt to the queue and it will run. Use it only
+after verifying outside Runpool — in the provider's own UI or API —
+that the workload never executed.
+
+--settle-may-have-run closes the attempt as possibly executed. It
+never runs again. Use it when execution cannot be ruled out.
+
+Without --apply this is a preview.
+
+```
+runpool attempts resolve <attempt-id> [flags]
+```
+
+### Options
+
+```
+      --actor string          who is deciding (default: $USER)
+      --apply                 perform the resolution (default is a preview)
+  -h, --help                  help for resolve
+      --reason string         why this decision is correct (required)
+      --retry                 return the attempt to the queue (verify externally that it never executed first)
+      --settle-may-have-run   close the attempt as possibly executed; it never runs again
+```
+
+### SEE ALSO
+
+* [runpool attempts](runpool_attempts.md)	 - The work held for a person, and how to decide it

--- a/docs/reference/cli/runpool_cleanup.md
+++ b/docs/reference/cli/runpool_cleanup.md
@@ -1,0 +1,18 @@
+## runpool cleanup
+
+Remove resources no live lease needs (dry run by default)
+
+```
+runpool cleanup [flags]
+```
+
+### Options
+
+```
+      --apply   perform the removals (default is a dry run)
+  -h, --help    help for cleanup
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_config.md
+++ b/docs/reference/cli/runpool_config.md
@@ -1,0 +1,19 @@
+## runpool config
+
+Validate and inspect the configuration
+
+```
+runpool config [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners
+* [runpool config effective](runpool_config_effective.md)	 - Print the defaulted, validated configuration
+* [runpool config validate](runpool_config_validate.md)	 - Validate a configuration file

--- a/docs/reference/cli/runpool_config_effective.md
+++ b/docs/reference/cli/runpool_config_effective.md
@@ -1,0 +1,19 @@
+## runpool config effective
+
+Print the defaulted, validated configuration
+
+```
+runpool config effective [flags]
+```
+
+### Options
+
+```
+      --file string   path to the configuration file (default: the environment)
+  -h, --help          help for effective
+      --redacted      accepted for forward compatibility; the schema holds secret references, never secret values, so nothing is redacted
+```
+
+### SEE ALSO
+
+* [runpool config](runpool_config.md)	 - Validate and inspect the configuration

--- a/docs/reference/cli/runpool_config_validate.md
+++ b/docs/reference/cli/runpool_config_validate.md
@@ -1,0 +1,18 @@
+## runpool config validate
+
+Validate a configuration file
+
+```
+runpool config validate [flags]
+```
+
+### Options
+
+```
+      --file string   path to the configuration file
+  -h, --help          help for validate
+```
+
+### SEE ALSO
+
+* [runpool config](runpool_config.md)	 - Validate and inspect the configuration

--- a/docs/reference/cli/runpool_doctor.md
+++ b/docs/reference/cli/runpool_doctor.md
@@ -1,0 +1,18 @@
+## runpool doctor
+
+Check the host, storage and credentials
+
+```
+runpool doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+      --json   emit the report as JSON
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_gc.md
+++ b/docs/reference/cli/runpool_gc.md
@@ -1,0 +1,19 @@
+## runpool gc
+
+Collect cache lanes and finished lease records (dry run by default)
+
+```
+runpool gc [flags]
+```
+
+### Options
+
+```
+      --aggressive   plan every free lane, not just expired and over-budget ones
+      --apply        perform the evictions (default is a dry run)
+  -h, --help         help for gc
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_healthcheck.md
+++ b/docs/reference/cli/runpool_healthcheck.md
@@ -1,0 +1,18 @@
+## runpool healthcheck
+
+Container health probe
+
+```
+runpool healthcheck [flags]
+```
+
+### Options
+
+```
+  -h, --help          help for healthcheck
+      --mode string   liveness or readiness (default "liveness")
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_serve.md
+++ b/docs/reference/cli/runpool_serve.md
@@ -1,0 +1,17 @@
+## runpool serve
+
+Run the controller (configuration from the environment)
+
+```
+runpool serve [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for serve
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_status.md
+++ b/docs/reference/cli/runpool_status.md
@@ -1,0 +1,18 @@
+## runpool status
+
+What this instance owns, and whether the books agree with the daemon
+
+```
+runpool status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+      --json   emit the status as JSON
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_uninstall.md
+++ b/docs/reference/cli/runpool_uninstall.md
@@ -1,0 +1,25 @@
+## runpool uninstall
+
+Remove everything this instance owns
+
+### Synopsis
+
+Removes every container, network and volume this instance owns,
+including cache lanes. The state volume is left for you to remove.
+Without --confirm it is a dry run and prints the exact command.
+
+```
+runpool uninstall [flags]
+```
+
+### Options
+
+```
+      --confirm string      the instance id being uninstalled
+      --delete-scale-sets   also delete this instance's scale sets from the provider
+  -h, --help                help for uninstall
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/cli/runpool_version.md
+++ b/docs/reference/cli/runpool_version.md
@@ -1,0 +1,19 @@
+## runpool version
+
+Print the build version
+
+```
+runpool version [flags]
+```
+
+### Options
+
+```
+      --check-release   fail unless this binary's version is a publishable SemVer release
+  -h, --help            help for version
+      --json            emit the build facts as JSON
+```
+
+### SEE ALSO
+
+* [runpool](runpool.md)	 - Docker-native autoscaling for ephemeral GitHub Actions runners

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -1,0 +1,116 @@
+# Status API reference
+
+`runpool status --json` emits a reporting document, not the database.
+Persistence rows change with migrations; this shape changes only with
+its `api_version`, so something reading it can be written once.
+
+**Current version: `v1`.** The product version and this document version move
+independently; consumers must reject unknown versions rather than interpreting
+them under the wrong schema.
+
+## Rules the document keeps
+
+- **`snake_case` throughout.** Persistence field names never appear; a
+  test asserts they have not leaked in.
+- **Collections are always arrays.** An empty one is `[]`, never
+  `null`, so a consumer branches on length rather than presence.
+- **`null` means absent, not empty.** `disk_pressure` is `null` before
+  the monitor has run once; `discrepancies` is `null` when the daemon
+  could not be reached, which is different from finding none.
+
+## Shape
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `api_version` | string | `v1` |
+| `instance` | string | This instance's opaque id |
+| `host_topology` | string | Effective `shared-daemon` or `dedicated-daemon`; `unknown` only when status cannot read configuration |
+| `schema_version` | number | The state schema in use |
+| `scheduling` | object, optional | Present when status can read configuration: `mode`, `instance_parallelism`, `effective_parallelism`, `active`, `available`, `queued`, and `tiers[]` |
+| `disk_pressure` | object or null | `level`, `free_bytes`, `free_inodes`, `managed_bytes`, `measured_at` |
+| `bindings` | array | `target_id`, `provider_kind`, `source_binding_key`, `desired_state`, and the provider reach fields below |
+| `leases` | array | `id`, `state`, `terminal`, `attempt_id`, `project`, `runtime_name`, `evidence`, `created_at`, `resources[]`. Every live lease, plus recent finished ones — see below |
+| `released_total` | number | How many finished leases the store holds, which is more than the `leases` array carries |
+| `cache_lanes` | array | `id`, `source_project_key`, `generation`, `leased_by`, `last_used` |
+| `manual_review` | array | Attempts held for a person: `id`, `workload`, `project`, `state`, `review_reason`, `age_seconds`, and once resolved `resolution` and `reviewed_by` |
+| `containers` | array | Owned containers: `name`, `role`, `lease_id`, `running` |
+| `networks`, `volumes` | array | Owned objects: `kind`, `role`, `name`, `lease_id` |
+| `discrepancies` | array or null | Where the books and the daemon disagree; `null` if the daemon could not be asked |
+| `docker_error` | string, optional | Why the daemon could not be asked |
+
+Each binding reports what its own loop last managed with its provider:
+`last_contact_at` when a provider call last succeeded, and `last_error`
+with `last_error_at` for what it cannot do now. A success clears the
+error, and a failure leaves the last success alone, so the pair says both
+how long a binding has been unreachable and what it is failing at. All
+three are absent on a binding that has not served yet.
+
+They are reported because nothing else in this document distinguishes an
+instance with no work to do from one reaching nothing: both hold no
+leases, and both answer every other field identically. A binding whose
+`last_error_at` is at or after its `last_contact_at` is not serving,
+however healthy the rest of the document looks — the two are recorded by
+the same loop pass and a tie means the failure came last.
+
+`scheduling.queued` is how many attempts wait for admission across every
+binding. An attempt waiting for admission holds no lease, so a queue that
+stopped draining is invisible in `leases`.
+
+`scheduling.mode` is `global` when `scheduling.parallelism` is configured and
+`independent-tiers` otherwise. `instance_parallelism` is the configured global
+value or `null`; `effective_parallelism` is the global value or the sum of tier
+limits. Each tier reports `id`, `parallelism`, `active`, currently
+admissible `available` capacity, and the `capsule_image` its jobs run in —
+the image the tier names, or the one this build ships. All unreleased leases count as active,
+including cleanup, failed, and quarantined leases.
+
+`leases` carries **every unreleased lease**, without exception — that set is
+what the instance is still responsible for, and a consumer may rely on it being
+complete. Released leases are **recent history, not all of it**: the array
+carries at most the **50** that finished most recently, so the document stays
+bounded by live work rather than by every job the host has ever run. A
+consumer may rely on that ceiling — it is the reason `released_total` exists.
+
+Both halves are ordered oldest first, but by different clocks, because they
+answer different questions. Unreleased leases are ordered by `created_at`: they
+are still running, so when each began is what ranks them. Released leases are
+ordered by `updated_at`, which for a finished lease is when it finished — a
+lease that was held for weeks and released a minute ago is recent history, and
+ranking it by its start would put it outside the window the array carries.
+
+`released_total` is how many finished leases the store holds. A consumer that
+needs that figure must read it there rather than measure the `leases` array,
+whose length is what the document reports and not what exists.
+
+## Vocabulary
+
+The document is provider neutral, and deliberately so: a consumer that
+parses `source_binding_key` is reading the wrong document. It is the
+provider's own identity, versioned and opaque here; for a GitHub Actions
+binding it reads as scope, URL, runner group and scale set name, which
+is enough to tell two bindings apart without knowing what any of it
+means.
+
+Lease states are `reserved`, `provisioning`, `runtime_registered`,
+`workload_running`, `draining`, `cleaning`, `released`, `failed`,
+`quarantined`. They describe the host resources an attempt consumes,
+never what the workload did — `evidence` is the attempt's, joined in
+here because a report is where the two belong side by side.
+
+## Discrepancies
+
+The comparison covers containers, networks **and** volumes. Judged from
+containers alone — as it once was — a leaked network was invisible to
+the one command that claims to answer whether the books agree.
+
+Instance infrastructure is recognised rather than flagged: the uplink
+network and cache lanes carry no lease on purpose, and reporting them
+as orphans would bury the real findings. What is reported:
+
+- a container, network or volume belonging to no live lease;
+- a lease claiming to be running with no container;
+- an owned object carrying neither a lease nor a persistent role.
+
+An unreachable daemon yields `discrepancies: null` and a
+`docker_error`, never an empty list — a report that compared nothing
+must not look like a clean one.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
+	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.56.0
 )
@@ -22,6 +23,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/cubicdaiya/gonp v1.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -64,7 +66,7 @@ require (
 	github.com/rhysd/actionlint v1.7.12 // indirect
 	github.com/riza-io/grpc-go v0.2.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/sqlc-dev/doubleclick v1.0.0 // indirect
 	github.com/sqlc-dev/sqlc v1.31.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151X
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cubicdaiya/gonp v1.0.4 h1:ky2uIAJh81WiLcGKBVD5R7KsM/36W6IqqTy6Bo6rGws=
 github.com/cubicdaiya/gonp v1.0.4/go.mod h1:iWGuP/7+JVTn02OWhRemVbMmG1DOUnmrGTYYACpOI0I=
@@ -144,6 +145,7 @@ github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=

--- a/internal/command/attempts.go
+++ b/internal/command/attempts.go
@@ -1,0 +1,228 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// attemptView is the reporting DTO: reporting rows are not persistence
+// rows, and this one adds the derived age an operator triages by.
+type attemptView struct {
+	ID           string `json:"id"`
+	Workload     string `json:"workload"`
+	Project      string `json:"project"`
+	State        string `json:"state"`
+	ReviewReason string `json:"review_reason,omitempty"`
+	Resolution   string `json:"resolution,omitempty"`
+	ReviewedBy   string `json:"reviewed_by,omitempty"`
+	AgeSeconds   int64  `json:"age_seconds"`
+	// Evidence is the furthest this attempt's execution was ever shown to
+	// have got. It is what a resolution turns on — retrying is safe only
+	// where the work provably never began — so a report that withheld it
+	// left the decision to be made without the fact it depends on.
+	// Reported by inspect; list is a triage view.
+	Evidence string `json:"evidence,omitempty"`
+	// Provider carries the provider's own identifiers, by name, for the
+	// external check resolving a held attempt requires. Empty when the
+	// provider recorded none.
+	Provider map[string]string `json:"provider,omitempty"`
+}
+
+func viewOf(a store.Attempt, now time.Time) attemptView {
+	return attemptView{
+		ID:           a.ID,
+		Workload:     a.SourceWorkloadKey,
+		Project:      a.TenantKey + "/" + a.ProjectKey,
+		State:        a.State,
+		ReviewReason: a.ReviewReason,
+		Resolution:   a.Resolution,
+		ReviewedBy:   a.ReviewedBy,
+		AgeSeconds:   int64(now.Sub(time.Unix(a.ReceivedAt, 0)).Seconds()),
+	}
+}
+
+// inReadOnlyStore runs fn against the read-only store: listing and
+// inspecting must not migrate — or create — a database a live
+// controller owns.
+func inReadOnlyStore(streams IO, asJSON bool, fn func(*store.Tx) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	st, err := store.OpenReadOnly(stateDir())
+	if errors.Is(err, store.ErrNoState) {
+		return reportNoState(streams, asJSON)
+	}
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+	return st.Tx(ctx, fn)
+}
+
+func runAttemptsList(streams IO, stateFilter string, asJSON bool) error {
+	if stateFilter != "manual-review" && stateFilter != "ready" {
+		// Capability-accurate: no silent empty answers for filters this
+		// command does not actually serve.
+		return usagef("attempts list serves --state manual-review and ready; %q is not wired", stateFilter)
+	}
+
+	return inReadOnlyStore(streams, asJSON, func(s *store.Tx) error {
+		attempts, err := listAttempts(s, stateFilter)
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		views := make([]attemptView, len(attempts))
+		for i, a := range attempts {
+			views[i] = viewOf(a, now)
+		}
+		if asJSON {
+			return json.NewEncoder(streams.Out).Encode(views)
+		}
+		if len(views) == 0 {
+			fmt.Fprintf(streams.Out, "no attempts in %s\n", stateFilter)
+			return nil
+		}
+		fmt.Fprintf(streams.Out, "%-22s %-28s %-24s %-24s %s\n", "ATTEMPT", "WORKLOAD", "PROJECT", "REASON", "AGE")
+		for _, v := range views {
+			fmt.Fprintf(streams.Out, "%-22s %-28s %-24s %-24s %s\n",
+				v.ID, v.Workload, v.Project, v.ReviewReason,
+				(time.Duration(v.AgeSeconds) * time.Second).String())
+		}
+		return nil
+	})
+}
+
+// listAttempts serves the two states an operator can act on: work held
+// for review, and work waiting for admission. Ready attempts are gathered
+// per binding because that is how the queue is keyed, and because an
+// operator asking why nothing runs wants to know which binding is holding
+// the backlog.
+func listAttempts(s *store.Tx, stateFilter string) ([]store.Attempt, error) {
+	if stateFilter == "manual-review" {
+		return s.ManualReviewAttempts()
+	}
+	bindings, err := s.Bindings()
+	if err != nil {
+		return nil, err
+	}
+	var out []store.Attempt
+	for _, b := range bindings {
+		ready, err := s.ReadyAttempts(b.ID)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ready...)
+	}
+	return out, nil
+}
+
+func runAttemptsInspect(streams IO, id string, asJSON bool) error {
+	return inReadOnlyStore(streams, asJSON, func(s *store.Tx) error {
+		attempt, err := s.Get(id)
+		if err != nil {
+			return err
+		}
+		events, err := s.Events(id)
+		if err != nil {
+			return err
+		}
+		refs, err := s.AttemptProviderReferences(id)
+		if err != nil {
+			return err
+		}
+		v := viewOf(attempt, time.Now())
+		v.Evidence = string(attempt.Evidence)
+		v.Provider = refs
+		if asJSON {
+			return json.NewEncoder(streams.Out).Encode(map[string]any{
+				"attempt": v,
+				"events":  events,
+			})
+		}
+		fmt.Fprintf(streams.Out, "attempt   %s\nworkload  %s\nproject   %s\nstate     %s\n",
+			v.ID, v.Workload, v.Project, v.State)
+		if v.Evidence != "" {
+			fmt.Fprintf(streams.Out, "evidence  %s\n", v.Evidence)
+		}
+		if v.ReviewReason != "" {
+			fmt.Fprintf(streams.Out, "held      %s\n", v.ReviewReason)
+		}
+		if v.Resolution != "" {
+			fmt.Fprintf(streams.Out, "resolved  %s by %s\n", v.Resolution, v.ReviewedBy)
+		}
+		for _, name := range slices.Sorted(maps.Keys(v.Provider)) {
+			fmt.Fprintf(streams.Out, "provider  %-18s %s\n", name, v.Provider[name])
+		}
+		fmt.Fprintln(streams.Out, "lifecycle:")
+		for _, ev := range events {
+			fmt.Fprintf(streams.Out, "  %s  %-28s %s\n",
+				time.Unix(ev.CreatedAt, 0).UTC().Format(time.RFC3339), ev.Kind, ev.Detail)
+		}
+		return nil
+	})
+}
+
+// runAttemptsResolve is the operator deciding held work. Exactly one of
+// retry and settle is a decision; both or neither is a person who has
+// not decided, and guessing which they meant is how a job runs twice.
+func runAttemptsResolve(streams IO, id string, retry, settle bool, reason, actor string, apply bool) error {
+	if retry == settle {
+		return usagef("choose exactly one of --retry and --settle-may-have-run")
+	}
+	if reason == "" {
+		return usagef("--reason is required: every resolution is audited")
+	}
+	if actor == "" {
+		actor = os.Getenv("USER")
+	}
+	if actor == "" {
+		return usagef("--actor is required: every resolution names its actor, and $USER is empty")
+	}
+
+	decision := "settle as may-have-run"
+	if retry {
+		decision = "retry"
+	}
+	if !apply {
+		fmt.Fprintf(streams.Out, "would %s attempt %s\n  actor:  %s\n  reason: %s\nre-run with --apply to perform it\n",
+			decision, id, actor, reason)
+		return nil
+	}
+
+	// The resolve mutates live scheduling state, so it takes the same
+	// singleton lock the controller holds: a resolution racing a live
+	// controller could requeue an attempt the controller is disposing.
+	lock, err := store.TryAcquire(stateDir())
+	if err != nil {
+		return fmt.Errorf("cannot take the maintenance lock: %w; stop the controller before resolving attempts", err)
+	}
+	defer lock.Release()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	st, err := store.Open(stateDir())
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+
+	if err := st.Tx(ctx, func(tx *store.Tx) error {
+		if retry {
+			return tx.ResolveReviewToReady(id, reason, actor)
+		}
+		return tx.ResolveReviewToSettled(id, assignment.ResolutionMayHaveExecuted, reason, actor)
+	}); err != nil {
+		return err
+	}
+	fmt.Fprintf(streams.Out, "attempt %s: %s (by %s)\n", id, decision, actor)
+	return nil
+}

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -1,0 +1,401 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/credential"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// Destructive commands default to dry-run: the operator must ask for the
+// change, and for uninstall must name the instance being destroyed.
+// Neither command ever prunes daemon-wide or touches a resource whose
+// ownership labels do not name this instance.
+
+func runCleanup(streams IO, apply bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	st, dock, unlock, err := openForMaintenance(ctx, apply)
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	defer st.Close()
+	defer dock.Close()
+
+	plan, err := planOwnedResources(ctx, st, dock)
+	if err != nil {
+		return err
+	}
+
+	// Cleanup removes what no live lease needs: resources belonging to
+	// released leases, and objects the books never recorded. A running
+	// capsule is left alone — stopping work is what drain is for.
+	keep := map[string]bool{}
+	snap, err := st.Snapshot()
+	if err != nil {
+		return err
+	}
+	for _, l := range snap.Leases {
+		if !l.State.Terminal() {
+			keep[l.ID] = true
+		}
+	}
+	removable := plan.exclude(keep)
+
+	if removable.empty() {
+		fmt.Fprintln(streams.Out, "nothing to clean up")
+		return nil
+	}
+	fmt.Fprint(streams.Out, removable.describe("would remove", apply))
+	if !apply {
+		fmt.Fprintln(streams.Out, "\nre-run with --apply to remove them")
+		return nil
+	}
+	if err := removable.remove(ctx, dock); err != nil {
+		return err
+	}
+	fmt.Fprintln(streams.Out, "cleanup complete")
+	return nil
+}
+
+func runUninstall(streams IO, confirm string, deleteScaleSets bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	st, dock, unlock, err := openForMaintenance(ctx, confirm != "")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	defer st.Close()
+	defer dock.Close()
+
+	snap, err := st.Snapshot()
+	if err != nil {
+		return err
+	}
+	plan, err := planOwnedResources(ctx, st, dock)
+	if err != nil {
+		return err
+	}
+
+	// The scale sets are the adapter's, read from its own metadata: the
+	// core knows bindings, and only this composition layer turns one
+	// back into something GitHub can be asked to delete.
+	var ghBindings []store.GitHubBinding
+	if deleteScaleSets {
+		if err := st.Tx(ctx, func(tx *store.Tx) error {
+			var err error
+			ghBindings, err = tx.GitHubBindings()
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+
+	dryRun := confirm == ""
+	// Before anything is described in the present tense. A wrong id is
+	// refused, and a command that will refuse must not first print the
+	// line it would print while removing.
+	if !dryRun && confirm != snap.InstanceID {
+		return fmt.Errorf("confirmation %q does not name this instance (%s)", confirm, snap.InstanceID)
+	}
+	fmt.Fprintf(streams.Out, "instance %s\n", snap.InstanceID)
+	fmt.Fprint(streams.Out, plan.describe("would remove", !dryRun))
+	for _, gb := range ghBindings {
+		fmt.Fprintf(streams.Out, "  scale set %s on %s\n", gb.ScaleSetName, gb.CanonicalURL)
+	}
+	// Every lease row, not the snapshot's bounded view: this number is
+	// what an operator weighs before destroying the books.
+	fmt.Fprintf(streams.Out, "  %d lease records\n", liveLeaseCount(snap)+snap.ReleasedTotal)
+	// Queued attempts have no lease yet, so the count above does not see
+	// them. They are work the provider assigned and this instance
+	// acknowledged, and purging is what loses it.
+	if queued := queuedAttemptCount(snap.Queued); queued > 0 {
+		fmt.Fprintf(streams.Out, "  %d attempts waiting for a lease\n", queued)
+	}
+
+	if dryRun {
+		fmt.Fprintf(streams.Out, "\ndry run. To proceed: runpool uninstall --confirm=%s%s\n",
+			snap.InstanceID, map[bool]string{true: " --delete-scale-sets"}[deleteScaleSets])
+		return nil
+	}
+
+	if err := plan.remove(ctx, dock); err != nil {
+		return err
+	}
+	if len(ghBindings) > 0 {
+		if err := deleteConfiguredScaleSets(ctx, streams, ghBindings); err != nil {
+			return fmt.Errorf("delete scale sets (local resources are removed; retry uninstall to finish): %w", err)
+		}
+	}
+	// Everything durable goes in one transaction, children before
+	// parents: intents, leases, then the delivery and attempt evidence.
+	// That evidence is the record of work this instance accepted, and
+	// uninstall is the operator saying it goes with the instance.
+	if err := st.Tx(ctx, func(tx *store.Tx) error {
+		return tx.PurgeEverything()
+	}); err != nil {
+		return fmt.Errorf("purging durable records: %w", err)
+	}
+	fmt.Fprintln(streams.Out, "uninstall complete; the deployment-managed state volume remains for the operator to remove")
+	return nil
+}
+
+// deleteConfiguredScaleSets removes the scale sets this instance created,
+// resolving each target's credential from the current configuration.
+func deleteConfiguredScaleSets(ctx context.Context, streams IO, bindings []store.GitHubBinding) error {
+	cfg, err := config.Load(os.Getenv)
+	if err != nil {
+		return fmt.Errorf("configuration needed to reach GitHub: %w", err)
+	}
+	creds := map[string]config.Credential{}
+	for _, c := range cfg.Credentials {
+		creds[c.ID] = c
+	}
+	byURL := map[string]config.Target{}
+	for _, t := range cfg.Targets {
+		if ref, err := config.ParseTargetURL(t.URL); err == nil {
+			byURL[ref.CanonicalURL] = t
+		}
+	}
+	for _, gb := range bindings {
+		if gb.ScaleSetID == 0 {
+			fmt.Fprintf(streams.Out, "  %s: no scale set was recorded\n", gb.ScaleSetName)
+			continue
+		}
+		target, ok := byURL[gb.CanonicalURL]
+		if !ok {
+			return fmt.Errorf("scale set %s belongs to %s, which is absent from the current configuration", gb.ScaleSetName, gb.CanonicalURL)
+		}
+		secret, err := credential.Resolve(os.Getenv, creds[target.CredentialID])
+		if err != nil {
+			return err
+		}
+		gh, err := githubactions.NewClient(githubactions.ClientConfig{
+			ConfigURL: gb.CanonicalURL, Credential: secret, Version: "uninstall",
+		})
+		if err != nil {
+			return err
+		}
+		remote, found, err := gh.ScaleSetByName(ctx, gb.RunnerGroup, gb.ScaleSetName)
+		if err != nil {
+			return err
+		}
+		if !found {
+			fmt.Fprintf(streams.Out, "  scale set %s is already absent\n", gb.ScaleSetName)
+			continue
+		}
+		if int64(remote.ID) != gb.ScaleSetID {
+			return fmt.Errorf("scale set %s now has id %d, but this instance recorded %d; refusing to delete a different resource",
+				gb.ScaleSetName, remote.ID, gb.ScaleSetID)
+		}
+		if err := gh.DeleteScaleSet(ctx, int(gb.ScaleSetID)); err != nil {
+			return fmt.Errorf("delete scale set %s: %w", gb.ScaleSetName, err)
+		}
+		fmt.Fprintf(streams.Out, "  deleted scale set %s\n", gb.ScaleSetName)
+	}
+	return nil
+}
+
+// ownedPlan is the set of Docker objects this instance owns, grouped so
+// removal happens in dependency order.
+type ownedPlan struct {
+	instanceID string
+	containers []docker.OwnedContainer
+	networks   []docker.OwnedResource
+	volumes    []docker.OwnedResource
+}
+
+func planOwnedResources(ctx context.Context, st *store.Store, dock *docker.Client) (ownedPlan, error) {
+	p := ownedPlan{instanceID: st.InstanceID()}
+	var err error
+	id := p.instanceID
+	if p.containers, err = dock.ListOwnedContainers(ctx, id); err != nil {
+		return p, err
+	}
+	if p.networks, err = dock.ListOwnedNetworks(ctx, id); err != nil {
+		return p, err
+	}
+	p.volumes, err = dock.ListOwnedVolumes(ctx, id)
+	return p, err
+}
+
+func (p ownedPlan) exclude(keep map[string]bool) ownedPlan {
+	out := ownedPlan{instanceID: p.instanceID}
+	for _, c := range p.containers {
+		// A helper the instance is still running is not garbage. Apply
+		// holds the singleton lock so it cannot meet one, but the dry
+		// run opens read-only to inspect a live controller — and that
+		// preview has to name what an apply would take, not what it
+		// happened to catch mid-measurement.
+		if c.HelperInFlight() {
+			continue
+		}
+		if !keep[c.LeaseID] {
+			out.containers = append(out.containers, c)
+		}
+	}
+	for _, n := range p.networks {
+		// Instance infrastructure is not lease garbage; uninstall removes
+		// it via the full plan.
+		if n.InstanceInfrastructure() {
+			continue
+		}
+		if !keep[n.LeaseID] {
+			out.networks = append(out.networks, n)
+		}
+	}
+	for _, v := range p.volumes {
+		// A cache lane has no lease on purpose: warm cache is the
+		// product working, not garbage. Cleanup leaves lanes alone;
+		// uninstall removes them because it takes the full plan.
+		if v.InstanceInfrastructure() {
+			continue
+		}
+		if !keep[v.LeaseID] {
+			out.volumes = append(out.volumes, v)
+		}
+	}
+	return out
+}
+
+func (p ownedPlan) empty() bool {
+	return len(p.containers)+len(p.networks)+len(p.volumes) == 0
+}
+
+func (p ownedPlan) describe(verb string, applying bool) string {
+	if applying {
+		verb = "removing"
+	}
+	out := fmt.Sprintf("%s %d containers, %d networks, %d volumes\n",
+		verb, len(p.containers), len(p.networks), len(p.volumes))
+	for _, c := range p.containers {
+		out += fmt.Sprintf("  container %s\n", c.Name)
+	}
+	for _, n := range p.networks {
+		out += fmt.Sprintf("  network %.12s\n", n.ID)
+	}
+	for _, v := range p.volumes {
+		out += fmt.Sprintf("  volume %s\n", v.ID)
+	}
+	return out
+}
+
+// remove deletes containers first, then the networks and volumes they
+// held open.
+func (p ownedPlan) remove(ctx context.Context, dock *docker.Client) error {
+	for _, c := range p.containers {
+		if err := dock.RemoveOwnedContainer(ctx, c.ID, p.instanceID, c.LeaseID); err != nil {
+			return fmt.Errorf("remove container %s: %w", c.Name, err)
+		}
+	}
+	for _, n := range p.networks {
+		if err := dock.RemoveOwnedNetwork(ctx, n.ID, p.instanceID, n.LeaseID); err != nil {
+			return fmt.Errorf("remove network %.12s: %w", n.ID, err)
+		}
+	}
+	for _, v := range p.volumes {
+		if err := dock.RemoveOwnedVolume(ctx, v.ID, p.instanceID, v.LeaseID); err != nil {
+			return fmt.Errorf("remove volume %s: %w", v.ID, err)
+		}
+	}
+	return nil
+}
+
+// openStoreAndDocker takes the singleton lock before touching anything
+// destructive: a maintenance command that races a live controller can
+// delete resources out from under a running job. The lock is released
+// when the returned closer runs.
+func openStoreAndDocker(ctx context.Context) (*store.Store, *docker.Client, func(), error) {
+	lock, err := store.TryAcquire(stateDir())
+	if err != nil {
+		if errors.Is(err, store.ErrLockHeld) {
+			return nil, nil, nil, fmt.Errorf(
+				"a controller is running against this state directory; stop it before running maintenance")
+		}
+		return nil, nil, nil, err
+	}
+	st, err := store.Open(stateDir())
+	if err != nil {
+		lock.Release()
+		return nil, nil, nil, err
+	}
+	return finishOpen(ctx, st, func() { lock.Release() })
+}
+
+// openForMaintenance picks the store a maintenance command may have: a
+// dry run only reports, so it opens read-only and takes no lock; an apply
+// changes things and takes the singleton lock first.
+func openForMaintenance(ctx context.Context, apply bool) (*store.Store, *docker.Client, func(), error) {
+	if apply {
+		return openStoreAndDocker(ctx)
+	}
+	return previewStore(ctx)
+}
+
+// previewStore opens the store read-only for a dry run, the same rule the
+// rest of the CLI follows: reporting must not migrate — or create — a store
+// a live controller owns. Going through openStoreAndDocker meant `runpool
+// uninstall` with no flags, the preview the help text tells an operator to
+// run first, upgraded the schema and wrote a pre-migration backup; run with
+// an older binary it refused to preview at all. It also took the exclusive
+// lock, so neither preview could inspect a running controller.
+func previewStore(ctx context.Context) (*store.Store, *docker.Client, func(), error) {
+	st, err := store.OpenReadOnly(stateDir())
+	if errors.Is(err, store.ErrSchemaBehind) {
+		// The preview reads and the applying form migrates, so a schema
+		// the controller has not caught up to closes the safe path while
+		// leaving the irreversible one open. Saying so is what keeps an
+		// operator from reading the refusal as "this instance is fine".
+		return nil, nil, nil, fmt.Errorf("%w\n"+
+			"  - a preview reads the state and does not migrate it; the applying form would", err)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return finishOpen(ctx, st, func() {})
+}
+
+func finishOpen(ctx context.Context, st *store.Store, release func()) (*store.Store, *docker.Client, func(), error) {
+	dock, err := docker.New(ctx)
+	if err != nil {
+		st.Close()
+		release()
+		return nil, nil, nil, err
+	}
+	return st, dock, release, nil
+}
+
+// queuedAttemptCount is the work admitted from the provider that has not
+// reached a lease. It is invisible to liveLeaseCount by construction, and
+// it is exactly what an idle-looking instance can still be holding.
+func queuedAttemptCount(queued map[int64]int) int {
+	n := 0
+	for _, q := range queued {
+		n += q
+	}
+	return n
+}
+
+// liveLeaseCount counts the leases a snapshot carries whole. Released
+// ones are bounded, so their total comes from the snapshot's own count
+// rather than from the slice.
+func liveLeaseCount(snap store.Snapshot) int {
+	n := 0
+	for _, l := range snap.Leases {
+		if !l.State.Terminal() {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/command/cleanup_test.go
+++ b/internal/command/cleanup_test.go
@@ -1,0 +1,136 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestExcludeSparesTheInstancesOwnObjects pins the rule the three limbs of
+// a sweep have to agree on: an object with no lease belongs to the
+// instance, not to lease garbage.
+//
+// The containers limb is the one that needs a second condition. A
+// lease-less network or volume is persistent — the uplink, a cache lane —
+// so it is never garbage. A lease-less container is a helper the instance
+// starts for itself, and RunTask removes its own on a deadline of its
+// own: one still running is in flight, and taking it away fails the
+// measurement that started it. One that is stopped outlived the process
+// that owned it, and collecting it is the whole point of the sweep.
+func TestExcludeSparesTheInstancesOwnObjects(t *testing.T) {
+	plan := ownedPlan{
+		instanceID: "inst-1",
+		containers: []docker.OwnedContainer{
+			{ID: "c1", Name: "runpool-inst-1-df-probe-aa", Role: "probe", Running: true},
+			{ID: "c2", Name: "runpool-inst-1-hostnet-probe-bb", Role: "probe", Running: false},
+			{ID: "c3", Name: "runner-live", Role: "capsule", LeaseID: "lse-live", Running: true},
+			{ID: "c4", Name: "runner-done", Role: "capsule", LeaseID: "lse-done"},
+		},
+		networks: []docker.OwnedResource{
+			{ID: "n1", Role: "uplink"},
+			{ID: "n2", Role: "capsule-net", LeaseID: "lse-done"},
+		},
+		volumes: []docker.OwnedResource{
+			{ID: "v1", Role: "cache-lane"},
+			{ID: "v2", Role: "dind-data", LeaseID: "lse-done"},
+		},
+	}
+
+	got := plan.exclude(map[string]bool{"lse-live": true})
+
+	want := map[string]bool{"c2": true, "c4": true, "n2": true, "v2": true}
+	for _, id := range collectIDs(got) {
+		if !want[id] {
+			t.Errorf("exclude offered %s for removal; it is not lease garbage", id)
+		}
+		delete(want, id)
+	}
+	for id := range want {
+		t.Errorf("exclude withheld %s; it is garbage a cleanup has to collect", id)
+	}
+}
+
+func collectIDs(p ownedPlan) []string {
+	out := make([]string, 0, len(p.containers)+len(p.networks)+len(p.volumes))
+	for _, c := range p.containers {
+		out = append(out, c.ID)
+	}
+	for _, n := range p.networks {
+		out = append(out, n.ID)
+	}
+	for _, v := range p.volumes {
+		out = append(out, v.ID)
+	}
+	return out
+}
+
+// TestLiveLeaseCount: the snapshot carries live leases whole and finished
+// ones bounded, so counting the slice would report the bound. Only the
+// live half can be counted from it.
+func TestLiveLeaseCount(t *testing.T) {
+	snap := store.Snapshot{Leases: []store.Lease{
+		{ID: "a", State: store.LeaseWorkloadRunning},
+		{ID: "b", State: store.LeaseQuarantined},
+		{ID: "c", State: store.LeaseReleased},
+		{ID: "d", State: store.LeaseCleaning},
+	}}
+	if got := liveLeaseCount(snap); got != 3 {
+		t.Errorf("liveLeaseCount = %d; want the three non-terminal leases", got)
+	}
+	if got := liveLeaseCount(store.Snapshot{}); got != 0 {
+		t.Errorf("liveLeaseCount of an empty snapshot = %d; want 0", got)
+	}
+}
+
+// TestDescribeNamesEveryObjectItWouldTake. This string is the whole
+// preview: an operator reads it and decides whether to pass --apply, so
+// an object missing from it is one removed without being announced.
+func TestDescribeNamesEveryObjectItWouldTake(t *testing.T) {
+	plan := ownedPlan{
+		instanceID: "inst-1",
+		containers: []docker.OwnedContainer{{ID: "c1", Name: "runner-1", Role: "capsule"}},
+		networks:   []docker.OwnedResource{{ID: "n1", Role: "capsule-net"}},
+		volumes:    []docker.OwnedResource{{ID: "v1", Role: "dind-data"}},
+	}
+	if plan.empty() {
+		t.Fatal("a plan with three objects reported itself empty")
+	}
+	got := plan.describe("would remove", false)
+	for _, want := range []string{"runner-1", "n1", "v1", "would remove"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the preview does not name %q:\n%s", want, got)
+		}
+	}
+	// Applying says so in the present tense; a preview that reads like an
+	// action already taken is worse than no preview.
+	if applying := plan.describe("would remove", true); !strings.Contains(applying, "removing") {
+		t.Errorf("the applying form still reads as a preview:\n%s", applying)
+	}
+	if (ownedPlan{}).empty() != true {
+		t.Error("an empty plan did not report itself empty")
+	}
+}
+
+// TestQueuedAttemptsAreVisibleBeforeAPurge. What uninstall counts out is
+// what an operator weighs before destroying the books, and it counted
+// leases. A queued attempt has none: it is work the provider assigned and
+// this instance acknowledged, waiting for a lane. An instance whose lanes
+// are idle under disk pressure, or whose binding has stalled, holds a
+// backlog and reports zero — so the confirmation an operator reads before
+// the purge is the one shape where the number has to be right.
+func TestQueuedAttemptsAreVisibleBeforeAPurge(t *testing.T) {
+	backlog := store.Snapshot{Queued: map[int64]int{1: 4, 2: 2}}
+
+	if got := liveLeaseCount(backlog); got != 0 {
+		t.Fatalf("liveLeaseCount = %d; this case is the one where no lease is live", got)
+	}
+	if got := queuedAttemptCount(backlog.Queued); got != 6 {
+		t.Errorf("queuedAttemptCount = %d; want the sum across bindings, 6 — the purge "+
+			"destroys every one of them", got)
+	}
+	if got := queuedAttemptCount(nil); got != 0 {
+		t.Errorf("queuedAttemptCount of nothing queued = %d; want 0", got)
+	}
+}

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,0 +1,204 @@
+// Package command is the runpool CLI surface.
+//
+// Cobra owns parsing, help, completion, and generated reference data. Every
+// command declares its positional-argument contract. Usage is printed for
+// parse failures and omitted for operational failures.
+package command
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Exit codes: 0 success, 1 operational failure, 2 usage error.
+const (
+	exitOK    = 0
+	exitError = 1
+	exitUsage = 2
+)
+
+// usageError marks a failure the caller could have avoided by typing
+// something else, which is the only kind that earns the usage text.
+type usageError struct{ err error }
+
+func (e usageError) Error() string { return e.err.Error() }
+func (e usageError) Unwrap() error { return e.err }
+
+func usagef(format string, args ...any) error {
+	return usageError{fmt.Errorf(format, args...)}
+}
+
+// IO is where a command reads and writes. Tests supply buffers; main
+// supplies the process streams. Commands never reach for os.Stdout
+// directly, or their output could not be asserted on.
+type IO struct {
+	In  io.Reader
+	Out io.Writer
+	Err io.Writer
+}
+
+// streamsOf is where a command body gets its writers. Execute points the
+// root at the caller's IO and Cobra carries them down the tree, so a
+// test asserts on buffers and main writes to the process streams without
+// any command body knowing which of the two it got.
+func streamsOf(cmd *cobra.Command) IO {
+	return IO{In: cmd.InOrStdin(), Out: cmd.OutOrStdout(), Err: cmd.ErrOrStderr()}
+}
+
+// BuildInfo is what `version` reports: stamped at build time, never
+// guessed at run time.
+type BuildInfo struct {
+	Version      string
+	Commit       string
+	Built        string
+	Dirty        bool
+	CapsuleImage string
+}
+
+// Execute runs one CLI invocation and returns its exit code.
+func Execute(args []string, build BuildInfo, streams IO) int {
+	root := NewRootCommand(build, streams)
+	root.SetArgs(args)
+	err := root.Execute()
+	return exitCodeFor(err, root, streams)
+}
+
+// Run is Execute over the process streams, with the build facts the
+// toolchain recorded filled in around whatever the linker stamped.
+func Run(args []string, build BuildInfo) int {
+	return Execute(args, BuildInfoFromDebug(build), IO{
+		In: os.Stdin, Out: os.Stdout, Err: os.Stderr,
+	})
+}
+
+// exitCodeFor maps one error to one exit code, in one place. Scattering
+// this decision is how a command ends up reporting a usage problem as
+// an operational failure, which tells a script the wrong thing.
+func exitCodeFor(err error, root *cobra.Command, streams IO) int {
+	if err == nil {
+		return exitOK
+	}
+	var usage usageError
+	if errors.As(err, &usage) {
+		fmt.Fprintln(streams.Err, "runpool:", usage.Error())
+		return exitUsage
+	}
+	// Cobra's own parse failures — unknown command, unknown flag, wrong
+	// argument count. SilenceErrors keeps Cobra from printing them, so
+	// they are printed here: an unknown command that produced no output
+	// at all leaves a person with an exit code and no idea why.
+	if isCobraUsageError(err) {
+		fmt.Fprintln(streams.Err, "runpool:", err)
+		fmt.Fprintf(streams.Err, "run 'runpool --help' for usage.\n")
+		return exitUsage
+	}
+	// A command that already reported its own failure says so by
+	// returning errSilent; printing again would double the message.
+	if !errors.Is(err, errSilent) {
+		fmt.Fprintln(streams.Err, "runpool:", err)
+	}
+	return exitError
+}
+
+// isCobraUsageError distinguishes a parse failure from an operational
+// one. Cobra has no error type for this, so the check is on the text it
+// produces; a miss costs an exit code of 1 instead of 2, never a
+// success reported for a failure.
+func isCobraUsageError(err error) bool {
+	for _, marker := range []string{
+		"unknown command",
+		"unknown flag",
+		"unknown shorthand flag",
+		"invalid argument",
+		"accepts ",
+		"requires at least",
+		"requires exactly",
+		"flag needs an argument",
+	} {
+		if containsFold(err.Error(), marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsFold(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if equalFold(s[i:i+len(sub)], sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalFold(a, b string) bool {
+	for i := range a {
+		x, y := a[i], b[i]
+		if 'A' <= x && x <= 'Z' {
+			x += 'a' - 'A'
+		}
+		if 'A' <= y && y <= 'Z' {
+			y += 'a' - 'A'
+		}
+		if x != y {
+			return false
+		}
+	}
+	return true
+}
+
+// NewRootCommand builds the whole tree. It takes its dependencies so a
+// test can drive every command without a process.
+func NewRootCommand(build BuildInfo, streams IO) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "runpool",
+		Short: "Docker-native autoscaling for ephemeral GitHub Actions runners",
+		Long: "Runpool coordinates GitHub Actions scale-set demand against a finite\n" +
+			"pool of per-job execution capsules on one Docker host.",
+		SilenceErrors: true,
+		// Usage is printed for parse failures, which Cobra decides
+		// before RunE is reached; each command silences it once it is
+		// running, so an operational failure shows the error alone.
+		SilenceUsage: false,
+		// A bare `runpool` is not an error: it is someone asking what
+		// this is. Print help and succeed.
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	root.SetIn(streams.In)
+	root.SetOut(streams.Out)
+	root.SetErr(streams.Err)
+	root.CompletionOptions.HiddenDefaultCmd = false
+
+	root.AddCommand(
+		newVersionCommand(build, streams),
+		newServeCommand(build),
+		newDoctorCommand(),
+		newHealthcheckCommand(),
+		newStatusCommand(build),
+		newAttemptsCommand(),
+		newGCCommand(),
+		newCleanupCommand(),
+		newUninstallCommand(),
+		newConfigCommand(),
+	)
+	return root
+}
+
+// operational marks a command as past parsing: from here a failure is
+// the world's, not the caller's, so the usage text would be noise.
+func operational(cmd *cobra.Command) { cmd.SilenceUsage = true }
+
+// errSilent is a failure whose detail a command already wrote to its
+// own output — the doctor's per-check lines, a gc pass's per-eviction
+// errors. Returning it sets the exit code without printing a second,
+// emptier version of the same news.
+var errSilent = errors.New("")

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -1,0 +1,325 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// run drives the whole tree with captured streams, which is the point
+// of injecting them: every assertion here is about what a person or a
+// script actually sees.
+func run(t *testing.T, args ...string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	code = Execute(args, BuildInfo{
+		Version:      "v1.2.3",
+		Commit:       "abc123",
+		Built:        "2026-08-13T00:00:00Z",
+		CapsuleImage: "ghcr.io/rhobuild/runpool/capsule@sha256:test",
+	},
+		IO{In: strings.NewReader(""), Out: &out, Err: &errBuf})
+	return code, out.String(), errBuf.String()
+}
+
+// TestHelpIsNotAnUnknownCommand verifies every conventional help form.
+func TestHelpIsNotAnUnknownCommand(t *testing.T) {
+	for _, args := range [][]string{{"--help"}, {"-h"}, {"help"}, {}} {
+		code, stdout, stderr := run(t, args...)
+		if code != exitOK {
+			t.Errorf("runpool %v = %d; want 0 — asking for help is not an error", args, code)
+		}
+		if !strings.Contains(stdout, "runpool") {
+			t.Errorf("runpool %v printed no help: %q %q", args, stdout, stderr)
+		}
+	}
+}
+
+// TestSubcommandHelp verifies help at each command depth.
+func TestSubcommandHelp(t *testing.T) {
+	for _, args := range [][]string{
+		{"attempts", "--help"}, {"config", "--help"}, {"attempts", "resolve", "--help"},
+	} {
+		code, stdout, _ := run(t, args...)
+		if code != exitOK {
+			t.Errorf("runpool %v = %d; want 0", args, code)
+		}
+		if !strings.Contains(stdout, "Usage:") {
+			t.Errorf("runpool %v printed no usage: %q", args, stdout)
+		}
+	}
+}
+
+// TestExtraArgumentsAreRefused keeps positional-argument contracts strict.
+func TestExtraArgumentsAreRefused(t *testing.T) {
+	for _, args := range [][]string{
+		{"version", "extra"},
+		{"serve", "unexpected"},
+		{"status", "surplus"},
+		{"doctor", "surplus"},
+		{"gc", "surplus"},
+		{"attempts", "list", "surplus"},
+	} {
+		code, _, _ := run(t, args...)
+		if code != exitUsage {
+			t.Errorf("runpool %v = %d; want %d — an unexpected argument is a usage error", args, code, exitUsage)
+		}
+	}
+}
+
+// TestArgumentCountsAreExact: a command that takes an id must say so
+// when it is missing, rather than proceeding with none.
+func TestArgumentCountsAreExact(t *testing.T) {
+	for _, args := range [][]string{
+		{"attempts", "inspect"},
+		{"attempts", "inspect", "a", "b"},
+		{"attempts", "resolve"},
+	} {
+		if code, _, _ := run(t, args...); code != exitUsage {
+			t.Errorf("runpool %v = %d; want %d", args, code, exitUsage)
+		}
+	}
+}
+
+// TestUnknownThingsAreReported: an exit code with no message leaves a
+// person guessing. Both the unknown command and the unknown flag have
+// to say what was wrong, on stderr, where a script's error handling
+// looks.
+func TestUnknownThingsAreReported(t *testing.T) {
+	code, _, stderr := run(t, "bogus")
+	if code != exitUsage {
+		t.Errorf("unknown command = %d; want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr, "bogus") {
+		t.Errorf("unknown command did not name it on stderr: %q", stderr)
+	}
+
+	if code, _, _ := run(t, "status", "--nope"); code != exitUsage {
+		t.Errorf("unknown flag = %d; want %d", code, exitUsage)
+	}
+}
+
+// TestVersionOutputs: the plain form is one line a human reads; the
+// JSON form carries the build facts a support request or a
+// release record needs.
+func TestVersionOutputs(t *testing.T) {
+	code, stdout, _ := run(t, "version")
+	if code != exitOK || !strings.Contains(stdout, "v1.2.3") {
+		t.Fatalf("version = %d, %q", code, stdout)
+	}
+
+	code, stdout, _ = run(t, "version", "--json")
+	if code != exitOK {
+		t.Fatalf("version --json = %d", code)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(stdout), &doc); err != nil {
+		t.Fatalf("version --json is not JSON: %v\n%s", err, stdout)
+	}
+	for _, key := range []string{"version", "commit", "built", "dirty", "go", "platform", "capsule_image", "release_qualification_reference"} {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("version --json has no %q: %v", key, doc)
+		}
+	}
+	if doc["version"] != "v1.2.3" {
+		t.Errorf("version = %v; want the stamped one", doc["version"])
+	}
+}
+
+// TestValidReleaseVersion: a release may only be published from a
+// SemVer tag. "dev" is what a local build carries, and a build that was
+// never tagged was never released.
+func TestValidReleaseVersion(t *testing.T) {
+	for _, ok := range []string{"v1.0.0", "v1.0.0-rc.1", "v0.1.0", "v1.2.3+build.5", "v10.20.30"} {
+		if err := ValidReleaseVersion(ok); err != nil {
+			t.Errorf("ValidReleaseVersion(%q) = %v; want valid", ok, err)
+		}
+	}
+	for _, bad := range []string{"", "dev", "1.0.0", "v1.0", "v1.0.0.0", "latest", "v01.0.0", "release-1"} {
+		if err := ValidReleaseVersion(bad); err == nil {
+			t.Errorf("ValidReleaseVersion(%q) accepted an unpublishable version", bad)
+		}
+	}
+}
+
+// TestDestructiveCommandsPreviewByDefault: uninstall, cleanup and gc
+// all change the world, so none of them may act on a bare invocation.
+// The check is on the flag's default, because that is what decides.
+func TestDestructiveCommandsPreviewByDefault(t *testing.T) {
+	root := NewRootCommand(BuildInfo{Version: "test"}, IO{Out: &bytes.Buffer{}, Err: &bytes.Buffer{}})
+	for name, flag := range map[string]string{
+		"cleanup":   "apply",
+		"gc":        "apply",
+		"uninstall": "confirm",
+	} {
+		cmd, _, err := root.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", name, err)
+		}
+		f := cmd.Flags().Lookup(flag)
+		if f == nil {
+			t.Errorf("%s has no --%s", name, flag)
+			continue
+		}
+		if f.DefValue != "false" && f.DefValue != "" {
+			t.Errorf("%s --%s defaults to %q; a destructive command must preview by default", name, flag, f.DefValue)
+		}
+	}
+}
+
+// TestConfigContract distinguishes valid input, usage errors, and operational
+// failures.
+func TestConfigContract(t *testing.T) {
+	valid := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: runpool.rhobuild.com/v1
+kind: RunpoolConfig
+host:
+  topology: dedicated-daemon
+targets:
+  - id: app
+    url: https://github.com/acme/app
+    credential: github-default
+    tiers:
+      - tier: standard
+credentials:
+  - id: github-default
+    tokenEnv: RUNPOOL_GITHUB_TOKEN
+tiers:
+  - id: standard
+`
+	if err := os.WriteFile(valid, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		args []string
+		want int
+	}{
+		{[]string{"config"}, exitOK}, // prints help
+		{[]string{"config", "validate"}, exitUsage},
+		{[]string{"config", "validate", "--file", valid}, exitOK},
+		{[]string{"config", "validate", "--file", valid + ".missing"}, exitError},
+		{[]string{"config", "effective", "--file", valid}, exitOK},
+	} {
+		if code, _, _ := run(t, tc.args...); code != tc.want {
+			t.Errorf("runpool %v = %d; want %d", tc.args, code, tc.want)
+		}
+	}
+}
+
+// TestCobraIsTheOnlyParser guards the single-parser architecture.
+func TestCobraIsTheOnlyParser(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(body), "flag.NewFlagSet") {
+			t.Errorf("%s builds a second flag parser; Cobra owns parsing, and a "+
+				"command body takes typed parameters", name)
+		}
+	}
+}
+
+// TestEveryDeclaredFlagReachesItsCommand walks the tree and drives each
+// flag through Execute. A flag the tree declares but nothing reads is
+// documentation for behaviour that does not exist; a flag a body needs
+// but the tree omits is rejected as unknown. Both are the same defect
+// seen from opposite ends.
+func TestEveryDeclaredFlagReachesItsCommand(t *testing.T) {
+	// --state is the one that was missing. A value the command does not
+	// serve must be a usage error naming it, not "unknown flag".
+	code, _, stderr := run(t, "attempts", "list", "--state", "settled")
+	if code != exitUsage {
+		t.Errorf("attempts list --state settled = %d; want %d", code, exitUsage)
+	}
+	if strings.Contains(stderr, "unknown flag") {
+		t.Errorf("--state is declared by the body but not the tree: %q", stderr)
+	}
+	if !strings.Contains(stderr, "manual-review") {
+		t.Errorf("the refusal does not say which states are served: %q", stderr)
+	}
+
+	// Both served values parse; with no state directory they report that
+	// rather than failing. Ready is here because a queue that stops
+	// draining is the shape a stuck binding takes, and until it was
+	// listable an operator could see the count and not the attempts.
+	t.Setenv("RUNPOOL_STATE_DIR", t.TempDir())
+	for _, state := range []string{"manual-review", "ready"} {
+		if code, _, stderr := run(t, "attempts", "list", "--state", state); code != exitOK {
+			t.Errorf("attempts list --state %s = %d; want 0 (%q)", state, code, stderr)
+		}
+	}
+}
+
+// TestOperatorResolveRefusesAnUndecidedDecision: both flags or neither
+// is a person who has not decided, and guessing which they meant is how
+// a job runs twice.
+func TestOperatorResolveRefusesAnUndecidedDecision(t *testing.T) {
+	for _, args := range [][]string{
+		{"attempts", "resolve", "att-1", "--reason", "checked"},
+		{"attempts", "resolve", "att-1", "--retry", "--settle-may-have-run", "--reason", "checked"},
+		{"attempts", "resolve", "att-1", "--retry"},
+	} {
+		if code, _, _ := run(t, args...); code != exitUsage {
+			t.Errorf("runpool %v = %d; want %d", args, code, exitUsage)
+		}
+	}
+}
+
+// TestConfigCommandsSayWhatTheyDecided. These ran through the tree
+// already, but everything they printed escaped to the test process's own
+// stdout: only the exit code could be asserted, so a command that exited
+// zero while saying nothing — or saying the wrong thing — read as
+// passing.
+func TestConfigCommandsSayWhatTheyDecided(t *testing.T) {
+	valid := filepath.Join(t.TempDir(), "config.yaml")
+	content := `apiVersion: runpool.rhobuild.com/v1
+kind: RunpoolConfig
+host:
+  topology: dedicated-daemon
+targets:
+  - id: app
+    url: https://github.com/acme/app
+    credential: github-default
+    tiers:
+      - tier: standard
+credentials:
+  - id: github-default
+    tokenEnv: RUNPOOL_GITHUB_TOKEN
+tiers:
+  - id: standard
+`
+	if err := os.WriteFile(valid, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := run(t, "config", "validate", "--file", valid)
+	if code != exitOK || !strings.Contains(stdout, "configuration valid") {
+		t.Errorf("validate = %d %q; want a stated verdict", code, stdout)
+	}
+
+	code, stdout, _ = run(t, "config", "effective", "--file", valid)
+	if code != exitOK {
+		t.Fatalf("effective = %d", code)
+	}
+	// The effective document is the defaults made visible. A deletion
+	// policy that is on by default must be among them, or an operator
+	// reading this output does not know their records expire.
+	for _, want := range []string{"retention:", "leaseHistory:", "topology: dedicated-daemon"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the effective configuration does not mention %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -1,0 +1,296 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Each constructor declares its positional-argument contract with Cobra.
+// Command bodies receive typed flag values and return errors; Cobra remains
+// the single parser and the source for generated CLI documentation.
+
+func newVersionCommand(build BuildInfo, streams IO) *cobra.Command {
+	var asJSON, checkRelease bool
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the build version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			if checkRelease {
+				// The release pipeline asks the binary whether its own
+				// stamped version may be published. Asking the artifact
+				// is the point: a check on a string somewhere else can
+				// pass while the binary carries something different.
+				if err := ValidReleaseVersion(build.Version); err != nil {
+					return err
+				}
+				fmt.Fprintln(streams.Out, "release version accepted:", build.Version)
+				return nil
+			}
+			if !asJSON {
+				fmt.Fprintln(streams.Out, "runpool", build.Version)
+				return nil
+			}
+			// Structured build facts for support and release evidence.
+			enc := json.NewEncoder(streams.Out)
+			enc.SetIndent("", "  ")
+			return enc.Encode(map[string]any{
+				"version":                         build.Version,
+				"commit":                          build.Commit,
+				"built":                           build.Built,
+				"dirty":                           build.Dirty,
+				"go":                              runtime.Version(),
+				"platform":                        runtime.GOOS + "/" + runtime.GOARCH,
+				"capsule_image":                   build.CapsuleImage,
+				"release_qualification_reference": releaseQualificationReference(),
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the build facts as JSON")
+	cmd.Flags().BoolVar(&checkRelease, "check-release", false,
+		"fail unless this binary's version is a publishable SemVer release")
+	return cmd
+}
+
+func newServeCommand(build BuildInfo) *cobra.Command {
+	return &cobra.Command{
+		Use:   "serve",
+		Short: "Run the controller (configuration from the environment)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runServe(build)
+		},
+	}
+}
+
+func newDoctorCommand() *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "doctor",
+		Short: "Check the host, storage and credentials",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runDoctor(streamsOf(cmd), asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the report as JSON")
+	return cmd
+}
+
+func newHealthcheckCommand() *cobra.Command {
+	var mode string
+	cmd := &cobra.Command{
+		Use:   "healthcheck",
+		Short: "Container health probe",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runHealthcheck(streamsOf(cmd), mode)
+		},
+	}
+	cmd.Flags().StringVar(&mode, "mode", "liveness", "liveness or readiness")
+	return cmd
+}
+
+func newStatusCommand(build BuildInfo) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "What this instance owns, and whether the books agree with the daemon",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runStatus(streamsOf(cmd), asJSON, build.CapsuleImage)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the status as JSON")
+	return cmd
+}
+
+func newAttemptsCommand() *cobra.Command {
+	attempts := &cobra.Command{
+		Use:   "attempts",
+		Short: "The work held for a person, and how to decide it",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	var (
+		listJSON  bool
+		listState string
+	)
+	list := &cobra.Command{
+		Use:   "list",
+		Short: "List attempts waiting for a decision",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runAttemptsList(streamsOf(cmd), listState, listJSON)
+		},
+	}
+	list.Flags().BoolVar(&listJSON, "json", false, "emit the list as JSON")
+	// The body has always served this flag; the tree never declared it,
+	// so `--state` was an unknown flag while the reference generated
+	// from the tree said nothing about it either way. Declaring it is
+	// what makes the two agree.
+	list.Flags().StringVar(&listState, "state", "manual-review",
+		"attempt state to list: manual-review or ready")
+
+	var inspectJSON bool
+	inspect := &cobra.Command{
+		Use:   "inspect <attempt-id>",
+		Short: "Show one attempt and its lifecycle events",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			operational(cmd)
+			return runAttemptsInspect(streamsOf(cmd), args[0], inspectJSON)
+		},
+	}
+	inspect.Flags().BoolVar(&inspectJSON, "json", false, "emit the attempt as JSON")
+
+	var (
+		retry  bool
+		settle bool
+		reason string
+		actor  string
+		apply  bool
+	)
+	resolve := &cobra.Command{
+		Use:   "resolve <attempt-id>",
+		Short: "Decide a held attempt (preview by default)",
+		Long: "Decides work Runpool could not decide alone.\n\n" +
+			"--retry returns the attempt to the queue and it will run. Use it only\n" +
+			"after verifying outside Runpool — in the provider's own UI or API —\n" +
+			"that the workload never executed.\n\n" +
+			"--settle-may-have-run closes the attempt as possibly executed. It\n" +
+			"never runs again. Use it when execution cannot be ruled out.\n\n" +
+			"Without --apply this is a preview.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			operational(cmd)
+			return runAttemptsResolve(streamsOf(cmd), args[0], retry, settle, reason, actor, apply)
+		},
+	}
+	resolve.Flags().BoolVar(&retry, "retry", false,
+		"return the attempt to the queue (verify externally that it never executed first)")
+	resolve.Flags().BoolVar(&settle, "settle-may-have-run", false,
+		"close the attempt as possibly executed; it never runs again")
+	resolve.Flags().StringVar(&reason, "reason", "", "why this decision is correct (required)")
+	// No default here: the flag's default is baked into the generated
+	// reference, and $USER at generation time would ship whoever ran
+	// the generator. The command resolves it at run time instead.
+	resolve.Flags().StringVar(&actor, "actor", "", "who is deciding (default: $USER)")
+	resolve.Flags().BoolVar(&apply, "apply", false, "perform the resolution (default is a preview)")
+
+	attempts.AddCommand(list, inspect, resolve)
+	return attempts
+}
+
+func newGCCommand() *cobra.Command {
+	var apply, aggressive bool
+	cmd := &cobra.Command{
+		Use:   "gc",
+		Short: "Collect cache lanes and finished lease records (dry run by default)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runGC(streamsOf(cmd), apply, aggressive)
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "perform the evictions (default is a dry run)")
+	cmd.Flags().BoolVar(&aggressive, "aggressive", false, "plan every free lane, not just expired and over-budget ones")
+	return cmd
+}
+
+func newCleanupCommand() *cobra.Command {
+	var apply bool
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "Remove resources no live lease needs (dry run by default)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runCleanup(streamsOf(cmd), apply)
+		},
+	}
+	cmd.Flags().BoolVar(&apply, "apply", false, "perform the removals (default is a dry run)")
+	return cmd
+}
+
+func newUninstallCommand() *cobra.Command {
+	var (
+		confirm         string
+		deleteScaleSets bool
+	)
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove everything this instance owns",
+		Long: "Removes every container, network and volume this instance owns,\n" +
+			"including cache lanes. The state volume is left for you to remove.\n" +
+			"Without --confirm it is a dry run and prints the exact command.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runUninstall(streamsOf(cmd), confirm, deleteScaleSets)
+		},
+	}
+	cmd.Flags().StringVar(&confirm, "confirm", "", "the instance id being uninstalled")
+	cmd.Flags().BoolVar(&deleteScaleSets, "delete-scale-sets", false, "also delete this instance's scale sets from the provider")
+	return cmd
+}
+
+func newConfigCommand() *cobra.Command {
+	config := &cobra.Command{
+		Use:   "config",
+		Short: "Validate and inspect the configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+
+	var validateFile string
+	validate := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a configuration file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runConfigValidate(streamsOf(cmd), validateFile)
+		},
+	}
+	validate.Flags().StringVar(&validateFile, "file", "", "path to the configuration file")
+
+	// The schema carries secret references — environment variable names,
+	// file paths — and never secret values, so there is nothing to
+	// redact. The flag is accepted and does nothing, which the help text
+	// says outright rather than implying a redaction happened.
+	var (
+		effectiveFile string
+		redacted      bool
+	)
+	effective := &cobra.Command{
+		Use:   "effective",
+		Short: "Print the defaulted, validated configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operational(cmd)
+			return runConfigEffective(streamsOf(cmd), effectiveFile)
+		},
+	}
+	effective.Flags().StringVar(&effectiveFile, "file", "", "path to the configuration file (default: the environment)")
+	effective.Flags().BoolVar(&redacted, "redacted", false,
+		"accepted for forward compatibility; the schema holds secret references, never secret values, so nothing is redacted")
+	_ = redacted
+
+	config.AddCommand(validate, effective)
+	return config
+}

--- a/internal/command/config.go
+++ b/internal/command/config.go
@@ -1,0 +1,42 @@
+package command
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+func runConfigValidate(streams IO, file string) error {
+	if file == "" {
+		return usagef("config validate: --file is required")
+	}
+	if _, err := config.LoadFile(file); err != nil {
+		return err
+	}
+	fmt.Fprintln(streams.Out, "configuration valid")
+	return nil
+}
+
+func runConfigEffective(streams IO, file string) error {
+	var (
+		c   *config.Config
+		err error
+	)
+	if file != "" {
+		c, err = config.LoadFile(file)
+	} else {
+		c, err = config.Load(os.Getenv)
+	}
+	if err != nil {
+		return err
+	}
+	out, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+	_, err = streams.Out.Write(out)
+	return err
+}

--- a/internal/command/doctor.go
+++ b/internal/command/doctor.go
@@ -1,0 +1,132 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/credential"
+	"github.com/rhobuild/runpool/internal/doctor"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+func runDoctor(streams IO, asJSON bool) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	// A configuration error is itself a diagnosis: report it and check
+	// the host anyway, since the operator needs both answers at once.
+	cfg, cfgErr := config.Load(os.Getenv)
+	dock, dockErr := docker.New(ctx)
+	if dockErr == nil {
+		defer dock.Close()
+	}
+
+	opts := doctor.Options{
+		Config:   cfg,
+		Docker:   dock,
+		StateDir: stateDir(),
+		Environ:  os.Getenv,
+	}
+	// Injecting the probe is what asks for the live credential checks, and
+	// it is this layer's job: the doctor stays provider-neutral, and only
+	// the composition root names an adapter.
+	if cfg != nil {
+		opts.NewCredentialProbe = newGitHubCredentialProbe
+	}
+	report := doctor.Run(ctx, opts)
+
+	if asJSON {
+		enc := json.NewEncoder(streams.Out)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+	} else {
+		fmt.Fprint(streams.Out, report)
+	}
+	// The report itself is the output; a failing check has already been
+	// printed line by line, so the error carries the verdict rather than
+	// repeating the findings.
+	switch {
+	case cfgErr != nil:
+		return fmt.Errorf("configuration: %w", cfgErr)
+	case !report.OK():
+		return errors.New("host does not meet the runtime contract; see the failing checks above")
+	}
+	return nil
+}
+
+// runHealthcheck is the container health command. Liveness answers
+// whether this process can still reach its own state; readiness adds
+// the host contract. It is deliberately cheap and local: no GitHub call,
+// so a broker outage never marks the controller unhealthy.
+func runHealthcheck(streams IO, mode string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	switch mode {
+	case "liveness":
+		// The state directory is the one resource whose loss makes the
+		// controller unable to do anything correctly.
+		if _, err := os.Stat(stateDir() + "/" + store.DatabaseFile); err != nil {
+			return fmt.Errorf("state database unreachable: %w", err)
+		}
+		fmt.Fprintln(streams.Out, "ok")
+		return nil
+	case "readiness":
+		cfg, err := config.Load(os.Getenv)
+		if err != nil {
+			return fmt.Errorf("configuration: %w", err)
+		}
+		dock, err := docker.New(ctx)
+		if err != nil {
+			return fmt.Errorf("docker: %w", err)
+		}
+		defer dock.Close()
+		report := doctor.Run(ctx, doctor.Options{
+			Config: cfg, Docker: dock, StateDir: stateDir(), Environ: os.Getenv,
+		})
+		if !report.OK() {
+			fmt.Fprint(streams.Err, report)
+			return errors.New("host does not meet the runtime contract")
+		}
+		fmt.Fprintln(streams.Out, "ok")
+		return nil
+	default:
+		return usagef("--mode must be liveness or readiness, not %q", mode)
+	}
+}
+
+// newGitHubCredentialProbe builds the doctor's provider probe for one
+// target. The error path returns an explicit nil: handing back a typed
+// nil pointer would give the doctor a non-nil interface holding nothing.
+func newGitHubCredentialProbe(configURL string, secret credential.Secret) (doctor.CredentialProbe, error) {
+	client, err := githubactions.NewClient(githubactions.ClientConfig{
+		ConfigURL: configURL, Credential: secret, Version: "doctor",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return githubProbe{client}, nil
+}
+
+// githubProbe narrows the adapter's client to what the doctor declares.
+// The adapter answers with its own scale set type, and the doctor stays
+// provider-neutral by never naming one — so the translation belongs here,
+// in the layer that already knows which adapter this is.
+type githubProbe struct{ *githubactions.Client }
+
+func (p githubProbe) ScaleSetID(ctx context.Context, group, name string) (int, bool, error) {
+	set, found, err := p.Client.ScaleSetByName(ctx, group, name)
+	if err != nil || !found {
+		return 0, false, err
+	}
+	return set.ID, true, nil
+}

--- a/internal/command/gc.go
+++ b/internal/command/gc.go
@@ -1,0 +1,186 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// runGC is the operator's collection pass: plan first, always; touch
+// nothing without --apply. The dry run opens the store read-only so it
+// can inspect a live controller; apply takes the maintenance lock,
+// because evicting under a serving controller's feet is what the
+// controller's own monitor is for.
+func runGC(streams IO, apply, aggressive bool) error {
+	// The policy comes from the configuration when there is one, and
+	// from the documented defaults otherwise — a gc run must not invent
+	// thresholds the serving controller would not use.
+	cfg, err := config.Load(os.Getenv)
+	if err != nil {
+		return err
+	}
+	if cfg == nil {
+		cfg = &config.Config{}
+		config.ApplyDefaults(cfg)
+	}
+	opts := cache.GCOptions{
+		TTL: time.Duration(cfg.Cache.Defaults.UnusedTTL),
+		TargetBytes: cache.GCTarget(int64(cfg.Cache.Global.MaxManagedBytes),
+			cfg.Cache.Global.LowWatermarkPercent),
+		AllFree: aggressive,
+		Now:     time.Now(),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	var st *store.Store
+	var dock *docker.Client
+	if apply {
+		var unlock func()
+		st, dock, unlock, err = openStoreAndDocker(ctx)
+		if err != nil {
+			return err
+		}
+		defer unlock()
+	} else {
+		st, err = store.OpenReadOnly(stateDir())
+		if errors.Is(err, store.ErrNoState) {
+			fmt.Fprintf(streams.Out, "no state in %s: this instance has not run yet\n", stateDir())
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		dock, err = docker.New(ctx)
+		if err != nil {
+			return fmt.Errorf("docker: %w", err)
+		}
+	}
+	defer st.Close()
+	defer dock.Close()
+
+	mgr := cache.New(st, dock, st.InstanceID())
+	plan, err := mgr.PlanGC(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(streams.Out, "managed cache: %s across lanes; plan keeps %s\n",
+		config.ByteSize(plan.ManagedBytes), config.ByteSize(plan.KeptBytes))
+	verb := "would evict"
+	if apply {
+		verb = "evicting"
+	}
+	if len(plan.Evictions) == 0 {
+		fmt.Fprintln(streams.Out, "nothing to evict")
+	}
+	for _, e := range plan.Evictions {
+		if e.Orphan {
+			fmt.Fprintf(streams.Out, "  %s %-34s %8s  orphan volume (no lane row)\n", verb, e.Volume, config.ByteSize(e.Bytes))
+			continue
+		}
+		fmt.Fprintf(streams.Out, "  %s %-34s %8s  %s  %s (%s)\n", verb, e.Volume,
+			config.ByteSize(e.Bytes), e.Reason, e.SourceProjectKey, e.Generation)
+	}
+
+	// Lease history is the second thing this pass collects. It is reported
+	// separately because lanes and rows are different objects: one is disk
+	// an operator can see, the other is the books.
+	if err := reportLeaseHistory(ctx, streams, st, cfg, apply); err != nil {
+		return err
+	}
+
+	if !apply {
+		fmt.Fprintln(streams.Out, "\ndry run; re-run with --apply to collect")
+		return nil
+	}
+	if len(plan.Evictions) == 0 {
+		return nil
+	}
+
+	res, err := mgr.RunGC(ctx, plan, "cli")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(streams.Out, "evicted %d, skipped %d (leased since planning), failed %d\n",
+		res.Applied, res.Skipped, len(res.Failed))
+	for _, ferr := range res.Failed {
+		fmt.Fprintln(streams.Err, " ", ferr)
+	}
+	// An audit row that could not be written is a hole in the trail, not a
+	// failed collection: the lane is already gone, so no later pass can
+	// retry it and reporting it as a failure would be false twice over.
+	for _, aerr := range res.AuditFailed {
+		fmt.Fprintln(streams.Err, "  evicted but not recorded in the audit log:", aerr)
+	}
+	if len(res.Failed) > 0 {
+		return fmt.Errorf("%d eviction(s) failed; the next pass retries them", len(res.Failed))
+	}
+	return nil
+}
+
+// reportLeaseHistory counts, and on --apply forgets, the record of leases
+// finished longer ago than the retention window. A zero window keeps
+// every one, and says nothing.
+//
+// The delete runs here rather than through the cache manager because it
+// shares nothing with lane eviction: no daemon, no objects to enumerate,
+// no per-item outcome. Only the plan-then-apply shape is borrowed.
+func reportLeaseHistory(ctx context.Context, streams IO, st *store.Store, cfg *config.Config, apply bool) error {
+	window := cfg.Retention.Window()
+	if window <= 0 {
+		fmt.Fprintln(streams.Out, "lease history: kept indefinitely (retention.leaseHistory is 0)")
+		return nil
+	}
+
+	const perRun = 5000
+	before := time.Now().Add(-window)
+	if !apply {
+		var n int
+		if err := st.Tx(ctx, func(tx *store.Tx) error {
+			var err error
+			n, err = tx.CountPrunableLeases(before, perRun)
+			return err
+		}); err != nil {
+			return err
+		}
+		fmt.Fprintf(streams.Out, "lease history: would forget %d record(s) finished before %s",
+			n, before.UTC().Format(time.RFC3339))
+		// The count is bounded by the same per-run limit the apply uses, so
+		// reaching it means "at least this many", not "this many". Printed
+		// unqualified it reads as a total, and an operator who ran the apply
+		// and saw the same figure would conclude the backlog was cleared.
+		if n == perRun {
+			fmt.Fprintf(streams.Out, " (this run's limit; more remain)")
+		}
+		fmt.Fprintln(streams.Out)
+		return nil
+	}
+
+	var pruned int
+	if err := st.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		pruned, err = tx.PruneLeaseHistory(before, perRun)
+		if err != nil || pruned == 0 {
+			return err
+		}
+		return tx.RecordAudit("cli", "retention_prune", "capsule_leases",
+			fmt.Sprintf("pruned=%d older_than=%s", pruned, window))
+	}); err != nil {
+		return err
+	}
+	fmt.Fprintf(streams.Out, "lease history: forgot %d record(s)", pruned)
+	if pruned == perRun {
+		fmt.Fprintf(streams.Out, " (this run's limit; run again to continue)")
+	}
+	fmt.Fprintln(streams.Out)
+	return nil
+}

--- a/internal/command/gc_test.go
+++ b/internal/command/gc_test.go
@@ -1,0 +1,55 @@
+package command
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+func capture() (IO, *bytes.Buffer, *bytes.Buffer) {
+	var out, errBuf bytes.Buffer
+	return IO{In: strings.NewReader(""), Out: &out, Err: &errBuf}, &out, &errBuf
+}
+
+// TestReportLeaseHistorySaysWhatItWouldDo. Retention deletes an
+// operator's records without being asked, so this line is the only place
+// they see it happening. Three things it has to get right: zero says it
+// keeps everything, a dry run promises rather than acts, and a count
+// that reached the per-run limit says so — an operator who reads the
+// same number from the preview and the apply otherwise concludes the
+// backlog is gone.
+func TestReportLeaseHistorySaysWhatItWouldDo(t *testing.T) {
+	st, err := store.Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{}
+	config.ApplyDefaults(cfg)
+
+	streams, out, _ := capture()
+	if err := reportLeaseHistory(t.Context(), streams, st, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "would forget 0 record(s)") {
+		t.Errorf("a dry run over an empty store said %q; it must promise, and say how much", out.String())
+	}
+	if strings.Contains(out.String(), "limit") {
+		t.Errorf("a count nowhere near the per-run limit claimed to be capped: %q", out.String())
+	}
+
+	keep := config.Duration(0)
+	cfg.Retention.LeaseHistory = &keep
+	streams, out, _ = capture()
+	if err := reportLeaseHistory(t.Context(), streams, st, cfg, true); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "kept indefinitely") {
+		t.Errorf("a zero window said %q; the operator asked for every record to be kept "+
+			"and has to be told that is what is happening", out.String())
+	}
+}

--- a/internal/command/gen/main.go
+++ b/internal/command/gen/main.go
@@ -1,0 +1,115 @@
+// Command gen writes the CLI reference and the shell completions from
+// the command tree itself, so the documentation cannot drift from what
+// the binary does. Run it with `go generate ./internal/command/...`.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/command"
+	"github.com/spf13/cobra/doc"
+)
+
+func main() {
+	// go generate runs in the package directory, so the repository root
+	// is found rather than assumed: writing relative to the caller's
+	// directory once produced a whole documentation tree nested inside
+	// internal/command.
+	rootDir, err := repoRoot()
+	if err != nil {
+		fail(err)
+	}
+	if err := os.Chdir(rootDir); err != nil {
+		fail(err)
+	}
+
+	root := command.NewRootCommand(command.BuildInfo{Version: "dev"}, command.IO{
+		In: os.Stdin, Out: os.Stdout, Err: os.Stderr,
+	})
+	root.DisableAutoGenTag = true
+
+	refDir := filepath.Join("docs", "reference", "cli")
+	if err := os.MkdirAll(refDir, 0o755); err != nil {
+		fail(err)
+	}
+	// Remove what a previous run wrote, so a command that no longer
+	// exists does not linger as documentation for something absent.
+	entries, err := filepath.Glob(filepath.Join(refDir, "runpool*.md"))
+	if err != nil {
+		fail(err)
+	}
+	for _, e := range entries {
+		if err := os.Remove(e); err != nil {
+			fail(err)
+		}
+	}
+	if err := doc.GenMarkdownTree(root, refDir); err != nil {
+		fail(err)
+	}
+	generated, err := filepath.Glob(filepath.Join(refDir, "runpool*.md"))
+	if err != nil {
+		fail(err)
+	}
+	for _, path := range generated {
+		if err := normalizeMarkdown(path); err != nil {
+			fail(err)
+		}
+	}
+
+	compDir := filepath.Join("dist", "completions")
+	if err := os.MkdirAll(compDir, 0o755); err != nil {
+		fail(err)
+	}
+	for name, gen := range map[string]func(string) error{
+		"runpool.bash": root.GenBashCompletionFile,
+		"runpool.zsh":  root.GenZshCompletionFile,
+		"runpool.fish": func(p string) error { return root.GenFishCompletionFile(p, true) },
+	} {
+		if err := gen(filepath.Join(compDir, name)); err != nil {
+			fail(err)
+		}
+	}
+	fmt.Println("wrote the CLI reference to", refDir, "and completions to", compDir)
+}
+
+// normalizeMarkdown removes generator-specific trailing whitespace and leaves
+// exactly one final newline. The generated reference is committed and must pass
+// the same repository hygiene checks as handwritten documentation.
+func normalizeMarkdown(path string) error {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(strings.ReplaceAll(string(body), "\r\n", "\n"), "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	normalized := strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
+	return os.WriteFile(path, []byte(normalized), 0o644)
+}
+
+// repoRoot walks up until it finds the module definition.
+func repoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "gen:", err)
+	os.Exit(1)
+}

--- a/internal/command/generate.go
+++ b/internal/command/generate.go
@@ -1,0 +1,7 @@
+package command
+
+// The CLI reference under docs/reference/cli and the shell completions
+// under dist/ are generated from this command tree, so documentation
+// cannot describe a flag the binary does not have.
+//
+//go:generate go run ./gen

--- a/internal/command/platform_summary.go
+++ b/internal/command/platform_summary.go
@@ -1,0 +1,31 @@
+package command
+
+import "github.com/rhobuild/runpool/internal/platform"
+
+// releaseQualificationReference summarizes the exact evidence host reported by
+// `version --json`. Runtime compatibility remains a separate doctor check.
+func releaseQualificationReference() map[string]string {
+	ref, err := platform.Load()
+	if err != nil {
+		return map[string]string{"error": err.Error()}
+	}
+	if ref.Status != platform.ReferenceStatusFrozen {
+		return map[string]string{
+			"status":         ref.Status,
+			"os":             ref.Policy.OS + " " + ref.Policy.OSVersion,
+			"arch":           ref.Policy.Arch,
+			"docker_channel": ref.Policy.DockerChannel,
+			"selection":      ref.Policy.Selection,
+			"target_engine":  ref.Policy.TargetEngine,
+			"reviewed":       ref.Policy.Reviewed,
+		}
+	}
+	return map[string]string{
+		"status":   ref.Status,
+		"os":       ref.Platform.OS + " " + ref.Platform.OSVersion,
+		"arch":     ref.Platform.Arch,
+		"engine":   ref.Platform.Engine,
+		"cgroup":   "v" + ref.Platform.CgroupVersion + "/" + ref.Platform.CgroupDriver,
+		"recorded": ref.Recorded,
+	}
+}

--- a/internal/command/serve.go
+++ b/internal/command/serve.go
@@ -1,0 +1,49 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/rhobuild/runpool/internal/app"
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// The state mount point in the reference deployment; RUNPOOL_STATE_DIR
+// overrides it for development hosts. Cache lanes are daemon-side
+// volumes and need no directory of the controller's own.
+const defaultStateDir = "/var/lib/runpool/state"
+
+func stateDir() string { return dirOrDefault("RUNPOOL_STATE_DIR", defaultStateDir) }
+
+func dirOrDefault(env, fallback string) string {
+	if v := os.Getenv(env); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func runServe(build BuildInfo) error {
+	cfg, err := config.Load(os.Getenv)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// A cancelled context is the signal that asked for the shutdown, so
+	// a clean drain is a success however it was triggered.
+	err = app.Serve(ctx, cfg, app.Options{
+		Version:      build.Version,
+		CapsuleImage: build.CapsuleImage,
+		StateDir:     stateDir(),
+		Environ:      os.Getenv,
+	})
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -1,0 +1,268 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// runStatus answers the operability questions the design requires an
+// operator to answer without reading SQLite: what this instance owns,
+// which leases are live, which cache lanes are held, and whether the
+// books agree with the daemon.
+func runStatus(streams IO, asJSON bool, shippedCapsule string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Read-only: reporting must not migrate — or create — a store a live
+	// controller owns.
+	st, err := store.OpenReadOnly(stateDir())
+	if errors.Is(err, store.ErrNoState) {
+		// A report that answers in prose is still a report, and --json
+		// promised a document. The first scripted call after an install
+		// meets exactly this state, so answering it with a line of text
+		// and exit 0 is a parse failure that looks like success.
+		return reportNoState(streams, asJSON)
+	}
+	if err != nil {
+		return err
+	}
+	defer st.Close()
+
+	snap, err := st.Snapshot()
+	if err != nil {
+		return err
+	}
+
+	// The held-work queue rides along: an operator reading status must
+	// see what is waiting for a person without knowing to ask.
+	var review []attemptView
+	if err := st.Tx(ctx, func(tx *store.Tx) error {
+		attempts, err := tx.ManualReviewAttempts()
+		if err != nil {
+			return err
+		}
+		now := time.Now()
+		for _, a := range attempts {
+			review = append(review, viewOf(a, now))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Docker observation is best-effort: status must still report the
+	// books when the daemon is unreachable, which is itself a finding.
+	// Containers, networks and volumes are all observed — agreement
+	// judged from containers alone once hid every leaked network.
+	var obs daemonObservation
+	if dock, err := docker.New(ctx); err == nil {
+		defer dock.Close()
+		if obs.containers, err = dock.ListOwnedContainers(ctx, snap.InstanceID); err == nil {
+			if obs.networks, err = dock.ListOwnedNetworks(ctx, snap.InstanceID); err == nil {
+				obs.volumes, err = dock.ListOwnedVolumes(ctx, snap.InstanceID)
+			}
+		}
+		obs.err = err
+	} else {
+		obs.err = err
+	}
+
+	cfg := configuredStatusConfig(os.Getenv)
+	doc := statusDocument(snap, cfg, review, obs, shippedCapsule)
+	if asJSON {
+		enc := json.NewEncoder(streams.Out)
+		enc.SetIndent("", "  ")
+		return enc.Encode(doc)
+	}
+
+	fmt.Fprintf(streams.Out, "instance %s (schema v%d, %s)\n", snap.InstanceID, snap.SchemaVersion, doc.HostTopology)
+	if capacity := doc.Scheduling; capacity != nil {
+		fmt.Fprintf(streams.Out, "scheduling: %s, effective parallelism %d, %d active, %d available, %d queued\n",
+			capacity.Mode, capacity.EffectiveParallelism, capacity.Active, capacity.Available, capacity.Queued)
+		for _, tier := range capacity.Tiers {
+			fmt.Fprintf(streams.Out, "  %-16s parallelism %-4d active %-4d available %d\n",
+				tier.ID, tier.Parallelism, tier.Active, tier.Available)
+		}
+	}
+
+	if p := snap.Pressure; p != nil {
+		fmt.Fprintf(streams.Out, "\ndisk pressure: %s (free %s, managed cache %s, measured %s ago)\n",
+			p.Level, config.ByteSize(p.FreeBytes), config.ByteSize(p.ManagedBytes),
+			time.Since(time.Unix(p.MeasuredAt, 0)).Round(time.Second))
+		if p.Level != "normal" {
+			fmt.Fprintln(streams.Out, "  see docs/runbook.md for what this level means and what to do")
+		}
+	}
+
+	fmt.Fprintf(streams.Out, "\nbindings (%d)\n", len(snap.Bindings))
+	now := time.Now()
+	for _, b := range snap.Bindings {
+		fmt.Fprintf(streams.Out, "  %-14s %-16s %-8s %s\n",
+			b.TargetID, b.ProviderKind, b.DesiredState, b.SourceBindingKey)
+		fmt.Fprintf(streams.Out, "  %-14s %s\n", "", providerReach(b.Contact, now))
+	}
+
+	// The released figure is the store's total, not what the snapshot
+	// carries: the snapshot bounds finished history, and a count that
+	// silently meant "the recent ones" would understate what is there.
+	live, released := splitLeases(snap.Leases)
+	fmt.Fprintf(streams.Out, "\nleases: %d live, %d released", len(live), snap.ReleasedTotal)
+	if snap.ReleasedTotal > len(released) {
+		fmt.Fprintf(streams.Out, " (showing the %d most recent)", len(released))
+	}
+	fmt.Fprintln(streams.Out)
+	for _, l := range live {
+		resources := snap.Resources[l.ID]
+		project := ""
+		if a, ok := snap.Attempts[l.ID]; ok {
+			project = a.TenantKey + "/" + a.ProjectKey
+		}
+		fmt.Fprintf(streams.Out, "  %-16s %-18s %-28s %d resources\n", l.ID, l.State, project, len(resources))
+	}
+
+	if len(review) > 0 {
+		fmt.Fprintf(streams.Out, "\nmanual review (%d) — resolve with `runpool attempts resolve`\n", len(review))
+		for _, v := range review {
+			fmt.Fprintf(streams.Out, "  %-22s %-28s %-24s held %s for %s\n",
+				v.ID, v.Workload, v.Project, v.ReviewReason,
+				(time.Duration(v.AgeSeconds) * time.Second).String())
+		}
+	}
+
+	fmt.Fprintf(streams.Out, "\ncache lanes (%d)\n", len(snap.CacheLanes))
+	for _, c := range snap.CacheLanes {
+		holder := "free"
+		if c.LeasedBy != "" {
+			holder = "leased by " + c.LeasedBy
+		}
+		fmt.Fprintf(streams.Out, "  %-16s %-12s %-40s %s\n", c.ID, c.Generation, c.SourceProjectKey, holder)
+	}
+
+	fmt.Fprintf(streams.Out, "\nowned containers (%d)\n", len(obs.containers))
+	for _, c := range obs.containers {
+		running := "exited"
+		if c.Running {
+			running = "running"
+		}
+		fmt.Fprintf(streams.Out, "  %-30s %-8s %-8s lease %s\n", c.Name, c.Role, running, c.LeaseID)
+	}
+	fmt.Fprintf(streams.Out, "\nowned networks (%d), volumes (%d)\n", len(obs.networks), len(obs.volumes))
+	if obs.err != nil {
+		fmt.Fprintf(streams.Out, "\ndocker: %v — the books could not be compared with the daemon\n", obs.err)
+		return nil
+	}
+
+	// The disagreements that matter, across every observed object kind.
+	// Reconciliation fixes them at startup; surfacing them here explains
+	// a degraded instance.
+	if len(doc.Discrepancies) > 0 {
+		fmt.Fprintf(streams.Out, "\ndiscrepancies\n")
+		for _, d := range doc.Discrepancies {
+			fmt.Fprintf(streams.Out, "  %s\n", d)
+		}
+	}
+	return nil
+}
+
+// configuredStatusConfig is best-effort because status remains useful when
+// the active configuration is temporarily invalid or credentials are absent.
+// File mode can be decoded without resolving credential values. Quick Start
+// reconstructs only the fields needed by reporting.
+func configuredStatusConfig(environ func(string) string) *config.Config {
+	if path := environ(config.EnvConfigFile); path != "" {
+		if cfg, err := config.LoadFile(path); err == nil {
+			return cfg
+		}
+		return nil
+	}
+	topology := environ(config.EnvHostTopology)
+	if topology == "" {
+		return nil
+	}
+	parallelism := 1
+	if raw := environ(config.EnvParallelism); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 {
+			return nil
+		}
+		parallelism = parsed
+	}
+	tierID := environ(config.EnvTier)
+	if tierID == "" {
+		tierID = config.DefaultTierID
+	}
+	return &config.Config{
+		Host:  config.Host{Topology: topology},
+		Tiers: []config.Tier{{ID: tierID, Parallelism: parallelism}},
+	}
+}
+
+func splitLeases(all []store.Lease) (live, released []store.Lease) {
+	for _, l := range all {
+		if l.State.Terminal() {
+			released = append(released, l)
+		} else {
+			live = append(live, l)
+		}
+	}
+	return live, released
+}
+
+// providerReach is the one line that separates an idle instance from one
+// reaching nothing. Both hold no leases and answer every local query, so
+// without this the most likely first-run failure — a binding whose
+// provider never sends it work — looks exactly like success.
+func providerReach(c store.ProviderContact, now time.Time) string {
+	switch {
+	case c.LastContact.IsZero() && c.LastError == "":
+		return "provider: no contact recorded; this binding has not served yet"
+	// Not strictly after: the two moments are recorded by the same loop
+	// pass and a failure that lands in the same millisecond as the success
+	// before it is still the later fact. A tie goes to the failure,
+	// because a report that hides one is worse than one that shows a
+	// stale one.
+	case c.LastError != "" && !c.LastContact.After(c.LastErrorAt):
+		since := "never reached"
+		if !c.LastContact.IsZero() {
+			since = "last reached " + ago(now, c.LastContact)
+		}
+		return fmt.Sprintf("provider: failing since %s (%s): %s",
+			ago(now, c.LastErrorAt), since, c.LastError)
+	default:
+		return "provider: last reached " + ago(now, c.LastContact)
+	}
+}
+
+// ago renders a gap the way an operator reads one: the size of the wait,
+// not a timestamp to subtract from the current time by hand.
+func ago(now, then time.Time) string {
+	d := now.Sub(then).Round(time.Second)
+	if d < 0 {
+		d = 0
+	}
+	return d.String() + " ago"
+}
+
+// reportNoState answers the one state every command can meet before the
+// controller has ever run, in whichever form the caller asked for.
+func reportNoState(streams IO, asJSON bool) error {
+	if asJSON {
+		return json.NewEncoder(streams.Out).Encode(map[string]any{
+			"api_version": statusAPIVersion,
+			"state_dir":   stateDir(),
+			"served":      false,
+			"detail":      "this instance has not run yet",
+		})
+	}
+	fmt.Fprintf(streams.Out, "no state in %s: this instance has not run yet\n", stateDir())
+	return nil
+}

--- a/internal/command/status_test.go
+++ b/internal/command/status_test.go
@@ -1,0 +1,114 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestProviderReachSeparatesIdleFromUnreachable pins the distinction the
+// report exists to make. An instance holding no leases is either idle or
+// reaching nothing, and every other field in the document reads the same
+// in both cases.
+func TestProviderReachSeparatesIdleFromUnreachable(t *testing.T) {
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	for name, tc := range map[string]struct {
+		contact store.ProviderContact
+		want    []string
+		unwant  []string
+	}{
+		"never served": {
+			contact: store.ProviderContact{},
+			want:    []string{"no contact recorded"},
+			unwant:  []string{"failing"},
+		},
+		"reaching its provider": {
+			contact: store.ProviderContact{LastContact: now.Add(-30 * time.Second)},
+			want:    []string{"last reached", "30s ago"},
+			unwant:  []string{"failing"},
+		},
+		"failing in the same instant it last reached": {
+			contact: store.ProviderContact{
+				LastContact: now.Add(-time.Second),
+				LastError:   "broker unreachable",
+				LastErrorAt: now.Add(-time.Second),
+			},
+			want: []string{"failing since", "broker unreachable"},
+		},
+		"failing after having reached it": {
+			contact: store.ProviderContact{
+				LastContact: now.Add(-2 * time.Hour),
+				LastError:   "401 Unauthorized",
+				LastErrorAt: now.Add(-1 * time.Minute),
+			},
+			want: []string{"failing since", "1m0s ago", "last reached 2h0m0s ago", "401 Unauthorized"},
+		},
+		"failing without ever having reached it": {
+			contact: store.ProviderContact{
+				LastError:   "no such host",
+				LastErrorAt: now.Add(-5 * time.Second),
+			},
+			want: []string{"failing since", "never reached", "no such host"},
+		},
+		"recovered since the last failure": {
+			contact: store.ProviderContact{
+				LastContact: now.Add(-10 * time.Second),
+				LastError:   "connection refused",
+				LastErrorAt: now.Add(-1 * time.Hour),
+			},
+			want:   []string{"last reached", "10s ago"},
+			unwant: []string{"failing", "connection refused"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := providerReach(tc.contact, now)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("%q does not contain %q", got, want)
+				}
+			}
+			for _, unwant := range tc.unwant {
+				if strings.Contains(got, unwant) {
+					t.Errorf("%q contains %q and should not", got, unwant)
+				}
+			}
+		})
+	}
+}
+
+// TestNoStateAnswersInTheFormAsked: the first scripted call after an
+// install meets a state directory the controller has never written.
+// Answering --json with a line of prose and exit 0 is a parse failure
+// that looks like success, which is the worst shape a first contact can
+// take.
+func TestNoStateAnswersInTheFormAsked(t *testing.T) {
+	var out bytes.Buffer
+	if err := reportNoState(IO{Out: &out}, true); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("--json produced %q, which is not a document: %v", out.String(), err)
+	}
+	if doc["served"] != false {
+		t.Errorf("document = %v; want it to say this instance has not served", doc)
+	}
+	if doc["api_version"] != statusAPIVersion {
+		t.Errorf("document = %v; want the same version the served document carries", doc)
+	}
+
+	out.Reset()
+	if err := reportNoState(IO{Out: &out}, false); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "has not run yet") {
+		t.Errorf("human report = %q", out.String())
+	}
+	if strings.HasPrefix(strings.TrimSpace(out.String()), "{") {
+		t.Errorf("human report = %q; want prose, not a document", out.String())
+	}
+}

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -1,0 +1,352 @@
+package command
+
+import (
+	"time"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// The status document is a reporting contract, not a mirror of the
+// database: persistence rows change with migrations, while this shape
+// changes only with its version string. Field names are snake_case,
+// collections are always arrays — an empty one is `[]`, never null,
+// because consumers branch on length, not on presence.
+const statusAPIVersion = "v1"
+
+type statusDoc struct {
+	APIVersion    string         `json:"api_version"`
+	Instance      string         `json:"instance"`
+	HostTopology  string         `json:"host_topology"`
+	SchemaVersion int            `json:"schema_version"`
+	Scheduling    *schedulingDTO `json:"scheduling,omitempty"`
+	DiskPressure  *pressureDTO   `json:"disk_pressure"`
+	Bindings      []bindingDTO   `json:"bindings"`
+	Leases        []leaseDTO     `json:"leases"`
+	// ReleasedTotal is how many finished leases the store holds, which the
+	// leases array does not say: that array carries only the most recently
+	// finished, so its length is what was reported and not what exists. A
+	// consumer measuring the array would understate the history by every
+	// job beyond the bound.
+	ReleasedTotal int            `json:"released_total"`
+	CacheLanes    []laneDTO      `json:"cache_lanes"`
+	ManualReview  []attemptView  `json:"manual_review"`
+	Containers    []containerDTO `json:"containers"`
+	Networks      []resourceDTO  `json:"networks"`
+	Volumes       []resourceDTO  `json:"volumes"`
+	// Discrepancies is the books-versus-daemon comparison across every
+	// observed object kind. It is null only when the daemon could not
+	// be asked, which docker_error then explains: an unreadable daemon
+	// must not report as a clean one.
+	Discrepancies []string `json:"discrepancies"`
+	DockerError   string   `json:"docker_error,omitempty"`
+}
+
+type schedulingDTO struct {
+	Mode                 string `json:"mode"`
+	InstanceParallelism  *int   `json:"instance_parallelism"`
+	EffectiveParallelism int    `json:"effective_parallelism"`
+	Active               int    `json:"active"`
+	Available            int    `json:"available"`
+	// Queued is work admitted from the provider and waiting for a lease.
+	// Active counts leases, so without this an instance holding a hundred
+	// attempts and running one reports the same as an idle one.
+	Queued int               `json:"queued"`
+	Tiers  []tierCapacityDTO `json:"tiers"`
+}
+
+type tierCapacityDTO struct {
+	ID          string `json:"id"`
+	Parallelism int    `json:"parallelism"`
+	Active      int    `json:"active"`
+	Available   int    `json:"available"`
+	// CapsuleImage is what this tier's jobs actually run in: the image the
+	// tier names, or the one this build ships. It is reported because a
+	// deployment that replaced it is outside the configuration the release
+	// gates observed, and that should be visible rather than inferred from
+	// a configuration file the reader may not have.
+	CapsuleImage string `json:"capsule_image"`
+}
+
+type pressureDTO struct {
+	Level        string `json:"level"`
+	FreeBytes    int64  `json:"free_bytes"`
+	FreeInodes   int64  `json:"free_inodes"`
+	ManagedBytes int64  `json:"managed_bytes"`
+	MeasuredAt   string `json:"measured_at"`
+}
+
+// bindingDTO reports one configured source of work. It is provider
+// neutral by design: source_binding_key is the provider's own identity,
+// versioned and opaque, and a consumer that needs to parse it is reading
+// the wrong document.
+type bindingDTO struct {
+	TargetID         string `json:"target_id"`
+	ProviderKind     string `json:"provider_kind"`
+	SourceBindingKey string `json:"source_binding_key"`
+	DesiredState     string `json:"desired_state"`
+	// LastContactAt is when a provider call for this binding last
+	// succeeded, and LastError what it cannot do now. Both are reported
+	// because neither answers alone: an instance holding no leases is
+	// either idle or reaching nothing, and only the pair tells them
+	// apart. Empty on a binding that has not run yet.
+	LastContactAt string `json:"last_contact_at,omitempty"`
+	LastError     string `json:"last_error,omitempty"`
+	LastErrorAt   string `json:"last_error_at,omitempty"`
+}
+
+// leaseDTO reports one lease's runtime footprint. The attempt fields are
+// joined in from the record the lease serves: evidence and the project
+// belong to the attempt, and reporting them beside the lease is the
+// report's job, not the schema's.
+type leaseDTO struct {
+	ID          string        `json:"id"`
+	State       string        `json:"state"`
+	Terminal    bool          `json:"terminal"`
+	AttemptID   string        `json:"attempt_id"`
+	Project     string        `json:"project,omitempty"`
+	RuntimeName string        `json:"runtime_name,omitempty"`
+	Evidence    string        `json:"evidence"`
+	CreatedAt   string        `json:"created_at"`
+	Resources   []resourceDTO `json:"resources"`
+}
+
+type laneDTO struct {
+	ID               string `json:"id"`
+	SourceProjectKey string `json:"source_project_key"`
+	Generation       string `json:"generation"`
+	LeasedBy         string `json:"leased_by,omitempty"`
+	LastUsed         string `json:"last_used"`
+}
+
+type containerDTO struct {
+	Name    string `json:"name"`
+	Role    string `json:"role"`
+	LeaseID string `json:"lease_id,omitempty"`
+	Running bool   `json:"running"`
+}
+
+// resourceDTO reports one owned object — a recorded intent on a lease,
+// or a network/volume observed on the daemon.
+type resourceDTO struct {
+	Kind    string `json:"kind"`
+	Role    string `json:"role,omitempty"`
+	Name    string `json:"name"`
+	LeaseID string `json:"lease_id,omitempty"`
+	State   string `json:"state,omitempty"`
+}
+
+func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptView, obs daemonObservation, shippedCapsule string) statusDoc {
+	topology := "unknown"
+	if cfg != nil {
+		topology = cfg.Host.Topology
+	}
+	doc := statusDoc{
+		APIVersion:    statusAPIVersion,
+		Instance:      snap.InstanceID,
+		HostTopology:  topology,
+		SchemaVersion: snap.SchemaVersion,
+		Bindings:      []bindingDTO{},
+		Leases:        []leaseDTO{},
+		ReleasedTotal: snap.ReleasedTotal,
+		CacheLanes:    []laneDTO{},
+		ManualReview:  []attemptView{},
+		Containers:    []containerDTO{},
+		Networks:      []resourceDTO{},
+		Volumes:       []resourceDTO{},
+	}
+	if cfg != nil {
+		doc.Scheduling = schedulingStatus(cfg, snap.Leases, snap.Queued, shippedCapsule)
+	}
+	if p := snap.Pressure; p != nil {
+		doc.DiskPressure = &pressureDTO{
+			Level:        p.Level,
+			FreeBytes:    p.FreeBytes,
+			FreeInodes:   p.FreeInodes,
+			ManagedBytes: p.ManagedBytes,
+			MeasuredAt:   time.Unix(p.MeasuredAt, 0).UTC().Format(time.RFC3339),
+		}
+	}
+	for _, b := range snap.Bindings {
+		doc.Bindings = append(doc.Bindings, bindingDTO{
+			TargetID: b.TargetID, ProviderKind: b.ProviderKind,
+			SourceBindingKey: b.SourceBindingKey, DesiredState: b.DesiredState,
+			LastContactAt: rfc3339(b.Contact.LastContact),
+			LastError:     b.Contact.LastError,
+			LastErrorAt:   rfc3339(b.Contact.LastErrorAt),
+		})
+	}
+	for _, l := range snap.Leases {
+		attempt := snap.Attempts[l.ID]
+		project := ""
+		if attempt.TenantKey != "" || attempt.ProjectKey != "" {
+			project = attempt.TenantKey + "/" + attempt.ProjectKey
+		}
+		lease := leaseDTO{
+			ID:          l.ID,
+			State:       string(l.State),
+			Terminal:    l.State.Terminal(),
+			AttemptID:   l.AttemptID,
+			Project:     project,
+			RuntimeName: l.RuntimeName,
+			Evidence:    string(attempt.Evidence),
+			CreatedAt:   l.CreatedAt.UTC().Format(time.RFC3339),
+			Resources:   []resourceDTO{},
+		}
+		for _, in := range snap.Resources[l.ID] {
+			lease.Resources = append(lease.Resources, resourceDTO{
+				Kind: string(in.Kind), Role: in.Role, Name: in.Name, LeaseID: in.LeaseID, State: in.State,
+			})
+		}
+		doc.Leases = append(doc.Leases, lease)
+	}
+	for _, c := range snap.CacheLanes {
+		doc.CacheLanes = append(doc.CacheLanes, laneDTO{
+			ID: c.ID, SourceProjectKey: c.SourceProjectKey, Generation: c.Generation,
+			LeasedBy: c.LeasedBy, LastUsed: time.Unix(c.LastUsed, 0).UTC().Format(time.RFC3339),
+		})
+	}
+	doc.ManualReview = append(doc.ManualReview, review...)
+	for _, c := range obs.containers {
+		doc.Containers = append(doc.Containers, containerDTO{
+			Name: c.Name, Role: c.Role, LeaseID: c.LeaseID, Running: c.Running,
+		})
+	}
+	for _, n := range obs.networks {
+		doc.Networks = append(doc.Networks, resourceDTO{Kind: "network", Role: n.Role, Name: n.ID, LeaseID: n.LeaseID})
+	}
+	for _, v := range obs.volumes {
+		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: v.Role, Name: v.ID, LeaseID: v.LeaseID})
+	}
+	if obs.err != nil {
+		doc.DockerError = obs.err.Error()
+	} else {
+		doc.Discrepancies = discrepancies(snap.Leases, obs)
+	}
+	return doc
+}
+
+func schedulingStatus(cfg *config.Config, leases []store.Lease, queued map[int64]int, shippedCapsule string) *schedulingDTO {
+	activeByTier := make(map[string]int, len(cfg.Tiers))
+	active := 0
+	for _, lease := range leases {
+		if lease.State.Terminal() {
+			continue
+		}
+		active++
+		activeByTier[lease.TierID]++
+	}
+
+	mode := "independent-tiers"
+	effective := 0
+	if cfg.Scheduling.Parallelism != nil {
+		mode = "global"
+		effective = *cfg.Scheduling.Parallelism
+	} else {
+		for _, tier := range cfg.Tiers {
+			effective += tier.Parallelism
+		}
+	}
+	dto := &schedulingDTO{
+		Mode: mode, InstanceParallelism: cfg.Scheduling.Parallelism,
+		EffectiveParallelism: effective, Active: active, Tiers: []tierCapacityDTO{},
+	}
+	dto.Queued = queuedAttemptCount(queued)
+	dto.Available = dto.EffectiveParallelism - active
+	if dto.Available < 0 {
+		dto.Available = 0
+	}
+	for _, tier := range cfg.Tiers {
+		tierActive := activeByTier[tier.ID]
+		available := tier.Parallelism - tierActive
+		if available < 0 {
+			available = 0
+		}
+		if cfg.Scheduling.Parallelism != nil && available > dto.Available {
+			available = dto.Available
+		}
+		image := tier.CapsuleImage
+		if image == "" {
+			image = shippedCapsule
+		}
+		dto.Tiers = append(dto.Tiers, tierCapacityDTO{
+			ID: tier.ID, Parallelism: tier.Parallelism, Active: tierActive, Available: available,
+			CapsuleImage: image,
+		})
+	}
+	return dto
+}
+
+// daemonObservation is what the daemon reported about this instance's
+// objects, or the error that prevented asking.
+type daemonObservation struct {
+	containers []docker.OwnedContainer
+	networks   []docker.OwnedResource
+	volumes    []docker.OwnedResource
+	err        error
+}
+
+// discrepancies compares the books with everything the daemon showed —
+// containers, networks and volumes, not containers alone, because a
+// leaked network is exactly as much a disagreement as a leaked
+// container and used to be invisible here. An empty (non-nil) result
+// means the comparison ran and found agreement.
+func discrepancies(leases []store.Lease, obs daemonObservation) []string {
+	live := map[string]bool{}
+	for _, l := range leases {
+		if !l.State.Terminal() {
+			live[l.ID] = true
+		}
+	}
+	out := []string{}
+
+	withContainer := map[string]bool{}
+	for _, c := range obs.containers {
+		// A helper the instance is measuring with belongs to no lease by
+		// design, so judging it against the lease set reports a
+		// disagreement on every pass that catches one. Stopped is
+		// different: that one outlived its process and is a real leak.
+		if c.HelperInFlight() {
+			continue
+		}
+		withContainer[c.LeaseID] = true
+		if !live[c.LeaseID] {
+			out = append(out, "container "+c.Name+" belongs to no live lease")
+		}
+	}
+	for _, l := range leases {
+		if live[l.ID] && l.State == store.LeaseWorkloadRunning && !withContainer[l.ID] {
+			out = append(out, "lease "+l.ID+" claims to be running with no container")
+		}
+	}
+
+	check := func(kind string, resources []docker.OwnedResource, persistentRole string) {
+		for _, r := range resources {
+			switch {
+			case r.Role == persistentRole:
+				// Instance infrastructure: a lane or the uplink carries
+				// no lease on purpose.
+			case r.LeaseID == "":
+				out = append(out, kind+" "+r.ID+" carries no lease and no persistent role")
+			case !live[r.LeaseID]:
+				out = append(out, kind+" "+r.ID+" belongs to no live lease")
+			}
+		}
+	}
+	check("network", obs.networks, capsule.RoleUplink)
+	check("volume", obs.volumes, cache.RoleCacheLane)
+	return out
+}
+
+// rfc3339 renders a time for the report, and renders a zero time as
+// nothing at all: a field that has never been set is absent rather than
+// carrying an epoch a consumer would read as a real moment.
+func rfc3339(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -1,0 +1,219 @@
+package command
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// TestStatusDocumentShape pins the reporting contract: versioned,
+// snake_case, and every collection an array even when empty — a
+// consumer branches on length, and a null would make it branch on
+// presence instead.
+func TestStatusDocumentShape(t *testing.T) {
+	doc := statusDocument(store.Snapshot{InstanceID: "i-1", SchemaVersion: 1}, &config.Config{
+		Host:  config.Host{Topology: config.HostTopologySharedDaemon},
+		Tiers: []config.Tier{{ID: "standard", Parallelism: 1}},
+	}, nil, daemonObservation{}, "runpool-capsule:dev")
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+
+	if !strings.Contains(body, `"api_version":"v1"`) {
+		t.Errorf("document is not versioned: %s", body)
+	}
+	for _, field := range []string{
+		`"bindings":[]`, `"leases":[]`, `"cache_lanes":[]`,
+		`"manual_review":[]`, `"containers":[]`, `"networks":[]`,
+		`"volumes":[]`, `"discrepancies":[]`,
+	} {
+		if !strings.Contains(body, field) {
+			t.Errorf("empty collection did not serialize as []: want %s in %s", field, body)
+		}
+	}
+	if strings.Contains(body, "null,") || strings.HasSuffix(body, "null}") {
+		// disk_pressure is the one legitimate null: an absent
+		// measurement is absent, not empty.
+		if !strings.Contains(body, `"disk_pressure":null`) {
+			t.Errorf("unexpected null in %s", body)
+		}
+	}
+	for _, upper := range []string{"InstanceID", "SourceBindingKey", "LeaseID", "AttemptID"} {
+		if strings.Contains(body, upper) {
+			t.Errorf("persistence field name %q leaked into the reporting document", upper)
+		}
+	}
+}
+
+func TestConfiguredStatusConfigFromEnvironment(t *testing.T) {
+	environ := func(name string) string {
+		if name == "RUNPOOL_HOST_TOPOLOGY" {
+			return "shared-daemon"
+		}
+		return ""
+	}
+	got := configuredStatusConfig(environ)
+	if got == nil || got.Host.Topology != "shared-daemon" || got.Tiers[0].Parallelism != 1 {
+		t.Fatalf("status config = %+v; want shared-daemon with parallelism one", got)
+	}
+}
+
+// TestStatusDiscrepanciesCoverEveryKind: agreement judged from
+// containers alone once hid every leaked network and volume; the
+// comparison must name all three, and must not run at all when the
+// daemon could not be asked.
+func TestStatusDiscrepanciesCoverEveryKind(t *testing.T) {
+	leases := []store.Lease{
+		{ID: "lease-live", State: store.LeaseWorkloadRunning},
+		{ID: "lease-done", State: store.LeaseReleased},
+	}
+	obs := daemonObservation{
+		containers: []docker.OwnedContainer{
+			{Name: "c-orphan", LeaseID: "lease-done"},
+			// The instance's own helpers carry no lease. One in flight is
+			// the daemon and the books agreeing; one left stopped is a
+			// leak, and telling them apart is the whole report.
+			{Name: "probe-running", Role: "probe", Running: true},
+			{Name: "probe-leaked", Role: "probe"},
+		},
+		networks: []docker.OwnedResource{
+			{ID: "net-orphan", LeaseID: "lease-done"},
+			{ID: "uplink", Role: capsule.RoleUplink},
+		},
+		volumes: []docker.OwnedResource{
+			{ID: "vol-unclassified"},
+			{ID: "lane", Role: cache.RoleCacheLane},
+		},
+	}
+	got := discrepancies(leases, obs)
+
+	for _, want := range []string{
+		"container c-orphan belongs to no live lease",
+		"container probe-leaked belongs to no live lease",
+		"lease lease-live claims to be running with no container",
+		"network net-orphan belongs to no live lease",
+		"volume vol-unclassified carries no lease and no persistent role",
+	} {
+		found := false
+		for _, d := range got {
+			if d == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing discrepancy %q in %v", want, got)
+		}
+	}
+	for _, d := range got {
+		if strings.Contains(d, "uplink") || strings.Contains(d, "lane") {
+			t.Errorf("instance infrastructure reported as a discrepancy: %s", d)
+		}
+		if strings.Contains(d, "probe-running") {
+			t.Errorf("a helper still measuring reported as a discrepancy: %s", d)
+		}
+	}
+
+	// An unreachable daemon yields no comparison, and the document says
+	// why instead of claiming agreement.
+	doc := statusDocument(store.Snapshot{InstanceID: "i"}, nil, nil, daemonObservation{err: errors.New("daemon down")}, "")
+	if doc.Discrepancies != nil {
+		t.Errorf("discrepancies = %v with an unreachable daemon; want null (not compared)", doc.Discrepancies)
+	}
+	if doc.DockerError == "" {
+		t.Error("an unreachable daemon must be reported in docker_error")
+	}
+}
+
+func TestSchedulingStatusCountsEveryUnreleasedLease(t *testing.T) {
+	one := 1
+	cfg := &config.Config{
+		Scheduling: config.Scheduling{Parallelism: &one},
+		Tiers: []config.Tier{
+			{ID: "small", Parallelism: 1},
+			{ID: "large", Parallelism: 1},
+		},
+	}
+	leases := []store.Lease{
+		{ID: "active", TierID: "large", State: store.LeaseCleaning},
+		{ID: "released", TierID: "small", State: store.LeaseReleased},
+	}
+	got := schedulingStatus(cfg, leases, map[int64]int{7: 3}, "")
+	if got.Mode != "global" || got.Active != 1 || got.Available != 0 || got.EffectiveParallelism != 1 {
+		t.Fatalf("scheduling = %+v", got)
+	}
+	if got.Tiers[1].Active != 1 || got.Tiers[1].Available != 0 {
+		t.Fatalf("large tier accounting = %+v", got.Tiers[1])
+	}
+}
+
+// TestReleasedTotalIsTheStoresCountNotTheArrayLength. The leases array
+// carries only the most recently finished, so a consumer measuring it
+// understates the history by every job past the bound. The figure has to
+// come from the store, which is the reason it is published at all.
+func TestReleasedTotalIsTheStoresCountNotTheArrayLength(t *testing.T) {
+	doc := statusDocument(store.Snapshot{
+		InstanceID: "i-1",
+		Leases: []store.Lease{
+			{ID: "a", State: store.LeaseReleased},
+			{ID: "b", State: store.LeaseReleased},
+		},
+		ReleasedTotal: 4321,
+	}, nil, nil, daemonObservation{}, "")
+
+	if doc.ReleasedTotal != 4321 {
+		t.Errorf("released_total = %d; want the store's count, 4321", doc.ReleasedTotal)
+	}
+	if doc.ReleasedTotal == len(doc.Leases) {
+		t.Errorf("released_total was taken from the array, which is bounded by design")
+	}
+}
+
+// TestQueuedWorkIsReported. Active counts leases, and an attempt waiting
+// for admission has none — so an instance holding a backlog and running
+// one job reported exactly like an idle one. A queue that stops draining
+// is the shape a stuck binding takes, and it was invisible.
+func TestQueuedWorkIsReported(t *testing.T) {
+	cfg := &config.Config{Tiers: []config.Tier{{ID: "standard", Parallelism: 2}}}
+	got := schedulingStatus(cfg, nil, map[int64]int{1: 4, 2: 2}, "")
+	if got.Queued != 6 {
+		t.Errorf("queued = %d; want the sum across bindings, 6", got.Queued)
+	}
+	if idle := schedulingStatus(cfg, nil, nil, ""); idle.Queued != 0 {
+		t.Errorf("an instance with nothing waiting reports queued = %d", idle.Queued)
+	}
+}
+
+// TestTierReportsTheImageItRuns: a deployment that replaced the capsule
+// for a tier is outside the configuration the release gates observed, and
+// the report says so rather than leaving it to be inferred from a
+// configuration file the reader may not have.
+func TestTierReportsTheImageItRuns(t *testing.T) {
+	const shipped = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"4444444444444444444444444444444444444444444444444444444444444444"
+	const operators = "ghcr.io/acme/capsule@sha256:" +
+		"5555555555555555555555555555555555555555555555555555555555555555"
+	cfg := &config.Config{Tiers: []config.Tier{
+		{ID: "standard", Parallelism: 1},
+		{ID: "heavy", Parallelism: 1, CapsuleImage: operators},
+	}}
+
+	got := schedulingStatus(cfg, nil, nil, shipped)
+	if len(got.Tiers) != 2 {
+		t.Fatalf("tiers = %+v", got.Tiers)
+	}
+	if got.Tiers[0].CapsuleImage != shipped {
+		t.Errorf("a tier naming no image reports %q, want the shipped capsule", got.Tiers[0].CapsuleImage)
+	}
+	if got.Tiers[1].CapsuleImage != operators {
+		t.Errorf("a tier naming an image reports %q, want its own", got.Tiers[1].CapsuleImage)
+	}
+}

--- a/internal/command/version.go
+++ b/internal/command/version.go
@@ -1,0 +1,64 @@
+package command
+
+import (
+	"fmt"
+	"regexp"
+	"runtime/debug"
+)
+
+// Runpool versions are SemVer. The compatibility surface a release
+// promises — the CLI, the configuration schema, the on-disk state and
+// the operational contract — is exactly what SemVer describes, and a
+// date-based scheme would say nothing about any of it.
+var semverPattern = regexp.MustCompile(
+	`^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+		`(-((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+		`(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$`)
+
+// ValidReleaseVersion reports whether a tag may be published.
+//
+// "dev" is what a local build carries and is deliberately not valid:
+// the check exists so a release cannot be cut from an unversioned or
+// hand-typed string, and a build that has not been tagged has not been
+// released.
+func ValidReleaseVersion(v string) error {
+	if v == "" {
+		return fmt.Errorf("no version: a release must be published from a tag")
+	}
+	if v == "dev" {
+		return fmt.Errorf("version %q is a local build, not a release", v)
+	}
+	if !semverPattern.MatchString(v) {
+		return fmt.Errorf("version %q is not SemVer; a release tag looks like v1.0.0 or v1.0.0-rc.1", v)
+	}
+	return nil
+}
+
+// BuildInfoFromDebug fills in what the Go toolchain already recorded —
+// the commit, the build time and whether the tree was dirty — so a
+// local build reports the truth without a release pipeline stamping it.
+// Values the linker stamped explicitly win, because a release states
+// its own facts rather than inferring them.
+func BuildInfoFromDebug(build BuildInfo) BuildInfo {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return build
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if build.Commit == "" {
+				build.Commit = setting.Value
+			}
+		case "vcs.time":
+			if build.Built == "" {
+				build.Built = setting.Value
+			}
+		case "vcs.modified":
+			if setting.Value == "true" {
+				build.Dirty = true
+			}
+		}
+	}
+	return build
+}


### PR DESCRIPTION
## What changes

`internal/command` and `cmd/runpool` arrive with the generated CLI
reference and the status API reference. CI gains three gates: the
generated documentation must match the commands, the release binaries
must cross-build, and the configuration example must still validate.

## What was found

**Generated documentation is the only kind that stays true.** A flag
renamed in code and described in hand-written prose produces a document
that is wrong and a build that is green. Generating the reference and
failing CI on a diff makes the prose a consequence of the code rather
than a parallel claim about it.

**The status document is a contract, and the database is not.** Rows
change with every migration; consumers cannot be rewritten each time. So
the reporting shape carries its own version, never exposes persistence
field names, and a test asserts they have not leaked in.

Two rules in it exist because of how consumers break. Collections are
always arrays, so an empty one is `[]` and a consumer branches on length
— `null` for empty forces every reader to handle two shapes for one
meaning. And `null` genuinely means absent: `disk_pressure` is null
before the monitor has run once, and `discrepancies` is null when the
daemon could not be reached, which is a different fact from finding none.

**Reporting must not migrate.** A `status` or `attempts` command that
opened the state read-write would migrate a schema as a side effect of
being asked a question — including on a host where an older controller
is still running. Reporting commands open read-only and report a schema
they cannot read rather than moving it.

**Cross-building is a gate, not a release step.** A build tag or a cgo
dependency that only breaks on another platform breaks at release time
otherwise, which is the worst moment to find it. The binaries are built
for every platform a release ships on every change.

## Evidence

Hermetic only in CI, and that is the honest answer here: the command
layer composes packages that carry their own coverage, and the
documentation gate is itself the evidence that the reference matches.

```text
generated CLI docs   ok — regeneration produced no diff
release binaries     ok — linux/amd64, linux/arm64, darwin/arm64
config examples      ok — internal/config/testdata/example.yaml validates
```

## What would notice this regressing

The generated-documentation gate fails if a command, flag or description
changes without the reference moving with it. `internal/command`'s suite
fails if a persistence field name appears in the status document, if a
collection is emitted as `null`, or if a reporting command opens the
state read-write. The cross-build step fails if a platform stops
compiling.

## Risk, compatibility and operations

Trust boundary: the commands run as the operator and reach the same
Docker socket and state directory the controller uses. `uninstall` is
the one destructive verb; it removes only objects carrying this
instance's ownership labels.

Credentials: `doctor` resolves credentials to verify them. No command
prints or persists a secret.

Status API: `v1` is established here. The product version and this
document version move independently, and consumers are required to reject
an unknown version rather than interpret it under the wrong schema.

Schema and migration: reporting commands never migrate. `serve` is the
only verb that moves a schema forward.

Ownership and cleanup: `gc` and `cleanup` act on labelled objects only,
so an unrelated container on the same daemon is never a candidate.

Deployment and rollback: `healthcheck` is what a container platform
calls; it answers without touching the provider.

Networking: only `doctor` makes outbound calls.

Runbook: the operator-facing narrative lands with the documentation.

## Changelog

```text
NONE
```
