### PR TITLE
fix(app): sessions close together, and a spent drain abandons to the successor

### DIFF
--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -323,6 +323,18 @@ func (s *Controller) recoverCapsuleFailure(b *binding, leaseID string, startObs 
 	}
 	log := s.log.With("binding", bindingKey, "lease", leaseID)
 
+	// After the drain window, recovery belongs to the successor. The
+	// failures that arrive here now are the shutdown itself — the client
+	// and store closing under a live wait — and acting on them would
+	// rewrite a running lease to cleaning, handing the next start a
+	// failure to dismantle instead of a capsule to adopt. A recovery
+	// already past this point runs to completion: its transitions are
+	// durable, and the successor resumes whatever it left.
+	if s.abandoning.Load() {
+		log.Warn("drain window elapsed; the lease is left as it is for the next start to recover")
+		return nil
+	}
+
 	was, err := s.leases.ToCleaning(ctx, leaseID)
 	if err != nil {
 		log.Error("failure transition failed", "error", err)

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/allocator"
@@ -35,7 +36,13 @@ const (
 	// first, the sessions stay open, and the next start waits each one
 	// out as a conflict.
 	drainTimeout = 60 * time.Second
-	pollBackoff  = 5 * time.Second
+	// sessionCloseBudget bounds closing every binding's message session
+	// at shutdown — all of them together, under one budget. One budget
+	// and not one per binding: the deployment's stop grace period has to
+	// hold drain plus this, and a bound that grew with the binding count
+	// would outgrow any grace period an operator chose.
+	sessionCloseBudget = 15 * time.Second
+	pollBackoff        = 5 * time.Second
 
 	// capsulePrepTimeout bounds getting a capsule to the point of running:
 	// minting a credential, acquiring a lane, building the sandbox,
@@ -294,22 +301,11 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 		b.newSession = func(ctx context.Context) (providerSession, error) {
 			return b.gh.OpenSession(ctx, b.scaleSetID, owner)
 		}
-		defer func(b *binding) {
-			// A session the broker still holds is one the next start has
-			// to wait out, and it reports that wait as a predecessor's
-			// crash. Saying so here is what tells the two apart.
-			if b.session == nil {
-				return // never opened, or discarded by the loop
-			}
-			cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-			defer cancel()
-			if err := b.session.Close(cctx); err != nil {
-				log.Warn("cannot close the message session; the broker holds it until it "+
-					"expires and the next start waits that out",
-					"binding", b.key, "error", err)
-			}
-		}(b)
 	}
+	// A session the broker still holds is one the next start has to wait
+	// out, and it reports that wait as a predecessor's crash. Saying so
+	// here is what tells the two apart.
+	defer s.closeSessions()
 
 	var loops sync.WaitGroup
 	loops.Add(1)
@@ -482,20 +478,65 @@ type Controller struct {
 	launch func(b *binding, lease store.Lease)
 
 	wg sync.WaitGroup // capsule goroutines, for drain
+
+	// abandoning is set when the drain window elapses. From then on the
+	// destructive recovery paths leave leases exactly as they are: the
+	// successor's adoption owns recovery now, and a dying process that
+	// rewrites a running lease to cleaning hands the next start a
+	// failure to dismantle instead of a capsule to adopt.
+	abandoning atomic.Bool
+
+	// drainWindow overrides drainTimeout in tests; zero means the
+	// default. Held for the same reason as pollBackoff: a minute is not
+	// something a test waits.
+	drainWindow time.Duration
 }
 
 func (s *Controller) drain() error {
 	s.log.Info("draining")
+	window := s.drainWindow
+	if window == 0 {
+		window = drainTimeout
+	}
 	done := make(chan struct{})
 	go func() { s.wg.Wait(); close(done) }()
 	select {
 	case <-done:
 		s.log.Info("drained cleanly")
 		return nil
-	case <-time.After(drainTimeout):
-		s.log.Warn("drain window elapsed; live capsules will be adopted on next start")
+	case <-time.After(window):
+		// The goroutines that did not finish are woken moments from now
+		// by the client and store closing under them, and their failure
+		// paths would rewrite running leases on the way down. Marking
+		// the abandonment first is what turns those paths into no-ops.
+		s.abandoning.Store(true)
+		s.log.Warn("drain window elapsed; live capsules are left for the next start to adopt")
 		return nil
 	}
+}
+
+// closeSessions closes every binding's message session concurrently
+// under one shared budget. The loops have already been waited out, so
+// each binding's session field is quiescent here.
+func (s *Controller) closeSessions() {
+	ctx, cancel := context.WithTimeout(context.Background(), sessionCloseBudget)
+	defer cancel()
+	var wg sync.WaitGroup
+	for _, b := range s.bindings {
+		if b.session == nil {
+			continue // never opened, or discarded by the loop
+		}
+		wg.Add(1)
+		go func(b *binding) {
+			defer wg.Done()
+			if err := b.session.Close(ctx); err != nil {
+				s.log.Warn("cannot close the message session; the broker holds it until it "+
+					"expires and the next start waits that out",
+					"binding", b.key, "error", err)
+			}
+		}(b)
+	}
+	wg.Wait()
 }
 
 // claimLease takes ownership of a lease's recovery. It reports false when

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -1,0 +1,172 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
+	"github.com/rhobuild/runpool/internal/store"
+)
+
+// gatedSession reports when its Close begins and then holds until the
+// test releases it. What it measures is overlap: with every session
+// closing under one budget the starts all arrive before any release,
+// and a shutdown that closed one session at a time can only present
+// one start at a time.
+type gatedSession struct {
+	started chan<- string
+	release <-chan struct{}
+	key     string
+}
+
+func (g *gatedSession) Receive(context.Context) (*githubactions.Message, error) { return nil, nil }
+func (g *gatedSession) Acknowledge(context.Context, int) error                  { return nil }
+func (g *gatedSession) SetCapacity(int)                                         {}
+func (g *gatedSession) Initial() *githubactions.Statistics                      { return nil }
+func (g *gatedSession) Close(ctx context.Context) error {
+	g.started <- g.key
+	select {
+	case <-g.release:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// The deployment's stop grace period is sized against drain plus one
+// session-close budget, so the closes have to overlap: a shutdown that
+// closed sessions one after another would owe the platform a bound that
+// grows with the binding count, and no grace period an operator chose
+// would keep holding it.
+func TestSessionsCloseTogether(t *testing.T) {
+	started := make(chan string, 3)
+	release := make(chan struct{})
+	defer close(release)
+
+	s := &Controller{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	for _, key := range []string{"a", "b", "c"} {
+		s.bindings = append(s.bindings, &binding{
+			key:     key,
+			session: &gatedSession{started: started, release: release, key: key},
+		})
+	}
+	// A binding whose loop never opened a session has nothing to close;
+	// it must be skipped, not dereferenced.
+	s.bindings = append(s.bindings, &binding{key: "never-opened"})
+
+	done := make(chan struct{})
+	go func() { s.closeSessions(); close(done) }()
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("after %d of 3 closes began no further close arrived; "+
+				"sessions are closing one at a time", i)
+		}
+	}
+	// All three are in flight at once; releasing them ends the shutdown.
+	select {
+	case <-done:
+		t.Fatal("closeSessions returned while sessions were still closing")
+	default:
+	}
+}
+
+// countingRemover is the daemon's removal surface, succeeding and
+// counting: the abandonment test needs to see zero removals, and its
+// mutation half needs to see some.
+type countingRemover struct{ calls atomic.Int64 }
+
+func (c *countingRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+	c.calls.Add(1)
+	return nil
+}
+func (c *countingRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+	c.calls.Add(1)
+	return nil
+}
+func (c *countingRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+	c.calls.Add(1)
+	return nil
+}
+
+// Once the drain window has elapsed the successor's adoption owns
+// recovery, and the failures still arriving in this process are the
+// shutdown itself — the client and store closing under live waits.
+// Recovery acting on them would rewrite a running lease to cleaning and
+// hand the next start a failure to dismantle instead of a capsule to
+// adopt, so with the abandonment marked it must leave the lease exactly
+// as it is.
+func TestDrainExpiryAbandonsRecovery(t *testing.T) {
+	h := newHarness(t, 1)
+	remover := &countingRemover{}
+	h.useRemover(remover)
+	if err := h.deliver(demand("job-abandoned", "app", 41)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-abandoned")
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		id, err := tx.PlanResource(lease.ID, store.ResourceContainer, "runner", "runpool-runner-abandoned")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "abandoned-1")
+	}); err != nil {
+		t.Fatal(err)
+	}
+	before := reloadLease(t, h, lease.ID).State
+
+	h.srv.abandoning.Store(true)
+	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err != nil {
+		t.Fatalf("abandoned recovery reported an error: %v", err)
+	}
+	if got := reloadLease(t, h, lease.ID).State; got != before {
+		t.Fatalf("lease moved from %s to %s during abandonment; it must be left as it is", before, got)
+	}
+	if n := remover.calls.Load(); n != 0 {
+		t.Fatalf("abandonment removed %d objects; it must dismantle nothing", n)
+	}
+
+	// The mutation half: the same call without the abandonment is the
+	// destructive path, so the assertions above are proven able to fail.
+	h.srv.abandoning.Store(false)
+	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err != nil {
+		t.Fatalf("live recovery failed: %v", err)
+	}
+	if got := reloadLease(t, h, lease.ID).State; got == before {
+		t.Fatalf("live recovery left the lease in %s; the test cannot observe the destructive path", got)
+	}
+	if remover.calls.Load() == 0 {
+		t.Fatal("live recovery removed nothing; the test cannot observe the destructive path")
+	}
+}
+
+// The flag is raised by the drain window elapsing and by nothing else: a
+// clean drain hands the sessions a quiet shutdown, and recovery keeps
+// acting until the window is genuinely spent.
+func TestDrainWindowExpiryMarksAbandonment(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.drainWindow = 30 * time.Millisecond
+	h.srv.wg.Add(1) // a capsule goroutine that will not finish in time
+	defer h.srv.wg.Done()
+	if err := h.srv.drain(); err != nil {
+		t.Fatal(err)
+	}
+	if !h.srv.abandoning.Load() {
+		t.Fatal("the drain window elapsed and abandonment was not marked")
+	}
+
+	clean := newHarness(t, 1)
+	clean.srv.drainWindow = time.Second
+	if err := clean.srv.drain(); err != nil {
+		t.Fatal(err)
+	}
+	if clean.srv.abandoning.Load() {
+		t.Fatal("a clean drain marked abandonment")
+	}
+}

