### PR TITLE
fix(config, app, doctor): common target addresses parse as what they name, and every credential says where it travels

### DIFF
--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -45,6 +45,17 @@ The distinction that matters: a workflow author who is trusted still
 runs untrusted third-party code — dependencies, actions, containers.
 Runpool's per-job disposal and egress policy exist for that layer.
 
+**The target host is inside the trusted set, because the operator names
+it.** A target accepts any `https` host — an Enterprise Server or a
+data-residency domain speaks the same protocol — and the credential the
+target references travels to that host on every call. Runpool does not
+allowlist hosts; it makes the boundary visible instead: the first serve
+logs, per target, the host each credential authenticates against, a host
+GitHub does not operate is logged at `Warn`, and `runpool doctor` names
+the host in the credential verdict and warns beside it. A mistyped host
+is therefore a line in the first start's log and in every doctor run,
+not a silent standing grant to whoever holds the name.
+
 ## Deployment topologies
 
 Runpool requires an explicit host topology:

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -48,6 +48,20 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 		if err != nil {
 			return err
 		}
+		// Where this target's credential travels is stated at startup,
+		// once per target, because nothing else makes it visible: any
+		// https host is accepted by design, so a typo squatting one
+		// letter away would otherwise authenticate quietly forever. A
+		// host GitHub operates is ordinary; any other is the operator's
+		// own claim, and the log says so at Warn without blocking it.
+		if githubactions.IsHostedDomain(ref.Host) {
+			s.log.Info("target authenticates against the provider",
+				"target", target.ID, "host", ref.Host, "credential", target.CredentialID)
+		} else {
+			s.log.Warn("target authenticates against a host GitHub does not operate; "+
+				"the credential travels there on every call",
+				"target", target.ID, "host", ref.Host, "credential", target.CredentialID)
+		}
 
 		for _, tb := range target.Tiers {
 			tier := tiers[tb.TierID]

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -3,11 +3,14 @@ package app
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/rhobuild/runpool/internal/allocator"
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
@@ -333,4 +336,62 @@ func (r *recordingScaleSets) EnsureScaleSet(_ context.Context, _, _ string, _ in
 		r.duringCall()
 	}
 	return githubactions.ScaleSet{ID: r.id}, nil
+}
+
+// TestStartupSaysWhereEachCredentialTravels: any https host is accepted
+// by design, so the boundary has to be visible instead of enforced. A
+// host GitHub operates logs as ordinary; any other logs at Warn naming
+// the target, the host and the credential — which is what makes a
+// one-letter typosquat visible on the first start instead of quietly
+// authenticated forever.
+func TestStartupSaysWhereEachCredentialTravels(t *testing.T) {
+	build := func(t *testing.T, url string) string {
+		t.Helper()
+		st, err := store.Open(t.TempDir(), store.DefaultRetryBudget)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { st.Close() })
+		var buf strings.Builder
+		s := &Controller{
+			log:       slog.New(slog.NewTextHandler(&buf, nil)),
+			store:     st,
+			alloc:     allocator.New(),
+			byBinding: map[int64]*binding{},
+		}
+		cfg := &config.Config{
+			Instance:    config.Instance{Name: "test"},
+			Credentials: []config.Credential{{ID: "gh", TokenEnv: "TOKEN"}},
+			Targets: []config.Target{{
+				ID: "app", URL: url, CredentialID: "gh",
+				Tiers: []config.TierBinding{{TierID: "standard", ScaleSetName: "runpool-standard"}},
+			}},
+			Tiers: []config.Tier{{ID: "standard", Parallelism: 1}},
+		}
+		environ := func(k string) string {
+			if k == "TOKEN" {
+				return "t0ken"
+			}
+			return ""
+		}
+		if err := s.buildBindings(t.Context(), cfg, environ); err != nil {
+			t.Fatal(err)
+		}
+		return buf.String()
+	}
+
+	logged := build(t, "https://github.com/acme/app")
+	if !strings.Contains(logged, "host=github.com") {
+		t.Errorf("a hosted target's log does not name the host:\n%s", logged)
+	}
+	if strings.Contains(logged, "level=WARN") {
+		t.Errorf("a hosted target warned:\n%s", logged)
+	}
+
+	logged = build(t, "https://ghes.internal/acme/app")
+	if !strings.Contains(logged, "level=WARN") ||
+		!strings.Contains(logged, "host=ghes.internal") ||
+		!strings.Contains(logged, "credential=gh") {
+		t.Errorf("a non-hosted target must warn naming host and credential:\n%s", logged)
+	}
 }

