### PR TITLE
docs(runbook, contract): every operational sentence works as written

### DIFF
--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -30,6 +30,7 @@ on:
       - "build/controller/**"
       - "deploy/compose/**"
       - "scripts/drills/**"
+      - "test/drills/**"
       - "test/contract/**"
       - ".github/workflows/integration-docker.yml"
   push:

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -64,8 +64,6 @@ services:
     # session left open is one the next start waits out as a conflict.
     # Anything still running is adopted on the next start.
     stop_grace_period: 2m
-    labels:
-      io.runpool.role: controller
 
 volumes:
   # State holds the lease and ownership records: back this up. Cache
@@ -73,7 +71,9 @@ volumes:
   # named volumes (runpool-cache-<lane>), labeled and garbage-collected;
   # they are warm build state, disposable by design, and belong outside
   # any backup.
-  runpool-state:
-    labels:
-      io.runpool.managed: "true"
-      io.runpool.kind: state
+  #
+  # Deliberately unlabeled: the io.runpool.* vocabulary belongs to the
+  # objects the controller creates and may collect, and this volume is
+  # the one thing it must never collect. A managed label here would be a
+  # false claim on exactly the object whose loss is unrecoverable.
+  runpool-state: {}

--- a/docs/maintainers/qualification-host.md
+++ b/docs/maintainers/qualification-host.md
@@ -28,12 +28,15 @@ Docker Engine from the official stable channel
 https://download.docker.com/linux/debian
 ```
 
-Architecture is checked against the lock, which records `amd64`. A host of
-another architecture has no entry there and fails the gate for that
-reason — not because the suites would fail on it. Qualifying a second
-architecture is an added lock entry and a run of the same gates on that
-host; the [support matrix](../reference/support-matrix.md) states what
-has been observed and what has not.
+Architecture is checked against the lock, which records one policy and
+names `amd64` in it. A host of another architecture fails the comparison
+for that reason — not because the suites would fail on it. Recording
+several qualified platforms side by side is the subject of the
+[multiplatform locks decision](../adrs/2026-08-17-multiplatform-locks.md),
+accepted with its implementation pending; until it lands, the lock holds
+exactly one platform and the
+[support matrix](../reference/support-matrix.md) states what has been
+observed and what has not.
 
 ## Sizing
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -36,6 +36,11 @@ supported yet.** There is no release. See
 - **Accepted work is not lost.** It is durable before it is
   acknowledged, and where evidence cannot decide what happened, the
   attempt is held for a person instead of being guessed at.
+- **A restart adopts running work; it never re-runs it.** A capsule that
+  outlives the controller is adopted by the next start and observed to
+  its real outcome. Work is requeued only when the evidence proves the
+  runner never started; from the start authorization onward, at-most-once
+  governs and an undecidable outcome is held for a person.
 - **The host cannot be filled silently.** Admission closes before the
   disk does.
 - **Under the restricted profile, a capsule has no route out.** Its
@@ -80,6 +85,7 @@ on and SemVer is what describes them:
 | Configuration schema | [Configuration reference](reference/configuration.md); the validator is the authority |
 | `status --json` document | [Status API reference](reference/status-api.md) — versioned separately as `v1` |
 | On-disk state | Migrations, forward-only after a release |
+| Capsule control protocol | `internal/capsule/protocol` — the version a capsule declares and the controller speaks; a capsule declaring a version this build does not speak is refused, never guessed at |
 | Operational procedures | [Runbook](runbook.md) |
 
 The configuration and status API versions move independently of the product

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -195,11 +195,11 @@ Then decide it. Exactly one of the two decisions, and `--apply` to make
 it:
 
 ```bash
-runpool attempts resolve <id> --retry --reason "..." --apply
+runpool attempts resolve <id> --retry --reason "..." --actor "<name>" --apply
 ```
 
 ```bash