--- a/scripts/verify/drain-window.sh
+++ b/scripts/verify/drain-window.sh
@@ -1,16 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# The controller's drain window must fit inside the deployment's stop
-# grace period. Nothing else ties them: a Go constant and a Compose key
-# are separate ecosystems, and the drift is invisible in a green build
-# because neither side can see the other.
+# The controller's whole shutdown — the drain window plus the shared
+# budget for closing every message session — must fit inside the
+# deployment's stop grace period. Nothing else ties them: two Go
+# constants and a Compose key are separate ecosystems, and the drift is
+# invisible in a green build because neither side can see the other.
 #
 # The drift is not cosmetic. A capsule running a job outlives any drain
 # window, so the window is always spent whenever work is in flight. When
-# it outlasts the grace period the platform sends SIGKILL first, the
-# deferred session closes never run, and every restart with a live job
-# leaves the broker holding a session the next start has to wait out as a
-# conflict.
+# shutdown outlasts the grace period the platform sends SIGKILL first,
+# the deferred session closes never run, and every restart with a live
+# job leaves the broker holding a session the next start has to wait out
+# as a conflict.
 #
 # Usage: scripts/verify/drain-window.sh
 cd "$(dirname "$0")/../.."
@@ -46,6 +47,18 @@ if [ -z "$drain" ]; then
   exit 1
 fi
 
