### PR TITLE
ci: run the Docker-backed suites on a real daemon

### DIFF
--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -1,0 +1,164 @@
+# The live Docker contracts: every property that only a kernel can
+# answer for. The hermetic suite in ci.yml skips these by design — a
+# container property that has never run against a real daemon has not
+# been shown at all.
+#
+# It runs on a GitHub-hosted runner, which gives a rootful Engine and a
+# cgroup v2 host without Runpool being involved anywhere in its own
+# verification. That makes it fast feedback on every change — and
+# explicitly **not** release qualification: this is not the reference
+# platform, so the suites run without RUNPOOL_CONTRACT_QUALIFY and assert
+# only what any conforming host must do. The release workflow runs the same
+# suites on the host named in build/platform.lock.json.
+name: integration-docker
+
+on:
+  pull_request:
+    paths:
+      - "internal/app/**"
+      - "internal/command/**"
+      - "internal/config/**"
+      - "internal/lease/**"
+      - "internal/platform/docker/**"
+      - "internal/capsule/**"
+      - "internal/cache/**"
+      - "internal/egress/**"
+      - "internal/disk/**"
+      - "internal/store/**"
+      - "cmd/capsule-supervisor/**"
+      - "build/capsule/**"
+      - "build/controller/**"
+      - "deploy/compose/**"
+      - "scripts/drills/**"
+      - "test/contract/**"
+      - ".github/workflows/integration-docker.yml"
+  push:
+    branches: [main]
+  schedule:
+    # Daily, so drift in the daemon or the pinned images is found by the
+    # schedule rather than by a release.
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+  workflow_call:
+
+defaults:
+  run:
+    # GitHub's default shell omits pipefail, so a step that pipes into tee
+    # reports tee's exit status and a failing suite reads as a pass.
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: integration-docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  daemon:
+    name: moby adapter, cache lanes and disk
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Report the host contract
+        # The suite asserts against this host, so what it was is part of
+        # the record: engine, cgroup driver and security options.
+        run: |
+          docker version --format 'engine {{.Server.Version}} api {{.Server.APIVersion}}'
+          docker info --format 'cgroup {{.CgroupVersion}} driver {{.CgroupDriver}} rootless {{.SecurityOptions}}'
+      - name: Remove the pull fixture so the pull path is real
+        # TestPullOnMissingImage proves the pull, which it can only do
+        # if the image is genuinely absent first.
+        run: docker rmi busybox:1.36.1-uclibc 2>/dev/null || true
+      - name: Docker contracts
+        env:
+          RUNPOOL_DOCKER_CONTRACT: "1"
+        run: go test -count=1 -v ./test/contract/docker/...
+
+  capsule:
+    name: outer capsule, JIT and the egress sandbox
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Build the capsule image from the pinned inputs
+        run: docker build -f build/capsule/Dockerfile -t runpool-capsule:dev .
+      - name: Capsule and bypass contracts
+        # The lifecycle drives a real runner with a fake credential —
+        # the runner rejects it and exits, which proves it ran without
+        # needing a provider. The bypass suite proves the capsule has no
+        # route out and that its only egress is the policy.
+        env:
+          RUNPOOL_CAPSULE_CONTRACT: "1"
+        run: go test -count=1 -v -timeout 20m ./test/contract/capsule/...
+      - name: No capsule objects were left behind
+        # Every object carries ownership labels; a leak here is a
+        # cleanup bug that would leak on an operator's host too.
+        run: |
+          containers=$(docker ps -aq --filter label=io.runpool.managed=true)
+          networks=$(docker network ls -q --filter label=io.runpool.managed=true)
+          volumes=$(docker volume ls -q --filter label=io.runpool.managed=true)
+          if [ -n "$containers$networks$volumes" ]; then
+            echo "managed capsule objects remain"
+            docker ps -a --filter label=io.runpool.managed=true
+            docker network ls --filter label=io.runpool.managed=true
+            docker volume ls --filter label=io.runpool.managed=true
+            exit 1
+          fi
+
+  lifecycle:
+    name: lifecycle drills
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Install, backup, restore, upgrade, uninstall
+        # The runbook's procedures, executed rather than described:
+        # every step asserts its outcome against the real image and a
+        # real state volume.
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$dir/drill-seed" ./test/drills/seed
+          git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$dir/src.tgz" --null -T -
+          bash test/drills/remote-drills.sh "$dir"
+
+  sqlite:
+    name: sqlite durability
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Build the suite for the container
+        run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/sqlite-contract.test ./test/contract/sqlite
+      - name: Durability on a named volume, with the disk-full case
+        # The state database lives on a named volume in production, so
+        # it is tested on one here: WAL behaviour, contention, and
+        # SQLITE_FULL on a capped filesystem.
+        run: |
+          cp test/contract/sqlite/testdata/remote-harness.sh /tmp/
+          bash /tmp/remote-harness.sh /tmp


