### PR TITLE
test: the refusals and inheritances that only wiring can prove

### DIFF
--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
 )
@@ -94,9 +95,17 @@ func (f *fakeRegistry) RemoveRunner(context.Context, int) error { return nil }
 type fakeWaiter struct {
 	exit    int64
 	waitErr error
+	// deadline captures the wait context's bound, which is where the
+	// tier's ceiling — or what a lease has left of it — must arrive.
+	deadline time.Time
 }
 
-func (f *fakeWaiter) WaitExit(context.Context, string) (int64, error) { return f.exit, f.waitErr }
+func (f *fakeWaiter) WaitExit(ctx context.Context, _ string) (int64, error) {
+	if d, ok := ctx.Deadline(); ok {
+		f.deadline = d
+	}
+	return f.exit, f.waitErr
+}
 func (f *fakeWaiter) TailLogs(context.Context, string, int) (string, error) {
 	return "", nil
 }
@@ -503,4 +512,50 @@ func TestPeriodicReconcileSpareAJobBeingLaunched(t *testing.T) {
 	if h.srv.alloc.TryReserve(h.bind.key) {
 		t.Error("the launching lease's admission credit was released out from under it")
 	}
+}
+
+// TestTheWaitInheritsWhatTheLeaseHasLeft: the ceiling bounds how long
+// this instance waits for one capsule, and a lease adopted after a
+// restart has already spent part of it. remainingCeiling holds that
+// rule; this pins the wiring — that runCapsule's wait actually receives
+// the remainder, because a wait built from the tier's full ceiling
+// would hand every restart a fresh budget and the wedge the ceiling
+// exists to bound would be extended by each one.
+func TestTheWaitInheritsWhatTheLeaseHasLeft(t *testing.T) {
+	h := newHarness(t, 1)
+	h.bind.tier.JobTimeout = ptrDuration(2 * time.Hour)
+	caps := &fakeCapsule{}
+	wait := &fakeWaiter{}
+	h.srv.caps = caps
+	h.srv.wait = wait
+	h.bind.gh = &fakeRegistry{}
+	if err := h.deliver(demand("job-adopted", "app", 61)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-adopted")
+
+	// An adopted lease is one whose clock started in a previous process:
+	// age it ninety minutes, then drive it.
+	aged := lease
+	aged.CreatedAt = time.Now().Add(-90 * time.Minute)
+	before := time.Now()
+	h.srv.wg.Add(1)
+	h.srv.runCapsule(h.bind, aged)
+
+	if wait.deadline.IsZero() {
+		t.Fatal("the wait carried no deadline; the ceiling never reached it")
+	}
+	left := wait.deadline.Sub(before)
+	if left > 40*time.Minute {
+		t.Fatalf("the wait was given %s; a ninety-minute-old lease on a two-hour ceiling has ~30m left, "+
+			"so the restart handed it a fresh budget", left.Round(time.Minute))
+	}
+	if left < 20*time.Minute {
+		t.Fatalf("the wait was given %s; want roughly the thirty minutes the lease has left", left.Round(time.Minute))
+	}
+}
+
+func ptrDuration(d time.Duration) *config.Duration {
+	cd := config.Duration(d)
+	return &cd
 }

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -127,25 +127,57 @@ func defaultedConfig(t *testing.T) *config.Config {
 
 // TestCollectGarbageRunsWhatTheLevelObliges: high pressure works the
 // managed total down to the low watermark, a soft emergency takes every
-// free lane. The two are one formula apart and the level is the only
-// input that distinguishes them.
+// free lane — asserted against real lanes, because with an empty
+// fixture both levels plan nothing and a pass that never forwarded the
+// level would look identical. A fresh free lane surviving High and
+// falling to SoftEmergency is the observable difference between the two
+// postures.
 func TestCollectGarbageRunsWhatTheLevelObliges(t *testing.T) {
 	h := newHarness(t, 1)
 	h.srv.disk.policy = diskPolicy{
-		thresholds: disk.Thresholds{MaxManagedBytes: 1000, LowPct: 60},
+		ttl:        30 * 24 * time.Hour,
+		thresholds: disk.Thresholds{MaxManagedBytes: 1 << 40, LowPct: 60},
 	}
-	// No lanes exist, so a pass plans nothing and returns without
-	// touching the daemon; what is under test is that both levels reach
-	// the planner at all rather than one of them silently doing nothing.
-	for _, level := range []disk.Level{disk.High, disk.SoftEmergency} {
-		h.srv.disk.collectGarbage(t.Context(), level)
+	// One fresh, free lane: within TTL, within the managed budget.
+	loc, ok, err := h.srv.cache.Acquire(t.Context(), "https://github.com/acme/app", "gen", "lease-gc", 4)
+	if err != nil || !ok {
+		t.Fatalf("acquire: ok=%v, %v", ok, err)
 	}
-	if got := cache.GCTarget(1000, 60); got != 600 {
-		t.Errorf("high pressure target = %d; want the low watermark, 600", got)
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.ReleaseCacheLane("lease-gc")
+	}); err != nil {
+		t.Fatal(err)
 	}
-	if !disk.SoftEmergency.Aggressive() || disk.High.Aggressive() {
-		t.Error("only a soft emergency asks for every free lane")
+	lanes := func() int {
+		var n int
+		if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+			all, err := tx.CacheLanes()
+			n = len(all)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return n
 	}
+	if lanes() != 1 {
+		t.Fatalf("fixture holds %d lanes; want 1", lanes())
+	}
+
+	// High pressure: the pass runs, and a fresh lane under the watermark
+	// is not its business.
+	h.srv.disk.collectGarbage(t.Context(), disk.High)
+	if lanes() != 1 {
+		t.Fatal("high pressure evicted a fresh lane under the low watermark")
+	}
+
+	// Soft emergency: every free lane goes, TTL and watermark
+	// notwithstanding — which is only observable if the level actually
+	// reaches the planner as AllFree.
+	h.srv.disk.collectGarbage(t.Context(), disk.SoftEmergency)
+	if lanes() != 0 {
+		t.Fatalf("a soft emergency left %d free lane(s); AllFree did not reach the planner", lanes())
+	}
+	_ = loc
 }
 
 // TestRediscoverClosesEveryGatewayWhenDiscoveryFails. The policy in force

--- a/internal/command/cleanup_test.go
+++ b/internal/command/cleanup_test.go
@@ -134,3 +134,30 @@ func TestQueuedAttemptsAreVisibleBeforeAPurge(t *testing.T) {
 		t.Errorf("queuedAttemptCount of nothing queued = %d; want 0", got)
 	}
 }
+
+// TestUninstallRefusesBeforeItDescribes: a wrong confirmation is
+// refused before anything is described in the present tense. The
+// refusal-first order matters because the description reads "removing"
+// once a confirmation is present — a command that prints the removal
+// line and then refuses has told the operator something happened that
+// did not.
+func TestUninstallRefusesBeforeItDescribes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNPOOL_STATE_DIR", dir)
+	st, err := store.Open(dir, store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+
+	code, stdout, stderr := run(t, "uninstall", "--confirm", "not-this-instance")
+	if code == exitOK {
+		t.Fatal("a wrong confirmation succeeded")
+	}
+	if !strings.Contains(stderr, "does not name this instance") {
+		t.Errorf("the refusal does not say what was wrong: %q", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("the refusal printed a description first:\n%s", stdout)
+	}
+}

--- a/internal/command/command_test.go
+++ b/internal/command/command_test.go
@@ -2,11 +2,16 @@ package command
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/store"
+	_ "modernc.org/sqlite"
 )
 
 // run drives the whole tree with captured streams, which is the point
@@ -369,5 +374,78 @@ func TestReportingShapesBeforeTheFirstServe(t *testing.T) {
 	}
 	if served, ok := doc["served"].(bool); !ok || served {
 		t.Errorf("served = %v; the pre-serve form carries served=false", doc["served"])
+	}
+}
+
+// TestLivenessReadsTheStateAndTheVerdictAge: a stat passes a corrupt
+// database and a wedged serve loop alike, which is exactly what a
+// liveness probe exists to catch. Readable state with a fresh verdict —
+// or none yet, which is the deployment start_period's window — is ok; a
+// stale verdict is a serve loop that stopped; garbage where the
+// database should be is a controller that cannot do anything correctly.
+func TestLivenessReadsTheStateAndTheVerdictAge(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNPOOL_STATE_DIR", dir)
+
+	// Before the first serve there is no state at all: liveness fails,
+	// and the start_period is what gives a booting controller its grace.
+	if code, _, _ := run(t, "healthcheck", "--mode", "liveness"); code == exitOK {
+		t.Error("liveness passed with no state; a stat of nothing would have failed too")
+	}
+
+	st, err := store.Open(dir, store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code, _, stderr := run(t, "healthcheck", "--mode", "liveness"); code != exitOK {
+		t.Errorf("liveness failed on a readable store with no verdict yet: %q", stderr)
+	}
+
+	// A fresh verdict passes; one far beyond the monitor's cadence is a
+	// serve loop that stopped writing.
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.SetPressure(store.PressureInfo{
+			Level: "normal", FreeBytes: 1 << 30, FreeInodes: 1 << 20,
+		})
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if code, _, stderr := run(t, "healthcheck", "--mode", "liveness"); code != exitOK {
+		t.Errorf("liveness failed on a fresh verdict: %q", stderr)
+	}
+	st.Close()
+
+	// The verdict is stamped by the store at write time, so a stale one
+	// cannot be produced through the API — which is the point: only a
+	// loop that genuinely stopped leaves an old moment behind. The
+	// fixture forges that state directly.
+	db, err := sql.Open("sqlite", filepath.Join(dir, store.DatabaseFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`UPDATE pressure SET measured_at = ?`, time.Now().Add(-time.Hour).Unix()); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+	code, _, stderr := run(t, "healthcheck", "--mode", "liveness")
+	if code == exitOK {
+		t.Error("liveness passed on an hour-old verdict; the serve loop writes one per minute")
+	}
+	if !strings.Contains(stderr, "serve loop") {
+		t.Errorf("the failure does not say what stopped: %q", stderr)
+	}
+
+	// The file present but not a database: the stat this replaced passed
+	// exactly this.
+	garbage := filepath.Join(t.TempDir(), "g")
+	t.Setenv("RUNPOOL_STATE_DIR", garbage)
+	if err := os.MkdirAll(garbage, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(garbage, store.DatabaseFile), []byte("not a database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if code, _, _ := run(t, "healthcheck", "--mode", "liveness"); code == exitOK {
+		t.Error("liveness passed on a file that is not a database")
 	}
 }

--- a/internal/command/doctor.go
+++ b/internal/command/doctor.go
@@ -68,16 +68,50 @@ func runDoctor(streams IO, asJSON bool) error {
 // whether this process can still reach its own state; readiness adds
 // the host contract. It is deliberately cheap and local: no GitHub call,
 // so a broker outage never marks the controller unhealthy.
+// livenessVerdictTolerance is how stale the disk monitor's last verdict
+// may be before liveness reads the serve loop as stopped. The monitor
+// writes one per minute; ten of them is far past any transient stall a
+// restart would not fix, while a single slow cycle never trips it.
+const livenessVerdictTolerance = 10 * time.Minute
+
 func runHealthcheck(streams IO, mode string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	switch mode {
 	case "liveness":
-		// The state directory is the one resource whose loss makes the
-		// controller unable to do anything correctly.
-		if _, err := os.Stat(stateDir() + "/" + store.DatabaseFile); err != nil {
-			return fmt.Errorf("state database unreachable: %w", err)
+		// Liveness answers "is the process able to do its job", and a
+		// stat cannot: a corrupt database, an unreadable schema and a
+		// wedged serve loop all leave the file present. Opening
+		// read-only proves the state is a database this build can read,
+		// and the disk verdict's age proves the serve loop is still
+		// turning — the monitor writes one every minute, so a verdict
+		// far older than its cadence is a loop that has stopped.
+		st, err := store.OpenReadOnly(stateDir())
+		if err != nil {
+			return fmt.Errorf("state unreadable: %w", err)
+		}
+		defer st.Close()
+		var measured int64
+		if err := st.Tx(ctx, func(tx *store.Tx) error {
+			p, err := tx.Pressure()
+			if err != nil {
+				return err
+			}
+			if p != nil {
+				measured = p.MeasuredAt
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("state unreadable: %w", err)
+		}
+		// No verdict yet is a controller that has not finished starting;
+		// the deployment's start_period owns that window.
+		if measured != 0 {
+			if age := time.Since(time.Unix(measured, 0)); age > livenessVerdictTolerance {
+				return fmt.Errorf("the disk monitor's last verdict is %s old; the serve loop has stopped",
+					age.Round(time.Second))
+			}
 		}
 		fmt.Fprintln(streams.Out, "ok")
 		return nil

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -119,7 +119,14 @@ func Run(ctx context.Context, opts Options) Report {
 	}
 	add(checkDaemon(ctx, opts.Docker))
 	add(checkIsolatedBridge(ctx, opts.Docker))
-	for _, res := range checkCgroups(ctx, opts.Docker, opts.Config) {
+	// A nil client must stay a nil interface: wrapped, it would be a
+	// non-nil daemonInfo holding nothing, and the guard inside would
+	// pass it to a method call.
+	var di daemonInfo
+	if opts.Docker != nil {
+		di = opts.Docker
+	}
+	for _, res := range checkCgroups(ctx, di, opts.Config) {
 		add(res)
 	}
 	// Cache lanes are daemon-side volumes now, so the daemon check above
@@ -259,7 +266,16 @@ func probeSuffix() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-func checkCgroups(ctx context.Context, d *docker.Client, cfg *config.Config) []Result {
+// daemonInfo is the one read checkCgroups makes. A seam rather than the
+// client, because every branch below is a Fail an operator can hit and
+// a live daemon cannot be asked to produce: v1, an unaddressable
+// driver, a missing controller. Reachable branches or untested refusals
+// — there is no third option.
+type daemonInfo interface {
+	Info(ctx context.Context) (docker.HostInfo, error)
+}
+
+func checkCgroups(ctx context.Context, d daemonInfo, cfg *config.Config) []Result {
 	if d == nil {
 		return []Result{{"cgroups", Fail, "daemon not connected", ""}}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -637,3 +637,60 @@ func TestCheckCredentialsNamesTheHost(t *testing.T) {
 		t.Errorf("the warning %q does not name where the credential travels", res[1].Detail)
 	}
 }
+
+// fakeDaemonInfo answers the one read checkCgroups makes.
+type fakeDaemonInfo struct {
+	info docker.HostInfo
+	err  error
+}
+
+func (f fakeDaemonInfo) Info(context.Context) (docker.HostInfo, error) { return f.info, f.err }
+
+// TestCheckCgroupsRefusesWhatItCannotEnforce: every branch here is a
+// refusal an operator can hit, and each was unreachable while the check
+// took the concrete client — a live daemon cannot present cgroup v1, an
+// unknown driver or a missing controller on demand. A limit that
+// silently does nothing is worse than one that fails, so each shape
+// must close admission rather than warn.
+func TestCheckCgroupsRefusesWhatItCannotEnforce(t *testing.T) {
+	cfg := &config.Config{}
+	good := docker.HostInfo{CgroupVersion: "2", CgroupDriver: "systemd", MemoryLimit: true, PidsLimit: true}
+
+	fails := func(res []Result) bool {
+		for _, r := range res {
+			if r.Status == Fail {
+				return true
+			}
+		}
+		return false
+	}
+
+	if res := checkCgroups(t.Context(), nil, cfg); !fails(res) {
+		t.Error("no daemon passed the cgroup check")
+	}
+	if res := checkCgroups(t.Context(), fakeDaemonInfo{err: errors.New("daemon down")}, cfg); !fails(res) {
+		t.Error("an unanswerable daemon passed the cgroup check")
+	}
+
+	v1 := good
+	v1.CgroupVersion = "1"
+	if res := checkCgroups(t.Context(), fakeDaemonInfo{info: v1}, cfg); !fails(res) {
+		t.Error("cgroup v1 passed; tier limits cannot be enforced on it")
+	}
+
+	odd := good
+	odd.CgroupDriver = "openrc"
+	if res := checkCgroups(t.Context(), fakeDaemonInfo{info: odd}, cfg); !fails(res) {
+		t.Error("a driver this build cannot address passed; the capsule and gateway would run under separate budgets")
+	}
+
+	noMem := good
+	noMem.MemoryLimit = false
+	if res := checkCgroups(t.Context(), fakeDaemonInfo{info: noMem}, cfg); !fails(res) {
+		t.Error("a host without the memory controller passed; the tier envelope would be advisory")
+	}
+
+	if res := checkCgroups(t.Context(), fakeDaemonInfo{info: good}, cfg); fails(res) {
+		t.Errorf("a conforming host failed: %+v", res)
+	}
+}

--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -65,6 +65,18 @@ var narrowDeps = map[string][]string{
 		module + "/internal/assignment",
 		module + "/internal/store",
 	},
+	// doctor validates a host before anything serves, so what it may
+	// know is the contract's vocabulary and the probes it drives — never
+	// the store, the lease machine or an adapter: a preflight that
+	// imports the machinery it is clearing would validate the host with
+	// the thing that needs the host validated.
+	module + "/internal/doctor": {
+		module + "/internal/capsule",
+		module + "/internal/config",
+		module + "/internal/credential",
+		module + "/internal/platform",
+		module + "/internal/platform/docker",
+	},
 	// capsule talks to the daemon; it must not also import the gateway,
 	// which is a separate process with its own lifecycle. The protocol
 	// leaf is the values the supervisor and the launcher must agree on —


### PR DESCRIPTION
## What changes

`healthcheck --mode=liveness` opens the state read-only and bounds the
disk verdict's age instead of stating a file. `checkCgroups` reads a
one-method seam, with every refusal branch covered. The collection test
runs against a real lane; the capsule wait's inherited ceiling, the
uninstall refusal order and the doctor's import set are each pinned.

## What was found

**Liveness was a stat.** A present file passed while the database was
corrupt, while the schema was one this build cannot read, and while the
serve loop had been wedged for hours — each a condition where a restart
is exactly the remedy a liveness probe exists to trigger. It now opens
the store read-only and, when a disk verdict exists, requires it younger
than ten monitor cadences. No verdict yet passes: that is a booting
controller, and the deployment's `start_period` owns that window. The
verdict is stamped by the store at write time, so a stale one cannot be
produced through the API — only by a loop that genuinely stopped.

**The refusals that close admission were the untested branches.**
`checkCgroups` took `*docker.Client`, and no live daemon can present
cgroup v1, an unknown driver or a disabled memory controller on demand —
precisely the shapes where a tier limit would silently become advisory.
A one-method `daemonInfo` seam makes each refusal reachable, with the
nil client kept a nil interface so the no-daemon guard still fires.

**Empty-against-empty told the collection test nothing.** Its own
comment said so: with no lanes, both pressure levels plan nothing, and
`AllFree` hardwired to false passed every assertion. Against a real
lane, High leaves a fresh lane under the watermark and SoftEmergency
takes every free lane — the observable difference between the postures.

**The ceiling's rule was tested; its wiring was not.** A wait built from
`tier.Ceiling()` instead of `remainingCeiling(tier, lease.CreatedAt)`
passes every unit test of the rule while handing each restart a fresh
budget. The waiter fake now captures its context deadline, and an aged
lease must arrive with roughly what it has left.

**The uninstall order was implemented and unpinned.** The refusal-first
rule had its comment and no test, so the reversed order — describe, then
refuse — would have survived. The pin asserts a wrong confirmation
produces the refusal and an empty description.

Each pin was watched failing against its regression: the stat form of
liveness, `AllFree: false`, the full-ceiling wait, and the reversed
uninstall order.

## Evidence

```text
go test ./... -race                              → ok, every package
TestLivenessReadsTheStateAndTheVerdictAge        fails against the stat form
TestCheckCgroupsRefusesWhatItCannotEnforce       covers all five refusal shapes
TestCollectGarbageRunsWhatTheLevelObliges        fails against AllFree: false
TestTheWaitInheritsWhatTheLeaseHasLeft           fails against a full-ceiling wait
TestUninstallRefusesBeforeItDescribes            fails against describe-then-refuse
test/architecture                                holds internal/doctor to five imports
```

## What would notice this regressing

The six tests above, each proven able to fail. The architecture suite
fails the moment the doctor gains an import outside its declared set.

## Risk, compatibility and operations

Operations: liveness is stricter — a wedged serve loop or unreadable
state now restarts the container instead of passing. The reference
deployment's probe (30s interval, 3 retries, 30s start period) holds:
the verdict tolerance is ten minutes against a one-minute write cadence,
so a healthy controller cannot flap, and a fresh boot passes on the
no-verdict rule until the store exists.

CLI: `healthcheck --mode=liveness` may now fail where the stat passed;
that is its purpose. Output shapes are unchanged.

Trust boundary, credentials, networking, schema, migration, deployment,
rollback, ownership, cleanup: N/A — one probe deepened, tests otherwise.

## Changelog

```text
Changed
- The liveness probe verifies the state is readable and the serve loop's
  disk verdict is recent, instead of only that the database file exists.
```