+close_expr=$(sed -n 's/^[[:space:]]*sessionCloseBudget[[:space:]]*=[[:space:]]*\(.*\)$/\1/p' internal/app/serve.go)
+if [ -z "$close_expr" ]; then
+  echo "FAIL  internal/app/serve.go declares no sessionCloseBudget"
+  exit 1
+fi
+close=$(seconds_from_go "$close_expr")
+if [ -z "$close" ]; then
+  echo "FAIL  internal/app/serve.go: cannot read sessionCloseBudget from '$close_expr'"
+  exit 1
+fi
+shutdown=$(( drain + close ))
+
 compose=deploy/compose/compose.yaml
 grace_raw=$(sed -n 's/^[[:space:]]*stop_grace_period:[[:space:]]*\([^[:space:]]*\).*/\1/p' "$compose")
 if [ -z "$grace_raw" ]; then
@@ -56,10 +69,10 @@ grace=$(seconds_from_compose "$grace_raw")
 if [ -z "$grace" ]; then
   echo "FAIL  $compose: cannot read stop_grace_period from '$grace_raw'"
   status=1
-elif [ "$grace" -gt "$drain" ]; then
-  echo "ok    $compose stop_grace_period ${grace}s over a ${drain}s drain"
+elif [ "$grace" -gt "$shutdown" ]; then
+  echo "ok    $compose stop_grace_period ${grace}s over a ${shutdown}s shutdown (${drain}s drain + ${close}s session close)"
 else