--- a/internal/command/doctor.go
+++ b/internal/command/doctor.go
@@ -39,6 +39,7 @@ func runDoctor(streams IO, asJSON bool) error {
 	// the composition root names an adapter.
 	if cfg != nil {
 		opts.NewCredentialProbe = newGitHubCredentialProbe
+		opts.HostedDomain = githubactions.IsHostedDomain
 	}
 	report := doctor.Run(ctx, opts)
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -402,13 +402,31 @@ const (
 	ScopeEnterprise TargetScope = "enterprise"
 )
 
-// TargetRef is a parsed target URL. V1 supports github.com only, so any
-// other host is rejected here rather than failing later against the API.
+// TargetRef is a parsed target URL: the scope it names, the identifiers
+// under that scope, and the canonical form rebuilt from the host that was
+// given. Which hosts serve the protocol is not decided here; see
+// ParseTargetURL.
 type TargetRef struct {
-	Scope        TargetScope
-	Owner        string
+	Scope TargetScope
+	Owner string
+	// Host is the lowercased host the URL named, carried so the surfaces
+	// that must say where a credential travels — the startup log and the
+	// doctor — do not re-parse the canonical URL to find out.
+	Host         string
 	Repository   string
 	CanonicalURL string
+}
+
+// reservedTargetRoutes are the provider's own page prefixes. Kept short
+// and certain: every entry 404s as an account on the REST API, so no
+// legitimate owner is ever shadowed by the refusal.
+var reservedTargetRoutes = map[string]bool{
+	"apps":          true,
+	"marketplace":   true,
+	"notifications": true,
+	"settings":      true,
+	"sponsors":      true,
+	"topics":        true,
 }
 
 var (
@@ -440,25 +458,59 @@ func ParseTargetURL(raw string) (TargetRef, error) {
 	host := strings.ToLower(u.Host)
 	base := "https://" + host + "/"
 	segments := strings.Split(strings.Trim(u.Path, "/"), "/")
+	// Reserved routes: pages whose first segment can never be an account
+	// — each verified unregistrable — so a pasted settings or
+	// marketplace address is refused with its reason instead of being
+	// read as an owner and failing much later against the provider.
+	// "orgs" and "enterprises" are not here: they are addresses of the
+	// scopes they name, and the cases below translate them.
+	if len(segments) > 0 && reservedTargetRoutes[strings.ToLower(segments[0])] {
+		return TargetRef{}, fmt.Errorf(
+			"invalid target url %q: %q is a reserved route on the provider, not an owner", raw, segments[0])
+	}
 	switch {
 	case len(segments) == 2 && strings.EqualFold(segments[0], "enterprises") && ownerRe.MatchString(segments[1]):
 		return TargetRef{
 			Scope:        ScopeEnterprise,
+			Host:         host,
 			Owner:        segments[1],
 			CanonicalURL: base + "enterprises/" + segments[1],
+		}, nil
+	case len(segments) == 2 && strings.EqualFold(segments[0], "orgs") && ownerRe.MatchString(segments[1]):
+		// The address a browser shows for an organization. Both segments
+		// satisfy the owner and repository patterns, so without a case of
+		// its own it is not refused — it is read as a repository named
+		// after the organization and owned by "orgs". Nothing can be
+		// named "orgs": the segment is a reserved path prefix, as
+		// "enterprises" is, so no account is shadowed by reading it.
+		return TargetRef{
+			Scope:        ScopeOrganization,
+			Host:         host,
+			Owner:        segments[1],
+			CanonicalURL: base + segments[1],
 		}, nil
 	case len(segments) == 1 && ownerRe.MatchString(segments[0]):
 		return TargetRef{
 			Scope:        ScopeOrganization,
+			Host:         host,
 			Owner:        segments[0],
 			CanonicalURL: base + segments[0],
 		}, nil
-	case len(segments) == 2 && ownerRe.MatchString(segments[0]) && repoRe.MatchString(segments[1]):
+	case len(segments) == 2 && ownerRe.MatchString(segments[0]):
+		// A clone URL carries a .git suffix that names no repository: the
+		// API does not address one, so keeping it turns a recognisable
+		// paste into a 404 against the provider long after the operator
+		// has stopped looking at the URL they wrote.
+		name := strings.TrimSuffix(segments[1], ".git")
+		if !repoRe.MatchString(name) {
+			break
+		}
 		return TargetRef{
 			Scope:        ScopeRepository,
+			Host:         host,
 			Owner:        segments[0],
-			Repository:   segments[1],
-			CanonicalURL: base + segments[0] + "/" + segments[1],
+			Repository:   name,
+			CanonicalURL: base + segments[0] + "/" + name,
 		}, nil
 	}
 	return TargetRef{}, fmt.Errorf(

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -1,9 +1,11 @@
 package config
 
 import (
-	"gopkg.in/yaml.v3"
+	"strings"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseByteSize(t *testing.T) {
@@ -256,5 +258,64 @@ func TestTierImage(t *testing.T) {
 	}
 	if got := (Tier{ID: "heavy", CapsuleImage: operators}).Image(shipped); got != operators {
 		t.Errorf("a tier naming an image runs %q, want its own", got)
+	}
+}
+
+// TestParseTargetURLTranslatesTheOrgsAddress: the address a browser
+// shows for an organization has two segments that both satisfy the
+// owner and repository patterns, so without its own case it would be
+// read as a repository named after the organization and owned by
+// "orgs" — an owner that cannot exist, discovered only at the provider.
+func TestParseTargetURLTranslatesTheOrgsAddress(t *testing.T) {
+	got, err := ParseTargetURL("https://github.com/orgs/acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Scope != ScopeOrganization || got.Owner != "acme" ||
+		got.CanonicalURL != "https://github.com/acme" {
+		t.Errorf("orgs address = %s %q %q; want the organization it names",
+			got.Scope, got.Owner, got.CanonicalURL)
+	}
+}
+
+// TestParseTargetURLTrimsTheCloneSuffix: a clone URL's .git names no
+// repository — the API does not address one — so keeping it turns a
+// recognisable paste into a 404 against the provider long after the
+// operator has stopped looking at the URL they wrote.
+func TestParseTargetURLTrimsTheCloneSuffix(t *testing.T) {
+	got, err := ParseTargetURL("https://github.com/acme/app.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Repository != "app" || got.CanonicalURL != "https://github.com/acme/app" {
+		t.Errorf("clone URL = %q %q; want the repository it names", got.Repository, got.CanonicalURL)
+	}
+	// The suffix alone is not a name.
+	if _, err := ParseTargetURL("https://github.com/acme/.git"); err == nil {
+		t.Error("a bare .git parsed as a repository")
+	}
+}
+
+// TestParseTargetURLRefusesReservedRoutes: every entry in the list 404s
+// as an account, so the refusal shadows nobody — and without it a pasted
+// settings or marketplace address reads as an owner and fails much later
+// with the provider's answer instead of this one.
+func TestParseTargetURLRefusesReservedRoutes(t *testing.T) {
+	for _, in := range []string{
+		"https://github.com/settings/profile",
+		"https://github.com/marketplace",
+		"https://github.com/notifications",
+		"https://github.com/sponsors/acme",
+		"https://github.com/topics/ci",
+		"https://github.com/apps/runpool",
+	} {
+		_, err := ParseTargetURL(in)
+		if err == nil {
+			t.Errorf("ParseTargetURL(%q) succeeded; the route is the provider's, not an owner's", in)
+			continue
+		}
+		if !strings.Contains(err.Error(), "reserved route") {
+			t.Errorf("ParseTargetURL(%q) = %v; want the refusal to say why", in, err)
+		}
 	}
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -87,6 +87,11 @@ type Options struct {
 	// It is a factory rather than a client because the provider is
 	// reached per target: each has its own URL and credential.
 	NewCredentialProbe func(configURL string, secret credential.Secret) (CredentialProbe, error)
+	// HostedDomain reports whether the provider itself operates a host.
+	// Injected like the probe factory so the doctor stays
+	// provider-neutral; nil treats every host as hosted and no boundary
+	// warning is raised.
+	HostedDomain func(host string) bool
 }
 
 // CredentialProbe proves one credential can reach one target's runner
@@ -368,8 +373,17 @@ func checkCredentials(ctx context.Context, opts Options) []Result {
 			continue
 		}
 		out = append(out, Result{name, Pass,
-			fmt.Sprintf("%s scope, runner group %s reachable, authenticated as %s",
-				ref.Scope, group, describe(secret)), ""})
+			fmt.Sprintf("%s scope on %s, runner group %s reachable, authenticated as %s",
+				ref.Scope, ref.Host, group, describe(secret)), ""})
+		if opts.HostedDomain != nil && !opts.HostedDomain(ref.Host) {
+			// Visibility, not admission: the host is the operator's own
+			// claim, and the one moment it is worth a second look is
+			// here, where the credential that travels to it is proven
+			// live.
+			out = append(out, Result{name, Warn,
+				fmt.Sprintf("%s is not a host GitHub operates; the credential travels there", ref.Host),
+				"verify the host is the Enterprise Server you meant"})
+		}
 		out = append(out, scaleSetResults(ctx, probe, target, group)...)
 	}
 	return out

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -587,3 +587,53 @@ func TestCheckCredentialsNamesTheIdentity(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckCredentialsNamesTheHost: any https host is accepted by
+// design, so where a credential travels has to be visible instead of
+// assumed. The verdict names the host it proved, and a host the
+// provider does not operate earns a warning beside the pass — the one
+// moment the boundary is worth a second look is when the credential
+// that crosses it has just been proven live.
+func TestCheckCredentialsNamesTheHost(t *testing.T) {
+	environ := func(k string) string {
+		if k == "TOKEN" {
+			return "t0ken"
+		}
+		return ""
+	}
+	cfgFor := func(url string) *config.Config {
+		return &config.Config{
+			Credentials: []config.Credential{{ID: "gh", TokenEnv: "TOKEN"}},
+			Targets:     []config.Target{{ID: "app", URL: url, CredentialID: "gh"}},
+		}
+	}
+	hosted := func(h string) bool { return h == "github.com" }
+
+	res := checkCredentials(t.Context(), Options{
+		Config: cfgFor("https://github.com/acme/app"), Environ: environ,
+		NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) {
+			return &fakeProbe{id: 7}, nil
+		},
+		HostedDomain: hosted,
+	})
+	if len(res) != 1 || res[0].Status != Pass {
+		t.Fatalf("hosted target = %+v; want one pass and no warning", res)
+	}
+	if !strings.Contains(res[0].Detail, "github.com") {
+		t.Errorf("the verdict %q does not name the host it proved", res[0].Detail)
+	}
+
+	res = checkCredentials(t.Context(), Options{
+		Config: cfgFor("https://ghes.internal/acme/app"), Environ: environ,
+		NewCredentialProbe: func(string, credential.Secret) (CredentialProbe, error) {
+			return &fakeProbe{id: 7}, nil
+		},
+		HostedDomain: hosted,
+	})
+	if len(res) != 2 || res[0].Status != Pass || res[1].Status != Warn {
+		t.Fatalf("enterprise target = %+v; want the pass and the boundary warning", res)
+	}
+	if !strings.Contains(res[1].Detail, "ghes.internal") {
+		t.Errorf("the warning %q does not name where the credential travels", res[1].Detail)
+	}
+}

--- a/internal/platform/githubactions/auth_test.go
+++ b/internal/platform/githubactions/auth_test.go
@@ -91,3 +91,22 @@ func TestAnEmptyTokenIsRefusedAtBuild(t *testing.T) {
 		t.Errorf("error = %v; want it to name the empty token", err)
 	}
 }
+
+// TestIsHostedDomain mirrors the upstream client's own classification,
+// which is what decides whether the API is addressed as api.<host> or
+// as <host>/api/v3. The predicate feeds visibility only — the startup
+// log and the doctor's boundary warning — never admission.
+func TestIsHostedDomain(t *testing.T) {
+	hosted := []string{"github.com", "GitHub.com", "www.github.com", "github.localhost", "acme.ghe.com", "eu.GHE.com"}
+	for _, h := range hosted {
+		if !IsHostedDomain(h) {
+			t.Errorf("IsHostedDomain(%q) = false; GitHub operates it", h)
+		}
+	}
+	notHosted := []string{"gihub.com", "ghe.com", "ghes.internal", "github.com.evil.example", "api.github.com.example"}
+	for _, h := range notHosted {
+		if IsHostedDomain(h) {
+			t.Errorf("IsHostedDomain(%q) = true; GitHub does not operate it", h)
+		}
+	}
+}

--- a/internal/platform/githubactions/client.go
+++ b/internal/platform/githubactions/client.go
@@ -11,11 +11,29 @@ package githubactions
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/actions/scaleset"
 
 	"github.com/rhobuild/runpool/internal/credential"
 )
+
+// IsHostedDomain reports whether GitHub itself operates the host: the
+// public site or a data-residency domain. It mirrors the upstream
+// client's own classification — github.com, www.github.com,
+// github.localhost and any subdomain of ghe.com resolve to the hosted
+// API endpoints, and every other host is addressed as an Enterprise
+// Server. The predicate exists for visibility, not admission: a
+// credential configured for an unrecognised host still travels there,
+// and the startup log and the doctor are the surfaces that say so.
+func IsHostedDomain(host string) bool {
+	host = strings.ToLower(host)
+	switch host {
+	case "github.com", "www.github.com", "github.localhost":
+		return true
+	}
+	return strings.HasSuffix(host, ".ghe.com")
+}
 
 type ClientConfig struct {
 	// ConfigURL is the canonical target URL (repository or organization).


### PR DESCRIPTION
## What changes

`ParseTargetURL` understands three shapes it previously misread or
mis-refused: `…/orgs/<name>` translates to the organization it names,
a `.git` clone suffix is trimmed while canonicalizing, and the
provider's own page prefixes are refused naming the reason. `TargetRef`
carries its parsed host, the first serve logs where each target's
credential authenticates — `Warn` for a host GitHub does not operate —
and `runpool doctor` names the host in each credential verdict with a
warning beside non-hosted ones. The threat model declares the boundary.

## What was found

**`github.com/orgs/acme` parsed as repository `acme` owned by `orgs`.**
Both segments satisfy the owner and repository patterns, so without its
own case the browser's address for an organization was silently
understood as a repository — the same mechanism `/enterprises/<name>`
suffered, resolved the same way. `orgs` is a reserved route: it 404s as
an account on the REST API, so no legitimate owner is shadowed by the
translation.

**A clone URL failed at the provider instead of parsing.** `.git` names
no repository to the API. Trimmed while canonicalizing, the recognisable
paste works; the bare suffix alone is still refused.

**A pasted provider page read as an owner.** `settings`, `marketplace`,
`notifications`, `sponsors`, `topics` and `apps` — each verified
unregistrable — now refuse with "reserved route on the provider, not an
owner" instead of failing later with the provider's answer to a question
about an owner that cannot exist.

**Where a credential travels was invisible.** Any `https` host is
accepted by design, because an Enterprise Server and a data-residency
domain speak exactly the protocol `github.com` speaks — so the door
stays open, and what closes the risk is that crossing it is now stated:
once per target at startup, in every doctor run, and in the threat
model. The classification mirrors the upstream client's own hosted set
and feeds visibility only; nothing is blocked by it.

## Evidence

```text
go test ./... -race                          → ok, all packages
TestParseTargetURLTranslatesTheOrgsAddress   fails without the orgs case
TestParseTargetURLTrimsTheCloneSuffix        fails without the trim
TestParseTargetURLRefusesReservedRoutes      fails with an empty route list
TestStartupSaysWhereEachCredentialTravels    fails when startup stops distinguishing
TestCheckCredentialsNamesTheHost             fails when the doctor loses the warning
TestIsHostedDomain                           pins the classification, including
                                             gihub.com, ghe.com and suffix-spoofs
```

Each behaviour was watched failing against its mutation before staging.
The reserved routes were each verified against the live API: all six
404 as accounts.

## What would notice this regressing

The six tests above. The parser tests pin the translations and refusals
byte-for-byte on the canonical URL; the wiring tests read the actual log
and the actual doctor results, so a surface that stops naming the host
fails even if the predicate survives.

## Risk, compatibility and operations

Configuration: three previously-refused-or-misread URL shapes now parse
to what they name; nothing that parsed before parses differently. A
target already misconfigured as `orgs/<name>` — which could never have
served — changes from a provider error to a working organization target.

Trust boundary: unchanged in substance, declared in the threat model. No
host is newly reachable; every reachable host is now named at startup
and by the doctor.

Credentials: the log and verdicts name hosts and credential ids, never
values.

CLI: doctor output gains the host in credential verdicts and a warning
row for non-hosted hosts. Status API, schema, migration, deployment,
rollback, networking, resource limits, ownership, cleanup: N/A.

## Changelog

```text
Added
- Target URLs accept the browser's organization address (…/orgs/name)
  and clone URLs (….git); the provider's own page addresses are refused
  with the reason.
- The first serve and `runpool doctor` name the host each target's
  credential authenticates against; a host GitHub does not operate is
  flagged without being blocked.
```
