### PR TITLE
fix(contract): crash rounds start from an established database

### DIFF
--- a/test/contract/sqlite/durability_test.go
+++ b/test/contract/sqlite/durability_test.go
@@ -56,6 +56,19 @@ func TestCrashRecovery(t *testing.T) {
 	dbPath := filepath.Join(dir, "crash.db")
 	logPath := filepath.Join(dir, "crash.log")
 
+	// The database is established before the first victim starts, for
+	// the same reason TestContention establishes it: the controller
+	// creates its database under the flock singleton before anything
+	// else can reach it, so the crash production can deal a writer is
+	// against an established WAL database. Without this, a kill that
+	// lands inside the victim's own schema bootstrap leaves no entries
+	// table — correct durability for an uncommitted CREATE TABLE, but
+	// the verifier reads the absence as a lost table. DDL atomicity has
+	// its own coverage in TestMigrationMechanics.
+	setup := open(t, dbPath)
+	mustExec(t, setup, schema)
+	setup.Close()
+
 	for round := range 12 {
 		cmd := writerCmd(dbPath, logPath, 0)
 		if err := cmd.Start(); err != nil {


### PR DESCRIPTION
## What changes

`TestCrashRecovery` establishes the schema before starting its first
crash victim, exactly as `TestContention` already does and for the same
stated reason.

## What was found

The first round raced the victim's own bootstrap. The writer child
creates the schema itself, and the parent kills it 40–400 ms after
`Start()`. That window has to hold process startup, the Go runtime, the
WAL conversion and the `CREATE TABLE` commit; on a loaded host it does
not, the kill lands before the schema commit is durable, and the
reopened database legitimately has no `entries` table. The verifier
reads that absence as a lost table and fails the round with
`no such table: entries`.

The absence is not a durability violation — an uncommitted `CREATE
TABLE` must not survive a kill — so the assertion and the scenario were
mismatched. Production also never presents this shape: the controller
migrates under the flock singleton before any other process can reach
the database, so the writer a crash can hit always faces an established
schema. `TestContention` already documents and applies this premise; the
crash test now does the same. Rounds one through eleven were never
exposed, because round zero's victim leaves the table behind.

Nothing is trimmed by the change: all twelve kills still land on live
writers, the verifier's sequence, atomicity and confirmed-durability
checks are untouched, and DDL atomicity has its own coverage in
`TestMigrationMechanics`.

## Evidence

Reproduced before fixing, by forcing the kill window down to 1–10 ms:

```text
unmodified test, hostile window:  round 0: SQL logic error: no such table: entries (1)
                                  (two runs, both failing round zero)
established test, hostile window: recovered cleanly 12 times — six runs, all passing
established test, real window:    full suite ok, 3.6s
```

The CI occurrence was identical: `round 0: SQL logic error: no such
table: entries (1)` on a shared runner, with every other test in the
suite passing.

## What would notice this regressing

The test itself, now deterministically: a kill inside the bootstrap can
no longer produce a passing-looking database with no table, because no
round starts without one. A genuinely lost table in any round still
fails the verifier.

## Risk, compatibility and operations

Trust boundary, credentials, ownership, networking, resource limits,
schema, migration, CLI, configuration, status API, deployment, rollback,
runbook: N/A — a test-only change; no product code is touched.

## Changelog

```text
NONE
```