-  echo "FAIL  $compose stop_grace_period is ${grace}s and the drain window is ${drain}s;"
+  echo "FAIL  $compose stop_grace_period is ${grace}s and shutdown needs ${shutdown}s (${drain}s drain + ${close}s session close);"
   echo "      the platform kills the controller before it closes its sessions"
   status=1
 fi


### PR DESCRIPTION
## What changes

Shutdown is bounded at seventy-five seconds regardless of the binding
count: every message session closes concurrently under one shared
fifteen-second budget after the sixty-second drain. A drain window that
elapses marks abandonment, and from that point the destructive recovery
path leaves leases exactly as they are for the next start to adopt.
`scripts/verify/drain-window.sh` now compares the sum of both constants
against the deployment's stop grace period.

## What was found

**The shutdown bound grew with the binding count.** Each binding's
session closed in its own deferred call with its own fifteen-second
budget, sequentially. The deployment's grace period is two minutes;
sixty seconds of drain plus fifteen per binding crosses it at five
bindings, and from there the platform's SIGKILL arrives before the later
sessions close. A session left open is one the broker holds until it
expires, and the next start waits that out as a conflict — on every
restart with live work. The closes were already independent of each
other; nothing about them required an order.

**A dying process competed with its successor.** The capsule goroutines
that outlive the drain window are woken moments later by the Docker
client and store closing under their waits. Those wakeups arrive as
errors, and the failure path treated them as capsule failures: it moved
running leases to cleaning and began dismantling — against capsules that
were healthy, mid-job, and exactly what the successor's adoption exists
to save. The successor then read cleaning where it would have read
running, and finished the dismantling. Recovery now checks the
abandonment mark at entry and declines: the lease is left as it is,
named in the log, and the next start re-takes the observation from the
daemon. A recovery already past the mark runs to completion, because its
transitions are durable and the successor resumes whatever it left.

The check keeps its constant honest: `drain-window.sh` parses both
declarations and fails on a sum the grace period cannot hold, and on
either constant becoming unreadable.

## Evidence

```text
go test ./internal/app -race                 → ok (three new tests)
scripts/verify/drain-window.sh               → ok: 120s grace over a 75s
                                               shutdown (60s drain + 15s close)
```

Each test was watched failing against the regression it guards:
sequential closes fail `TestSessionsCloseTogether` on the second close
never starting; removing the entry check fails
`TestDrainExpiryAbandonsRecovery` with the lease moving to released and
objects removed; dropping the mark on expiry fails
`TestDrainWindowExpiryMarksAbandonment`; raising the close budget past
the grace period fails the drain-window check with the sum named.

## What would notice this regressing

`TestSessionsCloseTogether` — closes must overlap, and a binding that
never opened a session is skipped, not dereferenced.
`TestDrainExpiryAbandonsRecovery` — with abandonment marked, recovery
must leave the lease state untouched and remove nothing; its second half
proves the same call without the mark is destructive, so the assertions
are able to fail. `TestDrainWindowExpiryMarksAbandonment` — the mark is
raised by expiry and only by expiry. `scripts/verify/drain-window.sh` —
the grace period must hold drain plus the close budget.

## Risk, compatibility and operations

Trust boundary: none crossed. Both changes order work the process
already did.

Failure behaviour: after the window, failures during shutdown are logged
and left rather than acted on. A lease abandoned mid-recovery stays
non-terminal and keeps its credit — the safe reading, and the process
holding that credit is exiting.

Ownership and cleanup: unchanged for every path that runs before the
window elapses. After it, cleanup belongs to the next start's
reconciliation, which already owns the crash case this now joins.

Operations: the deployment's `stop_grace_period: 2m` now bounds the
whole shutdown with forty-five seconds of headroom, independent of the
binding count. No configuration changes.

Deployment, rollback, CLI, configuration, status API, schema, migration,
credentials, networking, resource limits: N/A — no surface changes.

## Changelog

```text
Fixed
- Shutdown closes every binding's message session concurrently under one
  budget; its bound no longer grows with the binding count.
- A controller whose drain window elapses leaves live capsules untouched
  for the next start to adopt, instead of dismantling them on the way
  down.
```
