### PR TITLE
feat(deploy): the reference deployment

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,14 @@
+# Self-hosted runner labels this repository's workflows target.
+#
+# `runpool-release-qualification` identifies the dedicated evidence host
+# described by build/platform.lock.json. Only protected release gates use it.
+# Declaring the label here lets the linter distinguish it from a typo.
+#
+# `runpool-standard` is not a runner of this repository's. It is the label
+# a workflow uses to reach a Runpool tier — the default scale set name for
+# a tier called `standard` — and it appears in the example workflow under
+# deploy/workflows, which is the one place a reader can copy it from.
+self-hosted-runner:
+  labels:
+    - runpool-release-qualification
+    - runpool-standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,9 @@ jobs:
               go build -trimpath -o /dev/null ./cmd/runpool ./cmd/capsule-supervisor
           done
       - name: Verify the configuration examples still validate
-        run: /tmp/runpool config validate --file internal/config/testdata/example.yaml
+        run: |
+          /tmp/runpool config validate --file internal/config/testdata/example.yaml
+          /tmp/runpool config validate --file deploy/compose/config.example.yaml
 
   lint:
     name: workflows, scripts and containers
@@ -147,7 +149,11 @@ jobs:
       - name: Lint the workflows
         # Pinned in go.mod like every other gate: a linter resolved at
         # run time changes what passes without anyone deciding to.
