### PR TITLE
feat(qualification): the host collector and the JIT runner starter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Release qualification runs this same gate rather than a copy of it: two
+  # definitions of "the hermetic gate" would drift, and the one that
+  # decides a release must be the one every change already passed.
+  workflow_call:
 
 # Read-only by default; no job in this workflow needs more.
 defaults:

--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -1,0 +1,162 @@
+# Live contracts for the GitHub Actions runner-scale-set API. This workflow
+# never runs on pull requests because it accesses protected fixture resources.
+name: contracts-github-actions
+
+on:
+  schedule:
+    # Weekly. The upstream API is not ours to version, so drift is found
+    # on a schedule rather than at a release.
+    - cron: "23 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      qualify:
+        description: "Run in release-qualification mode: no skips, every contract must execute"
+        type: boolean
+        default: false
+  workflow_call:
+    inputs:
+      qualify:
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    # GitHub's default shell omits pipefail, so a step that pipes into tee
+    # reports tee's exit status and a failing suite reads as a pass.
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  # One fixture, one run: these contracts create scale sets and sessions
+  # against a real target, and two runs would fight over them.
+  group: contracts-github-actions
+  cancel-in-progress: false
+
+jobs:
+  contracts:
+    name: runner scale set API
+    runs-on: ubuntu-24.04
+    environment: upstream-contracts
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Validate the fixture configuration
+        env:
+          REPO_URL: ${{ vars.RUNPOOL_CONTRACT_REPO_URL }}
+          ORG_URL: ${{ vars.RUNPOOL_CONTRACT_ORG_URL }}
+          ORG: ${{ vars.RUNPOOL_CONTRACT_ORGANIZATION }}
+          REPO_A: ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
+          REPO_B: ${{ vars.RUNPOOL_CONTRACT_REPO_B }}
+          RUNNER_CMD: ${{ vars.RUNPOOL_CONTRACT_RUNNER_CMD }}
+          QUALIFYING: ${{ inputs.qualify && '1' || '' }}
+        run: |
+          missing=""
+          [ -n "$REPO_URL" ] || missing="$missing RUNPOOL_CONTRACT_REPO_URL"
+          [ -n "$ORG_URL" ] || missing="$missing RUNPOOL_CONTRACT_ORG_URL"
+          [ -n "$ORG" ] || missing="$missing RUNPOOL_CONTRACT_ORGANIZATION"
+          [ -n "$REPO_A" ] || missing="$missing RUNPOOL_CONTRACT_REPO_A"
+          [ -n "$REPO_B" ] || missing="$missing RUNPOOL_CONTRACT_REPO_B"
+          if [ -n "$QUALIFYING" ]; then
+            [ -n "$RUNNER_CMD" ] || missing="$missing RUNPOOL_CONTRACT_RUNNER_CMD"
+          fi
+          if [ -n "$missing" ]; then
+            echo "the upstream-contracts environment is missing:$missing"; exit 1
+          fi
+
+      - name: Mint the repository installation token
+        id: repo-token
+        # Installation tokens expire automatically and are revoked when
+        # the job ends. Each token receives only the permissions and scope
+        # required by its fixture.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RUNPOOL_CONTRACT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RUNPOOL_CONTRACT_APP_PRIVATE_KEY }}
+          owner: ${{ vars.RUNPOOL_CONTRACT_ORGANIZATION }}
+          repositories: ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
+          permission-actions: write
+          permission-administration: write
+          permission-contents: read
+
+      - name: Mint the organization installation token
+        id: org-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RUNPOOL_CONTRACT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RUNPOOL_CONTRACT_APP_PRIVATE_KEY }}
+          owner: ${{ vars.RUNPOOL_CONTRACT_ORGANIZATION }}
+          repositories: |
+            ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
+            ${{ vars.RUNPOOL_CONTRACT_REPO_B }}
+          permission-actions: write
+          permission-contents: read
+          permission-organization-self-hosted-runners: write
+
+      - name: Upstream contracts
+        # The suite creates its own scale sets and removes them through
+        # t.Cleanup, including on failure, so a run leaves the fixture
+        # as it found it. Release-qualification mode turns every skip into a
+        # failure: a contract that did not run cannot qualify a release.
+        env:
+          RUNPOOL_CONTRACT_REPO_URL: ${{ vars.RUNPOOL_CONTRACT_REPO_URL }}
+          RUNPOOL_CONTRACT_REPO_TOKEN: ${{ steps.repo-token.outputs.token }}
+          RUNPOOL_CONTRACT_ORG_URL: ${{ vars.RUNPOOL_CONTRACT_ORG_URL }}
+          RUNPOOL_CONTRACT_ORG_TOKEN: ${{ steps.org-token.outputs.token }}
+          RUNPOOL_CONTRACT_REPO_A: ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
+          RUNPOOL_CONTRACT_REPO_B: ${{ vars.RUNPOOL_CONTRACT_REPO_B }}
+          RUNPOOL_CONTRACT_RUNNER_CMD: ${{ vars.RUNPOOL_CONTRACT_RUNNER_CMD }}
+          RUNPOOL_CONTRACT_ARTIFACT_DIR: ${{ github.workspace }}/upstream-evidence
+          RUNPOOL_CONTRACT_QUALIFY: ${{ inputs.qualify && '1' || '' }}
+          # The lapse-and-requeue behaviour is the most drift-prone thing
+          # this suite watches: unversioned, and described in one
+          # paragraph of an upstream README. The weekly schedule exists to
+          # find that drift, so it runs there too and not only when a
+          # release is being qualified.
+          RUNPOOL_CONTRACT_REASSIGNMENT: "1"
+        run: |
+          mkdir -p upstream-evidence
+          go test -count=1 -v -timeout 40m ./test/contract/githubactions/... 2>&1 | tee upstream-evidence/contract.log
+
+      - name: Redact the evidence before it is kept
+        id: evidence-check
+        # The identity evidence records upstream message and job
+        # identifiers, which is the point of keeping it. It must not
+        # also carry the token: Actions masks it in the live log, but a
+        # file leaves the run. Fail rather than upload if anything that
+        # looks like a token survives.
+        if: always()
+        env:
+          REPO_TOKEN: ${{ steps.repo-token.outputs.token }}
+          ORG_TOKEN: ${{ steps.org-token.outputs.token }}
+        run: |
+          [ -d upstream-evidence ] || exit 0
+          for token in "$REPO_TOKEN" "$ORG_TOKEN"; do
+            [ -n "$token" ] || continue
+            if grep -rlF "$token" upstream-evidence 2>/dev/null; then
+              echo "a fixture credential appears in the evidence; refusing to archive it"
+              exit 1
+            fi
+          done
+          grep -rlE '(gh[pousr]_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9]{20,})' upstream-evidence 2>/dev/null && {
+            echo "a token-shaped string appears in the evidence; refusing to archive it"; exit 1
+          }
+          echo "evidence carries no credential"
+          echo "safe=true" >> "$GITHUB_OUTPUT"
+
+      - name: Keep the upstream evidence
+        if: ${{ always() && steps.evidence-check.outputs.safe == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: upstream-evidence
+          path: upstream-evidence
+          retention-days: 90
+          if-no-files-found: warn

--- a/.github/workflows/controller-e2e.yml
+++ b/.github/workflows/controller-e2e.yml
@@ -1,0 +1,158 @@
+name: controller-e2e
+
+on:
+  workflow_dispatch:
+    inputs:
+      controller_image:
+        description: Digest-qualified controller candidate
+        required: true
+        type: string
+      capsule_image:
+        description: Digest-qualified capsule candidate embedded in the controller
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      controller_image:
+        description: Digest-qualified controller candidate
+        required: true
+        type: string
+      capsule_image:
+        description: Digest-qualified capsule candidate embedded in the controller
+        required: true
+        type: string
+
+defaults:
+  run:
+    # GitHub's default shell omits pipefail, so a step that pipes into tee
+    # reports tee's exit status and a failing suite reads as a pass.
+    shell: bash
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: controller-e2e
+  cancel-in-progress: false
+
+jobs:
+  workload:
+    name: real assignment, restart, cache and cleanup
+    runs-on: [self-hosted, linux, x64, runpool-release-qualification]
+    environment: release-qualification
+    timeout-minutes: 70
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Validate the fixture configuration
+        env:
+          ORGANIZATION: ${{ vars.RUNPOOL_E2E_ORGANIZATION }}
+          REPOSITORY: ${{ vars.RUNPOOL_E2E_REPOSITORY }}
+          GIT_REVISION: ${{ vars.RUNPOOL_E2E_GIT_REVISION }}
+          CLIENT_ID: ${{ vars.RUNPOOL_E2E_APP_CLIENT_ID }}
+          PRIVATE_KEY: ${{ secrets.RUNPOOL_E2E_APP_PRIVATE_KEY }}
+        run: |
+          missing=""
+          [ -n "$ORGANIZATION" ] || missing="$missing RUNPOOL_E2E_ORGANIZATION"
+          [ -n "$REPOSITORY" ] || missing="$missing RUNPOOL_E2E_REPOSITORY"
+          [ -n "$GIT_REVISION" ] || missing="$missing RUNPOOL_E2E_GIT_REVISION"
+          [ -n "$CLIENT_ID" ] || missing="$missing RUNPOOL_E2E_APP_CLIENT_ID"
+          [ -n "$PRIVATE_KEY" ] || missing="$missing RUNPOOL_E2E_APP_PRIVATE_KEY"
+          if [ -n "$missing" ]; then
+            echo "the release-qualification environment is missing:$missing"
+            exit 1
+          fi
+          case "$REPOSITORY" in
+            */*) echo "RUNPOOL_E2E_REPOSITORY must be a repository name, not owner/repository"; exit 1 ;;
+          esac
+
+      - name: Mint the fixture installation token
+        id: fixture-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RUNPOOL_E2E_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RUNPOOL_E2E_APP_PRIVATE_KEY }}
+          owner: ${{ vars.RUNPOOL_E2E_ORGANIZATION }}
+          repositories: ${{ vars.RUNPOOL_E2E_REPOSITORY }}
+          permission-actions: write
+          permission-administration: write
+          permission-contents: read
+          permission-packages: write
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker_config="${RUNNER_TEMP}/runpool-e2e-docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
+          echo "$GHCR_TOKEN" | docker --config "$docker_config" login ghcr.io \
+            -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull the immutable candidates
+        env:
+          CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+          CONTROLLER_IMAGE: ${{ inputs.controller_image }}
+        run: |
+          for image in "$CONTROLLER_IMAGE" "$CAPSULE_IMAGE"; do
+            case "$image" in
+              *@sha256:*) ;;
+              *) echo "candidate references must be digest-qualified"; exit 1 ;;
+            esac
+            docker pull "$image"
+          done
+
+      - name: Drive a real controller workload
+        env:
+          RUNPOOL_CONTROLLER_E2E: "1"
+          RUNPOOL_CONTRACT_QUALIFY: "1"
+          RUNPOOL_E2E_CONTROLLER_IMAGE: ${{ inputs.controller_image }}
+          RUNPOOL_E2E_CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+          RUNPOOL_E2E_REPOSITORY: ${{ vars.RUNPOOL_E2E_ORGANIZATION }}/${{ vars.RUNPOOL_E2E_REPOSITORY }}
+          RUNPOOL_E2E_GIT_REVISION: ${{ vars.RUNPOOL_E2E_GIT_REVISION }}
+          RUNPOOL_E2E_TOKEN: ${{ steps.fixture-token.outputs.token }}
+          RUNPOOL_E2E_ARTIFACT_DIR: ${{ github.workspace }}/controller-e2e-evidence
+        run: go test -count=1 -v -timeout 60m ./test/e2e/controller/...
+
+      - name: Refuse credential-bearing evidence
+        id: evidence-check
+        if: always()
+        env:
+          FIXTURE_TOKEN: ${{ steps.fixture-token.outputs.token }}
+        run: |
+          [ -d controller-e2e-evidence ] || exit 0
+          if [ -n "$FIXTURE_TOKEN" ] && grep -rlF "$FIXTURE_TOKEN" controller-e2e-evidence 2>/dev/null; then
+            echo "the fixture credential appears in the evidence; refusing to archive it"
+            exit 1
+          fi
+          if grep -rlE '(gh[pousr]_[A-Za-z0-9]{20,}|ghs_[A-Za-z0-9]{20,})' controller-e2e-evidence 2>/dev/null; then
+            echo "a token-shaped string appears in the evidence; refusing to archive it"
+            exit 1
+          fi
+          echo "safe=true" >> "$GITHUB_OUTPUT"
+
+      - name: Keep controller E2E evidence
+        if: ${{ always() && steps.evidence-check.outputs.safe == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: controller-e2e-evidence
+          path: controller-e2e-evidence
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Close the registry session
+        if: always()
+        run: |
+          if [ -n "${DOCKER_CONFIG:-}" ]; then
+            docker --config "$DOCKER_CONFIG" logout ghcr.io >/dev/null 2>&1 || true
+            rm -rf -- "$DOCKER_CONFIG"
+          fi

--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -1,0 +1,324 @@
+name: qualify-release
+
+on:
+  workflow_call:
+    inputs:
+      controller_image:
+        description: Digest-qualified controller candidate
+        required: true
+        type: string
+      capsule_image:
+        description: Digest-qualified capsule candidate
+        required: true
+        type: string
+    outputs:
+      qualified_commit:
+        description: Commit covered by the release-qualification record
+        value: ${{ jobs.record.outputs.commit }}
+
+defaults:
+  run:
+    # GitHub's default shell omits pipefail, so a step that pipes into tee
+    # reports tee's exit status and a failing suite reads as a pass.
+    shell: bash
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: qualify-release-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  GOTOOLCHAIN: go1.26.6
+
+jobs:
+  validate-ref:
+    name: validate release inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Require a protected release tag and immutable images
+        env:
+          CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+          CONTROLLER_IMAGE: ${{ inputs.controller_image }}
+          REF: ${{ github.ref }}
+        run: |
+          case "$REF" in
+            refs/tags/v*) ;;
+            *) echo "release qualification runs only from a protected SemVer tag"; exit 1 ;;
+          esac
+          for image in "$CONTROLLER_IMAGE" "$CAPSULE_IMAGE"; do
+            case "$image" in
+              *@sha256:*) ;;
+              *) echo "release qualification requires digest-qualified image candidates"; exit 1 ;;
+            esac
+          done
+
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download the standalone candidates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts-candidate
+          path: release-artifacts
+
+      - name: Validate SemVer
+        env:
+          CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          go build -trimpath -ldflags "-X main.version=${VERSION}" -o /tmp/runpool-version ./cmd/runpool
+          /tmp/runpool-version version --check-release
+          (cd release-artifacts && sha256sum -c checksums.txt)
+          chmod +x release-artifacts/runpool-linux-amd64
+          release-artifacts/runpool-linux-amd64 version --check-release
+          release-artifacts/runpool-linux-amd64 version --json > /tmp/runpool-release-facts.json
+          python3 - <<'PY'
+          import json, os, sys
+
+          facts = json.load(open("/tmp/runpool-release-facts.json", encoding="utf-8"))
+          if facts.get("version") != os.environ["VERSION"]:
+              sys.exit("standalone candidate has the wrong version")
+          if facts.get("capsule_image") != os.environ["CAPSULE_IMAGE"]:
+              sys.exit("standalone candidate embeds the wrong capsule image")
+          PY
+
+  hermetic:
+    name: hermetic gate
+    needs: validate-ref
+    uses: ./.github/workflows/ci.yml
+
+  live:
+    name: live contracts on the reference host
+    needs: validate-ref
+    runs-on: [self-hosted, linux, x64, runpool-release-qualification]
+    environment: release-qualification
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Verify the release-qualification reference
+        run: |
+          scripts/qualification/platform-facts.sh | tee platform-facts.json
+          go run ./internal/platform/cmd/verify -observed platform-facts.json
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker_config="${RUNNER_TEMP}/runpool-qualification-docker-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$docker_config"
+          echo "DOCKER_CONFIG=$docker_config" >> "$GITHUB_ENV"
+          echo "$GHCR_TOKEN" | docker --config "$docker_config" login ghcr.io \
+            -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull the exact capsule candidate
+        env:
+          CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+        run: |
+          docker pull "$CAPSULE_IMAGE"
+          docker tag "$CAPSULE_IMAGE" runpool-capsule:dev
+
+      - name: Docker contracts
+        env:
+          RUNPOOL_DOCKER_CONTRACT: "1"
+          RUNPOOL_CONTRACT_QUALIFY: "1"
+        run: |
+          docker image rm -f busybox:1.36.1-uclibc >/dev/null 2>&1 || true
+          go test -count=1 -v ./test/contract/docker/... 2>&1 | tee docker-contract.log
+
+      - name: Capsule, egress and budget contracts
+        env:
+          RUNPOOL_CAPSULE_CONTRACT: "1"
+          RUNPOOL_CONTRACT_QUALIFY: "1"
+        run: go test -count=1 -v -timeout 30m ./test/contract/capsule/... 2>&1 | tee capsule-contract.log
+
+      - name: SQLite durability
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/sqlite-contract.test" ./test/contract/sqlite
+          cp test/contract/sqlite/testdata/remote-harness.sh "$dir/"
+          bash "$dir/remote-harness.sh" "$dir" 2>&1 | tee sqlite-contract.log
+
+      - name: Lifecycle drills
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$dir/drill-seed" ./test/drills/seed
+          git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$dir/src.tgz" --null -T -
+          bash test/drills/remote-drills.sh "$dir" 2>&1 | tee lifecycle-drills.log
+
+      - name: Verify cleanup
+        if: always()
+        run: |
+          status=0
+          left=$(docker ps -aq --filter label=io.runpool.managed=true)
+          if [ -n "$left" ]; then
+            echo "containers left behind:"
+            docker ps -a --filter label=io.runpool.managed=true
+            status=1
+          fi
+          left=$(docker network ls -q --filter label=io.runpool.managed=true)
+          if [ -n "$left" ]; then
+            echo "networks left behind:"
+            docker network ls --filter label=io.runpool.managed=true
+            status=1
+          fi
+          left=$(docker volume ls -q --filter label=io.runpool.managed=true)
+          if [ -n "$left" ]; then
+            echo "volumes left behind:"
+            docker volume ls --filter label=io.runpool.managed=true
+            status=1
+          fi
+          if [ -n "${DOCKER_CONFIG:-}" ]; then
+            docker --config "$DOCKER_CONFIG" logout ghcr.io >/dev/null 2>&1 || true
+            rm -rf -- "$DOCKER_CONFIG"
+          fi
+          exit "$status"
+
+      - name: Keep live evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: live-evidence
+          path: |
+            platform-facts.json
+            docker-contract.log
+            capsule-contract.log
+            sqlite-contract.log
+            lifecycle-drills.log
+          retention-days: 90
+          if-no-files-found: error
+
+  upstream:
+    name: live upstream contracts
+    needs: validate-ref
+    uses: ./.github/workflows/contracts-github-actions.yml
+    with:
+      qualify: true
+    secrets: inherit
+
+  controller-e2e:
+    name: controller end-to-end
+    needs: live
+    uses: ./.github/workflows/controller-e2e.yml
+    with:
+      controller_image: ${{ inputs.controller_image }}
+      capsule_image: ${{ inputs.capsule_image }}
+    secrets: inherit
+
+  record:
+    name: release-qualification record
+    needs: [hermetic, live, upstream, controller-e2e]
+    runs-on: ubuntu-24.04
+    outputs:
+      commit: ${{ github.sha }}
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download live evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: live-evidence
+          path: evidence/live
+
+      - name: Download upstream evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: upstream-evidence
+          path: evidence/upstream
+
+      - name: Download controller E2E evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: controller-e2e-evidence
+          path: evidence/controller-e2e
+
+      - name: Download the standalone candidates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts-candidate
+          path: evidence/release-artifacts
+
+      - name: Assemble the release-qualification record
+        env:
+          CAPSULE_IMAGE: ${{ inputs.capsule_image }}
+          COMMIT: ${{ github.sha }}
+          CONTROLLER_IMAGE: ${{ inputs.controller_image }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY' > release-qualification.json
+          import datetime, glob, json, os, sys
+
+          facts = json.load(open("evidence/live/platform-facts.json", encoding="utf-8"))
+          reference = json.load(open("build/platform.lock.json", encoding="utf-8"))
+          if reference.get("status") != "frozen":
+              sys.exit("release-qualification reference is not frozen")
+          checksums = open("evidence/release-artifacts/checksums.txt", encoding="utf-8").read().splitlines()
+          e2e_files = glob.glob("evidence/controller-e2e/controller-e2e-*.json")
+          if len(e2e_files) != 1:
+              sys.exit(f"expected one controller E2E record, found {len(e2e_files)}")
+          e2e = json.load(open(e2e_files[0], encoding="utf-8"))
+          if e2e.get("outcome") != "passed":
+              sys.exit("controller E2E record is not successful")
+          if e2e.get("controller_image") != os.environ["CONTROLLER_IMAGE"]:
+              sys.exit("controller E2E covered a different controller image")
+          if e2e.get("capsule_image") != os.environ["CAPSULE_IMAGE"]:
+              sys.exit("controller E2E covered a different capsule image")
+
+          record = {
+              "schema_version": 1,
+              "commit": os.environ["COMMIT"],
+              "controller_image": os.environ["CONTROLLER_IMAGE"],
+              "capsule_image": os.environ["CAPSULE_IMAGE"],
+              "run": os.environ["RUN_URL"],
+              "qualified_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "platform_policy": reference["policy"],
+              "platform_reference": reference["platform"],
+              "platform_observed": facts,
+              "standalone_artifacts": checksums,
+              "suites": [
+                  "hermetic",
+                  "docker-contract",
+                  "capsule-contract",
+                  "sqlite-durability",
+                  "lifecycle-drills",
+                  "contracts-github-actions",
+                  "controller-e2e",
+              ],
+          }
+          print(json.dumps(record, indent=2))
+          PY
+          cat release-qualification.json
+
+      - name: Keep the release-qualification record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-qualification
+          path: |
+            release-qualification.json
+            evidence
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,302 @@
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+defaults:
+  run:
+    # GitHub's default shell omits pipefail, so a step that pipes into tee
+    # reports tee's exit status and a failing suite reads as a pass.
+    shell: bash
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: validate release tag
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Validate the version stamped into the artifact
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          go build -trimpath -ldflags "-X main.version=${VERSION}" -o /tmp/runpool-version ./cmd/runpool
+          /tmp/runpool-version version --check-release
+
+  candidate:
+    name: build immutable candidates
+    needs: validate
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      capsule_image: ${{ steps.capsule.outputs.reference }}
+      controller_image: ${{ steps.controller.outputs.reference }}
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push the capsule candidate
+        id: capsule
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/capsule:candidate-${{ github.sha }}
+        run: |
+          docker build -f build/capsule/Dockerfile -t "$IMAGE" .
+          docker push "$IMAGE"
+          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE")
+          case "$reference" in
+            *@sha256:*) ;;
+            *) echo "registry returned no immutable capsule digest"; exit 1 ;;
+          esac
+          echo "reference=$reference" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push the controller candidate
+        id: controller
+        env:
+          CAPSULE_IMAGE: ${{ steps.capsule.outputs.reference }}
+          IMAGE: ghcr.io/${{ github.repository }}:candidate-${{ github.sha }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          docker build -f build/controller/Dockerfile \
+            --build-arg "VERSION=${VERSION}" \
+            --build-arg "CAPSULE_IMAGE=${CAPSULE_IMAGE}" \
+            -t "$IMAGE" .
+          docker push "$IMAGE"
+          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE")
+          case "$reference" in
+            *@sha256:*) ;;
+            *) echo "registry returned no immutable controller digest"; exit 1 ;;
+          esac
+          echo "reference=$reference" >> "$GITHUB_OUTPUT"
+
+      - name: Build the standalone release artifacts
+        env:
+          CAPSULE_IMAGE: ${{ steps.capsule.outputs.reference }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          mkdir -p release-artifacts
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
+            -ldflags "-s -w -X main.version=${VERSION} -X main.capsuleImage=${CAPSULE_IMAGE}" \
+            -o release-artifacts/runpool-linux-amd64 ./cmd/runpool
+          go generate ./internal/command/...
+          git diff --exit-code docs/reference/cli
+          tar -C dist/completions -czf release-artifacts/runpool-completions.tar.gz .
+          (cd release-artifacts && sha256sum runpool-linux-amd64 runpool-completions.tar.gz > checksums.txt)
+          release-artifacts/runpool-linux-amd64 version --check-release
+          release-artifacts/runpool-linux-amd64 version --json
+          (cd release-artifacts && sha256sum -c checksums.txt)
+
+      - name: Keep the immutable release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-artifacts-candidate
+          path: release-artifacts
+          retention-days: 90
+          if-no-files-found: error
+
+  qualify:
+    name: qualify the exact commit and candidates
+    needs: candidate
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/qualify-release.yml
+    with:
+      capsule_image: ${{ needs.candidate.outputs.capsule_image }}
+      controller_image: ${{ needs.candidate.outputs.controller_image }}
+    secrets: inherit
+
+  publish:
+    name: attest and publish qualified artifacts
+    needs: [candidate, qualify]
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download the release-qualification record
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-qualification
+          path: qualification
+
+      - name: Download the exact standalone artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-artifacts-candidate
+          path: dist
+
+      - name: Verify the release record and artifacts
+        env:
+          CAPSULE_IMAGE: ${{ needs.candidate.outputs.capsule_image }}
+          COMMIT: ${{ github.sha }}
+          CONTROLLER_IMAGE: ${{ needs.candidate.outputs.controller_image }}
+        run: |
+          python3 - <<'PY'
+          import json, os, sys
+
+          record = json.load(open("qualification/release-qualification.json", encoding="utf-8"))
+          expected = {
+              "commit": os.environ["COMMIT"],
+              "controller_image": os.environ["CONTROLLER_IMAGE"],
+              "capsule_image": os.environ["CAPSULE_IMAGE"],
+          }
+          for key, value in expected.items():
+              if record.get(key) != value:
+                  sys.exit(f"release-qualification record has the wrong {key}")
+          PY
+          (cd dist && sha256sum -c checksums.txt)
+          go run ./internal/platform/cmd/verify -observed qualification/evidence/live/platform-facts.json
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Promote the qualified images
+        id: promote
+        env:
+          CAPSULE_CANDIDATE: ${{ needs.candidate.outputs.capsule_image }}
+          CAPSULE_NAME: ghcr.io/${{ github.repository }}/capsule
+          CONTROLLER_CANDIDATE: ${{ needs.candidate.outputs.controller_image }}
+          CONTROLLER_NAME: ghcr.io/${{ github.repository }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          promote() {
+            candidate=$1
+            name=$2
+            docker pull "$candidate" >&2
+            docker tag "$candidate" "${name}:${VERSION}"
+            docker push "${name}:${VERSION}" >&2
+            docker pull "${name}:${VERSION}" >&2
+            reference="${name}@${candidate#*@}"
+            docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${name}:${VERSION}" | grep -Fxq "$reference" || {
+              echo "promoted digest differs from the qualified candidate"
+              exit 1
+            }
+            printf '%s' "$reference"
+          }
+          controller_reference=$(promote "$CONTROLLER_CANDIDATE" "$CONTROLLER_NAME")
+          capsule_reference=$(promote "$CAPSULE_CANDIDATE" "$CAPSULE_NAME")
+          {
+            echo "controller_name=$CONTROLLER_NAME"
+            echo "controller_digest=${controller_reference#*@}"
+            echo "controller_reference=$controller_reference"
+            echo "capsule_name=$CAPSULE_NAME"
+            echo "capsule_digest=${capsule_reference#*@}"
+            echo "capsule_reference=$capsule_reference"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate controller SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.promote.outputs.controller_reference }}
+          format: spdx-json
+          output-file: dist/controller.sbom.spdx.json
+          upload-artifact: false
+
+      - name: Generate capsule SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.promote.outputs.capsule_reference }}
+          format: spdx-json
+          output-file: dist/capsule.sbom.spdx.json
+          upload-artifact: false
+
+      - name: Attest standalone artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: dist/checksums.txt
+
+      - name: Attest controller provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.promote.outputs.controller_name }}
+          subject-digest: ${{ steps.promote.outputs.controller_digest }}
+          push-to-registry: true
+
+      - name: Attest controller SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.promote.outputs.controller_name }}
+          subject-digest: ${{ steps.promote.outputs.controller_digest }}
+          sbom-path: dist/controller.sbom.spdx.json
+          push-to-registry: true
+
+      - name: Attest capsule provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.promote.outputs.capsule_name }}
+          subject-digest: ${{ steps.promote.outputs.capsule_digest }}
+          push-to-registry: true
+
+      - name: Attest capsule SBOM
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ steps.promote.outputs.capsule_name }}
+          subject-digest: ${{ steps.promote.outputs.capsule_digest }}
+          sbom-path: dist/capsule.sbom.spdx.json
+          push-to-registry: true
+
+      - name: Publish a draft GitHub release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: |
+            dist/runpool-linux-amd64
+            dist/runpool-completions.tar.gz
+            dist/checksums.txt
+            dist/controller.sbom.spdx.json
+            dist/capsule.sbom.spdx.json
+            qualification/release-qualification.json
+          body: |
+            Release-qualified commit: `${{ github.sha }}`
+
+            Controller: `${{ steps.promote.outputs.controller_reference }}`
+
+            Capsule: `${{ steps.promote.outputs.capsule_reference }}`
+          draft: true
+          fail_on_unmatched_files: true

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Emit this host's platform facts as JSON for the release-qualification record.
+#
+# It reports what the host is, and says nothing about whether that is
+# right: the comparison against build/platform.lock.json belongs to the
+# contract suite, which embeds the reviewed manifest. Keeping the two
+# apart is the point — a collector that also decided would be free to
+# decide in favour of whatever it found.
+#
+# Usage: scripts/qualification/platform-facts.sh
+# shellcheck source=/dev/null # a host file, not a repository one
+os_id=$(. /etc/os-release && printf '%s' "$ID")
+# shellcheck source=/dev/null
+os_version=$(. /etc/os-release && printf '%s' "$VERSION_ID")
+# shellcheck source=/dev/null
+os_codename=$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-}")
+
+engine=$(docker version --format '{{.Server.Version}}')
+api=$(docker version --format '{{.Server.APIVersion}}')
+cgroup_version=$(docker info --format '{{.CgroupVersion}}')
+cgroup_driver=$(docker info --format '{{.CgroupDriver}}')
+storage=$(docker info --format '{{.Driver}}')
+containerd=$(docker info --format '{{.ContainerdCommit.ID}}')
+runc=$(docker info --format '{{.RuncCommit.ID}}')
+security=$(docker info --format '{{.SecurityOptions}}')
+rootless=false
+case "$security" in *rootless*) rootless=true ;; esac
+
+buildx=$(docker buildx version 2>/dev/null | awk '{print $2}' || true)
+compose=$(docker compose version --short 2>/dev/null || true)
+backing=$(stat -f -c %T /var/lib/docker 2>/dev/null || true)
+iptables_version=$(iptables --version 2>/dev/null || true)
+nft_version=$(nft --version 2>/dev/null || true)
+
+case "$(uname -m)" in
+  x86_64) arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) arch=$(uname -m) ;;
+esac
+
+cat <<JSON
+{
+  "os": "${os_id}",
+  "os_version": "${os_version}",
+  "os_codename": "${os_codename}",
+  "arch": "${arch}",
+  "kernel": "$(uname -r)",
+  "engine": "${engine}",
+  "api": "${api}",
+  "cgroup_version": "${cgroup_version}",
+  "cgroup_driver": "${cgroup_driver}",
+  "storage_driver": "${storage}",
+  "backing_filesystem": "${backing}",
+  "rootless": ${rootless},
+  "containerd": "${containerd}",
+  "runc": "${runc}",
+  "buildx": "${buildx}",
+  "compose": "${compose}",
+  "iptables": "${iptables_version}",
+  "nftables": "${nft_version}",
+  "collected_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+JSON

--- a/scripts/qualification/qualification/platform-facts.sh
+++ b/scripts/qualification/qualification/platform-facts.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Emit this host's platform facts as JSON for the release-qualification record.
+#
+# It reports what the host is, and says nothing about whether that is
+# right: the comparison against build/platform.lock.json belongs to the
+# contract suite, which embeds the reviewed manifest. Keeping the two
+# apart is the point — a collector that also decided would be free to
+# decide in favour of whatever it found.
+#
+# Usage: scripts/qualification/platform-facts.sh
+# shellcheck source=/dev/null # a host file, not a repository one
+os_id=$(. /etc/os-release && printf '%s' "$ID")
+# shellcheck source=/dev/null
+os_version=$(. /etc/os-release && printf '%s' "$VERSION_ID")
+# shellcheck source=/dev/null
+os_codename=$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-}")
+
+engine=$(docker version --format '{{.Server.Version}}')
+api=$(docker version --format '{{.Server.APIVersion}}')
+cgroup_version=$(docker info --format '{{.CgroupVersion}}')
+cgroup_driver=$(docker info --format '{{.CgroupDriver}}')
+storage=$(docker info --format '{{.Driver}}')
+containerd=$(docker info --format '{{.ContainerdCommit.ID}}')
+runc=$(docker info --format '{{.RuncCommit.ID}}')
+security=$(docker info --format '{{.SecurityOptions}}')
+rootless=false
+case "$security" in *rootless*) rootless=true ;; esac
+
+buildx=$(docker buildx version 2>/dev/null | awk '{print $2}' || true)
+compose=$(docker compose version --short 2>/dev/null || true)
+backing=$(stat -f -c %T /var/lib/docker 2>/dev/null || true)
+iptables_version=$(iptables --version 2>/dev/null || true)
+nft_version=$(nft --version 2>/dev/null || true)
+
+case "$(uname -m)" in
+  x86_64) arch=amd64 ;;
+  aarch64|arm64) arch=arm64 ;;
+  *) arch=$(uname -m) ;;
+esac
+
+cat <<JSON
+{
+  "os": "${os_id}",
+  "os_version": "${os_version}",
+  "os_codename": "${os_codename}",
+  "arch": "${arch}",
+  "kernel": "$(uname -r)",
+  "engine": "${engine}",
+  "api": "${api}",
+  "cgroup_version": "${cgroup_version}",
+  "cgroup_driver": "${cgroup_driver}",
+  "storage_driver": "${storage}",
+  "backing_filesystem": "${backing}",
+  "rootless": ${rootless},
+  "containerd": "${containerd}",
+  "runc": "${runc}",
+  "buildx": "${buildx}",
+  "compose": "${compose}",
+  "iptables": "${iptables_version}",
+  "nftables": "${nft_version}",
+  "collected_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+JSON

--- a/scripts/qualification/qualification/start-jit-runner.sh
+++ b/scripts/qualification/qualification/start-jit-runner.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Start one just-in-time runner for the live GitHub Actions contracts.
+#
+# RUNPOOL_CONTRACT_RUNNER_CMD points at this script. The suite appends the
+# runner name as the last argument and writes the JIT bundle to stdin, then
+# waits for the command to finish — so this starts the runner and returns
+# rather than following it.
+#
+# The bundle never reaches the host. It is delivered over stdin into an
+# already-running container, written there with a private mode, and removed
+# before the runner is executed; the only place it becomes an argument is the
+# upstream runner's required --jitconfig, inside the disposable container.
+# That is the same boundary the capsule supervisor keeps, for the same reason:
+# a bundle in host state or in a log outlives the runner it authorises.
+#
+# The runner image is the digest pinned in build/images.lock.json, so the
+# contracts exercise the bytes the capsule is built from.
+#
+# Usage: start-jit-runner.sh <runner-name>   # JIT bundle on stdin
+cd "$(dirname "$0")/../.."
+
+name=${1:?usage: start-jit-runner.sh <runner-name>}
+container="runpool-contract-${name}"
+
+image=$(python3 -c '
+import json
+lock = json.load(open("build/images.lock.json"))
+entry = lock["images"]["runner"]
+print(entry["ref"].split(":")[0] + "@" + entry["digest"])
+')
+
+# The container waits for the bundle instead of receiving it as an argument or
+# an environment value, both of which would be readable from the host for as
+# long as the container lived.
+docker run --detach --rm --name "$container" --entrypoint sh "$image" -c '
+  while [ ! -s /tmp/jitconfig ]; do sleep 0.1; done
+  config=$(cat /tmp/jitconfig)
+  rm -f /tmp/jitconfig
+  exec ./run.sh --jitconfig "$config"
+' >/dev/null
+
+# A container waiting for a bundle that never arrives waits forever, so a
+# failed delivery takes the container with it rather than leaving it spinning.
+trap 'docker rm --force "$container" >/dev/null 2>&1 || true' ERR
+
+# Delivered under a temporary name and renamed, so the waiting loop never
+# observes a partly written bundle and starts a runner with a truncated one.
+# Nothing here echoes it: the suite fails the contract if it finds the bundle
+# in this command's output, and it is right to.
+docker exec -i "$container" sh -c \
+  'umask 077; cat > /tmp/jitconfig.part && mv /tmp/jitconfig.part /tmp/jitconfig'
+
+trap - ERR
+printf 'started %s\n' "$container"

--- a/scripts/qualification/start-jit-runner.sh
+++ b/scripts/qualification/start-jit-runner.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Start one just-in-time runner for the live GitHub Actions contracts.
+#
+# RUNPOOL_CONTRACT_RUNNER_CMD points at this script. The suite appends the
+# runner name as the last argument and writes the JIT bundle to stdin, then
+# waits for the command to finish — so this starts the runner and returns
+# rather than following it.
+#
+# The bundle never reaches the host. It is delivered over stdin into an
+# already-running container, written there with a private mode, and removed
+# before the runner is executed; the only place it becomes an argument is the
+# upstream runner's required --jitconfig, inside the disposable container.
+# That is the same boundary the capsule supervisor keeps, for the same reason:
+# a bundle in host state or in a log outlives the runner it authorises.
+#
+# The runner image is the digest pinned in build/images.lock.json, so the
+# contracts exercise the bytes the capsule is built from.
+#
+# Usage: start-jit-runner.sh <runner-name>   # JIT bundle on stdin
+cd "$(dirname "$0")/../.."
+
+name=${1:?usage: start-jit-runner.sh <runner-name>}
+container="runpool-contract-${name}"
+
+image=$(python3 -c '
+import json
+lock = json.load(open("build/images.lock.json"))
+entry = lock["images"]["runner"]
+print(entry["ref"].split(":")[0] + "@" + entry["digest"])
+')
+
+# The container waits for the bundle instead of receiving it as an argument or
+# an environment value, both of which would be readable from the host for as
+# long as the container lived.
+docker run --detach --rm --name "$container" --entrypoint sh "$image" -c '
+  while [ ! -s /tmp/jitconfig ]; do sleep 0.1; done
+  config=$(cat /tmp/jitconfig)
+  rm -f /tmp/jitconfig
+  exec ./run.sh --jitconfig "$config"
+' >/dev/null
+
+# A container waiting for a bundle that never arrives waits forever, so a
+# failed delivery takes the container with it rather than leaving it spinning.
+trap 'docker rm --force "$container" >/dev/null 2>&1 || true' ERR
+
+# Delivered under a temporary name and renamed, so the waiting loop never
+# observes a partly written bundle and starts a runner with a truncated one.
+# Nothing here echoes it: the suite fails the contract if it finds the bundle
+# in this command's output, and it is right to.
+docker exec -i "$container" sh -c \
+  'umask 077; cat > /tmp/jitconfig.part && mv /tmp/jitconfig.part /tmp/jitconfig'
+
+trap - ERR
+printf 'started %s\n' "$container"


### PR DESCRIPTION
## What changes

`scripts/qualification/` arrives: the collector that emits a host's
platform facts as JSON, and the starter that brings up one JIT runner
from the locked image. Both are run on a dedicated qualification host by
the workflows that produce release evidence.

## What was found

**A collector must not also judge.** If the script compared the host
against the reference, the two halves of the qualification — what the
host is, and what it should be — would live in the same place and move
together. The collector emits facts; the reference is embedded in code
and compared there. That separation is what stops a qualification from
deriving its expectations from the machine it is qualifying.

**The runner must come from the locked digest.** A tag would let the
runner used to produce evidence differ from the one a release ships,
which makes the evidence describe a system nobody will run. The starter
resolves the digest recorded in the image lock.

**The JIT bundle must not touch the host's disk.** The qualification host
is reprovisioned after every run, but "eventually destroyed" is not the
same as "never written". The credential is passed to the runner without
being stored, so an interrupted run leaves nothing behind to find.

Both scripts are shellcheck-clean under the same gate as the rest, which
matters more here than elsewhere: they run against real hosts, where a
quoting bug deletes the wrong thing.

## Evidence

Not run here. Both require a provisioned qualification host — the
collector reads `/etc/os-release` and a real daemon, and the starter
needs a provider to register against.

```text
not run — both scripts target a dedicated qualification host, which does
not exist yet; shellcheck passes on both
```

## What would notice this regressing

shellcheck covers both scripts on every change. The collector's output
shape is consumed by the platform comparison, whose tests fail if a fact
it needs is missing — a collector that stopped emitting one would be
caught there rather than by reading the script.

## Risk, compatibility and operations

Trust boundary: these run on the qualification host, which holds no
services and no production credentials and is reprovisioned after each
run.

Credentials: the starter handles a JIT bundle and deliberately does not
persist it. No credential is written to the host's filesystem.

Ownership and cleanup: the starter brings up a single runner; the
workflow that invokes it owns tearing it down.

Networking: the starter registers against the configured provider.

Resource limits, schema, migration, CLI, configuration, status API,
deployment, rollback: N/A.

Runbook: the procedure that uses these lands with the maintainer
documentation.

## Changelog

```text
NONE
```
