### PR TITLE
feat(build): the controller image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,21 @@ updates:
         patterns: ["*"]
 
   - package-ecosystem: docker
+    directory: /build/controller
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      controller-images:
+        patterns: ["*"]
+    ignore:
+      # Same builder, same reason as the capsule below.
+      - dependency-name: golang
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-major
+
+  - package-ecosystem: docker
     directory: /build/capsule
     schedule:
       interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,26 @@ jobs:
         # twice. This is the comment on each declaration made executable.
         run: scripts/verify/capsule-protocol.sh
 
+  image:
+    name: controller image
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Build the controller image
+        # Built but not pushed: publishing is a release decision, and a
+        # pull request must never be able to publish.
+        run: docker build -f build/controller/Dockerfile -t runpool:ci .
+      - name: The runtime layer must carry no shell
+        run: |
+          if docker run --rm --entrypoint sh runpool:ci -c true 2>/dev/null; then
+            echo "a shell is reachable in the runtime layer"; exit 1
+          fi
+      - name: The image must run
+        run: docker run --rm runpool:ci version
+
   vulnerabilities:
     name: govulncheck
     runs-on: ubuntu-24.04

--- a/build/controller/Dockerfile
+++ b/build/controller/Dockerfile
@@ -1,0 +1,39 @@
+# The controller image. CGo is off because the SQLite driver is pure Go
+# (see docs/adrs/2026-08-11-sqlite-driver.md), so the binary is static and
+# the runtime layer is distroless: no shell, no package manager, nothing
+# for a compromised process to reach for beyond the base image's CA
+# certificates, timezone data and passwd.
+FROM golang:1.26.6-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build
+WORKDIR /src
+
+# Dependencies resolve in their own layer so source edits do not refetch.
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copied by allowlist: the binary is built from the module definition
+# and the two source trees, and nothing else can reach a builder layer.
+# .dockerignore stays as a second defense, not as the authority.
+COPY cmd/ cmd/
+COPY internal/ internal/
+ARG VERSION=dev
+ARG CAPSULE_IMAGE=runpool-capsule:dev
+RUN CGO_ENABLED=0 go build -trimpath \
+      -ldflags "-s -w -X main.version=${VERSION} -X main.capsuleImage=${CAPSULE_IMAGE}" \
+      -o /out/runpool ./cmd/runpool
+
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:1b7b9f0f0e0a1d2155f531db587cc48ec26aaf97ab64364225f5bf18a054e66a AS runtime
+COPY --from=build /out/runpool /usr/local/bin/runpool
+
+# The controller runs as root because the Docker socket's group is not
+# portable across hosts, and the socket already confers host-root
+# authority: dropping to a non-root uid would obscure that without
+# reducing it. The root filesystem is read-only and capabilities are
+# dropped in the deployment manifest, where those choices are visible to
+# whoever deploys it.
+#
+# Numeric, because a name has to resolve against the image's passwd and
+# uid 0 never does.
+# hadolint ignore=DL3002
+USER 0
+ENTRYPOINT ["/usr/local/bin/runpool"]
+CMD ["serve"]


### PR DESCRIPTION
## What changes

`build/controller/Dockerfile` arrives with a CI job that builds it,
proves the runtime layer has no shell, and runs the binary. Dependabot
gains the controller image directory, and both builder images are aligned
on the same reviewed Go toolchain digest.

## What was found

**A distroless runtime is only meaningful if the binary is static.** CGo
would put a libc dependency in the runtime layer and force a base image
with one, which brings back the shell and the package manager. The SQLite
driver being pure Go is what makes `CGO_ENABLED=0` possible, and that is
why the driver choice and this image are the same decision seen from two
sides.

**Copying by allowlist, not by exclusion.** `.dockerignore` is a deny
list, and a deny list fails open: a new directory at the repository root
reaches the builder layer unless someone remembers to exclude it. Naming
`go.mod`, `go.sum`, `cmd/` and `internal/` means anything else is absent
by default. The dockerignore file stays as a second defence.

**Running as uid 0 is the honest option here.** The controller needs the
Docker socket, whose group id differs between hosts, so a fixed non-root
uid would fail on some and require host-specific configuration on others.
More importantly the socket already grants host-root authority — a
non-root uid inside the container would make the image look more
constrained than the deployment actually is. The real constraints, a
read-only root filesystem and dropped capabilities, belong in the
manifest where an operator sees them.

**"No shell" is asserted, not assumed.** A base image can change, and a
build stage can leak a binary into the runtime layer. The CI job tries to
run a shell and fails the build if one answers.

**The two builders had drifted.** The capsule's builder digest was
updated and the controller's still named the previous bytes. Both build
Go binaries that ship, so they are aligned on the same digest here; each
now has its own Dependabot entry, with minor and major Go bumps held back
so the compiler stays the one `go.mod` declares and every test ran on.

## Evidence

Built and exercised locally, the same three steps CI runs:

```text
docker build -f build/controller/Dockerfile -t runpool:ci .   → built
docker run --rm --entrypoint sh runpool:ci -c true            → no shell
docker run --rm runpool:ci version                            → runpool dev
```

## What would notice this regressing

The `controller image` job fails if the image stops building, if a shell
becomes reachable in the runtime layer, or if the binary does not run.
`scripts/verify/go-version.sh` fails if either builder stops naming the
Go version `go.mod` declares. hadolint covers both Dockerfiles.

## Risk, compatibility and operations

Trust boundary: the image runs as uid 0 and is deployed with the host's
Docker socket, which is host-root authority. This change does not widen
it; the manifest that constrains the container lands with the deployment.

Credentials: none are baked in. Configuration and credentials arrive as
read-only mounts at run time.

Deployment: `VERSION` and `CAPSULE_IMAGE` are build arguments, so a
release stamps both into the binary and a development build gets dev
defaults.

Rollback: images are addressed by digest in the deployment, so rolling
back is selecting a previous digest.

Ownership, cleanup, networking, resource limits, schema, migration, CLI,
configuration, status API, runbook: N/A — this adds a build artifact and
changes no behaviour.

## Changelog

```text
NONE
```