-        run: go tool actionlint
+        #
+        # The example under deploy/ is named explicitly: actionlint scans
+        # .github/workflows by itself, and an example workflow nobody
+        # checks is worse than none — a reader copies it.
+        run: go tool actionlint && go tool actionlint deploy/workflows/*.yml
       - name: Lint the shell scripts
         # shellcheck ships with the runner image; the verification
         # scripts run against real hosts, where a quoting bug deletes
@@ -175,6 +181,18 @@ jobs:
         # cannot import the supervisor, so every shared value is declared
         # twice. This is the comment on each declaration made executable.
         run: scripts/verify/capsule-protocol.sh
+      - name: Verify the drain window fits the stop grace period
+        # A Go constant and a Compose key, with nothing between them: a
+        # drain that outlasts the grace period is killed before it closes
+        # its sessions.
+        run: scripts/verify/drain-window.sh
+      - name: Validate the reference deployment
+        run: |
+          mkdir -p /tmp/runpool-ci-credentials
+          RUNPOOL_IMAGE=ghcr.io/rhobuild/runpool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+            RUNPOOL_CONFIG_PATH="$GITHUB_WORKSPACE/deploy/compose/config.example.yaml" \
+            RUNPOOL_CREDENTIALS_PATH=/tmp/runpool-ci-credentials \
+            docker compose -f deploy/compose/compose.yaml config --quiet
 
   image:
     name: controller image

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -1,0 +1,79 @@
+# Reference deployment. The platform manages exactly one service — the
+# controller — and Runpool creates every job capsule through the Docker
+# API. Runner, dind, capsule networks and capsule volumes are never
+# declared here: they exist only while a job runs.
+#
+# WARNING: the controller holds the host's Docker socket, which confers
+# host-root authority, and job capsules run a privileged Docker daemon.
+# Runpool is a resource and hygiene boundary for CI you trust, not a
+# sandbox for hostile code. Do not point it at repositories whose
+# workflows you would not run on this host yourself.
+name: runpool
+
+services:
+  controller:
+    # Supply the complete digest-qualified reference published in the
+    # release, for example ghcr.io/rhobuild/runpool@sha256:.... A mutable
+    # tag such as latest cannot identify the bytes being deployed.
+    image: ${RUNPOOL_IMAGE:?set the digest-qualified released controller image (no release exists yet)}
+    restart: unless-stopped
+    init: true
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    environment:
+      # File mode supports any number of targets without copying credentials
+      # into the Compose model or the container environment.
+      RUNPOOL_CONFIG_FILE: /etc/runpool/config.yaml
+    volumes:
+      # Dokploy persists ../files across repository refreshes. Other Compose
+      # operators may override these two source paths explicitly.
+      - type: bind
+        source: ${RUNPOOL_CONFIG_PATH:-../files/runpool/config.yaml}
+        target: /etc/runpool/config.yaml
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ${RUNPOOL_CREDENTIALS_PATH:-../files/runpool/credentials}
+        target: /run/secrets/runpool
+        read_only: true
+        bind:
+          create_host_path: false
+      # Read-only on the mount prevents replacing the socket file; it does
+      # not restrict the Docker API, which is the authority that matters.
+      - type: bind
+        source: /var/run/docker.sock
+        target: /var/run/docker.sock
+        read_only: true
+      - type: volume
+        source: runpool-state
+        target: /var/lib/runpool/state
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/runpool", "healthcheck", "--mode=liveness"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    # Must exceed the controller's drain window, so the drain ends and the
+    # message sessions close before the platform kills the container. A
+    # session left open is one the next start waits out as a conflict.
+    # Anything still running is adopted on the next start.
+    stop_grace_period: 2m
+    labels:
+      io.runpool.role: controller
+
+volumes:
+  # State holds the lease and ownership records: back this up. Cache
+  # lanes are NOT declared here — the controller creates them as its own
+  # named volumes (runpool-cache-<lane>), labeled and garbage-collected;
+  # they are warm build state, disposable by design, and belong outside
+  # any backup.
+  runpool-state:
+    labels:
+      io.runpool.managed: "true"
+      io.runpool.kind: state

--- a/deploy/compose/config.example.yaml
+++ b/deploy/compose/config.example.yaml
@@ -1,0 +1,89 @@
+# Copy this file into the operator-managed configuration location. Replace
+# target identities and size host reserves and tier capacity from measurements;
+# the values below are an example, not production defaults.
+apiVersion: runpool.rhobuild.com/v1
+kind: RunpoolConfig
+
+instance:
+  name: primary
+
+host:
+  topology: shared-daemon
+  reserve:
+    cpu: "2"
+    memory: 4GiB
+    swap: 0B
+    freeDisk: 30GiB
+
+scheduling:
+  parallelism: 1
+
+targets:
+  # An organization target. A single-segment URL is an organization, not a
+  # user: a personal account has no runner groups and no org-scoped scale
+  # sets, so it cannot be a target of this shape. The runner group must
+  # already exist on GitHub and must grant access to the repositories
+  # whose workflows will run here — Runpool resolves a group, it never
+  # creates one.
+  - id: company
+    url: https://github.com/example-company
+    credential: github-company-runners
+    runnerGroup: default
+    cache:
+      enabled: false
+    tiers:
+      - tier: standard
+        # Workflows reach this tier with: runs-on: runpool-company-standard
+        scaleSetName: runpool-company-standard
+
+  # A repository target. Smaller to set up — no runner group — and the
+  # only shape that may hold a persistent cache, because a runner bound to
+  # one repository cannot execute another's job against its cache.
+  - id: app
+    url: https://github.com/example-company/app
+    credential: github-company-runners
+    cache:
+      enabled: false
+    tiers:
+      - tier: standard
+        # Workflows reach this tier with: runs-on: runpool-app-standard
+        scaleSetName: runpool-app-standard
+
+credentials:
+  # A token belongs to the person who minted it. For anything long-running
+  # prefer type: github_app, which belongs to the organization — see the
+  # configuration reference.
+  - id: github-company-runners
+    type: token
+    tokenFile: /run/secrets/runpool/github-company-runners
+
+tiers:
+  - id: standard
+    parallelism: 1
+    resources:
+      cpu: "2"
+      memory: 4GiB
+      swap: 0B
+      pids: 1024
+
+cache:
+  storage:
+    mode: volume
+
+retention:
+  leaseHistory: 2160h
+
+observability:
+  log:
+    format: json
+    level: info
+  metrics:
+    enabled: false
+
+network:
+  profile: public-internet-only
+  ipv6: disabled
+  dns:
+    mode: gateway
+  allowPrivateCIDRs: []
+  denyCIDRs: []

--- a/deploy/workflows/example.yml
+++ b/deploy/workflows/example.yml
@@ -1,0 +1,35 @@
+# The workflow side of a Runpool deployment, in full.
+#
+# `runs-on` names the scale set, not a set of labels. Runpool creates one
+# scale set per (target, tier) under `tiers[].scaleSetName`, which
+# defaults to `runpool-<tier id>`; `runpool doctor` prints the name for
+# every tier a deployment serves, beside the provider id where the set
+# already exists.
+#
+# `runs-on: [self-hosted, linux, x64]` does not reach a scale set. GitHub
+# matches a scale set by its name and nothing else.
+name: example
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: runpool-standard
+    steps:
+      - uses: actions/checkout@v5
+
+      # Every job gets its own Docker daemon inside its own capsule, so
+      # this needs no service, no socket mount and no privileged runner.
+      - name: The job has a Docker daemon of its own
+        run: |
+          docker version
+          docker run --rm alpine:3 echo "hello from a container this job started"
+
+      # Under the default network profile the capsule has no route out.
+      # Its only egress is a relay that applies the deployment's policy,
+      # and the proxy is set for the job, its steps, the daemon, and the
+      # containers that daemon creates. Anything that ignores proxy
+      # environment variables — git+ssh, arbitrary TCP — fails closed.
+      - name: Egress goes through the relay
+        run: curl -fsS https://api.github.com/zen

--- a/scripts/verify/drain-window.sh
+++ b/scripts/verify/drain-window.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# The controller's drain window must fit inside the deployment's stop
+# grace period. Nothing else ties them: a Go constant and a Compose key
+# are separate ecosystems, and the drift is invisible in a green build
+# because neither side can see the other.
+#
+# The drift is not cosmetic. A capsule running a job outlives any drain
+# window, so the window is always spent whenever work is in flight. When
+# it outlasts the grace period the platform sends SIGKILL first, the
+# deferred session closes never run, and every restart with a live job
+# leaves the broker holding a session the next start has to wait out as a
+# conflict.
+#
+# Usage: scripts/verify/drain-window.sh
+cd "$(dirname "$0")/../.."
+status=0
+
+seconds_from_go() {
+  # Exactly "N * time.Second" or "N * time.Minute". Anything else is
+  # unreadable rather than zero: a form this cannot parse must fail the
+  # check, not pass it with a window of no seconds.
+  awk '{
+    if ($0 !~ /^[0-9]+ \* time\.(Second|Minute)$/) { print ""; exit }
+    if ($0 ~ /time\.Minute/) { print $1 * 60 } else { print $1 }
+  }' <<<"$1"
+}
+
+seconds_from_compose() {
+  # "2m", "90s", "1m30s" is not emitted by Compose docs but is accepted
+  case "$1" in
+    *m) echo $(( ${1%m} * 60 )) ;;
+    *s) echo "${1%s}" ;;
+    *) echo "" ;;
+  esac
+}
+
+drain_expr=$(sed -n 's/^[[:space:]]*drainTimeout[[:space:]]*=[[:space:]]*\(.*\)$/\1/p' internal/app/serve.go)
+if [ -z "$drain_expr" ]; then
+  echo "FAIL  internal/app/serve.go declares no drainTimeout"
+  exit 1
+fi
+drain=$(seconds_from_go "$drain_expr")
+if [ -z "$drain" ]; then
+  echo "FAIL  internal/app/serve.go: cannot read drainTimeout from '$drain_expr'"
+  exit 1
+fi
+
+compose=deploy/compose/compose.yaml
+grace_raw=$(sed -n 's/^[[:space:]]*stop_grace_period:[[:space:]]*\([^[:space:]]*\).*/\1/p' "$compose")
+if [ -z "$grace_raw" ]; then
+  echo "FAIL  $compose declares no stop_grace_period"
+  exit 1
+fi
+grace=$(seconds_from_compose "$grace_raw")
+if [ -z "$grace" ]; then
+  echo "FAIL  $compose: cannot read stop_grace_period from '$grace_raw'"
+  status=1
+elif [ "$grace" -gt "$drain" ]; then
+  echo "ok    $compose stop_grace_period ${grace}s over a ${drain}s drain"
+else
+  echo "FAIL  $compose stop_grace_period is ${grace}s and the drain window is ${drain}s;"
+  echo "      the platform kills the controller before it closes its sessions"
+  status=1
+fi
+
+exit $status