-runpool attempts resolve <id> --settle-may-have-run --reason "..." --apply
+runpool attempts resolve <id> --settle-may-have-run --reason "..." --actor "<name>" --apply
 ```
 
 `--retry` returns the attempt to the queue; use it when the evidence
@@ -236,7 +236,10 @@ metadata is purged, so retrying is safe.
 **What uninstall does not take with it**, because none of it is a
 resource this instance owns and each is a separate decision:
 
-- the state volume, which is the final copy of the books;
+- the state volume — though not the books: uninstall purges the
+  delivery, attempt and lease records, so what the volume still holds
+  afterwards is the instance identity and the audit record of
+  maintenance actions, not a copy of the work;
 - the pre-migration copies beside it, `pre-migration-v<n>.db`;
 - the images Runpool pulled, and the credential files a deployment
   mounted;

--- a/docs/security/review-scope.md
+++ b/docs/security/review-scope.md
@@ -82,9 +82,9 @@ on judgement rather than on a property a test can assert.
    carrying labels it should not be able to set?
 5. Does recovery after a controller restart ever adopt or release a lease that
    belongs to different work?
-6. Do the credentials a deployment holds — provider tokens, the Docker socket,
-   the registry session during a build — have a shorter reach than the blast
-   radius they would have if leaked?
+6. Do the credentials a deployment holds — provider tokens, GitHub App
+   private keys, the Docker socket, the registry session during a build —
+   have a shorter reach than the blast radius they would have if leaked?
 
 ## Closing a finding
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -20,7 +20,7 @@ per-capsule gateway that relays under a default-deny policy.
 
 | Asset | Why it matters |
 |---|---|
-| Provider credential | Administers runners on the target; it remains in the controller |
+| Provider credential — a personal access token or a GitHub App private key | Administers runners on the target; either form remains in the controller |
 | Per-runner JIT bundle | Short-lived bootstrap material for one ephemeral runner; the assigned workload shares its execution identity |
 | The host Docker socket | Confers host-root authority |
 | The state database | Ownership records; deciding what Runpool may delete |
@@ -82,7 +82,7 @@ policy remain necessary in either topology.
 |---|---|---|
 | No state survives a job | Fresh dind data root, workspace and control tmpfs per capsule; the data root is a volume removed with the lease | Capsule contract, live |
 | A leaked runner cannot outlive its job | Ephemeral JIT runner, one job, removed on failure paths too | Live JIT flow, including removing a runner that never started |
-| Provider credentials never enter capsules; JIT state does not persist across jobs | Provider token remains in the controller. JIT arrives over exec stdin, its files are redirected to tmpfs, and it is absent from Docker configuration, environment, labels, and logs. The upstream runner requires it transiently in argv, visible to the assigned workload | Capsule contract asserts volatile materialization and no log disclosure; controller end-to-end qualification remains required |
+| Provider credentials never enter capsules; JIT state does not persist across jobs | The provider token or App private key remains in the controller. JIT arrives over exec stdin, its files are redirected to tmpfs, and it is absent from Docker configuration, environment, labels, and logs. The upstream runner requires it transiently in argv, visible to the assigned workload | Capsule contract asserts volatile materialization and no log disclosure; controller end-to-end qualification remains required |
 | Cross-repository cache contamination | Lanes are daemon-side named volumes, exclusive per lease, named by opaque ids, reused only for the same repository and generation | Live lane contract: marker persists for the same lane, another generation is blind |
 | Runpool deletes only what it owns | Instance- and lease-scoped ownership labels on every created object; creation recovery and destructive intent cleanup re-inspect ownership before acting; no daemon-wide prune | Foreign-resource contracts pass live; controller E2E asserts unrelated container, network and volume sentinels and still needs release qualification |
 | A crashed controller leaves nothing | Adoption of running capsules, sweep of orphans, singleton flock | Live SIGKILL mid-capsule, successor adopted and cleaned |

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -641,6 +641,11 @@ func (s *Controller) openSession(ctx context.Context, b *binding) error {
 	return nil
 }
 
+// announce publishes the binding's advertised capacity to its session
+// and logs the pool arithmetic when the number moved. Every announce
+// sets the session's capacity — the broker holds a total, not a delta —
+// but only a change is worth a log line, or a quiet pool would fill the
+// log with the same number every poll.
 func (s *Controller) announce(b *binding) {
 	credit := s.alloc.Advertised(b.key)
 	b.session.SetCapacity(credit)

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -59,6 +59,13 @@ const (
 	// systematic failure gets paid for instead of found.
 	MinRetryBudget = 1
 	MaxRetryBudget = 10
+	// DefaultRetryBudget is the budget a deployment gets without setting
+	// one. store.DefaultRetryBudget is its counterpart for maintenance
+	// commands, which open the store with no configuration to read; the
+	// consistency suite holds the two to one value, because an import in
+	// either direction would put deployment vocabulary in the store or
+	// persistence in the schema.
+	DefaultRetryBudget = 3
 	// DefaultLeaseHistory keeps a finished lease's record for 90 days.
 	// Long enough to explain an incident from last quarter, short enough
 	// that the books stay bounded by recent work on a host that runs for
@@ -120,6 +127,13 @@ func ApplyDefaults(c *Config) {
 		}
 	}
 
+	// Materialized rather than resolved at read time, for the same
+	// reason leaseHistory is: `config effective` prints this struct, and
+	// a value the controller fills in later is one the operator cannot
+	// see governing.
+	if c.Scheduling.RetryBudget == 0 {
+		c.Scheduling.RetryBudget = DefaultRetryBudget
+	}
 	for i := range c.Tiers {
 		t := &c.Tiers[i]
 		if t.Parallelism == 0 {
@@ -130,6 +144,13 @@ func ApplyDefaults(c *Config) {
 		}
 		if t.Resources.Memory == 0 {
 			t.Resources.Memory = 4 << 30 // 4GiB
+		}
+		// Same materialization rule as the retry budget above: Ceiling()
+		// still defends against a hand-built Tier, but a defaulted
+		// configuration shows the ceiling that governs.
+		if t.JobTimeout == nil {
+			d := DefaultJobTimeout
+			t.JobTimeout = &d
 		}
 		if t.Resources.PIDs == 0 {
 			t.Resources.PIDs = 1024

--- a/internal/platform/githubactions/client.go
+++ b/internal/platform/githubactions/client.go
@@ -36,7 +36,8 @@ func IsHostedDomain(host string) bool {
 }
 
 type ClientConfig struct {
-	// ConfigURL is the canonical target URL (repository or organization).
+	// ConfigURL is the canonical target URL, at any scope a target
+	// takes: repository, organization or enterprise.
 	ConfigURL string
 	// Credential is the resolved secret this client authenticates with. A
 	// token authenticates as the person who minted it; an App installation

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/rhobuild/runpool/internal/app"
 	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/store"
 )
 
 func repoPath(parts ...string) string {
@@ -196,4 +197,17 @@ func keys(m map[string]bool) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestTheTwoRetryBudgetDefaultsAgree: the deployment's default lives in
+// config, the maintenance commands' default lives in store, and an
+// import in either direction would put deployment vocabulary in the
+// store or persistence in the schema. Two constants, one value, held
+// here.
+func TestTheTwoRetryBudgetDefaultsAgree(t *testing.T) {
+	if config.DefaultRetryBudget != store.DefaultRetryBudget {
+		t.Fatalf("config.DefaultRetryBudget = %d, store.DefaultRetryBudget = %d; "+
+			"a deployment and a maintenance command would enforce different budgets",
+			config.DefaultRetryBudget, store.DefaultRetryBudget)
+	}
 }


### PR DESCRIPTION
## What changes

The runbook's uninstall section describes what the preserved volume
actually holds and its resolve examples run as written; `config
effective` prints the ceiling and retry budget that govern; the
qualification guide describes the lock format that exists; the compose
deployment drops the `io.runpool.*` labels it had no claim to; the
product contract gains the capsule protocol as a compatibility surface
and a precise statement of adoption; the security documents enumerate
both credential forms; the drills harness joins its workflow's path
filter; two godocs are brought to the code they sit on.

## What was found

**The uninstall paragraph inverted what survives.** "The state volume,
which is the final copy of the books" — but uninstall runs the purge:
deliveries, attempts, events, leases, intents, bindings and lanes are
removed, and the volume afterwards holds the instance identity and the
audit record. An operator retaining the volume as a backup of the work
had neither the work nor a warning.

**The documented resolve commands failed on the reference deployment.**
`--actor` falls back to `$USER`, the distroless image has no `$USER`,
and the runbook's examples omitted the flag — so following the page
produced a usage error at the exact moment an operator is resolving an
incident. The examples now carry the flag.

**`config effective` hid two governing values.** `jobTimeout: null` and
no `retryBudget` at all, while `leaseHistory` materialized beside them —
the reader could not see the eight hours and the three attempts that
actually govern. `ApplyDefaults` fills both now. The deployment default
and the maintenance default live in packages an import cannot join
without putting deployment vocabulary in the store, so
`TestTheTwoRetryBudgetDefaultsAgree` holds the two constants to one
value — the same mechanism the suite already applies to the engine lock.

**The qualification guide described a file that does not exist.** Per-
platform lock entries are the multiplatform decision's format, and that
decision is accepted with implementation pending; the file holds one
policy. The page now says so and links the record.

**The deployment claimed manageability on the unmanageable.** The state
volume carried `io.runpool.managed: "true"` — the label whose meaning is
"created by the controller, collectable by its sweeps" — on the one
volume whose collection is unrecoverable. Sweeps also filter on the
instance label, so nothing acted on the claim today; the reason to
remove it is that the reviewed deployment asserted something false
about its most valuable object.

**The contract left two surfaces unstated.** The capsule control
protocol is a compatibility surface — a capsule declaring an unknown
version is refused, and that refusal is a promise consumers can hold —
and what a restart does to running work was described in the
architecture but promised nowhere: adopted, observed to its real
outcome, re-run only when the evidence proves the runner never started.

## Evidence

```text
config effective (defaulted example):
  retryBudget: 3
  jobTimeout: 8h
