### PR TITLE
test(e2e): the controller, end to end

### DIFF
--- a/test/e2e/controller/docker_test.go
+++ b/test/e2e/controller/docker_test.go
@@ -1,0 +1,426 @@
+package controllere2e
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type dockerHarness struct {
+	settings          settings
+	dir               string
+	config            string
+	secrets           string
+	state             string
+	control           string
+	sentinelNetwork   string
+	sentinelVolume    string
+	sentinelContainer string
+	sentinelIDs       map[string]string
+	logs              []string
+	stateCreated      bool
+	secretsCreated    bool
+	sentinelCreated   bool
+	configReady       bool
+}
+
+func newDockerHarness(s settings, dir string) *dockerHarness {
+	return &dockerHarness{
+		settings:          s,
+		dir:               dir,
+		config:            filepath.Join(dir, "config.yaml"),
+		secrets:           "runpool-e2e-secrets-" + s.runID,
+		state:             "runpool-e2e-state-" + s.runID,
+		control:           "runpool-e2e-controller-" + s.runID,
+		sentinelNetwork:   "runpool-e2e-sentinel-net-" + s.runID,
+		sentinelVolume:    "runpool-e2e-sentinel-vol-" + s.runID,
+		sentinelContainer: "runpool-e2e-sentinel-container-" + s.runID,
+		sentinelIDs:       map[string]string{},
+	}
+}
+
+func (d *dockerHarness) prepare(ctx context.Context) error {
+	if _, err := d.run(ctx, "version"); err != nil {
+		return fmt.Errorf("docker daemon: %w", err)
+	}
+	// The token travels the way production delivers a secret: written by
+	// the daemon into a volume, owned by root with owner-only mode. The
+	// controller refuses a token readable by group or other, and its
+	// container drops every capability, so a file owned by the runner's
+	// user is unreadable however it is moded - root-owned 0600 is the one
+	// shape that satisfies both.
+	if _, err := d.run(ctx, "volume", "create", "--label", "io.runpool.e2e="+d.settings.runID, d.secrets); err != nil {
+		return fmt.Errorf("create secrets volume: %w", err)
+	}
+	d.secretsCreated = true
+	write := exec.CommandContext(ctx, "docker", "run", "--rm", "-i",
+		"--user", "0", "--entrypoint", "sh",
+		"--label", "io.runpool.e2e="+d.settings.runID,
+		"--mount", "type=volume,src="+d.secrets+",dst=/s",
+		d.settings.capsuleImage,
+		"-c", "umask 077 && cat > /s/provider-token")
+	write.Stdin = strings.NewReader(d.settings.token)
+	if out, err := write.CombinedOutput(); err != nil {
+		return fmt.Errorf("write the provider token into the secrets volume: %w (%s)", err, out)
+	}
+	if _, err := d.run(ctx, "volume", "create", "--label", "io.runpool.e2e="+d.settings.runID, d.state); err != nil {
+		return fmt.Errorf("create state volume: %w", err)
+	}
+	d.stateCreated = true
+	// Mark cleanup responsibility before the first sentinel effect so a
+	// partially created fixture is still removed when preparation fails.
+	d.sentinelCreated = true
+	if out, err := d.run(ctx, "network", "create", "--label", "io.runpool.e2e-sentinel="+d.settings.runID, d.sentinelNetwork); err != nil {
+		return fmt.Errorf("create sentinel network: %w", err)
+	} else {
+		d.sentinelIDs["network"] = strings.TrimSpace(out)
+	}
+	if out, err := d.run(ctx, "volume", "create", "--label", "io.runpool.e2e-sentinel="+d.settings.runID, d.sentinelVolume); err != nil {
+		return fmt.Errorf("create sentinel volume: %w", err)
+	} else {
+		d.sentinelIDs["volume"] = strings.TrimSpace(out)
+	}
+	if out, err := d.run(ctx, "create", "--name", d.sentinelContainer,
+		"--label", "io.runpool.e2e-sentinel="+d.settings.runID,
+		"--network", d.sentinelNetwork,
+		"--mount", "type=volume,src="+d.sentinelVolume+",dst=/sentinel",
+		d.settings.controllerImage, "version"); err != nil {
+		return fmt.Errorf("create sentinel container: %w", err)
+	} else {
+		d.sentinelIDs["container"] = strings.TrimSpace(out)
+	}
+	return d.verifyControllerPair(ctx)
+}
+
+func (d *dockerHarness) verifyControllerPair(ctx context.Context) error {
+	out, err := d.run(ctx, "run", "--rm", "--entrypoint", "/usr/local/bin/runpool",
+		d.settings.controllerImage, "version", "--json")
+	if err != nil {
+		return fmt.Errorf("read controller build facts: %w", err)
+	}
+	var facts struct {
+		CapsuleImage string `json:"capsule_image"`
+	}
+	if err := json.Unmarshal([]byte(out), &facts); err != nil {
+		return fmt.Errorf("decode controller build facts: %w", err)
+	}
+	if facts.CapsuleImage != d.settings.capsuleImage {
+		return fmt.Errorf("controller embeds capsule %q; qualification selected %q", facts.CapsuleImage, d.settings.capsuleImage)
+	}
+	return nil
+}
+
+func (d *dockerHarness) start(ctx context.Context, generation string) error {
+	if err := os.WriteFile(d.config, []byte(d.configuration(generation)), 0o644); err != nil {
+		return err
+	}
+	d.configReady = true
+	args := []string{
+		"run", "-d", "--name", d.control,
+		"--init", "--read-only", "--stop-timeout", "120",
+		"--cap-drop", "ALL", "--security-opt", "no-new-privileges:true",
+		"--tmpfs", "/tmp:size=64m,mode=1777",
+		"--label", "io.runpool.e2e=" + d.settings.runID,
+		"--env", "RUNPOOL_CONFIG_FILE=/run/runpool/config.yaml",
+		"--env", "RUNPOOL_STATE_DIR=/var/lib/runpool/state",
+		"--mount", "type=bind,src=" + d.settings.dockerSocket + ",dst=/var/run/docker.sock,readonly",
+		"--mount", "type=volume,src=" + d.state + ",dst=/var/lib/runpool/state",
+		"--mount", "type=bind,src=" + d.config + ",dst=/run/runpool/config.yaml,readonly",
+		"--mount", "type=volume,src=" + d.secrets + ",dst=/run/secrets,readonly",
+		d.settings.controllerImage,
+	}
+	if _, err := d.run(ctx, args...); err != nil {
+		return fmt.Errorf("start controller: %w", err)
+	}
+	return d.waitForLogCount(ctx, "session open", 1, 5*time.Minute)
+}
+
+func (d *dockerHarness) restart(ctx context.Context) error {
+	logs, err := d.run(ctx, "logs", d.control)
+	if err != nil {
+		return fmt.Errorf("read controller logs before restart: %w", err)
+	}
+	want := strings.Count(logs, "session open") + 1
+	if _, err := d.run(ctx, "restart", "--time", "30", d.control); err != nil {
+		return fmt.Errorf("restart controller: %w", err)
+	}
+	return d.waitForLogCount(ctx, "session open", want, 5*time.Minute)
+}
+
+func (d *dockerHarness) switchGeneration(ctx context.Context, generation string) error {
+	if err := d.stopAndRemove(ctx); err != nil {
+		return err
+	}
+	return d.start(ctx, generation)
+}
+
+func (d *dockerHarness) waitForLogCount(ctx context.Context, marker string, want int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		out, err := d.run(ctx, "logs", d.control)
+		if err == nil && strings.Count(out, marker) >= want {
+			return nil
+		}
+		if running, rerr := d.running(ctx); rerr == nil && !running {
+			return fmt.Errorf("controller exited before %q appeared in its logs: %s", marker, out)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+	return fmt.Errorf("controller did not report occurrence %d of %q within %s", want, marker, timeout)
+}
+
+func (d *dockerHarness) running(ctx context.Context) (bool, error) {
+	out, err := d.run(ctx, "inspect", "--format", "{{.State.Running}}", d.control)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "true", nil
+}
+
+func (d *dockerHarness) stopAndRemove(ctx context.Context) error {
+	if out, err := d.run(ctx, "logs", d.control); err == nil {
+		d.logs = append(d.logs, out)
+	}
+	if _, err := d.run(ctx, "stop", "--time", "120", d.control); err != nil && !isMissingDockerObject(err) {
+		return fmt.Errorf("stop controller: %w", err)
+	}
+	if _, err := d.run(ctx, "rm", "-f", d.control); err != nil && !isMissingDockerObject(err) {
+		return fmt.Errorf("remove controller: %w", err)
+	}
+	return nil
+}
+
+func (d *dockerHarness) cleanup(ctx context.Context) (map[string]string, error) {
+	result := map[string]string{}
+	var errs []error
+	if err := d.captureSecretChecks(ctx); err != nil {
+		errs = append(errs, err)
+	} else {
+		result["secret_exposure"] = "not observed"
+	}
+	if err := d.stopAndRemove(ctx); err != nil {
+		errs = append(errs, err)
+	}
+
+	if d.configReady {
+		instance, err := d.instanceID(ctx)
+		if err != nil {
+			errs = append(errs, err)
+		} else if instance != "" {
+			if err := d.uninstall(ctx, instance); err != nil {
+				errs = append(errs, err)
+			} else {
+				result["uninstall"] = "complete"
+			}
+			if err := d.assertNoManagedResources(ctx, instance); err != nil {
+				errs = append(errs, err)
+			} else {
+				result["managed_resources"] = "absent"
+			}
+		}
+	}
+	if d.secretsCreated {
+		if _, err := d.run(ctx, "volume", "rm", d.secrets); err != nil && !isMissingDockerObject(err) {
+			errs = append(errs, fmt.Errorf("remove secrets volume: %w", err))
+		}
+	}
+	if d.stateCreated {
+		if _, err := d.run(ctx, "volume", "rm", d.state); err != nil && !isMissingDockerObject(err) {
+			errs = append(errs, fmt.Errorf("remove state volume: %w", err))
+		}
+	}
+	if d.sentinelCreated {
+		checks := map[string]string{
+			"container": d.sentinelContainer,
+			"network":   d.sentinelNetwork,
+			"volume":    d.sentinelVolume,
+		}
+		preserved := true
+		for kind, name := range checks {
+			var out string
+			var err error
+			switch kind {
+			case "container":
+				out, err = d.run(ctx, "inspect", "--format", "{{.Id}}", name)
+			case "network":
+				out, err = d.run(ctx, "network", "inspect", "--format", "{{.Id}}", name)
+			case "volume":
+				out, err = d.run(ctx, "volume", "inspect", "--format", "{{.Name}}", name)
+			}
+			if err != nil {
+				preserved = false
+				errs = append(errs, fmt.Errorf("inspect foreign sentinel %s: %w", kind, err))
+				continue
+			}
+			if id := strings.TrimSpace(out); id != d.sentinelIDs[kind] {
+				preserved = false
+				errs = append(errs, fmt.Errorf("foreign sentinel %s changed id: got %q, want %q",
+					kind, id, d.sentinelIDs[kind]))
+			}
+		}
+		if preserved {
+			result["foreign_sentinels"] = "container, network and volume preserved"
+		}
+		if _, err := d.run(ctx, "rm", "-f", d.sentinelContainer); err != nil && !isMissingDockerObject(err) {
+			errs = append(errs, fmt.Errorf("remove sentinel container: %w", err))
+		}
+		if _, err := d.run(ctx, "network", "rm", d.sentinelNetwork); err != nil && !isMissingDockerObject(err) {
+			errs = append(errs, fmt.Errorf("remove sentinel network: %w", err))
+		}
+		if _, err := d.run(ctx, "volume", "rm", d.sentinelVolume); err != nil && !isMissingDockerObject(err) {
+			errs = append(errs, fmt.Errorf("remove sentinel volume: %w", err))
+		}
+	}
+	return result, errors.Join(errs...)
+}
+
+func (d *dockerHarness) captureSecretChecks(ctx context.Context) error {
+	if out, err := d.run(ctx, "logs", d.control); err == nil {
+		d.logs = append(d.logs, out)
+	}
+	for _, logs := range d.logs {
+		if strings.Contains(logs, d.settings.token) {
+			return errors.New("provider token appears in controller logs")
+		}
+	}
+	out, err := d.run(ctx, "inspect", "--format", "{{json .Config.Env}}", d.control)
+	if err != nil && !isMissingDockerObject(err) {
+		return fmt.Errorf("inspect controller environment: %w", err)
+	}
+	if strings.Contains(out, d.settings.token) {
+		return errors.New("provider token appears in controller environment")
+	}
+	return nil
+}
+
+func (d *dockerHarness) instanceID(ctx context.Context) (string, error) {
+	out, err := d.runOneOff(ctx, "status", "--json")
+	if err != nil {
+		if strings.Contains(err.Error(), "no state") {
+			return "", nil
+		}
+		return "", fmt.Errorf("read final status: %w", err)
+	}
+	var status struct {
+		Instance string `json:"instance"`
+	}
+	if err := json.Unmarshal([]byte(out), &status); err != nil {
+		return "", fmt.Errorf("decode final status: %w (output: %q)", err, out)
+	}
+	return status.Instance, nil
+}
+
+func (d *dockerHarness) uninstall(ctx context.Context, instance string) error {
+	_, err := d.runOneOff(ctx, "uninstall", "--confirm="+instance, "--delete-scale-sets")
+	if err != nil {
+		return fmt.Errorf("uninstall instance %s: %w", instance, err)
+	}
+	return nil
+}
+
+func (d *dockerHarness) runOneOff(ctx context.Context, command ...string) (string, error) {
+	args := []string{
+		"run", "--rm",
+		"--env", "RUNPOOL_CONFIG_FILE=/run/runpool/config.yaml",
+		"--env", "RUNPOOL_STATE_DIR=/var/lib/runpool/state",
+		"--mount", "type=bind,src=" + d.settings.dockerSocket + ",dst=/var/run/docker.sock,readonly",
+		"--mount", "type=volume,src=" + d.state + ",dst=/var/lib/runpool/state",
+		"--mount", "type=bind,src=" + d.config + ",dst=/run/runpool/config.yaml,readonly",
+		"--mount", "type=volume,src=" + d.secrets + ",dst=/run/secrets,readonly",
+		d.settings.controllerImage,
+	}
+	return d.run(ctx, append(args, command...)...)
+}
+
+func (d *dockerHarness) assertNoManagedResources(ctx context.Context, instance string) error {
+	queries := [][]string{
+		{"ps", "-aq", "--filter", "label=io.runpool.managed=true", "--filter", "label=io.runpool.instance=" + instance},
+		{"network", "ls", "-q", "--filter", "label=io.runpool.managed=true", "--filter", "label=io.runpool.instance=" + instance},
+		{"volume", "ls", "-q", "--filter", "label=io.runpool.managed=true", "--filter", "label=io.runpool.instance=" + instance},
+	}
+	for _, query := range queries {
+		out, err := d.run(ctx, query...)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(out) != "" {
+			return fmt.Errorf("managed resources remain after uninstall: %s", strings.TrimSpace(out))
+		}
+	}
+	return nil
+}
+
+func (d *dockerHarness) configuration(generation string) string {
+	return fmt.Sprintf(`apiVersion: runpool.rhobuild.com/v1
+kind: RunpoolConfig
+instance:
+  name: e2e-%s
+host:
+  topology: shared-daemon
+  reserve:
+    cpu: "1"
+    memory: 2GiB
+    swap: 0B
+    freeDisk: 20GiB
+
+scheduling:
+  parallelism: 1
+targets:
+  - id: fixture
+    url: https://github.com/%s
+    credential: fixture
+    cache:
+      enabled: true
+      generation: %s
+    tiers:
+      - tier: e2e
+        scaleSetName: %s
+credentials:
+  - id: fixture
+    type: token
+    tokenFile: /run/secrets/provider-token
+tiers:
+  - id: e2e
+    parallelism: 1
+    resources:
+      cpu: "2"
+      memory: 4GiB
+      swap: 0B
+      pids: 1024
+network:
+  profile: public-internet-only
+  ipv6: disabled
+  dns:
+    mode: gateway
+`, d.settings.runID, d.settings.repository, generation, d.settings.runnerLabel)
+}
+
+func (d *dockerHarness) run(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("docker %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return string(out), nil
+}
+
+func isMissingDockerObject(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "no such container") ||
+		strings.Contains(message, "no such network") ||
+		strings.Contains(message, "no such volume") ||
+		strings.Contains(message, "not found")
+}

--- a/test/e2e/controller/e2e_test.go
+++ b/test/e2e/controller/e2e_test.go
@@ -1,0 +1,260 @@
+// Package controllere2e drives a real provider assignment through the released
+// controller and capsule candidates. It is opt-in because it creates protected
+// GitHub fixture resources and Docker objects on a dedicated host.
+package controllere2e
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	envEnabled         = "RUNPOOL_CONTROLLER_E2E"
+	envQualify         = "RUNPOOL_CONTRACT_QUALIFY"
+	envControllerImage = "RUNPOOL_E2E_CONTROLLER_IMAGE"
+	envCapsuleImage    = "RUNPOOL_E2E_CAPSULE_IMAGE"
+	envRepository      = "RUNPOOL_E2E_REPOSITORY"
+	envGitRevision     = "RUNPOOL_E2E_GIT_REVISION"
+	envToken           = "RUNPOOL_E2E_TOKEN"
+	envArtifactDir     = "RUNPOOL_E2E_ARTIFACT_DIR"
+	envAPIURL          = "RUNPOOL_E2E_API_URL"
+	envDockerSocket    = "RUNPOOL_E2E_DOCKER_SOCKET"
+)
+
+type settings struct {
+	controllerImage string
+	capsuleImage    string
+	repository      string
+	owner           string
+	repositoryName  string
+	gitRevision     string
+	token           string
+	artifactDir     string
+	apiURL          string
+	dockerSocket    string
+	runID           string
+	runnerLabel     string
+}
+
+type qualificationEvidence struct {
+	StartedAt      time.Time          `json:"started_at"`
+	CompletedAt    time.Time          `json:"completed_at"`
+	Repository     string             `json:"repository"`
+	Controller     string             `json:"controller_image"`
+	Capsule        string             `json:"capsule_image"`
+	RunnerLabel    string             `json:"runner_label"`
+	CacheKey       string             `json:"cache_key"`
+	WorkflowRuns   []workflowEvidence `json:"workflow_runs"`
+	Cleanup        map[string]string  `json:"cleanup"`
+	Outcome        string             `json:"outcome"`
+	FailureSummary string             `json:"failure_summary,omitempty"`
+}
+
+type workflowEvidence struct {
+	Purpose string `json:"purpose"`
+	ID      int64  `json:"id"`
+	URL     string `json:"url"`
+}
+
+func TestControllerEndToEnd(t *testing.T) {
+	s := loadSettings(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 45*time.Minute)
+	defer cancel()
+
+	fixture, err := os.ReadFile("testdata/workload.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	github := newGitHubClient(s)
+	if err := github.verifyFixture(ctx, s.gitRevision, fixture); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence := qualificationEvidence{
+		StartedAt:   time.Now().UTC(),
+		Repository:  s.repository,
+		Controller:  s.controllerImage,
+		Capsule:     s.capsuleImage,
+		RunnerLabel: s.runnerLabel,
+		CacheKey:    "marker-" + s.runID,
+		Cleanup:     map[string]string{},
+		Outcome:     "incomplete",
+	}
+	docker := newDockerHarness(s, t.TempDir())
+	var runs []workflowRun
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 8*time.Minute)
+		defer cleanupCancel()
+		for _, run := range runs {
+			current, getErr := github.getRun(cleanupCtx, run.ID)
+			if getErr == nil && current.Status == "completed" {
+				// A completed run removed its own image: the workflow's
+				// final step deletes the version it pushed with the run's
+				// own token, which is the one credential class the
+				// packages API accepts here. The run's log is the proof.
+				continue
+			}
+			if getErr == nil {
+				if cancelErr := github.cancel(cleanupCtx, run.ID); cancelErr != nil {
+					t.Errorf("cleanup workflow %d: %v", run.ID, cancelErr)
+				}
+			}
+			tag, ok := strings.CutPrefix(run.DisplayName, "runpool-e2e-")
+			if !ok {
+				t.Errorf("workflow %d has unexpected display title %q", run.ID, run.DisplayName)
+				continue
+			}
+			// A run that never completed may not have reached its cleanup
+			// step, and this credential cannot look: the packages API
+			// refuses installation tokens. The tag is named in the
+			// evidence for the maintainer sweep.
+			evidence.Cleanup["ghcr_image_"+tag] = "run did not complete; the version, if pushed, outlives the run"
+			t.Logf("GHCR image %q may outlive the cancelled run %d", tag, run.ID)
+		}
+		cleanup, cleanupErr := docker.cleanup(cleanupCtx)
+		for key, value := range cleanup {
+			evidence.Cleanup[key] = value
+		}
+		if cleanupErr != nil {
+			t.Errorf("Docker cleanup: %v", cleanupErr)
+		}
+		evidence.CompletedAt = time.Now().UTC()
+		if t.Failed() {
+			evidence.Outcome = "failed"
+			evidence.FailureSummary = "see the linked workflow run and redacted job logs"
+		} else {
+			evidence.Outcome = "passed"
+		}
+		if err := writeEvidence(s.artifactDir, s.runID, evidence); err != nil {
+			t.Errorf("write E2E evidence: %v", err)
+		}
+	})
+
+	if err := docker.prepare(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := docker.start(ctx, "primary-"+s.runID); err != nil {
+		t.Fatal(err)
+	}
+
+	seed := dispatch(t, ctx, github, s, evidence.CacheKey, "seed", 90)
+	runs = append(runs, seed)
+	if _, err := github.waitForStatus(ctx, seed, "in_progress", 10*time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := docker.restart(ctx); err != nil {
+		t.Fatal(err)
+	}
+	seed = awaitSuccess(t, ctx, github, seed)
+	evidence.WorkflowRuns = append(evidence.WorkflowRuns, workflowEvidence{Purpose: "restart_and_seed", ID: seed.ID, URL: seed.HTMLURL})
+
+	reuse := dispatch(t, ctx, github, s, evidence.CacheKey, "reuse", 0)
+	runs = append(runs, reuse)
+	reuse = awaitSuccess(t, ctx, github, reuse)
+	evidence.WorkflowRuns = append(evidence.WorkflowRuns, workflowEvidence{Purpose: "cache_reuse", ID: reuse.ID, URL: reuse.HTMLURL})
+
+	if err := docker.switchGeneration(ctx, "isolated-"+s.runID); err != nil {
+		t.Fatal(err)
+	}
+	isolation := dispatch(t, ctx, github, s, evidence.CacheKey, "isolated", 0)
+	runs = append(runs, isolation)
+	isolation = awaitSuccess(t, ctx, github, isolation)
+	evidence.WorkflowRuns = append(evidence.WorkflowRuns, workflowEvidence{Purpose: "cache_generation_isolation", ID: isolation.ID, URL: isolation.HTMLURL})
+}
+
+func loadSettings(t *testing.T) settings {
+	t.Helper()
+	if os.Getenv(envEnabled) == "" {
+		if os.Getenv(envQualify) != "" {
+			t.Fatalf("%s is required during release qualification", envEnabled)
+		}
+		t.Skipf("set %s=1 to run the controller E2E suite", envEnabled)
+	}
+	require := func(name string) string {
+		t.Helper()
+		value := os.Getenv(name)
+		if value == "" {
+			t.Fatalf("%s is required", name)
+		}
+		return value
+	}
+	s := settings{
+		controllerImage: require(envControllerImage),
+		capsuleImage:    require(envCapsuleImage),
+		repository:      require(envRepository),
+		token:           require(envToken),
+		artifactDir:     require(envArtifactDir),
+		gitRevision:     valueOrDefault(envGitRevision, "main"),
+		apiURL:          valueOrDefault(envAPIURL, "https://api.github.com"),
+		dockerSocket:    valueOrDefault(envDockerSocket, "/var/run/docker.sock"),
+		runID:           randomHex(t, 6),
+	}
+	parts := strings.Split(s.repository, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		t.Fatalf("%s must be owner/repository, got %q", envRepository, s.repository)
+	}
+	s.owner, s.repositoryName = parts[0], parts[1]
+	s.runnerLabel = "runpool-e2e-" + s.runID
+	for _, image := range []struct {
+		name  string
+		value string
+	}{{envControllerImage, s.controllerImage}, {envCapsuleImage, s.capsuleImage}} {
+		if !strings.Contains(image.value, "@sha256:") {
+			t.Fatalf("%s must be digest-qualified, got %q", image.name, image.value)
+		}
+	}
+	return s
+}
+
+func dispatch(t *testing.T, ctx context.Context, github *githubClient, s settings, cacheKey, expectation string, hold int) workflowRun {
+	t.Helper()
+	runID := s.runID + "-" + expectation
+	run, err := github.dispatch(ctx, s.gitRevision, runID, s.runnerLabel, cacheKey, expectation, hold)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return run
+}
+
+func awaitSuccess(t *testing.T, ctx context.Context, github *githubClient, run workflowRun) workflowRun {
+	t.Helper()
+	completed, err := github.waitForSuccess(ctx, run, 20*time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return completed
+}
+
+func writeEvidence(dir, runID string, evidence qualificationEvidence) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(evidence, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "controller-e2e-"+runID+".json"), payload, 0o600)
+}
+
+func randomHex(t *testing.T, bytes int) string {
+	t.Helper()
+	payload := make([]byte, bytes)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+	return hex.EncodeToString(payload)
+}
+
+func valueOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/test/e2e/controller/github_test.go
+++ b/test/e2e/controller/github_test.go
@@ -1,0 +1,256 @@
+package controllere2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+type githubClient struct {
+	baseURL    string
+	repository string
+	token      string
+	http       *http.Client
+}
+
+type workflowRun struct {
+	ID          int64     `json:"id"`
+	DisplayName string    `json:"display_title"`
+	Status      string    `json:"status"`
+	Conclusion  string    `json:"conclusion"`
+	HTMLURL     string    `json:"html_url"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+func newGitHubClient(s settings) *githubClient {
+	return &githubClient{
+		baseURL:    strings.TrimRight(s.apiURL, "/"),
+		repository: s.repository,
+		token:      s.token,
+		http:       &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (g *githubClient) verifyFixture(ctx context.Context, ref string, expected []byte) error {
+	var content struct {
+		Encoding string `json:"encoding"`
+		Content  string `json:"content"`
+	}
+	endpoint := fmt.Sprintf("/repos/%s/contents/.github/workflows/runpool-e2e.yml?ref=%s",
+		g.repository, url.QueryEscape(ref))
+	if err := g.request(ctx, http.MethodGet, endpoint, nil, &content); err != nil {
+		return fmt.Errorf("read fixture workflow: %w", err)
+	}
+	if content.Encoding != "base64" {
+		return fmt.Errorf("fixture workflow encoding is %q; want base64", content.Encoding)
+	}
+	actual, err := base64.StdEncoding.DecodeString(strings.ReplaceAll(content.Content, "\n", ""))
+	if err != nil {
+		return fmt.Errorf("decode fixture workflow: %w", err)
+	}
+	if !bytes.Equal(bytes.TrimSpace(actual), bytes.TrimSpace(expected)) {
+		return errors.New("fixture .github/workflows/runpool-e2e.yml differs from test/e2e/controller/testdata/workload.yml")
+	}
+	return nil
+}
+
+func (g *githubClient) dispatch(ctx context.Context, ref, runID, runnerLabel, cacheKey, expectation string, holdSeconds int) (workflowRun, error) {
+	started := time.Now().UTC()
+	payload := map[string]any{
+		"ref": ref,
+		"inputs": map[string]string{
+			"run_id":            runID,
+			"runner_label":      runnerLabel,
+			"cache_key":         cacheKey,
+			"cache_expectation": expectation,
+			"hold_seconds":      fmt.Sprint(holdSeconds),
+		},
+	}
+	endpoint := fmt.Sprintf("/repos/%s/actions/workflows/runpool-e2e.yml/dispatches", g.repository)
+	if err := g.request(ctx, http.MethodPost, endpoint, payload, nil); err != nil {
+		return workflowRun{}, fmt.Errorf("dispatch workflow: %w", err)
+	}
+
+	title := "runpool-e2e-" + runID
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		runs, err := g.listRuns(ctx)
+		if err != nil {
+			return workflowRun{}, err
+		}
+		for _, run := range runs {
+			if run.DisplayName == title && !run.CreatedAt.Before(started.Add(-5*time.Second)) {
+				return run, nil
+			}
+		}
+		if err := wait(ctx, 2*time.Second); err != nil {
+			return workflowRun{}, err
+		}
+	}
+	return workflowRun{}, fmt.Errorf("dispatched workflow %q did not appear", title)
+}
+
+func (g *githubClient) listRuns(ctx context.Context) ([]workflowRun, error) {
+	var response struct {
+		Runs []workflowRun `json:"workflow_runs"`
+	}
+	endpoint := fmt.Sprintf("/repos/%s/actions/workflows/runpool-e2e.yml/runs?event=workflow_dispatch&per_page=30", g.repository)
+	if err := g.request(ctx, http.MethodGet, endpoint, nil, &response); err != nil {
+		return nil, fmt.Errorf("list workflow runs: %w", err)
+	}
+	return response.Runs, nil
+}
+
+func (g *githubClient) waitForStatus(ctx context.Context, run workflowRun, status string, timeout time.Duration) (workflowRun, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		current, err := g.getRun(ctx, run.ID)
+		if err != nil {
+			return workflowRun{}, err
+		}
+		if current.Status == status {
+			return current, nil
+		}
+		if current.Status == "completed" {
+			return current, fmt.Errorf("workflow completed as %s before reaching %s", current.Conclusion, status)
+		}
+		if err := wait(ctx, 3*time.Second); err != nil {
+			return workflowRun{}, err
+		}
+	}
+	return workflowRun{}, fmt.Errorf("workflow %d did not reach %s within %s", run.ID, status, timeout)
+}
+
+func (g *githubClient) waitForSuccess(ctx context.Context, run workflowRun, timeout time.Duration) (workflowRun, error) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		current, err := g.getRun(ctx, run.ID)
+		if err != nil {
+			return workflowRun{}, err
+		}
+		if current.Status == "completed" {
+			if current.Conclusion != "success" {
+				return current, fmt.Errorf("workflow %d concluded %q: %s", current.ID, current.Conclusion, current.HTMLURL)
+			}
+			return current, nil
+		}
+		if err := wait(ctx, 5*time.Second); err != nil {
+			return workflowRun{}, err
+		}
+	}
+	return workflowRun{}, fmt.Errorf("workflow %d did not complete within %s", run.ID, timeout)
+}
+
+func (g *githubClient) getRun(ctx context.Context, id int64) (workflowRun, error) {
+	var run workflowRun
+	endpoint := fmt.Sprintf("/repos/%s/actions/runs/%d", g.repository, id)
+	if err := g.request(ctx, http.MethodGet, endpoint, nil, &run); err != nil {
+		return run, fmt.Errorf("read workflow run %d: %w", id, err)
+	}
+	return run, nil
+}
+
+func (g *githubClient) cancel(ctx context.Context, id int64) error {
+	endpoint := fmt.Sprintf("/repos/%s/actions/runs/%d/cancel", g.repository, id)
+	err := g.request(ctx, http.MethodPost, endpoint, map[string]string{}, nil)
+	if err != nil && !strings.Contains(err.Error(), "409") {
+		return fmt.Errorf("cancel workflow run %d: %w", id, err)
+	}
+	return nil
+}
+
+func (g *githubClient) request(ctx context.Context, method, endpoint string, input, output any) error {
+	var body io.Reader
+	if input != nil {
+		payload, err := json.Marshal(input)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(payload)
+	}
+	if !strings.HasPrefix(endpoint, "/") {
+		return errors.New("GitHub API endpoint must start with a slash")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, g.baseURL+endpoint, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+g.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if input != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := g.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("GitHub API %s %s returned %d: %s", method, endpoint, resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+	if output != nil && len(payload) > 0 {
+		if err := json.Unmarshal(payload, output); err != nil {
+			return fmt.Errorf("decode GitHub API response: %w", err)
+		}
+	}
+	return nil
+}
+
+func wait(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func TestGitHubRequestPreservesEscapedPathAndQuery(t *testing.T) {
+	wantPath := "/orgs/acme/packages/container/repository%2Frunpool-e2e/versions"
+	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if got := r.URL.EscapedPath(); got != wantPath {
+			t.Errorf("escaped path = %q; want %q", got, wantPath)
+		}
+		if got := r.URL.Query().Get("per_page"); got != "100" {
+			t.Errorf("per_page = %q; want 100", got)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader("[]")),
+		}, nil
+	})
+
+	client := &githubClient{
+		baseURL: "https://api.github.test", token: "test",
+		http: &http.Client{Transport: transport},
+	}
+	endpoint := fmt.Sprintf("/orgs/acme/packages/container/%s/versions?per_page=100",
+		url.PathEscape("repository/runpool-e2e"))
+	var response []any
+	if err := client.request(t.Context(), http.MethodGet, endpoint, nil, &response); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}

--- a/test/e2e/controller/testdata/workload.yml
+++ b/test/e2e/controller/testdata/workload.yml
@@ -1,0 +1,141 @@
+name: Runpool controller E2E
+run-name: runpool-e2e-${{ inputs.run_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: Unique E2E run identifier
+        required: true
+        type: string
+      runner_label:
+        description: Run-scoped scale-set label
+        required: true
+        type: string
+      cache_key:
+        description: Marker shared by the cache assertions
+        required: true
+        type: string
+      cache_expectation:
+        description: seed, reuse, or isolated
+        required: true
+        type: choice
+        options: [seed, reuse, isolated]
+      hold_seconds:
+        description: Time reserved for the controller restart assertion
+        required: true
+        default: "0"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  workload:
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 20
+    steps:
+      - name: Check out the fixture
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: 1.26.6
+          cache: false
+
+      - name: Verify the cache contract
+        env:
+          CACHE_EXPECTATION: ${{ inputs.cache_expectation }}
+          CACHE_KEY: ${{ inputs.cache_key }}
+        run: |
+          set -euo pipefail
+          marker="/cache/${CACHE_KEY}"
+          case "$CACHE_EXPECTATION" in
+            seed)
+              test ! -e "$marker"
+              printf '%s\n' "$CACHE_KEY" > "$marker"
+              ;;
+            reuse)
+              test "$(cat "$marker")" = "$CACHE_KEY"
+              ;;
+            isolated)
+              test ! -e "$marker"
+              ;;
+            *)
+              echo "unknown cache expectation: $CACHE_EXPECTATION" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Hold the workload for controller restart
+        if: inputs.hold_seconds != '0'
+        env:
+          HOLD_SECONDS: ${{ inputs.hold_seconds }}
+        run: sleep "$HOLD_SECONDS"
+
+      - name: Download a pinned dependency
+        run: |
+          set -euo pipefail
+          module_dir="${RUNNER_TEMP}/runpool-module"
+          mkdir -p "$module_dir"
+          cd "$module_dir"
+          go mod init example.invalid/runpool-e2e
+          go mod download golang.org/x/sync@v0.17.0
+
+      - name: Build and push through the inner daemon
+        id: push
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          image="ghcr.io/${repository}/runpool-e2e:${RUN_ID}"
+          context="${RUNNER_TEMP}/runpool-image"
+          mkdir -p "$context"
+          printf '%s\n' \
+            'FROM busybox:1.37@sha256:f85340bf132ae937d2c2a763b8335c9bab35d6e8293f70f606b9c6178d84f42b' \
+            'ARG RUN_ID' \
+            'RUN test -n "$RUN_ID"' \
+            'CMD ["true"]' > "$context/Dockerfile"
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+          docker build --build-arg "RUN_ID=$RUN_ID" -t "$image" "$context"
+          docker push "$image"
+          docker logout ghcr.io
+          docker image rm "$image"
+
+      - name: Remove the pushed version with the workflow token
+        if: always()
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+          PUSH_OUTCOME: ${{ steps.push.outcome }}
+        run: |
+          set -euo pipefail
+          repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
+          package=$(printf '%s/runpool-e2e' "${repository#*/}" | sed 's|/|%2F|g')
+          endpoint="https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}/versions"
+          versions=$(curl -sSf -H "Authorization: Bearer $GHCR_TOKEN"             -H "Accept: application/vnd.github+json" "${endpoint}?per_page=100")
+          id=$(printf '%s' "$versions" | jq -r --arg tag "$RUN_ID"             '[.[] | select(.metadata.container.tags | index($tag))][0].id // empty')
+          if [ -z "$id" ]; then
+            if [ "$PUSH_OUTCOME" = "success" ]; then
+              echo "the pushed version is missing from the registry" >&2
+              exit 1
+            fi
+            echo "nothing pushed, nothing to remove"
+            exit 0
+          fi
+          curl -sSf -X DELETE -H "Authorization: Bearer $GHCR_TOKEN"             -H "Accept: application/vnd.github+json" "${endpoint}/${id}"
+          echo "removed version ${id} (tag ${RUN_ID})"
+          # The push publishes an index; deleting the tag removes the
+          # index and strands its untagged child manifests. This package
+          # exists for this test alone and its runs are serialized, so
+          # every untagged version is residue by definition.
+          curl -sSf -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" "${endpoint}?per_page=100" |
+            jq -r '.[] | select(.metadata.container.tags == []) | .id' |
+            while read -r orphan; do
+              curl -sSf -X DELETE -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" "${endpoint}/${orphan}"
+              echo "removed untagged version ${orphan}"
+            done


### PR DESCRIPTION
## What changes

`test/e2e/controller` arrives: the end-to-end suite and the workflow
fixture it dispatches. The workflow that runs it on the qualification
host lands with the operations change that restores its environment.

## What was found

**The fixture workload has to be a committed file.** The suite dispatches
a workflow in a fixture repository, and that repository serves its own
copy. If the harness generated the workflow, a drift between what the
fixture runs and what the suite expects would be invisible — the suite
would assert against the text it just wrote. Committing it means the two
copies can be compared byte for byte, and a divergence is a diff rather
than a mystery.

**Runs must be scoped or they collide.** Two runs on one host, or a
retried run overlapping an abandoned one, would otherwise compete for the
same assignments and the same objects. A generated run identifier and a
run-scoped scale-set label mean an assignment can only be claimed by the
run that created it, and leftovers from an interrupted run are
identifiable instead of ambiguous.

**Cache correctness is only observable across runs.** From inside one
job, a lane that was never warm and a lane warmed by another repository
look the same: the job succeeds either way. The suite therefore asserts
three related outcomes — a lane seeded, the same lane reused by a later
run, and a different repository isolated from it — because that triple is
what distinguishes working reuse from both failure modes.

**It proves what the unit tests cannot.** Every layer is covered
separately; what no hermetic test can show is that a real assignment
arrives, a real runner registers against a real capsule, the job's output
is what the workflow produced, and nothing is left behind afterwards.

## Evidence

Not run here, and it cannot be: it needs a dedicated Docker host, the
released image candidates and protected fixture resources.

```text
not run — the suite is opt-in and requires a qualification host with the
release candidates and the fixture repository; it does not run on pull
requests
```

## What would notice this regressing

The suite is itself the thing that notices, which is why it gates a
release rather than a merge. Within this change, the fixture workload is
committed so a divergence from the fixture repository's copy is a visible
diff.

## Risk, compatibility and operations

Trust boundary: the suite runs against a dedicated qualification host and
creates privileged capsules there. That host must not hold services or
production credentials and is reprovisioned after each run.

Credentials: supplied through the environment as a short-lived
installation token minted per run. No long-lived token is stored, and the
suite reads its identifiers from the environment rather than embedding
fixture names.

Ownership and cleanup: every object is created under the run's own
identifier, and the suite asserts the controller removed what it created
— a leftover is a failure rather than an untidiness.

Networking: reaches the configured provider host and a Docker socket on
the qualification host.

Resource limits, schema, migration, CLI, configuration, status API,
deployment, rollback: N/A.

Runbook: the qualification procedure lands with the maintainer
documentation.

## Changelog

```text
NONE
```