### PR DESCRIPTION
## What changes

`deploy/` arrives: the reference Compose deployment, an example
configuration and an example consumer workflow. CI gains four gates whose
targets now exist — the drain-window tie, the reference deployment's own
validation, linting of the example workflow, and validation of the
example configuration.

## What was found

**The drain window and the stop grace period are one constraint expressed
in two ecosystems.** Nothing connects a Go constant to a Compose key, and
the drift is invisible in a green build because neither side can see the
other. It is also not cosmetic: a capsule running a job outlives any
drain window, so the window is spent in full whenever work is in flight.
If it outlasts the grace period the platform kills the controller before
its deferred session closes run, and the next start meets a session
conflict it has to wait out — on every restart that had a live job.

**Only the controller belongs in the deployment.** Every other object is
created by Runpool through the Docker API and destroyed with the job.
Declaring them would give the platform and the controller both a claim on
the same containers, networks and volumes, and a `compose down` would
then race a running job's cleanup.

**The image must be digest-qualified.** The variable has no default and
fails with a message saying so. A tag can move, and this container is
handed the Docker socket — deploying "whatever `latest` means today" into
that position is not a deployment anyone reviewed.

**The state volume is declared; cache lanes are not.** They have opposite
backup semantics: state holds the lease and ownership records and must
survive, while cache lanes are warm build state that is safe to lose and
expensive to back up. Declaring only one makes that difference visible in
the file rather than in a paragraph someone has to find.