docker compose config --quiet     → the label-free deployment renders
scripts/verify/doc-links.sh       → every link resolves
go test ./... -race               → ok, every package
```

## What would notice this regressing

`TestTheTwoRetryBudgetDefaultsAgree` fails if the two defaults part.
The consistency suite's engine check keeps the guide's version claims
honest. The generated CLI reference pins `--actor`'s existence; nothing
mechanical pins prose to purge behaviour, which is stated rather than
implied — the runbook drill exercises uninstall, and its assertions are
where a future divergence would surface.

## Risk, compatibility and operations

Configuration: `config effective` output gains two fields it previously
hid; the governing values are unchanged. `retryBudget` is now
materialized into the struct, which serve passed through already —
`store.Open` receives 3 where it previously received 0 and substituted 3.

Deployment: the compose file's rendered output loses three labels that
nothing consumed. No object addressing changes.

Operations: the runbook's uninstall and resolve procedures now match
behaviour exactly.

Trust boundary, credentials, networking, schema, migration, CLI
surfaces, status API, rollback: N/A — documentation and defaults
visibility.

## Changelog

```text
Changed
- `config effective` prints the job ceiling and retry budget that
  govern, instead of leaving them null or absent.
Fixed
- The runbook's uninstall section describes what the preserved state
  volume holds; its resolve examples carry `--actor` and run unchanged
  on the distroless image.
- The reference deployment no longer labels the state volume as managed.
```
