### PR TITLE
docs: every link resolves and every record states what the code does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,261 @@
+# Changelog
+
+Notable changes, newest first. Runpool follows
+[Semantic Versioning](https://semver.org/): the compatibility surfaces
+a version speaks for are listed in
+[the product contract](docs/product-contract.md).
+
+## Unreleased
+
+**Nothing has been released.** There is no tag, no published binary and
+no image. The first release is `v1.0.0`, and it is
+blocked on the external security review and release qualification on
+the reference host — see
+[release readiness](docs/release-readiness.md) for the live status and
+for exactly what unblocks each.
+
+This section records the product delivered by the first release, grouped
+by its public and operational effects.
+
+### Isolation and egress
+
+- A job runs in **one capsule**: supervisor, runner and the job's own
+  Docker daemon in a single container under one aggregate cgroup.
+- **The egress gateway always runs the capsule this build ships.**
+  Extending the image a tier's jobs run in does not replace the container
+  that applies the network policy confining them.
+- **A tier may name its own capsule image.** `tiers[].capsuleImage` takes
+  a digest-qualified image built from the published capsule, so a
+  deployment can add packages and toolchains to its jobs without a fork.
+  The controller reads the protocol version the capsule declares before
+  handing it anything and refuses one it does not speak; that attempt is
+  held for review as `capsule_incompatible` rather than retried, because
+  the next attempt would launch the same image. `runpool status` reports the image each tier runs, because a
+  replaced capsule is outside the configuration the release gates
+  observed.
+- Under the restricted network profile a capsule has **no route out**.
+  Its only egress is a per-capsule gateway that resolves and connects
+  on its behalf under a default-deny policy, which is also the DNS
+  rebinding defence.
+- **The gateway is inside the lease's budget.** The tier is split
+  between capsule and gateway under one parent cgroup, so the two
+  together are the tier and never more.
+- **Policy changes are classified.** A restriction that cannot be
+  installed closes the affected gateway; discovery failing at all
+  closes every gateway. The previous policy is never treated as a safe
+  fallback.
+- The relay's CONNECT port set, header handling, parser strictness and
+  every concurrency and size bound are explicit, tested and fuzzed.
+- **Containers a job starts take the same relay.** A daemon does not pass
+  its own environment to what it runs, so the capsule's proxy did not
+  reach a `docker build` or a `docker run` the job issued — and under the
+  restricted profile those have no route out either. The supervisor
+  writes the proxy into the runner's Docker client configuration, which
+  is where the client injects it into every container and build it
+  creates.
+- **An operator allowance is bounded by what it reopens.**
+  `network.allowPrivateCIDRs` punches holes through the built-in deny
+  set, so an entry *broader* than a withheld range would reopen that
+  whole range as a side effect; the validator refuses exactly those.
+  Public prefixes are accepted because the profile already permits the
+  public internet — which is how a capsule reaches a service on the
+  host's own public address, an address the runtime deny set withholds
+  from facts static validation cannot see.
+
+### State and operations
+
+- **A deployment authenticates as itself, not as a person.** A credential
+  is a personal access token or an installation of a GitHub App;
+  `github_app` takes a client id, an installation id and a PEM key, and
+  the provider client mints and refreshes the installation token on its
+  own. An App credential belongs to the organization, so membership
+  changes stop being an outage. A secret file other local users can read
+  is refused for either type, and `runpool doctor` reports which identity
+  it authenticated as.
+- Host ownership is explicit: **`shared-daemon`** supports Dokploy-style
+  coexistence with positive host reserves, restricted egress, runner-group
+  isolation, ownership-verified destructive intents, and idle-uplink recovery;
+  **`dedicated-daemon`** remains the smaller-blast-radius option.
+- The schema ships as **one reviewed baseline**. After the first release,
+  migrations are forward-only and immutable.
+- **The attempt owns execution evidence and disposition**; a
+  `capsule_lease` owns only the host resources it consumes, and carries
+  no provider identifier. GitHub's scale sets, runner ids and workflow
+  runs live in the adapter's own tables.
+- **There are no down migrations.** Restoring the pre-migration backup
+  is the rollback, because a down script claims every schema change is
+  losslessly reversible and a dropped column is not.
+- **A schema is identified by its contents.** The applied migrations'
+  fingerprint is recorded with the schema, in the same transaction, and
+  checked on every open. A version counter cannot tell two schemas apart
+  while the reviewed baseline is still edited in place, which is exactly
+  when a database written by an earlier build would otherwise be accepted
+  and then fail on a missing table.
+- **A schema this build cannot account for is refused, not repaired** —
+  by reporting as well as by the controller. `status`, a `gc` dry run and
+  a `cleanup` or `uninstall` preview apply no migrations, so each says
+  what it found and how to recover: a newer schema names the build that
+  wrote it, an older one says to start the controller that migrates it.
+- **A restart is not a provider dependency.** Startup reconciliation
+  adopts running capsules and resolves interrupted leases before the
+  first call to the provider. A binding whose scale set or message
+  session cannot be reached retries on its own loop, so an outage or an
+  expired token costs that binding its turn rather than ending the
+  process while capsules are still running. The shutdown drain is sized
+  to end inside the deployment's stop grace period, so the message
+  sessions are closed rather than left for the next start to wait out.
+
+- Cache lanes are **daemon-side named volumes**, exclusive per lease,
+  reused only for the same repository and generation, garbage-collected
+  by TTL and LRU under disk pressure. A soft emergency sweeps every free
+  lane instead of working down to a byte watermark, so lanes the daemon
+  cannot size are reclaimed with the rest, and those evictions carry
+  their own reason in the audit log.
+- A **disk-pressure state machine** closes admission before the host
+  fills, with hysteretic recovery. Free bytes and free inodes are both
+  measured and both get a recovery band, so neither dimension flaps at
+  its boundary; a filesystem with nothing left at all reads as an
+  emergency rather than as a failed measurement.
+- **Finished lease records are forgotten on a window.**
+  `retention.leaseHistory` defaults to 90 days — long enough to explain
+  an incident from last quarter — and zero keeps every record. The
+  window is measured from when a lease finished. A bounded pass runs
+  with the periodic reconciler and `runpool gc` does the same on demand,
+  previewing by default. It never touches the attempt: what the work did
+  is the record, and a lease is the runtime plumbing that served it. A
+  lease whose attempt is still open, or that still owns a resource
+  intent, is never forgotten — either would hide live work.
+- **Three failures that said nothing now say something.** A `--json`
+  command answers with a document before the instance has ever run,
+  rather than a line of prose and a success exit code. A cgroup driver
+  this build cannot write a parent for fails the host contract, rather
+  than launching capsules whose tier quietly stops being the sum of the
+  capsule and its gateway. And a Quick Start variable set beside a
+  configuration file is refused rather than ignored.
+- **What is qualified is stated apart from what is accepted.** The
+  release gates observe `github.com` at repository and organization scope
+  on `linux/amd64`. Enterprise Server, data-residency hosts, enterprise
+  scope, other architectures and an operator-supplied capsule are
+  accepted and unqualified — no gate has observed them, which is neither
+  a promise nor a denial. GPU and device passthrough are not implemented
+  at all, and the support matrix says which is which.
+- **The workflow side is documented.** A workflow reaches a tier by naming
+  its scale set — `runs-on: runpool-<tier id>` by default, not a label
+  set — and the deployment guide states what the GitHub side has to be
+  true for work to arrive at all. `deploy/workflows/example.yml` is a
+  complete job, linted with the rest.
+- **`runpool attempts inspect` reports what a resolution turns on.** The
+  evidence rung and the provider's own identifiers for the run, so the
+  external check the command's help prescribes can be carried out from
+  the tool that prescribes it.
+- **A retry that repeats is bounded.** An attempt whose work provably
+  never began is served up to three times in all; past that it goes to
+  manual review as `retry_budget_exhausted` rather than burning a capsule
+  per pass forever. An operator resolving that review is not overruled by
+  the counter. `scheduling.retryBudget` moves the number within `1..10` —
+  a narrow range, because this breaks a loop rather than tunes a rate.
+- **A target is any host the protocol serves, at any scope it defines.**
+  The URL rule refused every host but `github.com`, which also refused an
+  Enterprise Server and a data-residency host that speak the same
+  endpoints — and it masked a defect, since `/enterprises/<name>` passed
+  that rule and was then read as a repository named after the enterprise.
+  Enterprise is now a scope of its own, carrying the runner-group rule an
+  organization carries; cache lanes stay repository-only. Whether a host
+  answers is what `runpool doctor` proves, and what has been qualified is
+  a separate statement in the support matrix.
+- **A job ceiling per tier.** `tiers[].jobTimeout` bounds how long Runpool
+  waits for a capsule that stopped reporting. It defaults to `8h`, above
+  the provider's own 360-minute maximum for a job, because a backstop
+  below that ends work the provider still permits and one equal to it
+  races the provider's own timeout. Expiry says which tier's ceiling
+  ended the capsule.
+- **Uninstall takes the cache lanes with it.** Their volumes are removed
+  and their rows purged, so a reinstall does not inherit a ceiling
+  consumed by lanes nothing can reach.
+- **Capacity is credit**: a tier advertises no more than it has, and a
+  rotating discovery credit keeps a quiet binding from going blind to
+  its own queue.
+- **Scheduling is explicit at two levels.** `tiers[].parallelism` limits
+  active leases per resource tier; the optional `scheduling.parallelism`
+  limits them across the whole instance, constraining both what the
+  controller advertises to the provider and what it admits locally.
+  Omitting the global field keeps tiers independent; zero is invalid
+  rather than overloaded to mean unlimited. A lease counts from durable
+  reservation until cleanup reaches `released`, and startup
+  reconciliation adopts existing leases before admitting new work.
+- **Resource envelopes are provider neutral**: `cpu`, `memory`, `swap`
+  and `pids`. `swap` is additional swap above the memory limit, not
+  Docker's combined memory-plus-swap total — the adapter derives that —
+  and Runpool never requests an unlimited value. `host.reserve.swap`
+  withholds host swap from scheduling. Preflight proves the worst
+  admitted CPU, memory and swap set plus the reserve fits the host, and
+  configured tier swap additionally requires cgroup swap enforcement.
+- Swap is an emergency buffer, not ordinary capacity: production
+  guidance recommends encrypted persistent swap where CI secrets may
+  reach memory.
+- **Pre-migration backups are never overwritten**, and a database from
+  an unknown build is refused with instructions rather than repaired.
+- Install, backup, restore, upgrade and uninstall are **executed** by
+  the lifecycle drills, not merely documented.
+- The lease machine, the cleanup saga and disposition-by-evidence live
+  in **`internal/lease`**, with their own tests. They know nothing about
+  providers, which is what keeps cleanup working when one is
+  unreachable.
+
+### Interface
+
+- The CLI is **Cobra**: `--help` works, extra arguments are usage
+  errors, exit codes are `0`/`1`/`2` and mean what they say, and
+  destructive commands preview by default.
+- **Cobra is the only parser.** Command bodies take typed parameters
+  and return errors; nothing re-parses a flag a second time, so the
+  generated reference and the behaviour cannot describe different flag
+  sets.
+- `status --json` is a **versioned reporting document** (`v1`),
+  and its books-versus-daemon comparison covers containers, networks
+  and volumes. It also reports the effective host topology and the
+  scheduling picture: mode, configured and effective parallelism,
+  active and available capacity, queue depth, and per-tier accounting.
+- **A binding reports what it reaches.** Each one carries when a provider
+  call for it last succeeded and what it cannot do now, so an instance
+  with no work to do is distinguishable from one reaching nothing —
+  which every other field in the document reads identically. The record
+  is durable, so the answer survives the controller that stopped being
+  able to reach anything.
+- **`runpool doctor` names the label workflows target.** For each scale
+  set a deployment serves it reports the provider id where one exists and
+  the `runs-on` value that reaches it, so the string in configuration and
+  the string in a workflow can be compared without reading either.
+- **The document is bounded by live work, not by history.** Its `leases`
+  array carries every unreleased lease without exception — that set is
+  what the instance is still responsible for — plus the finished ones
+  that finished most recently. `released_total` reports how many
+  finished leases exist, because the array's length is what was reported
+  and not what the store holds.
+- The CLI reference and shell completions are **generated from the
+  command tree**.
+
+### Release qualification and gates
+
+- A release qualifies the exact digest-qualified controller and capsule
+  candidates it later promotes; no image is rebuilt after qualification.
+- Platform qualification compares every locked host fact and fails when a
+  value is missing, not only when a reported subset differs.
+- The standalone binary and completions are built once before qualification,
+  retained by checksum, and published without rebuilding. Releases also carry
+  separate controller and capsule SBOMs plus signed provenance attestations.
+- Public-repository gates include CodeQL, dependency review, Dependabot,
+  vulnerability scanning, SHA-pinned actions, and least-privilege workflow
+  permissions.
+- The qualification policy is **pending in `build/platform.lock.json`**.
+  Docker Engine 29.6.2 on Debian 13 is selected for the first qualification;
+  the exact host facts must be captured, reviewed, and frozen before a release
+  candidate is authorized. Contract suites fail closed while the lock is
+  pending and later compare the host against the frozen manifest.
+- Release qualification runs its live suites **on the reference host** and
+  builds its record from evidence emitted there.
+- No contract may be skipped in release-qualification mode.
+- The controller E2E drives three real assignments through the exact image
+  candidates: restart recovery, cache reuse, generation isolation, restricted
+  egress, inner Docker build and registry push, remote cleanup, and preservation
+  of unrelated container, network and volume sentinels by exact id.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# Contributing to Runpool
+
+Runpool is pre-release infrastructure software with a host-level trust
+boundary. Contributions are welcome, but changes must be reviewable,
+reproducible, and supported by evidence proportionate to their risk.
+
+## Development prerequisites
+
+- Go 1.26.6, as pinned by `go.mod`;
+- Git;
+- Linux with rootful Docker Engine for live container contracts;
+- `shellcheck` for shell changes.
+
+The hermetic suite does not require Docker or network access:
+
+```bash
+gofmt -w .
+go vet ./...
+go tool staticcheck ./...
+go test -race -shuffle=on -count=1 ./...
+go test -covermode=atomic -coverprofile=coverage.out -count=1 ./...
+scripts/verify/coverage.sh coverage.out
+go tool sqlc diff
+go tool sqlc vet
+go tool govulncheck ./...
+```
+
+Use the scripts under `scripts/contracts/` for live Docker, SQLite and
+capsule contracts; the provider contract runs from its own CI workflow
+against real credentials. Never use production credentials or targets for
+test fixtures.
+
+### Where coverage lives
+
+The hermetic percentage is not the whole picture, and chasing it is how a
+suite ends up asserting a mock instead of the system. Two rules decide
+where a behaviour is proved.
+
+**Logic is covered hermetically, and the bar is high.** Anything that is a
+function of its inputs — admission arithmetic, the pressure state machine,
+the egress decision, configuration validation, the lease machine, the
+cache planner — is tested in its own package with no daemon. These are the
+packages where a gap is a real gap:
+
+| Package | Expected |
+| --- | --- |
+| `internal/assignment`, `internal/allocator`, `internal/disk` | ~100% |
+| `internal/config`, `internal/egress`, `internal/credential` | ~95% |
+| `internal/cache`, `internal/store`, `internal/lease` | ~80%, limited by SQL paths a fault has to be injected to reach |
+
+Those are review expectations, not a gate: `scripts/verify/coverage.sh`
+enforces one repo-wide floor (`RUNPOOL_COVERAGE_MIN`, 35% by default). A
+per-package gate would fail on the mechanics packages below, which are
+deliberately thin here and proved elsewhere.
+
+**Mechanics are covered live.** `internal/platform/docker`,
+`internal/platform/githubactions`, the daemon-facing half of
+`internal/capsule` and the socket-facing half of `internal/gateway` are
+thin translations of an external API. A unit test there asserts the mock,
+so they are proved by the suites that run against a real daemon and a real
+provider instead:
+
+| Code | Proved by |
+| --- | --- |
+| Docker adapter, capsule lifecycle, cgroup and envelope enforcement | `scripts/contracts/docker.sh`, `scripts/contracts/capsule.sh` |
+| Egress relay, DNS, firewall, bypass attempts | `test/contract/capsule` (`bypass_test.go`, `budget_test.go`) |
+| Installing a policy into the kernel: `gateway.installPolicy`, `ApplyFirewall`, `ClassifyLegs` | `test/contract/capsule/bypass_test.go` — these shell out to `iptables-restore` and read the container's own interfaces, so faking them would be simulating the platform rather than isolating a dependency. What is decidable without one — `RenderIPTables`, `Policy.Validate`, `ClassifyPolicy` — is tested hermetically. |
+| GitHub Actions adapter, scale sets, sessions, acquisition | `scripts/contracts/` provider suites under `test/contract/githubactions` |
+| SQLite durability and crash recovery | `scripts/contracts/sqlite.sh` |
+| Whole-controller recovery, cache reuse, restart | `test/e2e/controller` |
+
+When a bug is found in that second group, the fix belongs in a pure
+function the first group can reach. The capsule's execution observation is
+the worked example: the decision the daemon's own facts support is
+`classifySupervisorState`/`classifyContainerState`, tested hermetically,
+while only the exec around it needs a container.
+
+## Change design
+
+- Keep provider vocabulary inside its adapter. Core packages use neutral,
+  opaque identities; the architecture tests enforce dependency direction.
+- Keep responsibilities cohesive. Split a package or component when its
+  invariants, dependencies, or lifecycle can be tested independently.
+- Comments explain exported contracts, invariants, or non-obvious reasons.
+  They do not narrate the next statement or refer to temporary review phases.
+- Errors include the failed operation and enough observed context to act.
+- Destructive operations preview by default and prove ownership before
+  changing Docker or durable state.
+- Schema changes update the baseline migration, schema snapshot, sqlc
+  queries, generated code, and tests together. After the first release,
+  migrations become immutable and forward-only.
+
+Dependencies are evaluated on maintenance, security history, release cadence,
+API stability, transitive cost, and the amount of bespoke code they replace.
+Standard-library code is preferred when it is clearer, but avoiding a mature
+dependency is not a goal by itself. Go tooling belongs in `go.mod` and runs
+through `go tool`; the project does not add a second language toolchain for
+repository linting.
+
+## Pull requests and commits
+
+Open a focused pull request using the repository template. Describe the
+observable change, what the investigation found, the evidence you observed, and
+what would notice the behaviour regressing. Bug fixes include a regression test
+that fails without the fix.
+
+Paste evidence only where continuous integration cannot reach. A committed test
+is the better record everywhere else, and the provider contracts are the one
+surface that never runs on a pull request.
+
+Use imperative, scoped commit subjects where helpful, for example
+`fix(store): retain ambiguous attempts for review`. Keep generated outputs in
+the same commit as their source.
+
+Pull requests merge by merge commit, so your commits reach `main` unchanged.
+The message you write is what someone reads while bisecting, long after the
+review is gone; the pull request body is a review document and is not kept.
+
+One commit per logical change. Squash fixup-only commits before merge, and do
+not hide a meaningful design change inside a general cleanup.
+
+By participating, you agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+Report vulnerabilities privately according to [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,177 @@
+# Runpool
+
+[![CI](https://github.com/rhobuild/runpool/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rhobuild/runpool/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/rhobuild/runpool/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/rhobuild/runpool/actions/workflows/codeql.yml)
+[![Go](https://img.shields.io/badge/Go-1.26.6-00ADD8?logo=go&logoColor=white)](go.mod)
+[![Docker Engine](https://img.shields.io/badge/Docker_Engine-%E2%89%A528.0-2496ED?logo=docker&logoColor=white)](docs/reference/support-matrix.md)
+[![SQLite](https://img.shields.io/badge/SQLite-durable_state-003B57?logo=sqlite&logoColor=white)](docs/architecture.md)
+[![License](https://img.shields.io/github/license/rhobuild/runpool)](LICENSE)
+[![Status](https://img.shields.io/badge/status-pre--release-orange)](docs/release-readiness.md)
+
+Runpool is a Docker-native control plane for autoscaling ephemeral CI
+runners on a single, capacity-bounded host. It translates provider demand
+into durable assignments, isolated per-job execution capsules, and optional
+repository-scoped cache lanes—without requiring Kubernetes.
+
+> [!IMPORTANT]
+> Runpool is pre-release. No version is supported or release-qualified yet.
+> The controller end-to-end gate is implemented but has not yet run on the
+> release host. The first release still requires that evidence, an external
+> security review, and a successful no-skip release-qualification run on the
+> exact platform frozen before the candidate in
+> [`build/platform.lock.json`](build/platform.lock.json).
+
+## Why Runpool
+
+- **Clean execution:** every workload gets a fresh runner, workspace, Docker
+  daemon data root, and control filesystem.
+- **Bounded capacity:** runner, inner daemon, child containers, and egress
+  gateway share an aggregate cgroup budget.
+- **Durable delivery:** assignments are persisted before broker
+  acknowledgement; redelivery is idempotent and ambiguous execution is held
+  for operator review.
+- **Restricted egress:** the default profile provides kernel-enforced
+  no-route isolation plus a policy-enforcing DNS and HTTP relay.
+- **Safe ownership:** cleanup acts only on resources carrying the expected
+  instance labels; Runpool never performs daemon-wide pruning.
+- **Provider-neutral lifecycle core:** delivery, attempt, lease, cache, and
+  cleanup state use opaque provider keys. GitHub-specific configuration and
+  metadata remain at the composition and adapter boundary; GitHub Actions is
+  the only implemented provider.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    provider["GitHub Actions scale sets"] -->|"durable deliveries"| controller["Runpool controller"]
+    controller -->|"Moby API"| host["Docker Engine 28+"]
+    host --> capsule["Per-job capsule"]
+    host --> gateway["Per-job egress gateway"]
+    capsule -->|"DNS and HTTP proxy"| gateway
+    capsule --> runtime["Runner + dockerd + job containers"]
+    state[("SQLite state")] --- controller
+    cache[("Repository cache lane")] -. "optional" .- capsule
+```
+
+The controller has no inbound service dependency. It maintains outbound
+provider sessions, reconciles durable state with Docker, and admits work only
+while scheduling and disk budgets are healthy. See the
+[architecture guide](docs/architecture.md) for package boundaries, identity,
+recovery, and capacity semantics.
+
+## Security boundary
+
+Runpool is a resource-management, environment-hygiene, and network-policy
+boundary for CI workloads approved by the operator. It is **not** a hostile
+code sandbox:
+
+- the controller holds the Docker socket, which is host-root authority;
+- capsules run a privileged inner Docker daemon;
+- GitHub's required `--jitconfig` interface makes the one-run JIT bundle
+  observable to the assigned workload, although it is kept out of controller
+  persistence, Docker metadata, logs, and later capsules;
+- `shared-daemon` deliberately shares the Engine's compromise domain with the
+  platform and its services; `dedicated-daemon` reduces that blast radius but
+  is not a VM boundary;
+- public fork pull requests are outside the supported model.
+
+Under `public-internet-only`, direct egress is denied. Proxy-aware HTTP
+clients can use absolute-form requests or CONNECT to allowed addresses on
+ports 80 and 443. CONNECT is an opaque tunnel; Runpool applies destination
+and port policy, not application-layer inspection. `git+ssh`, direct TCP,
+non-DNS UDP, IPv6, and other ports fail closed. Read the complete
+[threat model](docs/security/threat-model.md) before deployment.
+
+## Evaluate locally
+
+Prerequisites are Go 1.26.6 and a Linux host with rootful Docker Engine 28.
+The selected release-qualification target and current lock status are documented in the
+[support matrix](docs/reference/support-matrix.md).
+
+```bash
+git clone https://github.com/rhobuild/runpool.git
+cd runpool
+go build -trimpath -o runpool ./cmd/runpool
+./runpool config validate --file internal/config/testdata/example.yaml
+go test ./...
+```
+
+That builds the controller and checks a configuration. Reaching a job
+takes three more things: the two images, a target on GitHub, and a
+workflow that names the tier.
+
+```bash
+docker build -f build/capsule/Dockerfile -t runpool-capsule:dev .
+docker build -f build/controller/Dockerfile -t runpool:dev .
+```
+
+`runpool-capsule:dev` is the exact name a development build looks for. A
+release binary carries its capsule by digest and refuses to be pointed
+elsewhere; from source, this tag is the pairing.
+
+Then a configuration, a credential, and the state directory:
+
+```bash
+RUNPOOL_GITHUB_URL=https://github.com/<owner>/<repo> RUNPOOL_GITHUB_TOKEN_FILE=/run/secrets/runpool/token RUNPOOL_HOST_TOPOLOGY=dedicated-daemon RUNPOOL_STATE_DIR=/var/lib/runpool/state ./runpool doctor
+```
+
+`doctor` proves the host and the credential, and prints the `runs-on`
+label for every tier it would serve. Then `./runpool serve`, and a
+workflow in that repository:
+
+```yaml
+jobs:
+  build:
+    runs-on: runpool-standard
+```
+
+The [complete example workflow](deploy/workflows/example.yml) shows what
+a job gets: its own Docker daemon, and egress through the relay.
+[Deployment](docs/deployment.md) covers the GitHub side — which target
+shapes exist, what a runner group has to grant, and which credential to
+use — and the [runbook](docs/runbook.md) covers operating it.
+
+The reference Compose deployment is version-pinned and cannot be used
+until a release exists; the images above are how a source checkout runs.
+Do not use a production credential for local experimentation.
+
+## Deployment
+
+Runpool provides a canonical Docker Compose manifest for its headless
+controller: no domain, reverse-proxy route, or public port is required.
+
+| Platform | Entry point |
+| --- | --- |
+| Docker Compose | [`deploy/compose/compose.yaml`](deploy/compose/compose.yaml) |
+| Dokploy | Deploy the canonical Compose file now; upstream One-Click catalog submission follows the first qualified release |
+
+Read the [deployment guide](docs/deployment.md) before installing. The
+Compose contract reads an operator-managed
+[configuration file](deploy/compose/config.example.yaml); the example selects
+`shared-daemon` for Dokploy-style hosts and illustrates an explicit reserve for
+colocated services. Measure that reserve before deployment. Choose
+`dedicated-daemon` only on an exclusive CI host.
+
+## Project documentation
+
+| Guide | Purpose |
+| --- | --- |
+| [Deployment](docs/deployment.md) | Compose, Dokploy, credentials, and lifecycle |
+| [Product contract](docs/product-contract.md) | Guarantees, exclusions, and compatibility surfaces |
+| [Architecture](docs/architecture.md) | Components, dependency direction, state, and recovery |
+| [Configuration](docs/reference/configuration.md) | Supported settings and validation rules |
+| [CLI reference](docs/reference/cli.md) | Generated commands, flags, and exit-code behaviour |
+| [Support matrix](docs/reference/support-matrix.md) | Engine compatibility, release reference, and provider scope |
+| [Runbook](docs/runbook.md) | Operations, recovery, backup, GC, and uninstall |
+| [Threat model](docs/security/threat-model.md) | Trust boundary, defences, and accepted exposure |
+| [ADRs](docs/adrs/README.md) | Architectural decisions and measured constraints |
+| [Release readiness](docs/release-readiness.md) | Objective gates for the first release |
+
+## Contributing and security
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Report
+security issues privately as described in [SECURITY.md](SECURITY.md); never
+open a public issue for a suspected vulnerability.
+
+Runpool is maintained by [Rhobuild](https://rhobuild.com) and licensed under
+the [Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub's security advisory form on this
+repository ("Report a vulnerability" under Security). Please do not open
+a public issue for a suspected vulnerability.
+
+Include what you did, what happened, and what you expected. A proof of
+concept helps; a full exploit is not required.
+
+You can expect an acknowledgement within a week and an assessment within
+two. Runpool is maintained by a small team, so those are honest targets
+rather than a contractual response time. If a report is confirmed, we
+will agree a disclosure timeline with you and credit you unless you
+prefer otherwise.
+
+## Supported versions
+
+Runpool has not released: there are no tags and no published binaries,
+so there is nothing to promise a fix window for. Every fix lands on
+`main` and nowhere else. When releases exist, this section will name
+exactly which ones receive fixes.
+
+## What is in scope
+
+Anything that breaks a defence the project claims. Those claims, and the
+evidence behind each, are in [the threat model](docs/security/threat-model.md).
+The most valuable reports concern:
+
+- making Runpool act on a Docker resource it does not own;
+- one repository's job reaching another repository's cache lane;
+- the long-lived provider credential reaching a job, log, state database, or
+  error message; or a per-runner JIT bundle reaching controller persistence,
+  Docker metadata, or logs;
+- a lease releasing while its resources survive, or an admission credit leaking so
+  the host is oversubscribed;
+- any bypass of the egress sandbox under the `public-internet-only`
+  profile: a capsule reaching a host, LAN, metadata or other-Docker
+  address, or reaching anything at all without its gateway.
+
+## What is out of scope
+
+These are documented properties of the design, not vulnerabilities:
+
+- **The controller holds the host Docker socket**, which confers
+  host-root authority. Controller compromise is host compromise.
+- **Job capsules run a privileged Docker daemon.** A kernel escape from
+  inside a capsule reaches the host. Runpool isolates with namespaces
+  and policy, not hardware.
+- **`shared-daemon` shares that compromise domain with platform and
+  application services.** Its reserve and ownership controls protect normal
+  coexistence, not a controller, daemon or kernel compromise.
+- **Workflows from fork pull requests on public repositories are
+  unsupported**, per GitHub's guidance for self-hosted runners.
+- **The `unsafe-open-egress` profile filters nothing**, by definition
+  and by its name: a deployment that selects it has chosen host-open
+  egress, and reports against that profile's reachability are reports
+  about the choice, not the code.
+- **The restricted profile is not transparent L3 egress.** Direct traffic,
+  `git+ssh`, non-DNS UDP, other ports, and proxy-unaware clients failing
+  closed is the design. CONNECT to an allowed address on ports 80 or 443 is
+  an opaque tunnel and is evaluated by destination and port, not payload.
+- **The assigned workload can observe its own JIT bootstrap state.** GitHub's
+  supported runner interface requires `--jitconfig`; it is transiently present
+  in the runner's argv, and the job runs under the same Unix identity. The
+  bundle is ephemeral and authorizes only that runner. Runpool protects it from
+  controller persistence, Docker metadata, and later workloads; it does not
+  claim secrecy from the workload it starts.
+
+Runpool is a resource and hygiene boundary for CI you already trust. If
+a report's premise is that it should contain hostile workflow code, the
+answer is in the threat model rather than in a patch.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+# Support
+
+Runpool is pre-release and unreleased. There are no published binaries,
+no version support window, and no service commitment. What follows is
+where to ask, and what the project can currently answer for.
+
+## Where to ask
+
+| You want to | Use |
+| --- | --- |
+| Report a bug | A GitHub issue, with the output of `runpool doctor` and `runpool status` |
+| Report a vulnerability | [SECURITY.md](SECURITY.md) — never a public issue |
+| Ask whether something is supported | The [support matrix](docs/reference/support-matrix.md), then an issue |
+| Propose a change | Read [CONTRIBUTING.md](CONTRIBUTING.md) first |
+
+## Implemented scope
+
+These are the boundaries intended for the first qualified release; they are
+not a support commitment while the project remains unreleased.
+
+| Area | State |
+| --- | --- |
+| CI provider | GitHub Actions, as the single adapter. The control plane is provider-neutral by construction, but no other adapter exists or is promised. |
+| Host | Linux amd64, rootful Docker Engine 28.0 or newer, cgroup v2 with the memory and pids controllers. Docker Engine 29.6.2 on Debian 13 is selected for the first release qualification; the remaining host facts have not yet been frozen. See the exact support matrix. |
+| Scope | Repository-scoped and organization-scoped scale sets. Persistent cache lanes are repository-scoped only. |
+| Egress | The restricted profile (implemented and tested live, not yet release-qualified) denies direct egress and permits proxy HTTP or CONNECT to allowed addresses on ports 80/443. See [the runbook](docs/runbook.md). |
+| State | SQLite in a Docker named volume, one controller per state directory, enforced by a lock. |
+
+## What is not supported
+
+- Public fork pull requests. The isolation boundary is a network policy
+  boundary, not a hostile-compute sandbox.
+- Treating `shared-daemon` as containment for hostile or public-fork code.
+- Deployments where platform-wide volume pruning cannot be disabled.
+- Any release. The project is blocked on the controller end-to-end gate,
+  external security review, and exact-platform release qualification before it
+  publishes one. Nothing here is a production commitment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,52 @@
+# Runpool documentation
+
+Documentation is organized by the question it answers.
+
+## Understand the system
+
+- [Product contract](product-contract.md): guarantees, exclusions, and
+  compatibility surfaces.
+- [Architecture](architecture.md): component boundaries, durable identity,
+  recovery, capacity, and storage.
+- [Threat model](security/threat-model.md): trust boundary, defences, and
+  accepted exposure.
+- [Architecture decision records](adrs/README.md): decisions that constrain
+  implementation and operations.
+
+## Operate Runpool
+
+- [Deployment](deployment.md): Docker Compose and Dokploy deployment
+  surfaces, credentials, upgrades, and removal.
+- [Compose configuration example](../deploy/compose/config.example.yaml):
+  multi-target file-mode deployment without embedded credentials.
+- [Runbook](runbook.md): startup, pressure response, backup, restore, upgrade,
+  rollback, cleanup, and uninstall.
+- [Configuration reference](reference/configuration.md): settings, defaults,
+  and validation.
+- [CLI reference](reference/cli.md): generated command and flag reference.
+- [Status API](reference/status-api.md): structured status contract.
+- [Support matrix](reference/support-matrix.md): runtime compatibility,
+  release-reference platform, and provider
+  scope.
+
+## Release Runpool
+
+- [Release readiness](release-readiness.md): objective gates that must be
+  satisfied before the first release.
+- [`build/platform.lock.json`](../build/platform.lock.json): reviewed platform
+  selection and, once frozen, exact facts required by qualification.
+- [`build/images.lock.json`](../build/images.lock.json): digest-pinned capsule
+  inputs.
+- [Repository settings](maintainers/repository-settings.md): GitHub rulesets,
+  environments, Actions permissions, and security features required before
+  public launch.
+- [Qualification host](maintainers/qualification-host.md): building, freezing,
+  and destroying the machine the live gates are answered on.
+- [Security review scope](security/review-scope.md): where the release boundary
+  runs, the evidence that already exists, and what a review must answer.
+- [Security review findings](security/review-findings.md): the register that
+  keeps the release authorization gate closed until findings are closed.
+
+The [security policy](../SECURITY.md), [support policy](../SUPPORT.md), and
+[contribution guide](../CONTRIBUTING.md) live at the repository root so GitHub
+can surface them automatically.

--- a/docs/adrs/2026-08-17-github-app-credentials.md
+++ b/docs/adrs/2026-08-17-github-app-credentials.md
@@ -1,6 +1,6 @@
 # A deployment authenticates as a GitHub App, not only as a person
 
-**Status:** accepted; implementation pending
+**Status:** accepted
 **Date:** 2026-08-17
 
 `credentials[].type` accepts `token` and nothing else, and the adapter

--- a/docs/adrs/2026-08-17-multiplatform-locks.md
+++ b/docs/adrs/2026-08-17-multiplatform-locks.md
@@ -1,0 +1,80 @@
+# A lock records the platforms that were qualified, not the only one that works
+
+**Status:** accepted; implementation pending
+**Date:** 2026-08-17
+
+`build/platform.lock.json` carries a single `policy.arch`, so one lock
+describes one platform. `build/images.lock.json` carries a single
+top-level `platform`. The maintainer guide states the consequence
+plainly: an arm64 host fails the gate "regardless of how well it runs
+the suites".
+
+That sentence is the problem. A gate that fails a host no matter how
+well it runs the suites is not measuring the host — it is measuring
+whether the host is the one platform the file can express. The
+qualification is evidence that the release ran correctly somewhere; the
+file's shape turns it into a claim that it runs correctly nowhere else.
+
+## What is actually platform-bound, and what is not
+
+The pinned base images are not. `images.lock.json` records
+`sha256:0cfdcc70…` for the runner and the corresponding digest for dind,
+and both are **image index** digests, not per-architecture manifests. A
+build targeting `linux/arm64` resolves the arm64 child of the same
+pinned digest. The Dockerfile needs no change, and the digests need no
+per-platform variant: they are already platform-agnostic.
+
+The upstream ceiling is the runner image, which publishes `linux/amd64`
+and `linux/arm64` and nothing else. dind additionally publishes armv6
+and armv7, so the intersection is two platforms.
+
+The controller binary is not platform-bound in an interesting way
+either. It embeds one capsule reference through `-X main.capsuleImage`.
+If that reference is the capsule's index digest, one string is correct
+for every architecture: the daemon resolves the matching child at pull
+time, and the digest is still exact and immutable.
+
+What is genuinely platform-bound is the observed evidence: kernel,
+cgroup driver, engine build, firewall backend, storage driver. Those are
+facts about one host, and there is one set of them per platform
+qualified.
+
+## Decision
+
+**`platform.lock.json` records a list of qualified platforms.** Each
+entry carries its own policy and its own observed facts. `verify
+-observed` selects the entry matching the platform it is running on and
+compares against that entry; a platform with no entry fails as "not
+qualified on this platform", naming the ones that are, rather than as an
+architecture mismatch.
+
+**`images.lock.json` declares the platforms the release builds for**,
+while the digests stay as they are, because they already describe every
+platform.
+
+**The release publishes an index per image** covering the declared
+platforms, and the standalone binaries are built per platform. All of
+them carry the same capsule index digest.
+
+**A published image is not a qualified platform**, and the two are
+stated separately. The support matrix names what the gates observed,
+with its evidence, and names separately what is built and published
+without that evidence. Neither sentence promises the other.
+
+## Consequences
+
+- Qualifying a second platform becomes an added entry rather than a
+  schema change, which matters because the lock is a versioned format
+  and changing its shape later is a migration of the file that is the
+  proof of the gate.
+- Two qualification hosts can be recorded at once, so a release is not
+  forced to serialize them.
+- An operator on arm64 can pull the published images. Whether they were
+  observed by the gates is a question the support matrix answers
+  honestly instead of a question the lock's shape answers by refusing.
+- The false claim disappears from the maintainer guide: architecture is
+  no longer checked literally against a single value, it selects which
+  recorded evidence applies.
+- Nothing is asserted about a platform that was never run. An
+  unqualified platform is unverified, which is neither a promise nor a
+  denial.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,25 @@
+# Architecture decision records
+
+One record per decision that constrains what the code may do. A record
+is written when the decision is made, and amended only by another
+record — a superseded ADR keeps its text, because the measurement that
+justified it usually still holds even when the remedy does not.
+
+| Date | Decision | Status |
+| --- | --- | --- |
+| 2026-08-11 | [SQLite driver](2026-08-11-sqlite-driver.md) — modernc, pinned and tested on a Linux named volume | accepted |
+| 2026-08-11 | [Session conflict](2026-08-11-session-conflict.md) — one session per scale set, and what a conflict means | accepted |
+| 2026-08-11 | [Shared network namespace](2026-08-11-shared-network-namespace.md) — the runner joins dind rather than attaching itself | accepted |
+| 2026-08-11 | [Advertised capacity](2026-08-11-advertised-capacity.md) — capacity is a total, not a delta | accepted |
+| 2026-08-11 | [Capacity floor](2026-08-11-capacity-floor.md) — every binding floored at one | superseded by admission credits |
+| 2026-08-11 | [Repository cache scope](2026-08-11-repository-cache-scope.md) — persistent lanes only where identity binds | accepted |
+| 2026-08-11 | [Plain L3 routing is rejected](2026-08-11-network-sandbox-proxy.md) — why an in-bridge gateway cannot forward, and the one path the host's rule leaves open | accepted, implemented by the egress relay |
+| 2026-08-12 | [Docker API client](2026-08-12-docker-api-client.md) — versioned Moby modules behind a live-tested adapter | accepted |
+| 2026-08-13 | [Egress is a relay, not a route](2026-08-13-egress-relay.md) — what the host's own `--internal` rule forces, and what it gives | accepted |
+| 2026-08-13 | [Admission credits](2026-08-13-admission-credits.md) — tier parallelism is shared credit with a rotating discovery credit | accepted |
+| 2026-08-14 | [Scheduling and swap semantics](2026-08-14-scheduling-and-swap.md) — optional global parallelism and provider-neutral resource units | accepted |
+| 2026-08-17 | [Capsule image substitution](2026-08-17-capsule-image-substitution.md) — a tier may name its capsule, and the capsule declares its protocol | accepted |
+| 2026-08-17 | [GitHub App credentials](2026-08-17-github-app-credentials.md) — a deployment authenticates as an App, not only as a person | accepted |
+| 2026-08-17 | [Job timeout](2026-08-17-job-timeout.md) — the lease ceiling is a backstop above the provider's own maximum | accepted |
+| 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; implementation pending |
+| 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,182 @@
+# Architecture
+
+This document describes the implemented system and its enforced package
+boundaries. Architectural decisions and the measurements behind them are
+retained separately as [ADRs](adrs/README.md).
+
+## The shape
+
+```text
+cmd/runpool
+    -> internal/command          the CLI tree (Cobra), argument and exit-code contracts
+    -> internal/app              composition, process lifecycle, the controller loops
+        -> internal/assignment   deliveries, attempts, lifecycle vocabulary
+        -> internal/allocator    admission credits
+        -> internal/capsule      prepare, start, inspect one execution capsule
+        -> internal/lease        the lease machine, the cleanup saga, disposition
+        -> internal/egress       pure egress policy: deny sets and decisions
+        -> internal/cache        cache lanes and their garbage collection
+        -> internal/disk         the disk-pressure state machine
+        -> internal/doctor       host preflight
+        -> internal/credential   provider tokens, read and guarded
+        -> internal/store        all durable state: schema, migrations, queries
+        -> internal/config       configuration, defaults, validation
+
+cmd/capsule-supervisor           pid 1 inside a capsule: boots the runner,
+                                 and in the gateway container runs the relay
+    -> internal/gateway          the egress relay's server, proxy, DNS and firewall
+    -> internal/egress
+
+internal/platform/githubactions  the provider adapter
+internal/platform/docker         the Moby adapter
+```
+
+`internal/gateway` hangs off the second binary, not the controller: the relay
+runs inside the gateway container, and `internal/app` does not import it. The
+controller's part is computing the policy and handing it over.
+
+The arrow never points from lifecycle or state domains to a provider. An
+architecture test enforces it: core packages may not depend on
+`internal/platform/githubactions` or on the provider SDK, directly or
+transitively. `internal/app` is deliberately exempt because injecting the
+adapter is its job. The configuration schema names GitHub scale-set settings
+because GitHub Actions is the only supported provider; it does not claim a
+generic provider API that does not exist.
+
+`internal/app` is the composition boundary. It owns process lifecycle and
+provider-facing control loops; durable state transitions and resource
+lifecycle rules remain in the packages it composes. The reconciler stays at
+this boundary because adoption needs both provider bindings and neutral lease
+state. The architecture test prevents that provider dependency from moving
+into a core package.
+
+## One job, one capsule, one budget
+
+A capsule is a single container: a first-party supervisor as PID 1, the
+GitHub Actions runner, and the job's own Docker daemon, with every
+container the job launches inside it. One container means one aggregate
+cgroup, so a job cannot escape its tier by spawning work in a sibling.
+
+The long-lived provider credential remains in the controller and never enters a
+capsule. A per-runner JIT bundle travels over `exec` stdin onto a 0600 tmpfs;
+the supervisor redirects the configuration files named by that bundle onto the
+same tmpfs. GitHub's runner interface requires the encoded bundle as
+`--jitconfig`, so it is transiently visible in the runner process's argv and to
+code with the same process-inspection authority. That exposure is explicit:
+Runpool relies on the bundle being one-run and short-lived, and does not claim
+to isolate it from the workload it authorizes. It never enters controller
+state, Docker container configuration, labels, environment variables, or logs.
+
+Under the restricted network profile the capsule has **no route out**:
+its bridge is internal in Engine 28's isolated gateway mode, so the
+host kernel drops anything it addresses beyond that bridge. That deny
+lives in the host's namespace, where a privileged capsule cannot reach
+it. Egress is a per-capsule gateway that resolves names and opens
+connections on the capsule's behalf, checking every resolved address
+against the policy — which is also why DNS rebinding changes nothing:
+the address checked is the address dialed.
+
+The gateway is inside the lease's budget, not beside it. The tier is
+split — a fixed reserve for the gateway, the rest for the capsule —
+and both run under one parent cgroup, so the sum is the tier by
+construction.
+
+## Identity, and why work is never lost
+
+Two keys carry the whole delivery machine:
+
+- a **delivery** is `(binding, source delivery key)` — the provider's
+  own message identity;
+- an **attempt** is `(delivery, source workload key)` — one execution
+  of one workload.
+
+Provider identifiers that are *observed metadata* rather than identity
+— runner request ids, workflow run ids — live in 1:1 adapter tables and
+are never keys. A partial unique index allows one open attempt per
+workload, which is what makes a redelivery idempotent. A requeued
+assignment carries the same workload key, so the index does not tell the
+two apart: it is what forces the requeue to supersede the open attempt
+instead of opening a second one beside it.
+
+Nothing is acknowledged before it is durable. Execution evidence is
+monotonic and never guesses: `not_started`, `runtime_prepared`,
+`execution_start_authorized`, `running_observed`, `exit_observed`.
+Where evidence cannot decide, the attempt goes to manual review with a
+reason, rather than being settled by inference.
+
+**The attempt owns that evidence, and its disposition.** A
+`capsule_lease` is the lifecycle of the host resources an attempt
+consumes — reserved, provisioning, runtime registered, workload
+running, draining, cleaning, released — and nothing more. It carries a
+binding, the attempt it serves and the runtime's registered name; it
+carries no provider identifier at all. Keeping the two apart is what
+stops a cleanup state being read as an execution outcome, which is how
+a job that never ran gets settled as if it had.
+
+An attempt whose work provably never began returns to the servable queue
+and is served again, so it holds one lease per serving: at most one live
+at a time, and the released ones are the record of what it cost. The
+retry budget is what ends that — a failure that repeats is not one more
+retries fix, so the attempt goes to review rather than being served
+without limit.
+
+The schema is one reviewed baseline, not a development history: nothing
+has been released, so `000001_initial` is the whole of it. After the
+first release migrations are forward-only and immutable. There are no
+down scripts — restoring the backup taken before a migration is the
+rollback, because a down script claims every schema change is
+losslessly reversible and a dropped column is not.
+
+## Everything created is recorded before it exists
+
+Every external object is created under a durable **resource intent**:
+planned, then creating, then confirmed with its id. A crash anywhere
+leaves an intent whose deterministic name either finds the object or
+proves its absence. Ownership is proven by labels, never by name — a
+name collision is refused rather than adopted. Destructive recovery repeats
+that proof immediately before removal, using the expected instance and lease;
+a stale intent cannot delete a foreign object that later reused its name.
+
+A lease's admission credit is released only after the transaction that verifies
+zero remaining intents commits.
+
+## Capacity is credit
+
+A tier holds as many credits as its configured parallelism. Running capsules hold theirs;
+free credits follow demand, max-min fair; one still-unclaimed credit is
+the tier's rotating discovery credit, which is what keeps a binding
+with no demand signal from going blind to its own queue. The sum a tier
+advertises never exceeds it.
+
+When `scheduling.parallelism` is configured, the same accounting also has an
+instance-wide ceiling across every tier and target. Provider announcements and
+local admission consume the same credits, and startup adoption restores the
+count before new work can enter. With no global limit, tiers remain independent.
+
+## The host is a budget too
+
+A monitor measures the daemon's filesystem from inside it and the
+daemon-accounted size of every cache lane, and a pure state machine
+decides the level: normal, high, soft emergency, hard emergency.
+Recovery is hysteretic. High collects garbage; soft closes admission
+and collects aggressively; hard fails closed and deletes nothing.
+
+The host topology is part of configuration, not an installation assumption.
+`shared-daemon` requires a positive reserve for colocated platform and
+application services, restricted egress, and ownership-safe cleanup;
+`dedicated-daemon` gives Runpool exclusive operational ownership. The mode
+changes coexistence policy, not the underlying compromise boundary: either
+controller holds host-root Docker API authority.
+
+The restricted sandbox state is synchronized and copied per launch. Before
+admitting a capsule, the controller re-proves the instance uplink and rebuilds
+the discovered deny set. This observes networks created by other stacks and
+recreates an idle uplink removed by external cleanup without sharing mutable
+policy slices between concurrent capsules.
+
+## Further reading
+
+- [Threat model](security/threat-model.md) — what is defended and what is accepted
+- [ADRs](adrs/README.md) — each irreversible choice with its evidence
+- [Runbook](runbook.md) — every operational procedure
+- [Release readiness](release-readiness.md) — what remains before a release

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,272 @@
+# Deployment
+
+Runpool ships one Compose contract. Every installation is headless: the
+controller has no inbound application endpoint, so it needs no domain,
+reverse-proxy route, or published port.
+
+Runpool is pre-release. The manifests require an explicit image reference and
+there is no released digest yet. A deployment becomes supported only after its
+exact image and host platform have passed the gates in
+[release readiness](release-readiness.md).
+
+## Deployment surface
+
+[`deploy/compose/compose.yaml`](../deploy/compose/compose.yaml) is the canonical
+operator-managed deployment. Platform catalogs derive their template from this
+contract; they are not duplicated here because an unreviewed second copy would
+drift.
+
+The Dokploy One-Click template follows the
+[official contribution workflow](https://dokploy.github.io/templates/): fork
+`Dokploy/templates`, add `blueprints/runpool`, open a pull request, test its
+automatically generated preview and Base64 import, and let the upstream merge
+become the catalog authority. Do not submit a mutable development image. The
+blueprint is created from an immutable release candidate or release and updated
+through an upstream pull request whenever the deployment contract changes.
+
+## Choose the host topology
+
+The controller has full Docker API authority even though the socket file is
+mounted read-only, and each job capsule runs a privileged inner daemon. The
+topology is therefore explicit rather than inferred:
+
+| Topology | Use it when | Contract |
+| --- | --- | --- |
+| `shared-daemon` | Dokploy and application services already use this Engine | Private, trusted CI only; restricted egress; explicit host reserve; no platform-wide volume prune |
+| `dedicated-daemon` | The Engine is exclusive to Runpool | Smaller compromise blast radius and the recommended security posture; still not a hostile-code sandbox |
+
+`shared-daemon` lets the operator run and observe the controller and ephemeral
+capsules through the same Docker control plane. It does not make Docker
+multi-tenant: controller, daemon or kernel compromise can affect Dokploy and
+every colocated service. Use it only when that impact is an accepted risk for
+the workflows being admitted.
+
+Runpool labels its controller-visible objects with `io.runpool.*` ownership
+and correlation fields. Cleanup re-inspects instance and lease ownership
+before deleting each recorded object. It never removes unrelated resources and
+never issues daemon-wide prune.
+
+### Shared-daemon cleanup policy
+
+Disable Dokploy jobs or maintenance actions that run any of the following
+against the shared Engine:
+
+- `docker volume prune`;
+- `docker system prune --volumes`;
+- an equivalent “full prune” or unused-volume cleanup.
+
+An idle cache lane is intentionally unattached, so Docker considers it unused
+even though Runpool plans to reuse it. Runpool's disk monitor and `runpool gc`
+own cache eviction. Container, network and image cleanup that excludes volumes
+does not delete cache state; missing immutable images are pulled again by
+digest. If an idle Runpool uplink network is removed, the controller re-proves
+and recreates it before the next capsule is admitted.
+
+## Immutable images
+
+Set `RUNPOOL_IMAGE` to the complete controller reference published by the
+release, including `@sha256:<digest>`. The controller binary is built with the
+exact capsule digest it is allowed to launch. Tags are discovery aids; they are
+not deployment identity, and `latest` is never accepted as an operator choice.
+
+Before starting the controller, verify:
+
+```text
+runpool version
+runpool config effective
+runpool doctor
+```
+
+Do not override a failed preflight. The exact V1 release-qualification target is in the
+[support matrix](reference/support-matrix.md).
+
+## Verify the release provenance
+
+Publication is attested, and it runs only after qualification has passed
+against the same digests. An attestation signed by the release workflow at a
+release tag therefore says more than "GitHub built this": it says these exact
+bytes are the ones the gates were answered on. Verify before a digest reaches a
+deployment.
+
+`--repo` and `--signer-workflow` bind the attestation to this repository's
+release workflow rather than to any workflow anywhere, and `--source-ref` binds
+it to the release being deployed:
+
+```bash
+gh attestation verify oci://ghcr.io/rhobuild/runpool@sha256:<digest> \
+  --repo rhobuild/runpool \
+  --signer-workflow rhobuild/runpool/.github/workflows/release.yml \
+  --source-ref refs/tags/<version> \
+  --deny-self-hosted-runners
+```
+
+Repeat it for `ghcr.io/rhobuild/runpool/capsule@sha256:<digest>`, which
+`runpool version --json` reports as `capsule_image`, and for a downloaded
+standalone binary by passing its path instead of the image URI.
+
+A release binary reports its version and that digest. One built from
+source reports `runpool dev` and `runpool-capsule:dev`, which is the
+pairing a development build uses and not something to verify against a
+registry.
+
+`--deny-self-hosted-runners` is not decoration. Publication runs on
+GitHub-hosted infrastructure, so an attestation claiming a self-hosted origin
+did not come from this path. Each image also carries an SBOM attestation,
+retrievable with `gh attestation download`.
+
+A failure here is a stop. It means the digest is not the one this release
+qualified, whatever a tag says about it.
+
+## Configuration and provider credentials
+
+The controller runs in file mode. Compose mounts one configuration document at
+`/etc/runpool/config.yaml` and one credential directory at
+`/run/secrets/runpool`; neither credential values nor target-specific settings
+enter the Compose model or the container environment. Start from
+[`deploy/compose/config.example.yaml`](../deploy/compose/config.example.yaml).
+
+Each `credentials[].tokenFile` names a file below the mounted credential
+directory. Create each source file with mode `0600`, give it a distinct name,
+and restrict access to the deployment operator. The controller needs all
+configured target credentials, so mounting one read-only directory has the
+same authority as mounting those files individually while allowing targets to
+be added without changing the deployment manifest.
+
+The default Compose source paths are
+`../files/runpool/config.yaml` and `../files/runpool/credentials`. Dokploy
+preserves `../files` across deployments, unlike files from a repository clone.
+Other Compose operators set `RUNPOOL_CONFIG_PATH` and
+`RUNPOOL_CREDENTIALS_PATH` to explicit existing sources. Both bind mounts use
+`create_host_path: false`, so a typo fails startup instead of silently creating
+an empty directory.
+
+Runpool authenticates with a personal access token or as an installation of
+a GitHub App. For a token, prefer a fine-grained one limited to the
+configured target and its required Administration or
+Self-hosted runners write permission, and verify it with `runpool doctor`;
+GitHub documents the accepted alternatives and classic scopes in its
+[self-hosted runner authentication requirements](https://docs.github.com/en/actions/reference/runners/self-hosted-runners#authentication-requirements).
+Alternatively, authenticate as an installation of a GitHub App, which is
+the better credential for a long-running deployment: it belongs to the
+organization rather than to a person, and the provider client mints and
+refreshes its installation token itself. See `credentials[].type` in the
+[configuration reference](reference/configuration.md#credentials).
+
+Runpool reads whichever credential it is given at startup. The platform
+control plane is not an external secret manager; rotate a credential
+through a controlled controller restart.
+
+## The GitHub side
+
+Runpool creates and owns a **scale set** per (target, tier). A workflow
+reaches one by naming it:
+
+```yaml
+jobs:
+  build:
+    runs-on: runpool-standard
+```
+
+The label is `tiers[].scaleSetName`, which defaults to `runpool-<tier
+id>`. It is a name, not a label set: `runs-on: [self-hosted, linux, x64]`
+does not reach a scale set, because GitHub matches one by its name and
+nothing else. `runpool doctor` prints the name for every tier a
+deployment serves, so the string in configuration and the string in a
+workflow can be compared without reading either. A complete example
+workflow is in [`deploy/workflows/example.yml`](../deploy/workflows/example.yml).
+
+Before a job can run, the GitHub side has to be true:
+
+| | |
+| --- | --- |
+| **Target shape** | `https://<host>/<owner>/<repo>` for one repository, `https://<host>/<owner>` for an organization, `https://<host>/enterprises/<name>` for an enterprise. A single-segment URL is an **organization**, not a user account: a personal account has no runner groups and no organization-scoped scale sets. |
+| **Runner group** | Required for an organization or enterprise target on a shared daemon, and it must already exist — Runpool resolves a group and never creates one. GitHub displays the built-in group as `Default`; configuration takes it lowercase, as `default`. Custom groups are a paid-plan feature. |
+| **Repository access** | The runner group must grant access to the repositories whose workflows will run here. If it does not, GitHub simply never sends work: the controller sits idle and the workflow queues. `runpool status` shows when each binding last reached the provider, which is what tells that apart from having nothing to do. |
+| **Actions enabled** | On the repository, and for the workflow's branch. |
+| **Credential** | A token with the target's runner administration permission, or a GitHub App installation. `runpool doctor` proves it and names the identity it used. |
+| **The scale set** | Runpool creates it on its first serve. Pre-creating one it has no record of is refused, because a set that merely shares a name is a stranger's. |
+
+## Installation sequence
+
+1. Verify the host and Docker daemon against the support matrix.
+2. Pull the controller by digest and
+   [verify its release provenance](#verify-the-release-provenance).
+3. Provision the configuration and one credential file per target through the
+   selected platform; verify that every credential source is restricted to the
+   deployment operator.
+4. Set `host.topology` in the configuration. For `shared-daemon`, size
+   `host.reserve` from the measured peak of Dokploy plus colocated production
+   services; values in the example are illustrative, not production defaults.
+5. Set `scheduling.parallelism` from the host budget. If it is omitted, every
+   tier may fill independently and the worst-case maximum is their sum. Enable
+   tier swap only when the host provides sufficient encrypted swap and
+   `runpool doctor` confirms Docker can enforce it.
+6. Disable platform-wide volume cleanup on a shared daemon.
+7. Render the complete Compose model and confirm there are no ports, domains,
+   proxy labels, or unexpected mounts.
+8. Start the controller and wait for its healthcheck.
+9. Run `runpool doctor` and `runpool status`; both report topology and scheduling capacity.
+10. Execute a private fixture workflow before admitting ordinary CI work —
+    one job, `runs-on` naming a tier this deployment serves. If it queues
+    without starting, the GitHub side above is where to look, and
+    `runpool status` says whether the binding is reaching the provider at
+    all.
+
+The default `public-internet-only` profile supports proxy-aware HTTP and HTTPS
+traffic. Read [capsule egress](runbook.md#capsule-egress) before evaluating a
+workflow that uses SSH or arbitrary TCP.
+
+## Upgrade, backup, and removal
+
+The named state volume is the ownership ledger and must be backed up before an
+upgrade. Cache lanes are disposable and are not part of that backup. Upgrade by
+replacing the controller digest explicitly, then follow the migration and
+rollback procedure in the [runbook](runbook.md#lifecycle-procedures).
+
+Deleting a platform service does not replace `runpool uninstall`. First stop
+admission, inspect the dry-run plan, and confirm the instance identifier so the
+controller can remove only the resources its state proves it owns. Delete the
+platform service and state volume only after the uninstall completes.
+
+## Catalog publication
+
+The Dokploy catalog is maintained upstream, not copied into this repository. A
+release maintainer derives the blueprint from the released, digest-qualified
+Compose contract and reviews the generated preview. Catalog updates are release
+work: a mutable development image or unreleased schema must never be published
+as a One-Click service.
+
+## Dokploy without a catalog entry
+
+The public One-Click catalog is not a prerequisite for deployment. Until the
+first qualified release is accepted upstream, use this procedure:
+
+1. In the Dokploy organization that owns the server, create project `runpool`,
+   environment `production`, and a Docker Compose service named `runpool`.
+2. Use the canonical
+   [`deploy/compose/compose.yaml`](../deploy/compose/compose.yaml) as the Compose
+   definition. It creates only the `controller` service inside the `runpool`
+   Compose project.
+3. Through **Advanced → Mounts**, create the configuration and credential files
+   under Dokploy's persistent `../files` area:
+   `../files/runpool/config.yaml`,
+   `../files/runpool/credentials/<credential-id>`. Copy the configuration
+   example, then replace target names and capacity with reviewed values.
+4. Put exactly one token in each credential file, terminate it with an optional
+   newline, and set every credential file to mode `0600`. Never put a token in
+   the configuration, Compose definition, or Dokploy environment editor.
+5. Set only `RUNPOOL_IMAGE` in the environment editor, using the complete
+   released `@sha256:` reference. Set `RUNPOOL_CONFIG_PATH` or
+   `RUNPOOL_CREDENTIALS_PATH` only when deliberately using non-default source
+   paths.
+6. Render the Compose model and verify that it contains no token values,
+   published ports, domains, or reverse-proxy labels. Validate the mounted
+   document with `runpool config effective` before starting `serve`.
+7. Deploy, wait for the healthcheck, and run `runpool doctor` and
+   `runpool status`. Admit ordinary work only after a private fixture workflow
+   succeeds for every target.
+
+The controller is headless: do not attach a domain or expose a port. This keeps
+the source of truth in Runpool while following Dokploy's normal Compose path;
+the later catalog blueprint is distribution metadata in the upstream template
+repository, not a second deployment implementation here.

--- a/docs/maintainers/qualification-host.md
+++ b/docs/maintainers/qualification-host.md
@@ -1,0 +1,122 @@
+# The release-qualification host
+
+[Release readiness](../release-readiness.md) names the gates a release must
+pass. Four of them can only be answered by a kernel, and this document builds
+the machine that answers them.
+
+It is not a machine you keep. It exists for one qualification run, holds no
+service and no production credential, and is destroyed afterwards. That is a
+security property, not tidiness: during the run it executes CI workloads with a
+privileged Docker daemon inside them.
+
+## Why not an existing host
+
+The controller end-to-end gate proves that cleanup removes every owned resource
+**and preserves unrelated container, network and volume sentinels by exact id**.
+On a host that already runs services, those sentinels are that host's real
+work. A test written to catch "Runpool destroys its neighbours" would be using
+production as the canary.
+
+## The platform
+
+[`build/platform.lock.json`](../../build/platform.lock.json) states the
+selection policy, and `internal/platform` refuses anything else:
+
+```
+debian 13 trixie · amd64
+Docker Engine from the official stable channel
+https://download.docker.com/linux/debian
+```
+
+Architecture is checked against the lock, which records `amd64`. A host of
+another architecture has no entry there and fails the gate for that
+reason — not because the suites would fail on it. Qualifying a second
+architecture is an added lock entry and a run of the same gates on that
+host; the [support matrix](../reference/support-matrix.md) states what
+has been observed and what has not.
+
+## Sizing
+
+Taken from what the suites actually request, not from a guess:
+
+| Suite | Asks for |
+| --- | --- |
+| Capsule budget contracts | 2 CPU, 2 GiB memory, 256 MiB swap, 512 PIDs |
+| Controller end-to-end | 2 CPU and 4 GiB for the tier, 1 CPU and 2 GiB reserved |
+
+Four vCPU and 8 GiB of memory clear both with headroom. Disk needs room for the
+runner image, the dind payload, an inner daemon's data root and the images a
+workload builds: 40 GB is comfortable.
+
+**Swap must exist.** The scheduling and swap envelope gate proves that
+configured swap is enforced inside a real capsule, and `runpool doctor` reads
+`SwapTotal` from the kernel. A host without swap cannot pass that gate — the
+check is not skipped, it fails.
+
+## Provisioning
+
+Install Docker from the official channel rather than the distribution's, so the
+engine matches the policy:
+
+```bash
+apt-get update && apt-get install -y ca-certificates curl
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+printf 'deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian trixie stable\n' \
+  > /etc/apt/sources.list.d/docker.list
+apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+**Hold the engine and disable unattended upgrades.** The lock freezes this
+host's exact facts, and the qualification run compares against them. An engine
+or kernel patch applied between the freeze and the run turns a passing gate
+into a mismatch:
+
+```bash
+apt-mark hold docker-ce docker-ce-cli containerd.io
+systemctl disable --now unattended-upgrades 2>/dev/null || true
+```
+
+Then the runner agent, version 2.327.1 or newer, registered to this repository
+with the labels the qualification jobs select on:
+
+```
+self-hosted, linux, x64, runpool-release-qualification
+```
+
+Put it in a runner group restricted to this repository, and never let it accept
+pull-request jobs: a pull request is code from outside, and this agent runs it
+next to a privileged daemon.
+
+## Capturing and freezing the reference
+
+[`scripts/qualification/platform-facts.sh`](../../scripts/qualification/platform-facts.sh)
+reports what the host is and decides nothing. The comparison lives elsewhere on
+purpose — a collector that also judged would be free to judge in favour of
+whatever it found.
+
+```bash
+scripts/qualification/platform-facts.sh
+```
+
+Read the eighteen facts. This is the reviewed step the gate asks for, not a
+formality: engine patches, cgroup drivers, storage drivers and backing
+filesystems all change container behaviour, which is why each is recorded
+rather than summarised.
+
+Then write them into `build/platform.lock.json` with `status` set to `frozen`
+and `recorded` set to the review date, copy the file byte for byte to
+`internal/platform/platform.lock.json`, and commit. A frozen manifest missing
+any fact is rejected, and the embedded and reviewed copies are compared by a
+test.
+
+## The run, and after it
+
+The freeze and the qualification run happen against the same live host. Tag
+after the lock is committed, let `release.yml` drive the qualification, and
+only then destroy the machine.
+
+Take a snapshot first. The next qualification reprovisions from it: a clean
+host with identical facts, which is what lets the frozen lock keep matching
+without a second review.

--- a/docs/maintainers/repository-settings.md
+++ b/docs/maintainers/repository-settings.md
@@ -1,0 +1,123 @@
+# Repository settings
+
+The repository files define CI behaviour, but GitHub security controls also
+require organization and repository settings. Maintainers should apply and
+review this baseline before making the repository public.
+
+## Rulesets
+
+Protect `main` with a repository ruleset that:
+
+- requires pull requests, resolved conversations, and dismissal of stale
+  approvals;
+- requires the `ci` and `codeql` workflow checks;
+- requires signed commits, and blocks force pushes and branch deletion;
+- allows the merge commit as the only merge method; and
+- restricts bypass to the Rhobuild maintainer team.
+
+Rebase merging replays commits without signing them, and squashing discards the
+branch's own messages. Only the merge commit keeps both, so linear history is
+not required: it forbids the one method that works.
+
+Whether that ruleset also requires an approving review depends on how many
+maintainers there are, and the two settings are stated here so neither reads as
+an oversight.
+
+**With more than one maintainer**, set `required_approving_review_count` to 1
+and require CODEOWNERS approval. Every path already has an owner, and an owner
+who did not write the change can answer for it.
+
+**With one maintainer**, set both off. GitHub does not allow anyone to approve
+their own pull request — no permission level changes that, including
+organization ownership — so a lone maintainer who requires an approving review
+can merge only by bypassing the rule. A bypass taken on every merge stops
+distinguishing the routine one from the one that should have given somebody
+pause, which leaves the branch less protected than an honest setting would.
+
+What holds `main` in that case is everything else: the required checks, signed
+commits, and conversations that must be resolved. CODEOWNERS
+still requests review on every pull request and still records who answers for
+each path; it simply stops being a lock only one person can close and only that
+same person can force. The approval that does exist is the `release`
+environment's, which permits self-review and gates the only irreversible act —
+publishing a release.
+
+Raise the setting as soon as the maintainer team gains a second member.
+
+Do not require the path-filtered Docker integration workflow for every pull
+request; documentation-only changes do not create that check. Require its
+successful result through review policy whenever a changed path triggers it.
+
+Protect `v*` tags from update and deletion and restrict tag creation to release
+maintainers. A release workflow is only as trustworthy as the tag that starts
+it.
+
+## Actions and environments
+
+- Set the default workflow token to read-only and disable workflows creating
+  or approving pull requests.
+- Allow only GitHub-authored actions and the explicitly reviewed third-party
+  actions pinned by full commit SHA in this repository.
+- Keep Dependabot enabled so pinned actions and modules receive reviewed
+  update pull requests.
+- Put the release-qualification runner in a dedicated runner group restricted
+  to this repository. Use labels `self-hosted`, `linux`, `x64`, and
+  `runpool-release-qualification`, with Actions Runner 2.327.1 or newer. It must not host
+  services or production credentials, must never accept pull-request jobs, and
+  must be reprovisioned after each qualification run.
+- Protect `release-qualification` with required release-maintainer approval. Approval
+  is required before any selected capsule digest reaches the privileged
+  self-hosted host. The workflow rejects non-tag refs; reviewers must still
+  verify the protected SemVer tag plus both image digests before approval.
+- In `release-qualification`, configure a dedicated private E2E fixture
+  repository with `.github/workflows/runpool-e2e.yml` byte-for-byte equal to
+  `test/e2e/controller/testdata/workload.yml`. Set
+  `RUNPOOL_E2E_ORGANIZATION`, `RUNPOOL_E2E_REPOSITORY`,
+  `RUNPOOL_E2E_GIT_REVISION`, and
+  `RUNPOOL_E2E_APP_CLIENT_ID` as Environment variables and
+  `RUNPOOL_E2E_APP_PRIVATE_KEY` as an Environment secret. Install the App only
+  on that repository with Actions and Administration write, Contents read, and
+  Packages write. The workflow mints a short-lived installation token; do not
+  store a personal access token. The fixture workflow removes the image
+  version it pushed as its final step, with its own run token — the packages
+  API refuses App installation tokens, so the harness cannot do it. A run
+  that never completes may leave its version behind; the evidence names the
+  tag, and the maintainer removes it with a classic personal token holding
+  `read:packages` and `delete:packages`.
+- Protect `upstream-contracts` and configure a GitHub App installed on the
+  fixture organization and limited to the fixture repositories. Grant only
+  repository Actions, Contents and Administration plus organization
+  Self-hosted runners permissions required by the contracts.
+  Store `RUNPOOL_CONTRACT_APP_CLIENT_ID` and fixture identifiers as Environment
+  variables, and `RUNPOOL_CONTRACT_APP_PRIVATE_KEY` as an Environment secret.
+  `RUNPOOL_CONTRACT_REPO_A` is also the repository-scoped contract target; no
+  separate repository selector is used. Both repository identifiers are
+  `owner/name`: the contracts address them as REST paths and the crossover
+  proof compares them against the owner and repository the runner reports.
+  `RUNPOOL_CONTRACT_RUNNER_CMD` is a command run from the contract package's
+  directory, so
+  [`scripts/qualification/start-jit-runner.sh`](../../scripts/qualification/start-jit-runner.sh)
+  is reached as `../../../scripts/qualification/start-jit-runner.sh`. It starts
+  one runner from the digest pinned in the image lock and keeps the JIT bundle
+  off the host.
+  The workflow mints separate, short-lived repository and organization tokens;
+  do not store a personal access token.
+
+  These contracts never run on a pull request, because they reach protected
+  fixtures. So a change to `github.com/actions/scaleset` merges on hermetic
+  tests alone unless somebody dispatches them: Dependabot keeps that update out
+  of the grouped batch, CODEOWNERS holds `go.mod`, and the reviewer runs
+  `contracts-github-actions` by hand and links the run before merging.
+- Protect `release` with required maintainers and the external security review
+  approval. Only the final publish job may use it.
+
+## Security features
+
+Enable the dependency graph, Dependabot alerts and security updates, CodeQL
+code scanning, secret scanning with push protection, and private vulnerability
+reporting. Retain artifact attestations and package provenance for every
+release.
+
+Review collaborators, deploy keys, webhooks, installed Apps, environments,
+ruleset bypasses, and organization secrets at least quarterly and after any
+maintainer change.

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -1,0 +1,94 @@
+# Product contract
+
+What Runpool promises, what it refuses to promise, and the words used
+to tell those apart. Nothing here is aspirational: a claim appears only
+once something enforces it.
+
+## The vocabulary
+
+| Word | Means |
+| --- | --- |
+| **implemented** | The code exists and the hermetic suite covers it |
+| **tested live** | It also passed its contract suite against a real Linux Docker host |
+| **release-qualified** | It passed the complete release workflow on the reference platform |
+| **supported** | Released, qualified where required, and inside the support matrix |
+
+Release qualification is reproducible first-party engineering evidence, not a
+third-party certification. **Nothing in this repository is release-qualified or
+supported yet.** There is no release. See
+[release readiness](release-readiness.md).
+
+## What Runpool promises
+
+- **Every accepted workload gets a fresh runner, a fresh Docker daemon
+  whose data root does not survive the job, and a fresh workspace.**
+  Nothing carries over except an explicitly mounted cache lane.
+- **A job cannot exceed its tier.** Runner, daemon, inner containers
+  and the job's egress gateway are one budget, enforced by one cgroup
+  hierarchy.
+- **Configured parallelism is enforced at both edges.** The controller never
+  advertises or locally admits aggregate work beyond the tier limits and the
+  optional instance-wide limit; unreleased and recovered leases continue to
+  count.
+- **Runpool deletes only what it owns.** Every object carries ownership
+  labels; a name match with foreign labels is refused, and no daemon
+  wide prune is ever issued.
+- **Accepted work is not lost.** It is durable before it is
+  acknowledged, and where evidence cannot decide what happened, the
+  attempt is held for a person instead of being guessed at.
+- **The host cannot be filled silently.** Admission closes before the
+  disk does.
+- **Under the restricted profile, a capsule has no route out.** Its
+  only egress is a policy-enforcing relay.
+
+## What Runpool refuses to promise
+
+- **It is not a sandbox for hostile code.** The controller holds the
+  Docker socket; capsules run a privileged inner daemon. It is a
+  resource, hygiene and network-policy boundary for CI you already
+  trust.
+- **It does not support fork pull requests from public repositories**,
+  per GitHub's own guidance for self-hosted runners.
+- **It does not turn a shared daemon into a security boundary.**
+  `shared-daemon` is an explicit coexistence contract for private, trusted CI:
+  admission leaves configured host capacity unused, restricted egress is
+  mandatory, and destructive operations remain instance-scoped. A controller,
+  daemon or kernel compromise can still affect every service on that host.
+- **It does not protect platform-wide cleanup from the platform itself.**
+  Operators must not run Docker volume prune or a system prune that includes
+  volumes on a shared daemon. Runpool owns collection of its cache lanes.
+- **It does not provide transparent L3 egress.** Under the restricted
+  profile, direct connections fail closed. Proxy-aware clients may use
+  HTTP or CONNECT to allowed addresses on ports 80 and 443; CONNECT is
+  an opaque tunnel. `git+ssh`, other ports, non-DNS UDP, and clients
+  that ignore proxy settings do not leave. `unsafe-open-egress` is the
+  explicit opt-out, and its name is the warning.
+- **It does not support IPv6 for capsules.** The sandbox denies it, and
+  the configuration rejects a value claiming otherwise.
+- **It does not promise a compatibility window for pre-release
+  schemas.** A database written by an unknown build is refused with
+  instructions, not repaired.
+
+## Compatibility surfaces, and what a version change means
+
+Runpool uses SemVer, because these are the surfaces a consumer depends
+on and SemVer is what describes them:
+
+| Surface | Where it is defined |
+| --- | --- |
+| CLI commands, flags, exit codes | [CLI reference](reference/cli.md) |
+| Configuration schema | [Configuration reference](reference/configuration.md); the validator is the authority |
+| `status --json` document | [Status API reference](reference/status-api.md) — versioned separately as `v1` |
+| On-disk state | Migrations, forward-only after a release |
+| Operational procedures | [Runbook](runbook.md) |
+
+The configuration and status API versions move independently of the product
+version. Breaking either V1 contract requires an explicit version change.
+
+## The support matrix
+
+See the [support matrix](reference/support-matrix.md) for what runs on
+what, and [SUPPORT.md](../SUPPORT.md) for where to ask. The release-reference
+platform is one exact configuration, frozen in `build/platform.lock.json` and
+checked by the contract suite rather than assumed; it does not replace the
+runtime compatibility range.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,431 @@
+# Configuration reference
+
+Two ways in, and they do not mix.
+
+**Quick Start** is environment variables and nothing else. It builds a
+complete, validated configuration for the common case: one target, one
+tier, no cache.
+
+**File mode** is `RUNPOOL_CONFIG_FILE` pointing at a YAML document.
+Setting it together with any Quick Start target variable is an error,
+not a merge — a configuration assembled from two sources is one nobody
+can read back.
+
+Whichever you use, the validator is the authority on what is accepted,
+and `runpool config effective` prints the defaulted, validated result.
+Run it before you run anything else: it is the only view that shows what
+the controller will actually do, defaults included.
+
+```bash
+RUNPOOL_GITHUB_URL=https://github.com/acme/app \
+RUNPOOL_GITHUB_TOKEN=… \
+RUNPOOL_HOST_TOPOLOGY=shared-daemon \
+RUNPOOL_HOST_RESERVE_CPU=1 \
+RUNPOOL_HOST_RESERVE_MEMORY=2GiB \
+RUNPOOL_HOST_RESERVE_SWAP=0B \
+RUNPOOL_HOST_RESERVE_FREE_DISK=20GiB \
+runpool config effective
+```
+
+## Quick Start variables
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `RUNPOOL_GITHUB_URL` | yes | `https://github.com/<owner>` or `https://github.com/<owner>/<repo>`. The scope decides what the runner may bind. |
+| `RUNPOOL_GITHUB_TOKEN` | one of | The token, read from the environment at startup. |
+| `RUNPOOL_GITHUB_TOKEN_FILE` | one of | A file to read the token from. Setting both is an error. |
+| `RUNPOOL_GITHUB_RUNNER_GROUP` | conditional | Required for an organization target in `shared-daemon`; invalid for a repository target. |
+| `RUNPOOL_HOST_TOPOLOGY` | yes | `shared-daemon` or `dedicated-daemon`; the compromise and cleanup model must be explicit. |
+| `RUNPOOL_HOST_RESERVE_CPU` | shared | CPU withheld from scheduling. Required and greater than zero in shared mode; dedicated default `1`. |
+| `RUNPOOL_HOST_RESERVE_MEMORY` | shared | Memory withheld from scheduling. Required and greater than zero in shared mode; dedicated default `2GiB`. |
+| `RUNPOOL_HOST_RESERVE_SWAP` | no | Host swap withheld from scheduling. Default `0B`. |
+| `RUNPOOL_HOST_RESERVE_FREE_DISK` | shared | Free disk floor for platform and host. Required and greater than zero in shared mode; dedicated default `20GiB`. |
+| `RUNPOOL_TIER` | no | The tier id. Default `standard`. |
+| `RUNPOOL_PARALLELISM` | no | Maximum active leases in the Quick Start tier. Default `1`. |
+| `RUNPOOL_LOG_LEVEL` | no | `debug`, `info`, `warn` or `error`. Default `info`. |
+| `RUNPOOL_NETWORK_PROFILE` | no | `public-internet-only` (default) or `unsafe-open-egress`. |
+| `RUNPOOL_CONFIG_FILE` | no | Switches to file mode. Mutually exclusive with **every** variable above: in file mode each of those settings comes from the file, and one that is neither applied nor refused is worse than either. |
+
+`RUNPOOL_STATE_DIR` selects the state directory and is read in both modes,
+by `serve` and by every command that reads or maintains state. It defaults
+to `/var/lib/runpool/state`, which is where the reference deployment
+mounts the state volume — so a command run outside that container reports
+an instance that has not run yet until it is pointed at the real
+directory.
+
+Quick Start leaves the cache **off**. Reuse across jobs is implemented
+but not release-qualified, and a default that enables an unqualified feature
+ships a promise the runtime has not kept.
+
+## The document
+
+`apiVersion: runpool.rhobuild.com/v1`, `kind: RunpoolConfig`.
+Unknown fields are rejected by name rather than ignored — a typo that
+silently does nothing is worse than one that stops startup.
+
+The version is the **configuration schema's**, not the product's. The
+two move independently, and neither is promoted while its contract is
+still moving.
+
+### instance
+
+`name` is a lowercase slug, default `primary`. It appears in logs and
+distinguishes co-located instances in a human's reading, not in
+ownership: ownership is the opaque instance id in the state directory.
+
+### host
+
+`topology` is required:
+
+| Value | Meaning |
+| --- | --- |
+| `shared-daemon` | Runpool shares the Engine with a platform such as Dokploy and its application services. Restricted egress and a positive explicit reserve are mandatory. |
+| `dedicated-daemon` | The Engine is operationally exclusive to Runpool. Default reserves are CPU `1`, memory `2GiB`, swap `0B`, free disk `20GiB`. |
+
+`reserve.cpu`, `reserve.memory`, `reserve.swap`, and `reserve.freeDisk` are
+capacity Runpool does not schedule. `freeDisk` also feeds disk-pressure
+admission. Shared mode requires CPU, memory, and free disk to be greater than
+zero because Runpool cannot infer the peak needs of colocated services. Swap
+may remain `0B`. These controls reduce resource contention; they do not isolate
+controller, daemon, or kernel compromise.
+
+### scheduling
+
+`scheduling.parallelism` is an optional instance-wide limit across every
+target and tier. When present, it constrains both provider capacity advertised
+by the controller and local admission. It must be between `1` and `10000` and
+must not exceed the sum of tier parallelism. A value of `0` is invalid.
+
+When omitted, tiers are deliberately independent and the effective maximum is
+the sum of `tiers[].parallelism`. This preserves a useful multi-tier default
+without hiding a global policy. Use an explicit global value on a shared host
+where one large workload or several smaller workloads must stay inside a
+single host budget.
+
+`scheduling.retryBudget` is how many times one attempt whose work
+provably never began may be served before it is held for review as
+`retry_budget_exhausted`. It defaults to `3`, which matches the
+provider's own budget for an assignment nobody takes, and may be set
+between `1` and `10`.
+
+The range is narrow on purpose. This breaks a loop rather than tunes a
+rate: a serving that ends before the work begins is a transient — an
+image that would not pull, a daemon that would not answer — and the
+failure that repeats is the one no number of retries fixes, while each
+retry costs a capsule, a runner registration and a lane. Raising it far
+is how a systematic failure gets paid for instead of found. An operator
+resolving a held attempt is not overruled by the counter.
+
+A lease counts from durable reservation through provisioning, execution,
+draining, cleanup, failure, and quarantine. Capacity returns only when cleanup
+reaches `released`. Startup reconciliation adopts existing leases before new
+work is admitted, so a controller restart cannot reset either the tier or
+instance-wide count.
+
+### tiers
+
+A tier is a named resource envelope with its own parallelism limit.
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Lowercase slug; targets reference it |
+| `parallelism` | Maximum active leases in the tier, `1..10000`; default `1` |
+| `resources.cpu` | CPU limit, `> 0` |
+| `resources.memory` | Memory limit, `> 0` |
+| `resources.swap` | Additional swap above memory, `>= 0B`; default `0B` |
+| `resources.pids` | Process ceiling, `>= 1` |
+| `capsuleImage` | Capsule image for this tier's jobs, digest-qualified; default is the image this build ships |
+| `jobTimeout` | How long Runpool waits for a capsule that stopped reporting, `>= 1m`; default `8h` |
+
+**The envelope covers the capsule and its egress gateway together.** The
+gateway takes a fixed reserve out of it, so a tier whose resources are
+smaller than that reserve plus a usable capsule is rejected at startup
+with the exact figures — better than a job that starves at run time
+because something invisible was charged to it.
+
+#### The job ceiling
+
+`jobTimeout` is not the job's time limit. GitHub ends a job at its own
+`timeout-minutes` — 360 minutes at most — the runner exits, and the lease
+resolves through the ordinary path. The ceiling is what bounds a capsule
+that stops reporting instead: a wedged process, a daemon that will not
+stop, a capsule that lost the ability to say anything. Without it, that
+lease would hold its credit and its privileged container indefinitely.
+
+So it belongs above the largest legitimate run, not below it. The default
+of `8h` leaves the provider's own maximum two hours to fire, reach the
+runner, exit it and be observed here, and `168h` is the most a tier may
+set — a wedged capsule holds a lane, an admission credit and a cache lane
+for the whole ceiling, so an unbounded value is how that becomes
+permanent by configuration. Lower it on a tier whose work is short to get
+its capacity back sooner; the log says which tier's ceiling ended a
+capsule, so it is never mistaken for a job that failed.
+
+**It bounds the wait for the job, and nothing else.** Getting a capsule
+to the point of running — minting a credential, acquiring a lane,
+building the sandbox, pulling and booting the image, handing over the
+credential — is this instance's own work against its own daemon and is
+bounded separately. That is why the floor can be as low as `1m` without
+ending capsules while they are still starting, and why an adopted capsule
+waits out what its lease has left rather than starting a fresh ceiling on
+every restart.
+
+#### The capsule image
+
+The capsule is not an arbitrary container. It is the other half of a
+control protocol: its entrypoint is the Runpool supervisor, which owns
+PID 1, boots the job's Docker daemon, answers `deliver`, `start` and
+`state` over `docker exec`, and writes the protocol version it speaks to
+`/run/runpool/protocol` at boot. The controller reads that file before it
+hands a capsule anything and refuses a version it does not speak. A
+mismatch holds that attempt for review as `capsule_incompatible` rather
+than retrying it: the next attempt would launch the same image and meet
+the same answer, so what a retry buys is the same fact three times.
+
+An operator's image therefore derives from the published one:
+
+```dockerfile
+FROM ghcr.io/rhobuild/runpool/capsule@sha256:<digest>
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends <packages> \
+ && rm -rf /var/lib/apt/lists/*
+USER runner
+```
+
+The supervisor, its entrypoint, and the `/run/runpool` control surface are
+the parts that may not be replaced. Everything else — packages, language
+toolchains, preinstalled software — is yours.
+
+`capsuleImage` must name a digest. The controller launching an image it
+can name exactly is the property the shipped pin provides, and a tag can
+move under a running controller; the validator refuses one rather than
+letting a deployment discover it later.
+
+**The egress gateway is not this image.** Each lease runs a gateway
+container that applies the network policy, and it always runs the capsule
+this build ships — extending the image a tier's jobs run in is not a
+request to replace what confines them.
+
+**A tier that names its own capsule is outside the configuration the
+release gates observed.** Nothing about that is unsafe — a deployment
+already holds the host's Docker socket, so its operator can run any image
+against that daemon directly — but it is not the configuration any
+qualification result speaks for. `runpool status` reports the image each
+tier runs, so the deviation is visible rather than inferred.
+
+`resources.memory` is the RAM hard limit. `resources.swap` is additional swap,
+not Docker's combined memory-plus-swap value. Runpool performs that adapter
+translation internally and never requests unlimited swap.
+
+`runpool doctor` gates swap on two separate conditions, because they ask
+different questions:
+
+- **When any tier uses swap**, Docker must be able to enforce a memory-swap
+  limit — cgroup v2 swap accounting. This keys on tier swap alone: a limit is
+  only ever set on a container, and `host.reserve.swap` never reaches one.
+- **When any tier swap or `host.reserve.swap` is non-zero**, the host swap
+  total must be readable and large enough for the conservative workload set
+  plus the reserve. Reserving swap the host does not have is a sizing error
+  whether or not a capsule would use it.
+
+On hosts that may contain CI secrets, persistent swap should be encrypted.
+Treat swap as an emergency buffer, not as normal execution capacity: sustained
+swap use is a sizing signal and can make CI dramatically slower.
+
+The capacity preflight is conservative. Without an instance-wide limit it
+budgets every tier at full parallelism. With a global limit of N it selects the
+N largest eligible envelopes independently for CPU, memory, and swap, then
+adds the host reserve. For `parallelism: 1`, that means the largest tier—not
+the sum of all tiers—must fit.
+
+### targets
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Lowercase slug |
+| `url` | The target: `https://<host>/<owner>`, `https://<host>/<owner>/<repository>` or `https://<host>/enterprises/<name>` |
+| `credential` | Credential id from `credentials[]` used to authenticate the target |
+| `runnerGroup` | Runner group. Required for organization and enterprise targets in shared mode; invalid for repository targets |
+| `cache.enabled` | Persistent cache lanes for this target |
+| `cache.generation` | Lowercase slug; changing it abandons the old lanes |
+| `tiers[].tier` | Tier id from `tiers[]` to serve with |
+| `tiers[].scaleSetName` | The scale set name on GitHub, lowercase slug. **This is the `runs-on` value** a workflow uses; defaults to `runpool-<tier id>` |
+
+**A persistent cache requires a repository-scoped target.** A runner that
+is not bound to one repository could execute another repository's job
+against its cache. The validator refuses the combination rather than
+trusting the operator to remember.
+
+**The host is carried, not checked.** Whether a host serves the protocol
+is a question the provider answers, and `runpool doctor` asks it with a
+real call before any work is served. Refusing an unfamiliar name here
+would refuse an Enterprise Server or a data-residency host that speaks
+exactly the endpoints `github.com` speaks. What has been *qualified* is a
+separate statement — see the [support matrix](support-matrix.md).
+
+The same `scaleSetName` in different GitHub scopes names different
+resources and is accepted.
+
+**A workflow reaches a tier by naming its scale set**, not by matching
+labels:
+
+```yaml
+jobs:
+  build:
+    runs-on: runpool-standard
+```
+
+`runs-on: [self-hosted, linux, x64]` does not reach one. `runpool doctor`
+prints the name for every tier a deployment serves. The complete example
+is [`deploy/workflows/example.yml`](../../deploy/workflows/example.yml).
+
+### credentials
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Lowercase slug |
+| `type` | `token` or `github_app` |
+| `tokenEnv` | Environment variable holding the token, for `token` |
+| `tokenFile` | File holding the token, for `token` |
+| `clientID` | The App's client id, for `github_app` |
+| `installationID` | The installation this deployment acts as, for `github_app` |
+| `privateKeyEnv` | Environment variable holding the App's PEM key |
+| `privateKeyFile` | File holding the App's PEM key |
+
+The configuration never contains the secret itself — it names where to
+find it, so a configuration dump is safe to paste into an issue. Exactly
+one reference per credential: `tokenEnv` or `tokenFile`, `privateKeyEnv`
+or `privateKeyFile`. A credential carrying the fields of both types is
+refused rather than resolved by precedence.
+
+Prefer the file forms for deployments, so the credential is mounted as a
+secret rather than persisted in Docker's container environment. A secret
+file other local users can read is refused: `shared-daemon` is a
+supported topology, so another uid on the host is a real party.
+
+Runpool reads the credential at startup; rotating it requires a
+controlled controller restart. Use `runpool doctor` to verify the target
+before serving work — it reports which identity it authenticated as.
+
+#### Which type
+
+**`token`** is a personal access token. It carries the permissions of the
+person who minted it, appears in their account, and stops working when
+they rotate it or leave. Grant only the target's self-hosted runner
+administration permissions.
+
+**`github_app`** authenticates as an installation of a GitHub App, which
+belongs to the organization rather than to a person. It is the right
+credential for anything long-running: membership changes stop being an
+outage, and the installation's scope replaces a person's permissions.
+Runpool hands the client id, the installation id and the key to the
+provider client, which mints the installation token and refreshes it
+before expiry on its own.
+
+The private key is the longest-lived secret a deployment holds, and the
+one whose leak revoking a single token cannot contain. Mount it as a
+file, owner-readable only.
+
+```yaml
+credentials:
+  - id: runners
+    type: github_app
+    clientID: Iv1.0123456789abcdef
+    installationID: 12345678
+    privateKeyFile: /run/secrets/runpool/app.pem
+```
+
+### cache
+
+`storage.mode` is `volume`. The quota-backed bind mode is not
+implemented, and the validator says so rather than accepting a value
+that does nothing.
+
+| Field | Meaning |
+| --- | --- |
+| `global.maxManagedBytes` | The cache budget the watermarks are a fraction of |
+| `global.highWatermarkPercent` | Where collection starts, `1 <= low < high <= 99` |
+| `global.lowWatermarkPercent` | What collection collects down to |
+| `global.softEmergencyFreeBytes` | Free space at which admission closes |
+| `global.hardEmergencyFreeBytes` | Free space at which everything fails closed; must be below the soft threshold |
+| `defaults.repositoryMaxBytes` | Per-project ceiling; may not exceed the global budget |
+| `defaults.unusedTTL` | How long a free lane survives unused, `> 0` |
+
+What each pressure level means operationally is in
+[the runbook](../runbook.md).
+
+### retention
+
+How long durable records outlive the work they describe.
+
+| Field | Meaning |
+| --- | --- |
+| `leaseHistory` | How long the record of a finished lease is kept. Default `2160h` (90 days); `0` keeps every one; otherwise at least `24h` |
+
+A `capsule_lease` is the runtime plumbing an attempt consumed — the
+containers, networks and volumes it held. **What the work did is the
+attempt's evidence, and is never pruned**: its disposition and its
+lifecycle events outlive the lease that produced them.
+
+Unlike `scheduling`, this section always appears in `config effective`
+even when the file omits it. A deletion policy that applies by default
+should not be invisible.
+
+The serving controller prunes on its reconcile interval, and `runpool gc`
+does the same pass on demand. A lease is skipped while the attempt it
+served is still unresolved, or while it still owns a resource intent —
+the first keeps a crashed-mid-release attempt findable, the second keeps
+a real leak visible.
+
+### observability
+
+`log.format` is `json` or `text`; `log.level` is `debug`, `info`, `warn`
+or `error`.
+
+`metrics.enabled` **must be false.** No metrics endpoint exists yet.
+Capacity, credits and disk pressure are reported by `runpool status` and
+the structured log; accepting `true` would advertise a scrape target
+that is not there.
+
+### network
+
+| Field | Accepted | Meaning |
+| --- | --- | --- |
+| `profile` | `public-internet-only` | The restricted profile: no route out, egress through the policy relay |
+| | `unsafe-open-egress` | Capsules reach whatever the host reaches, including the LAN. Logged loudly at startup |
+| `ipv6` | `disabled` | The sandbox denies IPv6 and the validator refuses a value claiming otherwise |
+| `dns.mode` | `gateway` | Names are resolved by the gateway that then dials them — which is the DNS-rebinding defence |
+| `allowPrivateCIDRs` | list | Private ranges a capsule may reach anyway. IPv4 only, and no entry may be broader than a range the built-in deny set withholds |
+| `denyCIDRs` | list | Ranges denied on top of the built-in set. IPv4 only |
+
+`allowPrivateCIDRs` punches holes through the built-in deny set, and an allow
+is consulted before a deny when a destination is decided. An entry that is
+*broader* than a withheld range therefore reopens that whole range as a side
+effect — `0.0.0.0/0` readmits every private network while `profile` still
+reads `public-internet-only` — so the validator refuses any entry that
+strictly contains a denied range.
+
+Narrower entries are the intended use, and public prefixes are accepted
+because they change nothing: the profile already permits the public internet.
+That is also how a capsule reaches a service on the host's own public
+address, which the runtime deny set withholds from facts static validation
+cannot see. Both lists render into an IPv4 ruleset; an IPv6 prefix is refused
+here rather than at gateway boot.
+
+Under the restricted profile, direct egress is denied. Proxy-aware clients
+may use HTTP or CONNECT to allowed addresses on ports 80 and 443; CONNECT is
+opaque. `git+ssh`, other ports, non-DNS UDP, and proxy-unaware clients fail
+closed; see
+[the product contract](../product-contract.md) for what that means for a
+workflow.
+
+`shared-daemon` rejects `unsafe-open-egress`: permitting a capsule to reach
+the host and private networks would contradict the coexistence contract. Move
+that workload to `dedicated-daemon` if it cannot use the restricted relay.
+
+## Where the rules actually live
+
+Every constraint above is enforced by `internal/config`, and the error
+messages name the field path and the reason. This page describes them;
+it does not define them. Where the two disagree, the validator is right
+and this page is a bug.

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -1,0 +1,174 @@
+# Support matrix
+
+What Runpool runs on, in the words of the vocabulary from
+[the product contract](../product-contract.md): **implemented** means
+the code exists and the hermetic suite covers it; **tested live** means
+it also passed its contract suite against a real Linux Docker host;
+**release-qualified** means it passed the complete release gate on the
+reference platform; **supported** means released, qualified where the
+property requires it, and inside this matrix. Release qualification is
+Runpool's reproducible engineering evidence, not a third-party product
+certification.
+
+**Nothing here is release-qualified or supported.** There is no release. This
+page exists so that when there is one, the line between what was proven
+and what was assumed is already drawn. Live status is in
+[release readiness](../release-readiness.md).
+
+## Runtime compatibility
+
+Runpool requires Docker Engine 28.0 or newer because its restricted network
+profile depends on the `isolated` gateway mode introduced in
+[Engine 28](https://docs.docker.com/engine/release-notes/28/). The
+controller negotiates a mutually supported Engine API version; it does not
+require the host daemon to equal the release-qualification patch and it does
+not reject a newer major solely for being newer.
+
+Compatibility and support are evidence-based:
+
+| Engine | Status before V1 |
+| --- | --- |
+| `< 28.0` | Incompatible: the required isolated bridge mode does not exist |
+| `28.x` | Compatible floor implemented; not selected for the first release qualification |
+| `29.7.2` | Latest official stable Debian 13 package at the 2026-08-16 policy review; selected for the first qualification, not yet qualified |
+| Other `29.x` | Expected to negotiate successfully, but must pass the complete live matrix before being listed as tested or supported |
+| Future majors | Unknown until their release notes and live matrix are reviewed |
+
+[Engine 29](https://docs.docker.com/engine/release-notes/29/) includes meaningful
+changes, including a different default image store for fresh installations and
+an experimental nftables backend. Engine
+[API negotiation](https://docs.docker.com/reference/api/engine/) makes it a
+reasonable compatibility target, not an automatic security result. The
+selected 29.7.2 host must record its image store and firewall backend as part
+of the no-skip qualification before the support statement expands.
+
+## Release-qualification target
+
+The policy selects Docker Engine
+[29.7.2](https://docs.docker.com/engine/release-notes/29/#2972) from Docker's
+[official stable Debian channel](https://download.docker.com/linux/debian/dists/trixie/pool/stable/amd64/).
+The exact platform reference is currently **pending**: the
+production-class Linux host has not yet supplied the remaining facts. Release
+qualification is fail-closed until those facts are reviewed and frozen in
+`build/platform.lock.json` before the candidate tag. The host under test never
+defines its own expectation.
+
+| | Reference value |
+| --- | --- |
+| OS | Debian 13 (trixie), amd64; exact patch pending host capture |
+| Kernel | Pending host capture |
+| Docker Engine | **29.7.2** selected; exact installed package pending capture |
+| Engine API, containerd, runc | Pending host capture |
+| cgroups | v2 required; exact driver pending capture |
+| Storage and backing filesystem | Pending host capture |
+| Rootless | no |
+| Firewall backend | Stable Docker backend required; exact tools pending capture |
+| Buildx / Compose | Pending host capture |
+| Policy reviewed | 2026-08-16 |
+
+Once frozen, every value is exact because a release record must identify what
+actually ran. That exactness is an evidence constraint, not an operator-side
+version pin. A later Docker update produces a new reviewed lock and record and
+does not invalidate earlier release evidence.
+
+## Host requirements
+
+| Requirement | Why it is a requirement |
+| --- | --- |
+| Linux | The isolation is cgroup v2 and kernel netfilter; nothing else provides it |
+| Rootful Docker Engine | The controller holds the daemon socket and capsules run a privileged inner daemon |
+| cgroup v2 with `memory` and `pids` | The tier envelope is enforced by those controllers; swap accounting is additionally required when a tier configures swap |
+| Explicit `host.topology` | `shared-daemon` and `dedicated-daemon` have different operational contracts; inference would hide the chosen blast radius |
+| Positive host reserve in shared mode | Colocated platform and application services need CPU, memory and free disk that CI cannot schedule; optional swap reserve is checked separately |
+| `public-internet-only` in shared mode | Open capsule egress to host and private networks is incompatible with the coexistence contract |
+| `systemd` or `cgroupfs` driver | Read from the daemon at startup; the parent form is generated for the reported driver and verified live |
+
+**Architecture is qualification evidence, not a design limit.** The gates
+observe `linux/amd64`, which is what the platform lock records and what
+the published images are built for. Nothing in the design restricts an
+architecture: the capsule's base images publish `linux/arm64`, the
+controller is a static Go binary, and the isolation is cgroup v2 and
+kernel netfilter on either. Another architecture is therefore *unverified*
+rather than unsupported — nobody has run the suites there, and this
+document will say so until somebody has.
+
+The self-hosted release-qualification runner must use GitHub Actions Runner 2.327.1
+or newer so the Node 24 runtime required by the pinned first-party actions is
+available. This is CI infrastructure only; Runpool has no Node.js build or
+runtime dependency.
+
+`runpool doctor` checks the machine-verifiable requirements and refuses to
+start when they are not met. In shared mode it reports a warning that capacity
+and ownership controls do not isolate a daemon compromise. Release
+qualification records the host inventory and preserves unrelated container,
+network and volume sentinels across controller cleanup. A host that cannot
+honour the machine contract must fail at startup, not midway through a job.
+
+## Provider support
+
+| Provider | State |
+| --- | --- |
+| GitHub Actions | The single adapter: implemented, tested live |
+| Anything else | Not implemented and not promised |
+
+Within GitHub, three things are configurable and only some of them have
+been run. The distinction is deliberate: a target is refused for not
+working, never for being unfamiliar, so what is *qualified* is stated
+separately from what is *accepted*.
+
+| Target | State |
+| --- | --- |
+| `github.com`, repository or organization scope | Qualified: this is what the release gates observe |
+| Enterprise Cloud with data residency (`*.ghe.com`) | Accepted, unqualified. It is GitHub's own hosted service under another hostname and reaches the same endpoints |
+| GitHub Enterprise Server | Accepted, unqualified. The provider client derives its API under `/api/v3`, using the same endpoints |
+| Enterprise scope (`/enterprises/<name>`) | Accepted, unqualified, and the least exercised of the three: runner registration goes to an endpoint no suite in this repository reaches |
+
+Unqualified means no gate has observed it, which is neither a promise nor
+a denial. `runpool doctor` makes a real call against whatever host and
+scope a deployment configures, so an operator learns in one command
+rather than at the first job.
+
+The lifecycle and state core is provider-neutral by construction — an
+architecture test fails the build if a core package imports the adapter — but
+public configuration currently describes GitHub Actions. A neutral domain is
+not a second adapter, and this matrix does not pretend otherwise.
+
+## Scope and feature support
+
+| Feature | State |
+| --- | --- |
+| Repository-scoped scale sets | Implemented, tested live |
+| Organization-scoped scale sets | Implemented, tested live |
+| Persistent cache lanes | Implemented; manager and named-volume reuse pass live contracts. **Repository-scoped only** and off by default until controller end-to-end reuse is release-qualified |
+| Restricted egress (`public-internet-only`) | Implemented and tested live; direct egress denied, proxy HTTP and CONNECT limited to allowed addresses on ports 80/443 |
+| Open egress (`unsafe-open-egress`) | Implemented; the name is the warning, and it is logged loudly at startup |
+| IPv6 for capsules | Not implemented. The sandbox denies it and the validator refuses a configuration claiming otherwise |
+| Metrics endpoint | Not implemented. `runpool status` and the structured log are the interface |
+| Standby / handover for a second controller | Not implemented. A second controller gets the lock error and stops |
+| Shared Docker daemon | Implemented with explicit reserves, restricted egress, ownership-verified cleanup and per-launch uplink recovery; controller E2E qualification remains required |
+| Dedicated Docker daemon | Implemented and recommended when the shared compromise domain is unacceptable |
+| Enterprise-scoped scale sets | Accepted, unqualified — see Provider support above |
+| Operator-supplied capsule image | `tiers[].capsuleImage`, digest-qualified, built from the published capsule. A tier that names one is outside the configuration the gates observed, and `runpool status` reports what each tier runs |
+| GitHub App credentials | Implemented. The provider client mints and refreshes the installation token; the App path has no live coverage, because proving it end to end needs an App installed on the protected fixture |
+| GPU and device passthrough | Not implemented. The tier envelope is cpu, memory, swap and pids; nothing reaches a device, and a GPU would have to be visible to the capsule and to the daemon inside it |
+| Architectures other than amd64 | Not qualified. Nothing in the design restricts one — see Host requirements |
+
+## What is explicitly out of scope
+
+- **Public fork pull requests.** Per GitHub's own guidance for
+  self-hosted runners. Runpool is a resource, hygiene and network-policy
+  boundary for CI you already trust — not a sandbox for hostile code.
+- **Treating shared mode as hostile-code containment.** A privileged capsule,
+  controller or daemon compromise can affect colocated services.
+- **Platform-wide volume prune in shared mode.** It bypasses Runpool's cache
+  ownership and retention policy.
+- **Transparent L3 egress** under the restricted profile: direct TCP,
+  `git+ssh`, other ports, non-DNS UDP, and proxy-unaware clients fail closed.
+- **A compatibility window for pre-release schemas.** A database written
+  by an unknown build is refused with instructions, not repaired.
+
+## Where the escalation goes
+
+See [SUPPORT.md](../../SUPPORT.md) for where to ask, and
+[SECURITY.md](../../SECURITY.md) for how to report a vulnerability —
+never a public issue.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -1,0 +1,64 @@
+# Release readiness
+
+Runpool is **pre-release and not release-qualified**. This document contains
+the objective publication gates; it is not a development log.
+
+## Release target
+
+The first release is `v1.0.0`. Docker Engine 29.7.2, the latest official
+stable Debian 13 package at the 2026-08-16 policy review, is selected for the
+first release qualification. The exact platform reference in
+[`build/platform.lock.json`](../build/platform.lock.json) remains `pending`
+until the production-class host's kernel, API, runtime, cgroup, storage,
+firewall, Buildx, and Compose facts are captured and independently reviewed.
+No candidate tag may be created while the reference is pending.
+
+That exact host is an evidence reference, not an operator-side version pin.
+Runtime admission requires Docker Engine 28.0 or newer and the capabilities it
+uses. A newer daemon is not rejected for being newer, but it does not become a
+tested or supported platform until it passes the relevant live matrix.
+
+## Required gates
+
+| Gate | Current state | Completion evidence |
+| --- | --- | --- |
+| Hermetic CI | Implemented | `ci.yml` passes formatting, vet, staticcheck, race, coverage, sqlc parity, builds, link checks, vulnerability scan, and image build |
+| Live Docker contracts | Implemented; qualification not executed | Docker, capsule, egress, cache, SQLite, and lifecycle suites pass without skips on the reference host |
+| Upstream provider contracts | Implemented; protected fixtures required | Live GitHub Actions contracts pass without skips using short-lived GitHub App installation tokens |
+| Controller end-to-end workload | Implemented; qualification not executed | The exact controller runs in `shared-daemon`, receives real fixture assignments, launches the exact capsule candidate under restricted egress, completes checkout, dependency download, Docker build and registry push, proves cache reuse and generation isolation, survives controller restart, removes owned resources, and preserves unrelated container, network and volume sentinels by exact id |
+| Host topology contracts | Implemented; qualification not executed | Shared mode enforces positive reserves, restricted egress, organization runner-group isolation, ownership-verified cleanup and idle-uplink recovery; the shared controller E2E and common Docker contracts pass on the reference host |
+| Scheduling and swap envelope | Implemented; live qualification not executed | Global and tier parallelism constrain provider announcements and local admission through restart and quarantine; preflight proves the worst admitted CPU, memory, and swap set plus host reserve fits; configured swap is enforced in a real capsule on the reference host |
+| Immutable release candidates | Implemented; qualification not executed | Controller and capsule images are built before qualification and identified by digest; the standalone binary and completions are retained by checksum; publication promotes or downloads those exact bytes without rebuilding |
+| Exact platform match | Engine 29.7.2 selected; exact host lock pending | The reviewed lock is frozen before the candidate; every observed fact matches and missing facts fail the gate |
+| External security review | Outstanding | Findings affecting the release boundary are [resolved or explicitly accepted](security/review-findings.md) before release approval |
+| Release authorization | Outstanding | The protected `release` environment approves publication only after all prior gates pass |
+
+The release-qualification host also needs GitHub Actions Runner 2.327.1 or
+newer and access to protected upstream and end-to-end fixtures. These are
+infrastructure prerequisites, not substitutes for a passing gate.
+
+## Release mechanics
+
+A protected SemVer tag starts the release workflow. The workflow:
+
+1. builds and pushes immutable controller and capsule candidates for that
+   commit, and builds the standalone release artifacts once;
+2. qualifies that exact commit, both image digests, and the retained artifact
+   checksums on the reference host;
+3. requires hermetic CI, live Docker and provider contracts, and the real
+   controller end-to-end workload with no skipped required contract;
+4. creates `release-qualification.json` from the evidence and verifies it
+   against the commit and candidate digests;
+5. promotes the qualified image digests and publishes the already-built
+   standalone artifacts without rebuilding them;
+6. creates provenance and SBOM attestations; and
+7. creates a draft GitHub release behind the protected `release` environment.
+
+The workflow cannot publish from a branch, a different commit, an unmeasured
+platform, a different image, or a post-qualification rebuild.
+
+## Release decision
+
+Do not publish while any required gate above is outstanding. Green hermetic CI
+is necessary but does not substitute for the controller end-to-end evidence,
+the external security review, or the no-skip live release-qualification run.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,349 @@
+# Runbook
+
+Operator procedures for a running Runpool instance. `runpool status` is
+always the first command. Installation and platform integration are
+covered by the [deployment guide](deployment.md).
+
+## Running these commands
+
+Every command here reads the state directory, and in the reference
+deployment that directory is a named volume mounted only inside the
+controller's container. A `runpool` binary on the host sees nothing: it
+looks at an empty default path and reports an instance that has not run
+yet. Run them in the container instead. The image has no shell, which is
+why `exec` names the binary directly rather than a shell that would
+interpret a command line:
+
+```bash
+docker compose exec controller runpool status
+```
+
+Outside Compose, `docker exec <container> runpool status` does the same.
+Running the binary on the host works when it is pointed at the state:
+`RUNPOOL_STATE_DIR` selects the directory, and the configuration
+variables the [configuration reference](reference/configuration.md) lists
+select the rest. A read-only command needs no configuration at all.
+
+Commands that change something take `--apply` or `--confirm`, preview
+without it, and take the singleton lock the controller holds — so they
+report that the controller is running rather than acting behind it.
+
+## Shared-daemon operations
+
+`runpool status` prints the configured topology and the scheduling picture —
+mode, effective parallelism, active and available capacity, and a line per
+tier — and `status --json` exposes the same under `host_topology` and
+`scheduling`. On a `shared-daemon` host:
+
+- keep the configured CPU, memory, swap and free-disk reserve above the
+  measured peak of Dokploy and colocated applications;
+- set `scheduling.parallelism` when the host budget must hold across every
+  target and tier, rather than letting each tier fill independently;
+- do not run `docker volume prune`, `docker system prune --volumes`, or a
+  platform “full prune”; use Runpool GC for cache lanes;
+- inspect ephemeral resources through `io.runpool.instance`,
+  `io.runpool.lease`, `io.runpool.attempt`, `io.runpool.target`,
+  `io.runpool.tier`, and `io.runpool.role` labels;
+- investigate a doctor topology warning as an acknowledgement of shared
+  compromise scope, not as a failed admission check.
+
+Runpool removal commands filter by instance and re-inspect lease ownership
+before each destructive intent. They never prune the daemon. An externally
+removed idle uplink is recreated and its policy rediscovered before the next
+capsule launches; an externally removed idle cache volume is recreated cold,
+so its warm contents are lost but ownership does not cross.
+
+## Disk pressure
+
+The controller measures once a minute: free space and inodes of the
+Docker daemon's storage filesystem (probed from inside it, so the
+answer is correct however the controller is deployed) and the total
+size of this instance's cache-lane volumes. The verdict is persisted —
+`runpool status` shows it, and a restart resumes under it.
+
+| Level | Meaning | Automatic response | Operator action |
+| --- | --- | --- | --- |
+| `normal` | Floors and watermarks respected | — | None |
+| `high` | Managed cache crossed `cache.global.highWatermarkPercent` of `maxManagedBytes` | GC evicts free lanes (TTL, then LRU) down to the low watermark | None required; investigate if it recurs every pass |
+| `soft_emergency` | Filesystem free space under `softEmergencyFreeBytes` or under `host.reserve.freeDisk`, or free inodes under 100k | **Admission closes** (running jobs finish; ready work waits durably) and GC evicts every free lane | Find what is eating the disk — it is usually not the cache. `docker system df`, then `runpool gc` for the managed view |
+| `hard_emergency` | Free space under `hardEmergencyFreeBytes`, or free inodes under 10k | **Fail closed**: admission stays closed, nothing is deleted automatically, an error-level log is emitted | Free space by hand. The state database and active leases are preserved; do not delete volumes without `runpool gc` or `runpool cleanup`, which prove ownership first |
+
+Recovery is hysteretic: an emergency releases only after free space
+clears the effective soft floor (`max(softEmergencyFreeBytes,
+host.reserve.freeDisk)`) by one soft−hard band, so admission does not
+flap at the boundary. `high` releases at the low watermark.
+
+Every level change, every GC eviction and every retention pass that
+forgot something is recorded in the audit log
+(`audit_log` table; evictions carry reason, size, repository and
+generation).
+
+## Garbage collection
+
+The serving controller collects automatically under pressure. Manually:
+
+```bash
+runpool gc
+```
+
+is always a dry run and can inspect a live controller (read-only).
+`runpool gc --apply` takes the maintenance lock, so it runs only
+against a stopped controller — a serving instance already collects for
+itself. `--aggressive` plans every free lane, not just expired and
+over-budget ones.
+
+GC collects two things, reported separately: this instance's cache-lane
+volumes, and the record of leases that finished longer ago than
+`retention.leaseHistory`.
+
+Of the volumes it touches only this instance's own lanes, and never a
+leased one: eviction deletes the lane's row first (refusing leased
+rows atomically), so a lane a job holds — or wins in a race with the
+plan — is skipped, reported as `skipped`, and untouched. Orphan lane
+volumes (a crash between row delete and volume removal) are found by
+their ownership labels and removed. Failures are retried by the next
+pass; they are reported. Inside the serving controller they are never fatal; `runpool gc --apply` exits non-zero when any eviction failed, so a scheduled maintenance job branches on a real result.
+
+Of the books it forgets only the runtime record — the `capsule_leases`
+row. What the work did is the attempt's evidence and is never pruned. A
+lease is skipped, not forced, while the attempt it served is still
+unresolved or while it still owns a resource intent: the first is how a
+crashed-mid-release attempt stays findable, and the second is a real leak
+that must stay visible. The serving controller does the same pass on its
+reconcile interval, so a running instance keeps its own books bounded.
+
+## Capsule egress
+
+Under the restricted profile (`network.profile: public-internet-only`) a
+capsule has **no route to anything**. Its bridge is internal in Engine
+28's isolated gateway mode, so the host kernel drops every packet the
+capsule addresses beyond that bridge — public destinations included.
+Egress happens through the capsule's own gateway container, which
+resolves names and opens connections on its behalf, refusing any
+address in the deny set (private ranges, link-local metadata, the host's
+own networks, every Docker subnet, the uplink itself).
+
+The capsule is created with `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`
+pointing at that gateway, inherited by the runner, the job and the inner
+Docker daemon. What this means in practice:
+
+- HTTPS and HTTP work — checkouts, package installs, image pulls,
+  API calls.
+- Direct connections and protocols that ignore proxy environment variables
+  do **not** work. Proxy-aware clients may use HTTP or CONNECT to allowed
+  addresses on ports 80 and 443; CONNECT is an opaque tunnel rather than
+  application inspection. `git+ssh`, other ports, and non-DNS UDP fail
+  closed. A workflow that needs transparent egress must use HTTPS where
+  possible. `unsafe-open-egress` is available only with
+  `dedicated-daemon`; shared mode rejects it.
+- Service containers are unaffected: they run inside the capsule on its
+  own daemon's network.
+
+A job that hits the policy sees `403` from the relay with the reason,
+and the gateway logs the denied host and address. Losing the gateway
+does not open egress — it removes it.
+
+### What a policy change does, and what a failure costs
+
+The deny set is rediscovered every 5 minutes and each change is
+classified before it is installed:
+
+- a **restriction** (a host interface or Docker network appeared) must
+  land. A gateway that will not take it is closed and removed, because
+  until the new set is in force that capsule can reach an address the
+  policy now denies. Its job loses egress and fails; that is the
+  intended cost.
+- a **relaxation** (something went away) may fail harmlessly. The
+  capsule keeps the stricter set it started with and its work
+  continues.
+- **discovery failing at all** closes every gateway. An undiscovered
+  network is indistinguishable from one that was never there, so a
+  policy that cannot be shown to be current is not treated as current.
+
+The handover is atomic on each half — one kernel restore, one file
+rename — and the window between them is deliberately the stricter of
+the two: the firewall is installed first, so a newly denied destination
+is already blocked while the relay still applies the old set. It is not
+a single transaction across both, and does not claim to be. Established
+connections are unaffected by a reload; revoking them is what closing
+the gateway does.
+
+## Physical capacity
+
+`runpool doctor` fails when the worst workload set allowed by global and tier
+parallelism plus `host.reserve` exceeds the CPU, memory, or swap the host
+reports. `runpool serve` refuses to start on a failing report. Raise host
+capacity or lower `scheduling.parallelism`, `tiers[].parallelism`, tier
+resources, or the reserve.
+
+Configured workload swap additionally requires Docker swap-limit support. Use
+encrypted host swap where CI secrets may be paged to disk, and investigate
+sustained swap activity as resource pressure rather than treating it as normal
+capacity.
+
+## Manual review
+
+`runpool status` lists attempts held for a person. Inspect one with
+`runpool attempts inspect <id>`, which reports the evidence the decision
+turns on and the provider identifiers for checking the run externally:
+
+```bash
+runpool attempts inspect <id>
+```
+
+Then decide it. Exactly one of the two decisions, and `--apply` to make
+it:
+
+```bash
+runpool attempts resolve <id> --retry --reason "..." --apply
+```
+
+```bash
+runpool attempts resolve <id> --settle-may-have-run --reason "..." --apply
+```
+
+`--retry` returns the attempt to the queue; use it when the evidence
+shows the work never began. `--settle-may-have-run` closes it as having
+possibly executed; use it when it may have, and a second run would repeat
+whatever external effects it had. The evidence line and the provider's own
+UI are what tell those apart — an attempt held as `start_outcome_unknown`
+is exactly the case where this instance could not tell.
+
+**`--apply` needs the controller stopped.** It takes the same singleton
+lock `serve` holds, and reports that it could not. A dry run does not.
+
+An attempt is held for one of two reasons:
+
+| Reason | What it means |
+| --- | --- |
+| `start_outcome_unknown` | The controller authorized a start and never learned whether execution began. Retrying could run the work twice. |
+| `retry_budget_exhausted` | The work provably never began, and the attempt has used every serving `scheduling.retryBudget` allows. Retrying is safe; the question is why it keeps failing. |
+| `capsule_incompatible` | The image this tier launches does not speak the controller's control protocol. The work never began, so retrying is safe and pointless — the next attempt launches the same image. Fix `tiers[].capsuleImage`, or pair the controller with the capsule it ships, then `--retry`. |
+
+An operator's decision is not overruled by the retry counter: resolving
+with `--retry` serves the attempt again whatever the budget says.
+
+## Cleanup and uninstall
+
+`runpool cleanup [--apply]` removes owned resources no live lease needs
+— it never touches cache lanes, which belong to the instance, not to a
+lease. `runpool uninstall --confirm=<instance-id>` removes everything
+this instance owns, cache lanes included; a wrong confirmation id is
+refused. Add `--delete-scale-sets` to remove the adapter resources recorded for
+the instance. A remote deletion failure stops the command before provider
+metadata is purged, so retrying is safe.
+
+**What uninstall does not take with it**, because none of it is a
+resource this instance owns and each is a separate decision:
+
+- the state volume, which is the final copy of the books;
+- the pre-migration copies beside it, `pre-migration-v<n>.db`;
+- the images Runpool pulled, and the credential files a deployment
+  mounted;
+- the deployment itself — the Compose service, its unit, its platform
+  entry;
+- without `--delete-scale-sets`, the scale sets on the provider, along
+  with any runner registration that outlived its capsule.
+
+## Quarantined leases
+
+A lease reaches `quarantined` when its cleanup could not finish: an
+object the daemon would not remove, a daemon that stopped answering
+mid-release. It is not terminal — `released` is the only terminal state —
+so a quarantined lease still holds its tier credit, and a pool with
+several of them advertises less capacity than the host has.
+
+There is no command for this, on purpose: the lease is not stuck on a
+decision, it is stuck on an object. Clear the obstruction and the
+periodic reconciler converges the lease on its own, without a restart.
+
+```bash
+docker compose exec controller runpool status
+```
+
+The `discrepancies` the report lists are where the books and the daemon
+disagree, and a quarantined lease's resources are named in its own entry.
+Find why the daemon will not remove the object — a container still
+running, a volume still mounted, a network with an endpoint attached —
+and remove the reason. The next reconciliation pass retries the release
+and the credit comes back.
+
+A quarantined lease is never swept as an orphan and never pruned by
+retention: both would take the resources of a job that may still be
+unwinding.
+
+## Lifecycle procedures
+
+Every procedure here is executed, not just described:
+`scripts/drills/lifecycle.sh <host>` runs them all against a real
+daemon and asserts each outcome, and the integration workflow runs the
+same drills on every change.
+
+**Install.** Build or pull the controller image, create the state
+volume, and run `runpool doctor`. On a healthy, unconfigured host the
+host checks all pass and doctor still exits non-zero naming the missing
+configuration — that is the expected shape, not a failure. `serve`
+refuses to start without a credential.
+
+**Backup.** With no controller running (the singleton lock guarantees a
+running one would be holding the state), archive the state volume. The
+name is the one Docker created, not the one the Compose file declares:
+Compose prefixes it with the project, so the reference deployment's
+`runpool-state` is `runpool_runpool-state` on the daemon. Confirm it
+before archiving — `docker run` creates a volume that does not exist,
+which produces a valid, non-empty and completely empty archive.
+
+```bash
+docker volume ls --filter name=runpool
+```
+
+```bash
+docker run --rm -v runpool_runpool-state:/state:ro busybox tar -czf - -C /state . > runpool-state-backup.tgz
+```
+
+```bash
+tar -tzf runpool-state-backup.tgz | grep runpool.db
+```
+
+The last command is the check that matters: an archive without the
+database is the failure this procedure has, and it is silent until a
+restore needs it.
+
+Cache lanes are never backed up: they are warm build state, disposable
+by design, and the next job recreates them cold.
+
+**Restore.** Recreate the volume and unpack the archive into it. The
+instance identity, the schema and the audit trail come back with it;
+`runpool status` on the restored volume is the verification.
+
+**Upgrade.** Stop the controller, back up (above), start the new
+version: it migrates the schema forward on open and refuses to serve if
+it cannot.
+
+Runpool identifies a schema by its contents, not by how many migrations
+produced it, so a database written from migrations this build does not
+have is refused by name rather than failing later on a missing table.
+Before the first release that includes the reviewed baseline itself,
+which is still edited in place: a state directory written by an earlier
+pre-release build is refused and has to be recreated. After the release
+the baseline is immutable and this can only report a genuine mismatch. It also takes its own pre-migration copy in the state
+directory, named `pre-migration-v<version>.db` and never overwritten —
+a retried upgrade gets `pre-migration-v<version>.1.db` rather than
+destroying the copy taken before the attempt that broke things.
+
+**Rollback** is restoring a pre-upgrade backup and starting the previous
+version. Runpool has no down migrations: a schema change is not assumed to
+be losslessly reversible, and restore also covers an upgrade that failed
+half-way.
+
+A database written by a build this one does not know is **refused, not
+repaired**: the error says how to export from the build that wrote it,
+or how to start clean. Runpool does not guess at a schema it cannot
+account for.
+
+**Uninstall.** `runpool uninstall --confirm=<instance-id>
+--delete-scale-sets` removes every owned container, network and volume (cache
+lanes included) plus the recorded remote scale sets, then the operator removes
+the state volume. The drill proves a wrong id is refused and nothing locally
+owned survives a correct one; the release E2E additionally proves remote scale
+set removal.

--- a/docs/security/review-findings.md
+++ b/docs/security/review-findings.md
@@ -1,0 +1,45 @@
+# Security review findings
+
+[Release readiness](../release-readiness.md) holds the release authorization
+gate closed until every finding affecting the release boundary is resolved or
+explicitly accepted. This is where that is recorded.
+
+[Review scope](review-scope.md) defines the boundary and the questions a review
+answers. This file records what came back.
+
+## State
+
+No external review has been conducted. The register is empty, and the release
+authorization gate is closed on that basis rather than on an absence of
+findings.
+
+## Recording a finding
+
+One entry per finding, appended in the order received, identified `RP-SEC-NNN`
+in sequence. Identifiers are never reused, and an entry is never deleted — a
+finding that turns out to be invalid is recorded as such.
+
+Each entry states:
+
+- **Reported** — the date and who reported it
+- **Surface** — which of the four boundary surfaces it lands on: admission, the
+  capsule envelope, egress, or ownership
+- **Claim** — what the reviewer says happens, in their terms
+- **Assessment** — whether it reproduces, and against which commit
+- **Disposition** — `resolved`, `accepted`, or `invalid`
+
+A resolved finding names the commit that changed the behaviour and the test
+that would catch it returning. Without that test the finding is not resolved,
+because nothing stops it coming back.
+
+An accepted finding names the reasoning, who accepted it, and what would make
+it unacceptable later. "Accepted" without that third part is indistinguishable
+from having ignored it.
+
+An invalid finding keeps its entry and says why it does not hold. Reviewers
+read this file before starting, and a reported behaviour with no recorded
+outcome reads as unexamined.
+
+## Findings
+
+None recorded.

--- a/docs/security/review-scope.md
+++ b/docs/security/review-scope.md
@@ -1,0 +1,100 @@
+# Security review scope
+
+[Release readiness](../release-readiness.md) holds publication until findings
+affecting the release boundary are resolved or explicitly accepted. This
+document says where that boundary runs, what already stands as evidence, and
+what a reviewer is being asked to answer.
+
+It exists so a review can start from the interesting questions instead of
+rediscovering the architecture.
+
+## What Runpool claims, and does not
+
+Runpool is a resource and hygiene boundary for CI that is already trusted. It
+is **not** a sandbox for hostile code, and the deployment manifest says so
+where an operator will read it.
+
+Two facts set the ceiling on any isolation claim:
+
+- The controller holds the host's Docker socket. That confers host-root
+  authority, and mounting the socket read-only restricts replacing the file,
+  not the API behind it.
+- Every job capsule runs a privileged Docker daemon so a workload can build
+  and run containers.
+
+A review that concludes "a malicious workflow could reach the host" is
+restating the design. The useful questions are narrower, and they are below.
+
+## The boundary
+
+Four surfaces decide whether Runpool keeps the promises it does make.
+
+**Admission.** Whether work that does not fit is refused before it starts
+rather than degrading everything else. Preflight compares the worst admitted
+workload set plus the host reserve against real kernel figures, and the
+comparison is strict.
+
+**The capsule envelope.** Whether a job — runner, inner daemon, child
+containers and egress gateway — stays inside one aggregate cgroup budget, and
+whether nothing survives to the next job: workspace, daemon data root, images,
+build cache, runner bootstrap state.
+
+**Egress.** Whether the default profile actually confines a job to the
+destinations and ports the policy allows, through kernel-enforced no-route
+isolation plus a DNS and HTTP relay that applies the policy rather than
+advertising it.
+
+**Ownership.** Whether cleanup only ever touches resources carrying this
+instance's labels, re-inspects ownership before each removal, and never issues
+a daemon-wide prune. On a shared daemon this is what stands between Runpool and
+its neighbours.
+
+## Evidence that already exists
+
+A reviewer should treat these as claims to test, not as answers:
+
+- [Threat model](threat-model.md) — the properties Runpool asserts and how each
+  is proved
+- [Architecture](../architecture.md) — package boundaries, identity, recovery
+  and capacity semantics
+- The live contract suites under `test/contract/` — Docker, capsule, egress,
+  cache, SQLite and lifecycle properties, run without skips on the reference
+  platform during qualification
+- The controller end-to-end suite under `test/e2e/controller/` — a real
+  assignment through a real provider, including the sentinel assertions that
+  unrelated resources survive cleanup
+- Provenance and SBOM attestations produced at publication for both images and
+  the standalone artifacts
+
+## Questions a review should be able to answer
+
+These are the ones the suites cannot settle by themselves, because each turns
+on judgement rather than on a property a test can assert.
+
+1. Does the admission arithmetic hold for every configuration the validator
+   accepts, or only for the shapes the tests exercise?
+2. Can a workload influence what the controller admits next — through the
+   provider protocol, through resource pressure, or through what it leaves
+   behind?
+3. Does the egress relay's policy decision survive connection reuse, protocol
+   downgrade, and a client that does not behave?
+4. Is ownership verification defeatable by a workload that creates objects
+   carrying labels it should not be able to set?
+5. Does recovery after a controller restart ever adopt or release a lease that
+   belongs to different work?
+6. Do the credentials a deployment holds — provider tokens, the Docker socket,
+   the registry session during a build — have a shorter reach than the blast
+   radius they would have if leaked?
+
+## Closing a finding
+
+A finding is closed one of two ways, and both are recorded in the
+[findings register](review-findings.md):
+
+- **Resolved** — the behaviour changed, with the commit that changed it and the
+  test that would catch it returning.
+- **Explicitly accepted** — the behaviour stands, with the reasoning, who
+  accepted it, and what would make it unacceptable later.
+
+Silence is not a third option. An unaddressed finding keeps the release
+authorization gate closed.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,156 @@
+# Threat model
+
+This states what Runpool defends, what it does not, and why. An auditor
+should be able to disagree with the boundary here rather than guess at
+it. Where a defence is claimed, the evidence for it is named; where the
+evidence is a suite that has not run in release qualification, the claim says
+"tested live", never "release-qualified".
+
+## What Runpool is
+
+A controller that watches GitHub Actions scale sets and creates one
+ephemeral execution capsule per job on a single Docker host. A capsule
+is **one container**: a first-party supervisor as PID 1, the runner, and
+the job's own Docker daemon, all inside one aggregate cgroup, with
+per-job volumes and an optional persistent cache lane. Under the
+restricted network profile the capsule has no route out; its egress is a
+per-capsule gateway that relays under a default-deny policy.
+
+## Assets
+
+| Asset | Why it matters |
+|---|---|
+| Provider credential | Administers runners on the target; it remains in the controller |
+| Per-runner JIT bundle | Short-lived bootstrap material for one ephemeral runner; the assigned workload shares its execution identity |
+| The host Docker socket | Confers host-root authority |
+| The state database | Ownership records; deciding what Runpool may delete |
+| Cache lanes | Build state reused across jobs of one repository |
+| Job workspaces and secrets | Whatever a workflow is given at runtime |
+| The host's other networks | The LAN, metadata services, and any other Docker network on the daemon |
+
+## Trust boundary
+
+```text
+trusted:   the operator, the host, the controller, the configuration
+semi:      workflow code in the operator's own private repositories
+untrusted: everything a workflow downloads and executes at runtime
+```
+
+Runpool V1 is a **resource-management, environment-hygiene and
+network-policy boundary for CI the operator already trusts**. It is not
+a sandbox for hostile code, and the documentation says so in the same
+words wherever the product is deployed.
+
+The distinction that matters: a workflow author who is trusted still
+runs untrusted third-party code — dependencies, actions, containers.
+Runpool's per-job disposal and egress policy exist for that layer.
+
+## Deployment topologies
+
+Runpool requires an explicit host topology:
+
+- **`shared-daemon`** is the Dokploy and single-server coexistence contract.
+  It is supported only for private workflows the operator already authorizes
+  on that host. Runpool withholds an explicit CPU, memory and free-disk reserve,
+  requires restricted egress, isolates organization targets in an explicit
+  runner group, and proves ownership before deleting an object. Those controls
+  protect capacity and lifecycle; they do not protect colocated services from
+  controller, daemon or kernel compromise.
+- **`dedicated-daemon`** gives Runpool exclusive operational ownership of the
+  Engine and is the recommended boundary when CI provenance is broader or the
+  impact of colocated service compromise is unacceptable. It still is not a
+  VM or hostile-code sandbox.
+
+Both topologies reject public fork workflows as a supported use. A trusted
+workflow can download untrusted dependencies, so per-job disposal and egress
+policy remain necessary in either topology.
+
+## Defences and their evidence
+
+| Defence | Mechanism | Evidence |
+|---|---|---|
+| No state survives a job | Fresh dind data root, workspace and control tmpfs per capsule; the data root is a volume removed with the lease | Capsule contract, live |
+| A leaked runner cannot outlive its job | Ephemeral JIT runner, one job, removed on failure paths too | Live JIT flow, including removing a runner that never started |
+| Provider credentials never enter capsules; JIT state does not persist across jobs | Provider token remains in the controller. JIT arrives over exec stdin, its files are redirected to tmpfs, and it is absent from Docker configuration, environment, labels, and logs. The upstream runner requires it transiently in argv, visible to the assigned workload | Capsule contract asserts volatile materialization and no log disclosure; controller end-to-end qualification remains required |
+| Cross-repository cache contamination | Lanes are daemon-side named volumes, exclusive per lease, named by opaque ids, reused only for the same repository and generation | Live lane contract: marker persists for the same lane, another generation is blind |
+| Runpool deletes only what it owns | Instance- and lease-scoped ownership labels on every created object; creation recovery and destructive intent cleanup re-inspect ownership before acting; no daemon-wide prune | Foreign-resource contracts pass live; controller E2E asserts unrelated container, network and volume sentinels and still needs release qualification |
+| A crashed controller leaves nothing | Adoption of running capsules, sweep of orphans, singleton flock | Live SIGKILL mid-capsule, successor adopted and cleaned |
+| The host cannot be starved by a job | One envelope per lease, split between the capsule and its egress gateway and placed under one parent cgroup: the capsule's aggregate covers runner, daemon and every inner container; the gateway holds the rest of the same tier, because every connection a job opens is work it performs. The doctor refuses a configuration whose full tiers plus reserve exceed the host, and the validator refuses a tier too small to split | Kernel-proven on the reference host: inner OOM charged to the capsule; both containers report one parent cgroup and their limits sum to the tier; a fork storm in the gateway stops at its own ceiling |
+| The host cannot be filled | Disk monitor probes the daemon's filesystem from inside it; admission closes at the soft floor, fails closed at the hard floor, and GC evicts only free lanes | Pressure transitions table-tested; disk-full behaviour live for both SQLite and containers |
+| Egress confinement | Under `public-internet-only`, the host kernel drops anything the capsule addresses beyond its bridge; the gateway relays DNS and HTTP(S) under default-deny, resolving before dialing (rebinding defence) | Live bypass suite: no direct route anywhere, denied addresses refused by name and by address, gateway loss removes egress |
+
+## Accepted exposure
+
+These are consequences of the design, not oversights:
+
+- **Controller compromise is host compromise.** It holds the Docker
+  socket. Nothing inside the container — read-only root, dropped
+  capabilities, no shell — changes that; they raise the cost of using a
+  foothold, not of having one.
+- **A privileged dind is not a VM.** A kernel escape from inside a
+  capsule reaches the host. Runpool's isolation is namespace and
+  policy, not hardware. On `shared-daemon`, the operator explicitly accepts
+  that kernel-level compromise can reach colocated services; use
+  `dedicated-daemon` when that impact is unacceptable.
+- **Platform-wide volume prune bypasses Runpool's ownership model.** Docker
+  treats an unattached cache lane as unused. On a shared daemon, disable
+  unused-volume cleanup and any system prune that includes volumes. Image
+  pruning is compatible: immutable images are pulled again when absent.
+- **Fork pull requests from public repositories are out of scope**, per
+  GitHub's own guidance for self-hosted runners. Configuration cannot
+  express them safely, and the documentation refuses them rather than
+  implying containment.
+- **The assigned workload can observe its own JIT bundle.** GitHub's runner
+  interface requires `--jitconfig`, and the job shares the runner's Unix
+  identity. The bundle is one-run and short-lived. Runpool prevents it from
+  reaching controller persistence, Docker metadata, logs, or a later workload;
+  it does not claim secrecy from the workload it authorizes.
+- **Only proxy-aware traffic leaves a sandboxed capsule, and CONNECT is
+  a tunnel.** Direct TCP cannot leave — the host drops it — but a
+  proxy-aware client can tunnel any protocol over CONNECT to an allowed
+  address, on an allowed port. The port set is explicit (443 and 80);
+  everything else is refused with a reason. The relay does not inspect
+  what flows inside a tunnel and does not claim to. `git+ssh` and
+  arbitrary TCP on other ports fail closed; a deployment that needs
+  them must choose `unsafe-open-egress`, whose name is its warning
+  label.
+
+## Supply chain
+
+- Runtime images are pinned by digest in `build/images.lock.json`; the
+  capsule image is built from those pinned inputs and both Dockerfiles
+  copy sources by allowlist.
+- A tier may run its jobs in an operator-supplied capsule
+  (`tiers[].capsuleImage`, digest-qualified, built from the published
+  one). That image is outside this chain by the operator's own decision,
+  and `runpool status` reports which image each tier runs. **The egress
+  gateway is not affected**: the container that applies the network
+  policy always runs the capsule this build ships, so extending what a
+  job runs in never replaces what confines it.
+- The controller is a static binary on distroless with no shell.
+- `actions/scaleset` is a Public Preview dependency: pinned, with live
+  contract tests that fail when upstream behaviour drifts.
+- The SQLite driver is CGo-free and covered by a durability suite — WAL
+  behaviour, contention, kill-recovery rounds, disk-full on a capped
+  filesystem — that runs against a Linux named volume. No release-qualification
+  record exists yet; the protected release workflow is what will produce one.
+
+## What an auditor should attack first
+
+Ranked by what would hurt most if it is wrong:
+
+1. **Ownership scoping.** Can any input make Runpool delete a resource
+   it does not own? The labels and the instance id are the only guard.
+2. **Egress.** The bypass suite is the starting point, not the finish
+   line: DNS tricks through the relay, proxy parsing, the gateway's own
+   INPUT surface, and anything that makes a capsule's packet cross the
+   host with a spoofed source.
+3. **Credential containment.** Does the provider token leave the controller,
+   or does JIT state reach Docker metadata, a log, the database, disk-backed
+   capsule state, or a later workload?
+4. **Cache lane isolation.** Can one repository's job reach another's
+   lane — through the lease machine, label spoofing, or reconciliation
+   after a crash? (There are no paths left to traverse; the volume
+   namespace and the store are the surfaces.)
+5. **Lease state machine.** Can a lease release while resources
+   survive, or an admission credit leak so the host is oversubscribed?


### PR DESCRIPTION
## What changes

The documentation arrives: `README.md`, `CONTRIBUTING.md`, `SECURITY.md`,
`SUPPORT.md`, `CHANGELOG.md`, and the `docs/` tree — architecture,
deployment, product contract, release readiness, runbook, the
configuration, status-API and support-matrix references, the security
documents, the maintainer procedures, and the decision index with its
sixteen records.

## What was found

**The documentation is one linked body, not a set of pages.** The README
points at seventeen files, the docs index at twenty-one, and most pages
reference the deployment, build or qualification files they describe.
That is why it lands whole: any subset has links that do not resolve, and
`scripts/verify/doc-links.sh` is the gate that turns that from a matter
of care into a check.

**A record's status is load-bearing.** It is the line a reader trusts
without reading the rest, so each one is written against the code beside
it. Fifteen records describe decisions the code implements, one of which
is superseded and names its successor.

**One is marked implementation pending, and it is accurate.** The
multiplatform lock decision calls for `build/platform.lock.json` to
record a list of qualified platforms — each with its own policy and its
own observed facts — and for `verify -observed` to select the entry
matching the host it runs on. The file carries a single `policy` object
and `internal/platform` reads a single `Policy`. The index carries the
same qualifier, so consulting either gives the same answer.

The four records whose decisions are recent were each read against the
code rather than against the index: `Tier.CapsuleImage` with
`capsule.ProtocolVersion` and `ErrIncompatibleImage`;
`Credential.ClientID` and `InstallationID` with the App client path in
the adapter; `Tier.Ceiling()` over `DefaultJobTimeout`, eight hours,
above the provider's 360-minute maximum exactly as its record argues; and
`ScopeEnterprise` with `/enterprises/<name>` parsed as a third scope.

**The support matrix separates observation from publication.** What the
gates ran on, with its evidence, and what the release builds and
publishes are two claims, and the matrix does not let one stand in for
the other. An unqualified platform is recorded as unverified, which is
neither a promise nor a denial.

## Evidence

Every relative link in every Markdown file resolves, checked offline
across the complete tree:

```text
scripts/verify/doc-links.sh          → ok, no broken links
docs/adrs bodies vs docs/adrs/README → every status agrees
```

Every other gate was run against this tree as well — gofmt, vet,
staticcheck, race, tidy, sqlc, generated CLI documentation, the coverage
floor, the release binaries, both configuration examples, the image lock,
go-version, drain-window, capsule-protocol, actionlint, shellcheck,
hadolint and govulncheck — all pass.

## What would notice this regressing

`scripts/verify/doc-links.sh` fails on any relative link that stops
resolving, which is what a documentation reorganisation breaks silently.
Nothing checks that a record's status matches its implementation; that is
stated plainly rather than implied, and it is why each recent record was
read against the code here.

## Risk, compatibility and operations

Trust boundary: the security documents describe it rather than change it.
The threat model and review scope state what Runpool is — a resource and
hygiene boundary for CI you trust — and what it is not, a sandbox for
hostile code.

Operations: the runbook, deployment guide and maintainer procedures are
the operator-facing half of behaviour that already exists.

Credentials: the maintainer procedures name App installations, their
permissions and their environment secrets, never a value.

Ownership, cleanup, networking, resource limits, schema, migration, CLI,
configuration, status API, deployment, rollback: N/A — no behaviour
changes.

## Changelog

```text
NONE
```