**The example workflow is linted.** It is the one place a reader copies a
consumer workflow from, so an error in it propagates into other people's
repositories. It is named explicitly because actionlint scans
`.github/workflows` by itself and would otherwise never see it.

## Evidence

The reference deployment was rendered exactly as CI renders it, with a
placeholder digest and an empty credentials directory:

```text
docker compose -f deploy/compose/compose.yaml config --quiet   → ok
scripts/verify/drain-window.sh                                 → ok
go tool actionlint deploy/workflows/*.yml                      → ok
runpool config validate --file deploy/compose/config.example.yaml → ok
```

## What would notice this regressing

`scripts/verify/drain-window.sh` fails if the drain constant grows past
the grace period, or if either value stops being parseable — an
unreadable form fails the check rather than passing it as zero. The
reference-deployment step fails if the Compose file stops rendering, and
the configuration step fails if the example stops validating against the
schema. actionlint covers the example workflow.

## Risk, compatibility and operations

Trust boundary: the manifest is where the container's real constraints
are visible — read-only root filesystem, all capabilities dropped,
`no-new-privileges`, and a tmpfs for scratch. The Docker socket mount is
host-root authority and is documented as such in the file itself, next to
the warning that Runpool is a hygiene boundary for CI you trust, not a
sandbox for hostile code.

Credentials: mounted read-only from a directory outside the Compose
model, so no secret is expressed in the deployment file or the container
environment.

Ownership and cleanup: only the controller and the state volume are
managed by the platform. Everything else is Runpool's, labelled, and
reclaimed by it.

Deployment and rollback: the image is selected by digest, so both are the
same operation with a different value.

Runbook: the operational narrative lands with the documentation.

Networking, resource limits, schema, migration, CLI, status API: N/A.

## Changelog

```text
NONE
```