### PR DESCRIPTION
## What changes

`.github/workflows/integration-docker.yml` arrives: four jobs that run
the Docker-backed suites against a real daemon — the Moby adapter with
cache lanes and disk accounting, the outer capsule with JIT and the
egress sandbox, the lifecycle drills, and SQLite durability on a named
volume.

## What was found

**These suites cannot prove anything hermetically.** Whether an option
struct reaches the daemon as intended, whether an aggregate cgroup
actually bounds a nested container, whether WAL survives an abrupt
termination on a named volume — each is a claim about a system this
repository does not contain. Mocking them would produce green tests that
assert the mock.

**A contract result is meaningless without its host.** The suites assert
against whatever daemon the runner provides, and that moves. Each job
therefore prints the engine version, API version, cgroup version and
driver first, so a failure months later can be read against the host it
happened on.

**The pull test needs the image genuinely absent.** The runner image
caches `busybox`, so a test that proves "a missing image is pulled" would
pass against a cache hit and never exercise the pull. The fixture is
removed first, deliberately, before the suite runs.

**A leaked object is a defect, not untidiness.** Every object Runpool
creates carries ownership labels, so the capsule job can ask the daemon
whether any remain and fail if they do. The same code runs on an
operator's host, where the leak would be a container holding a privileged
daemon.

**The daily schedule exists because the inputs move, not the code.** A
new daemon on the runner image or a rebuilt base image changes what these
suites face without a single commit. A schedule finds that; a
path-triggered run cannot.

`shell: bash` is set for the workflow because GitHub's default omits
`pipefail`, and a step that pipes a suite into `tee` would otherwise
report `tee`'s status — turning a failing suite into a passing job.

## Evidence

This workflow's own run on this pull request is the evidence: the change
touches its path, so all four jobs execute here against a real daemon.

```text
see the integration-docker run on this pull request — moby adapter,
outer capsule, lifecycle drills and sqlite durability, each against the
runner's daemon
```

## What would notice this regressing

The four jobs are themselves what notices. Within the workflow, the
"no capsule objects were left behind" step fails on any managed
container, network or volume surviving the suite, and the host-contract
step makes a daemon change visible in the log rather than as an
unexplained failure.

## Risk, compatibility and operations

Trust boundary: the jobs build and run privileged containers on a
GitHub-hosted runner that is destroyed afterwards. No fixture, credential
or protected resource is reached, which is why this workflow may run on a
pull request while the provider contracts may not.

Credentials: none. The capsule lifecycle drives a real runner with a
deliberately invalid credential — the runner rejects it and exits, which
proves the runner ran without needing a provider at all.

Ownership and cleanup: asserted, not assumed; see the final step of the
capsule job.

Resource limits: the capsule suite is what verifies a tier's limits
become one aggregate cgroup over everything the job starts.

Networking: the bypass suite verifies the capsule has no route out and
that its only egress is the policy.

Deployment, rollback, schema, migration, CLI, configuration, status API,
runbook: N/A — this adds a workflow and changes no behaviour.

This workflow is deliberately not a required check for every pull
request: it is path-filtered, and a documentation-only change never
creates it. Requiring a check that does not exist would block those
changes permanently.

## Changelog

```text
NONE
```
