### PR TITLE
fix(app, capsule): an aborted capsule settles as never run, and readiness is proven before the start is authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,17 @@ by its public and operational effects.
   The controller reads the protocol version the capsule declares before
   handing it anything and refuses one it does not speak; that attempt is
   held for review as `capsule_incompatible` rather than retried, because
-  the next attempt would launch the same image. `runpool status` reports the image each tier runs, because a
-  replaced capsule is outside the configuration the release gates
-  observed.
+  the next attempt would launch the same image. That version is read
+  before readiness is waited on, so an image that is not this build's
+  half of the protocol is refused in about a second rather than after a
+  readiness deadline that was never going to be met. `runpool status`
+  reports the image each tier runs, because a replaced capsule is outside
+  the configuration the release gates observed.
+- **A prepared capsule has a daemon that answers.** The state the
+  controller delivers a credential on is written by the supervisor only
+  once the job's own Docker daemon is up, so readiness is something the
+  capsule proves rather than something it announces on the way to
+  proving it.
 - Under the restricted network profile a capsule has **no route out**.
   Its only egress is a per-capsule gateway that resolves and connects
   on its behalf under a default-deny policy, which is also the DNS
@@ -153,6 +161,15 @@ by its public and operational effects.
   evidence rung and the provider's own identifiers for the run, so the
   external check the command's help prescribes can be carried out from
   the tool that prescribes it.
+- **A capsule that never handed the job over returns it to the queue.**
+  The supervisor exits with a status it reserves for stopping before the
+  start was authorized — the ordinary end of an idle capsule when a
+  controller shuts down — and both the path that awaited a capsule and
+  the one that adopted it read that status the same way. It outranks what
+  was recorded when the start was authorized: that record is written when
+  a capsule reports itself up, while this one is the capsule stating that
+  nothing ever came after it. A job read the other way around is settled
+  as one that ran and is never served again.
 - **A retry that repeats is bounded.** An attempt whose work provably
   never began is served up to three times in all; past that it goes to
   manual review as `retry_budget_exhausted` rather than burning a capsule

--- a/cmd/capsule-supervisor/gateway.go
+++ b/cmd/capsule-supervisor/gateway.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/gateway"
 )
 
@@ -31,7 +32,7 @@ func runGateway(log *slog.Logger) int {
 	})
 	if err != nil {
 		log.Error("gateway failed", "error", err)
-		setState("failed:" + err.Error())
+		setState(protocol.FailedPrefix + err.Error())
 		return 1
 	}
 	return 0

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -8,9 +8,13 @@
 //
 // The control surface is the filesystem under /run/runpool, all tmpfs:
 //
-//	protocol   written at boot: the protocol version, "1"
-//	state      waiting | running | exited:<code> | failed:<reason>
-//	           | aborted:<reason>
+//	protocol   written at boot, before any state: the protocol version
+//	state      booting | waiting | running | exited:<code>
+//	           | failed:<reason> | aborted:<reason>
+//	           `booting` is the control surface answering before the
+//	           daemon is proven; `waiting` is written only once dockerd
+//	           answers, because it is the state on which the launcher
+//	           delivers a credential and authorizes a start.
 //	           `aborted` is a failure before the runner started, so the job
 //	           was never handed over and must be retried; `failed` is a
 //	           failure after it started, which is an execution outcome.
@@ -133,7 +137,7 @@ func supervise(log *slog.Logger) int {
 	if err := boot(log); err != nil {
 		log.Error("capsule boot failed", "error", err)
 		// Boot is entirely before the runner: nothing was ever handed over.
-		setState("aborted:" + err.Error())
+		setState(protocol.AbortedPrefix + err.Error())
 		return exitAborted
 	}
 
@@ -142,7 +146,7 @@ func supervise(log *slog.Logger) int {
 		log.Error("capsule run failed", "error", err)
 		state := terminalFailure(currentState(), err)
 		setState(state)
-		if strings.HasPrefix(state, "aborted:") {
+		if strings.HasPrefix(state, protocol.AbortedPrefix) {
 			return exitAborted
 		}
 		return 1
@@ -152,7 +156,7 @@ func supervise(log *slog.Logger) int {
 		log.Warn("the runner exited with the reserved abort code; reporting it as a plain failure",
 			"runner_exit", code, "reported", reported)
 	}
-	setState("exited:" + strconv.Itoa(reported))
+	setState(protocol.ExitedPrefix + strconv.Itoa(reported))
 	log.Info("capsule finished", "exit", reported)
 	return reported
 }
@@ -192,7 +196,11 @@ func boot(log *slog.Logger) error {
 	if err := os.WriteFile(protocolFile, []byte(protocolVersion), 0o644); err != nil {
 		return err
 	}
-	setState("waiting")
+	// Booting, not waiting: the control surface answers from here, but
+	// the daemon the job needs has not been started, let alone proven.
+	// Waiting is what the launcher delivers a credential on, and it is
+	// written in run() once dockerd answers.
+	setState(protocol.StateBooting)
 	// The cache lane, when mounted, must be writable by the runner uid.
 	if info, err := os.Stat("/cache"); err == nil && info.IsDir() {
 		if err := os.Chown("/cache", runnerUID, runnerGID); err != nil {
@@ -329,12 +337,18 @@ func run(log *slog.Logger) (int, error) {
 		return -1, err
 	}
 	log.Info("dockerd ready", "socket", dockerSocket)
+	// Only now: waiting is the state the launcher reads as "this capsule
+	// can be given a job", and the daemon that runs it has just answered.
+	setState(protocol.StateWaiting)
 
 	if err := awaitStart(ctx); err != nil {
-		// Cancellation while waiting: the start was never authorized, so
-		// nothing ran — the state says so and the exit is clean shutdown.
-		log.Info("shutdown before any start authorization; nothing ran")
-		return 0, nil
+		// Cancellation while waiting is an abort, not a clean exit: the
+		// start was never authorized, so the job was never handed over
+		// and must run somewhere else. Reported as an error so the one
+		// function that decides started-or-not decides this too — a
+		// clean exit here left the controller reading a stop during
+		// shutdown as a job that ran and finished.
+		return -1, fmt.Errorf("shutdown before the start was authorized: %w", err)
 	}
 
 	return runRunner(ctx, log, reap)
@@ -460,7 +474,7 @@ func runRunner(ctx context.Context, log *slog.Logger, reap *reaper) (int, error)
 		// precisely so this case stays an abort.
 		return -1, fmt.Errorf("start runner: %w", err)
 	}
-	setState("running")
+	setState(protocol.StateRunning)
 
 	select {
 	case code := <-exit:
@@ -577,10 +591,10 @@ func setState(s string) {
 // dockerd never ready — the job never ran, and reporting an exit would settle
 // it as complete and never retry it.
 func terminalFailure(state string, err error) string {
-	if state == "running" {
-		return "failed:" + err.Error()
+	if state == protocol.StateRunning {
+		return protocol.FailedPrefix + err.Error()
 	}
-	return "aborted:" + err.Error()
+	return protocol.AbortedPrefix + err.Error()
 }
 
 func currentState() string {

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -229,9 +229,23 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		// Through the same seam the ordinary launch awaits its runner:
 		// an adopted capsule is a capsule, and one of the two paths
 		// reaching around it is how they come to behave differently.
-		if _, err := s.wait.WaitExit(ctx, runnerContainer); err != nil {
+		exit, err := s.wait.WaitExit(ctx, runnerContainer)
+		if err != nil {
 			s.log.Error("adopted capsule wait failed", "lease", lease.ID, "error", err)
 			if err := s.recoverCapsuleFailure(b, lease.ID, ""); err != nil {
+				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
+					"lease", lease.ID, "error", err)
+			}
+			return
+		}
+		// The same reading the launch path gives its own capsule: an
+		// adopted capsule that stopped on the reserved code never handed
+		// the job over, and discarding the status here settled it as a
+		// run that finished.
+		if obs := capsule.ClassifyExit(int(exit)); obs != assignment.ObservedExited {
+			s.log.Warn("the adopted capsule reports the runner never started; the attempt is returned to the queue",
+				"lease", lease.ID, "exit", exit)
+			if err := s.recoverCapsuleFailure(b, lease.ID, obs); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -239,6 +239,17 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	defer cancelWait()
 	exit, err := s.wait.WaitExit(waitCtx, runnerContainer)
 	if err == nil {
+		// What the status proves, not that the wait returned. The
+		// supervisor reserves one code for "the runner never owned the
+		// job", and a clean wait carrying it is not an execution:
+		// recording an observed exit settles an attempt that never ran
+		// as complete, and nothing requeues it afterwards.
+		if startObs = capsule.ClassifyExit(int(exit)); startObs != assignment.ObservedExited {
+			log.Warn("the capsule reports the runner never started; the attempt is returned to the queue",
+				"exit", exit)
+			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			return
+		}
 		if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
 			log.Error("cannot record that the runner completed", "error", err)
 		}

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -50,7 +50,12 @@ const (
 	// container's own overlayfs.
 	dindDataDir = "/var/lib/docker"
 
-	readyTimeout      = 90 * time.Second
+	readyTimeout = 90 * time.Second
+	// protocolTimeout bounds the wait for a capsule to declare what it
+	// speaks. The supervisor writes that file before any state, so a
+	// first-party capsule answers within moments of starting; this is
+	// the bound on "this is not a Runpool capsule", not on readiness.
+	protocolTimeout   = 30 * time.Second
 	readyPollInterval = 500 * time.Millisecond
 )
 
@@ -366,10 +371,14 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	if err := m.dock.StartContainer(ctx, outerID); err != nil {
 		return "", err
 	}
-	if err := m.awaitReady(ctx, outerID); err != nil {
+	// The version first, then readiness. A capsule that does not speak
+	// this protocol is refused in about a second rather than after the
+	// readiness deadline, and its operator is told the image is the
+	// problem instead of watching every job on the tier time out.
+	if err := m.awaitProtocol(ctx, outerID); err != nil {
 		return "", err
 	}
-	if err := m.checkProtocol(ctx, outerID); err != nil {
+	if err := m.awaitReady(ctx, outerID); err != nil {
 		return "", err
 	}
 	// The JIT bundle travels over exec stdin onto the capsule's tmpfs, where
@@ -387,28 +396,48 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	return outerID, nil
 }
 
-// checkProtocol refuses a capsule that does not speak this build's
-// control protocol, before anything is handed to it.
+// awaitProtocol refuses a capsule that does not speak this build's
+// control protocol, before anything is handed to it and before readiness
+// is waited on.
 //
-// It runs after readiness rather than before it. The supervisor writes the
-// file at boot, ahead of the daemon, so an earlier read would be racing a
-// capsule that has not written it yet and would need a poll of its own.
-// Readiness is the first moment a capsule is known to answer anything,
-// and it is still before the credential.
+// The supervisor writes its version at boot, ahead of every state, so
+// this reads a fact the capsule states about itself rather than inferring
+// one from a verb that happened to work. Without it a capsule whose
+// supervisor is older answers some verbs and not others, and the
+// mismatch arrives as a job that failed rather than as an image that
+// cannot be used — the difference between one operator reading one error
+// and every job on that tier failing until someone correlates them.
 //
-// The supervisor writes its version at boot, so this reads a fact the
-// capsule states about itself rather than inferring one from a verb that
-// happened to work. Without it a capsule whose supervisor is older
-// answers some verbs and not others, and the mismatch arrives as a job
-// that failed rather than as an image that cannot be used — which is the
-// difference between one operator reading one error and every job on that
-// tier failing until someone correlates them.
-func (m *Launcher) checkProtocol(ctx context.Context, outerID string) error {
-	code, out, err := m.dock.Exec(ctx, outerID, []string{"cat", protocolFile})
-	if err != nil {
-		return fmt.Errorf("read the capsule control protocol: %w", err)
+// It polls because "before every state" is still after the container
+// starts, and it does so under a bound of its own: this is the wait for
+// a capsule to say what it is, not the wait for it to be ready, and
+// conflating the two is what made a stated incompatibility cost a
+// readiness deadline.
+func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
+	deadline := time.Now().Add(protocolTimeout)
+	for {
+		code, out, err := m.dock.Exec(ctx, outerID, []string{"cat", protocolFile})
+		// Only a read that succeeded is a declaration to judge: a
+		// capsule that has not written the file yet is not a capsule
+		// that cannot.
+		if err == nil && code == 0 {
+			return protocolVerdict(code, out)
+		}
+		if time.Now().After(deadline) {
+			if err != nil {
+				return fmt.Errorf("read the capsule control protocol: %w", err)
+			}
+			// The last observation, judged: a capsule that never wrote
+			// the file declares no protocol, which is what the verdict
+			// says and what an operator has to act on.
+			return protocolVerdict(code, out)
+		}
+		select {
+		case <-time.After(readyPollInterval):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
-	return protocolVerdict(code, out)
 }
 
 // ErrIncompatibleImage reports a capsule that does not speak this
@@ -499,7 +528,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 	if err := m.dock.StartContainer(ctx, gwID); err != nil {
 		return netip.Addr{}, "", err
 	}
-	if err := m.awaitState(ctx, gwID, "ready"); err != nil {
+	if err := m.awaitState(ctx, gwID, protocol.StateReady); err != nil {
 		return netip.Addr{}, "", fmt.Errorf("gateway: %w", err)
 	}
 	ip, _, err := m.dock.ContainerIPOn(ctx, gwID, netID)
@@ -515,25 +544,41 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 
 // awaitReady polls the supervisor's state until the capsule reports
 // waiting: daemon booted, readiness proven, runner deliberately not
-// started.
+// started. The supervisor writes that state only once its daemon
+// answers, so reaching it is the proof — not the intention — that a job
+// delivered here has something to run on.
 func (m *Launcher) awaitReady(ctx context.Context, outerID string) error {
-	return m.awaitState(ctx, outerID, "waiting")
+	return m.awaitState(ctx, outerID, protocol.StateWaiting)
+}
+
+// stateVerdict is what one observation of a supervisor-family container
+// decides: the wanted state reached, a terminal state it can never leave,
+// or keep polling. It is separated from the poll because the decision is
+// where the cost is — a terminal state carries the reason the container
+// failed, that reason dies with the container, and treating it as "not
+// yet" spends the whole deadline and then reports a timeout instead.
+func stateVerdict(want string, code int, out string, execErr error) (done bool, err error) {
+	if execErr != nil || code != 0 {
+		return false, nil
+	}
+	switch s := strings.TrimSpace(out); {
+	case s == want:
+		return true, nil
+	case protocol.Terminal(s):
+		return true, fmt.Errorf("the container reported %s", s)
+	default:
+		return false, nil
+	}
 }
 
 // awaitState polls a supervisor-family container until it reports the
-// wanted state. The supervisor writing `failed:` is a boot failure
-// worth its reason.
+// wanted state or one it can no longer leave.
 func (m *Launcher) awaitState(ctx context.Context, containerID, want string) error {
 	deadline := time.Now().Add(readyTimeout)
 	for {
 		code, out, err := m.dock.Exec(ctx, containerID, []string{supervisorPath, "state"})
-		if err == nil && code == 0 {
-			switch s := strings.TrimSpace(out); {
-			case s == want:
-				return nil
-			case strings.HasPrefix(s, "failed:"):
-				return fmt.Errorf("boot failed: %s", strings.TrimPrefix(s, "failed:"))
-			}
+		if done, verdict := stateVerdict(want, code, out, err); done {
+			return verdict
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("container %s did not reach %q within %s", containerID[:12], want, readyTimeout)

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -40,10 +40,15 @@ func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntim
 // supervisor too, so the two sides cannot disagree.
 const SupervisorAbortedExitCode = protocol.AbortedExitCode
 
-// classifySupervisorExit reads a stopped capsule's exit code. Any code but
-// the reserved one means the runner owned the job, which includes a job
-// that failed: that is an execution outcome, not an unstarted runtime.
-func classifySupervisorExit(code int) assignment.ExecutionObservation {
+// ClassifyExit reads a stopped capsule's exit code. Any code but the
+// reserved one means the runner owned the job, which includes a job that
+// failed: that is an execution outcome, not an unstarted runtime.
+//
+// It is exported because a capsule's exit reaches the controller by two
+// paths — the launch that awaited it and the reconciliation that adopted
+// one — and a classification that only one of them applies is how the
+// same capsule settles two different ways.
+func ClassifyExit(code int) assignment.ExecutionObservation {
 	if code == SupervisorAbortedExitCode {
 		return assignment.ObservedCreated
 	}
@@ -57,13 +62,13 @@ func classifySupervisorExit(code int) assignment.ExecutionObservation {
 // an attempt that never ran as complete, and nothing requeues it.
 func classifySupervisorState(state string) (assignment.ExecutionObservation, error) {
 	switch {
-	case state == "waiting":
+	case state == protocol.StateBooting, state == protocol.StateWaiting:
 		return assignment.ObservedCreated, nil
-	case state == "running":
+	case state == protocol.StateRunning:
 		return assignment.ObservedRunning, nil
-	case strings.HasPrefix(state, "aborted:"):
+	case strings.HasPrefix(state, protocol.AbortedPrefix):
 		return assignment.ObservedCreated, nil
-	case strings.HasPrefix(state, "exited:"), strings.HasPrefix(state, "failed:"):
+	case strings.HasPrefix(state, protocol.ExitedPrefix), strings.HasPrefix(state, protocol.FailedPrefix):
 		return assignment.ObservedExited, nil
 	default:
 		return assignment.ObservedUnavailable, fmt.Errorf("capsule reports unrecognized state %q", state)
@@ -87,7 +92,7 @@ func classifyContainerState(runtimeID string, state docker.ContainerState) (obs 
 		// container and the control surface is tmpfs. The exit code is the
 		// only account it left, which is why the supervisor reserves one
 		// for "the runner never started".
-		return classifySupervisorExit(state.ExitCode), false, nil
+		return ClassifyExit(state.ExitCode), false, nil
 	case "running", "paused", "restarting":
 		return assignment.ObservedUnavailable, true, nil
 	default:

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -1,9 +1,12 @@
 package capsule
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 )
 
@@ -53,13 +56,13 @@ func TestClassifySupervisorStateRefusesToGuess(t *testing.T) {
 // is tmpfs — so the state file that distinguishes an abort is already gone
 // when the controller looks. The reserved exit code is what survives.
 func TestClassifySupervisorExitSeparatesAbortFromExit(t *testing.T) {
-	if got := classifySupervisorExit(SupervisorAbortedExitCode); got != assignment.ObservedCreated {
+	if got := ClassifyExit(SupervisorAbortedExitCode); got != assignment.ObservedCreated {
 		t.Errorf("the reserved abort code classified %q; want an unstarted runtime", got)
 	}
 	// Every other code means the runner owned the job, a failed job
 	// included: that is an execution outcome, not an unstarted runtime.
 	for _, code := range []int{0, 1, 2, 78, 80, 125, 137, 255, -1} {
-		if got := classifySupervisorExit(code); got != assignment.ObservedExited {
+		if got := ClassifyExit(code); got != assignment.ObservedExited {
 			t.Errorf("exit code %d classified %q; want an execution outcome", code, got)
 		}
 	}
@@ -103,5 +106,51 @@ func TestClassifyContainerStateNeverAsksAStoppedCapsule(t *testing.T) {
 	// An unknown status refuses to guess rather than settling an attempt.
 	if _, ask, err := classifyContainerState("c1", docker.ContainerState{Status: "removing"}); err == nil || ask {
 		t.Error("an unrecognised status must be an error, not a supervisor query")
+	}
+}
+
+// TestAwaitStateGivesUpOnEveryTerminalState: a container that has
+// reached a state it can never leave is done being polled.
+//
+// The reason a supervisor writes beside a terminal state is the only
+// account of what went wrong, and it dies with the container. Treating
+// one as "not the state I wanted, keep asking" spends the whole
+// readiness deadline and then reports a timeout — the operator gets
+// "did not reach waiting in 90s" instead of "dockerd did not become
+// ready in time", and the wait is burned as well as the reason.
+func TestAwaitStateGivesUpOnEveryTerminalState(t *testing.T) {
+	const want = protocol.StateWaiting
+	for name, tc := range map[string]struct {
+		code     int
+		out      string
+		execErr  error
+		wantDone bool
+		wantErr  string // substring; empty means done with no error, or not done
+	}{
+		"the wanted state":          {0, want, nil, true, ""},
+		"trailing newline":          {0, want + "\n", nil, true, ""},
+		"still booting":             {0, protocol.StateBooting, nil, false, ""},
+		"aborted before the runner": {0, protocol.AbortedPrefix + " dockerd did not become ready in time", nil, true, "dockerd did not become ready"},
+		"failed after the runner":   {0, protocol.FailedPrefix + " runner exploded", nil, true, "runner exploded"},
+		"already exited":            {0, protocol.ExitedPrefix + "0", nil, true, "exited:0"},
+		"the exec could not run":    {0, "", errors.New("daemon unreachable"), false, ""},
+		"the exec reported failure": {1, "no such file", nil, false, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			done, err := stateVerdict(want, tc.code, tc.out, tc.execErr)
+			if done != tc.wantDone {
+				t.Fatalf("done = %v, want %v (err %v)", done, tc.wantDone, err)
+			}
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tc.wantErr == "":
+				return
+			case err == nil:
+				t.Fatalf("no error; want one containing %q", tc.wantErr)
+			case !strings.Contains(err.Error(), tc.wantErr):
+				t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -8,18 +8,71 @@
 // instead of detectable: there is one declaration, so there is nothing
 // to compare.
 //
-// Only the values live here. The files they travel through, the verbs
-// spoken over exec and the machinery around them belong to their sides;
-// this package must stay dependency-free so the supervisor's static
-// binary carries nothing it does not run.
+// Only the values live here, and the one predicate that decides what a
+// value means. The files they travel through, the verbs spoken over exec
+// and the machinery around them belong to their sides; this package
+// depends on nothing outside the standard library so the supervisor's
+// static binary carries nothing it does not run.
 package protocol
+
+import "strings"
 
 // Version is the control protocol this build speaks. The supervisor
 // writes it to the control directory at boot, before it is asked
 // anything, and the launcher reads it before handing the capsule
 // anything: a capsule that declares a version this build does not speak
 // is refused, not retried.
-const Version = "1"
+//
+// Version 2 moved when StateWaiting is written. A version 1 supervisor
+// wrote it at boot, ahead of its daemon, so a launcher that treats the
+// state as readiness would deliver a credential and authorize a start
+// against a capsule whose daemon may never come up. The two builds are
+// not interchangeable in either direction, which is what the equality
+// check enforces.
+const Version = "2"
+
+// The states a supervisor-family container writes to its control
+// directory. The capsule's supervisor and the gateway are the same
+// binary in two containers and share this vocabulary; the launcher waits
+// on these names from the outside, so both sides read one declaration.
+const (
+	// StateBooting is the control surface answering before anything it
+	// supervises is proven. Nothing may be handed to a capsule here.
+	StateBooting = "booting"
+	// StateWaiting is the daemon proven ready and the runner deliberately
+	// not started: the state in which a credential is delivered and a
+	// start is authorized.
+	StateWaiting = "waiting"
+	// StateRunning is written immediately before the runner is executed,
+	// so its presence is the proof that the job was handed over.
+	StateRunning = "running"
+	// StateReady is the gateway's: ruleset installed and relay listening.
+	StateReady = "ready"
+)
+
+// The prefixes a terminal state carries, each with its reason appended.
+// Which one it is decides whether the job may run again, so they are
+// declared once rather than spelled at each side.
+const (
+	// ExitedPrefix carries the runner's own status.
+	ExitedPrefix = "exited:"
+	// FailedPrefix is a failure after the runner started: an execution
+	// outcome.
+	FailedPrefix = "failed:"
+	// AbortedPrefix is a failure before it started: the job was never
+	// handed over and must be retried.
+	AbortedPrefix = "aborted:"
+)
+
+// Terminal reports whether a state says the supervisor will never reach
+// another one. A caller waiting for a state it can no longer reach must
+// give up with the reason rather than poll out its deadline: the reason
+// is written here and lost when the container goes.
+func Terminal(state string) bool {
+	return strings.HasPrefix(state, ExitedPrefix) ||
+		strings.HasPrefix(state, FailedPrefix) ||
+		strings.HasPrefix(state, AbortedPrefix)
+}
 
 // AbortedExitCode is the status the supervisor exits with when it stops
 // before handing the job to the runner: the job was never handed over

--- a/internal/capsule/protocol_test.go
+++ b/internal/capsule/protocol_test.go
@@ -1,6 +1,7 @@
 package capsule
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -10,6 +11,16 @@ import (
 // credential. Without this the mismatch arrives as a job that failed
 // instead of an image that cannot be used.
 func TestProtocolVerdict(t *testing.T) {
+	// The neighbouring versions are derived from the one this build
+	// speaks, never written down: a table naming them by hand starts
+	// passing for the wrong reason on the day one of them ships, which
+	// is the same day the refusal matters most.
+	n, err := strconv.Atoi(ProtocolVersion)
+	if err != nil {
+		t.Fatalf("control protocol version %q is not a number", ProtocolVersion)
+	}
+	older, newer := strconv.Itoa(n-1), strconv.Itoa(n+1)
+
 	for name, tc := range map[string]struct {
 		code int
 		out  string
@@ -18,8 +29,8 @@ func TestProtocolVerdict(t *testing.T) {
 		"the version this build speaks":   {0, ProtocolVersion, ""},
 		"trailing newline from the file":  {0, ProtocolVersion + "\n", ""},
 		"surrounding whitespace":          {0, "  " + ProtocolVersion + "  \n", ""},
-		"an older supervisor":             {0, "0\n", "not a pair"},
-		"a newer supervisor":              {0, "2\n", "not a pair"},
+		"an older supervisor":             {0, older + "\n", "not a pair"},
+		"a newer supervisor":              {0, newer + "\n", "not a pair"},
 		"no protocol file at all":         {1, "cat: /run/runpool/protocol: No such file or directory", "declares no control protocol"},
 		"an empty file":                   {0, "\n", "not a pair"},
 		"a file the read could not parse": {0, "one", "not a pair"},

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/egress"
 )
 
@@ -90,14 +91,14 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("egress relay: %w", err)
 	}
 
-	cfg.SetState("ready")
+	cfg.SetState(protocol.StateReady)
 	cfg.Log.Info("gateway ready",
 		"internal", legs.InternalIf, "uplink", legs.UplinkIf,
 		"proxy", net.JoinHostPort(legs.InternalIP, fmt.Sprint(egress.ProxyPort)),
 		"deny", len(policy.Deny), "allow", len(policy.Allow),
 		"max_connections", MaxProxyConnections, "max_dns_inflight", MaxDNSInFlight)
 	<-ctx.Done()
-	cfg.SetState("exited:0")
+	cfg.SetState(protocol.ExitedPrefix + "0")
 	return nil
 }
 

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -212,6 +212,24 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 		return err
 	}
 	switch {
+	case startObs == assignment.ObservedCreated:
+		// Authorized, and the runtime proved the start never took
+		// effect: the work was not consumed, and this is the one path
+		// allowed back to ready past the authorization.
+		//
+		// It is decided before the evidence cases, not after them,
+		// because the evidence is the weaker statement. `running` and
+		// `running_observed` are written when the authorization is
+		// accepted and the capsule reports itself up — not when a runner
+		// is seen owning a job — while this observation only ever comes
+		// from a proof: a runtime still in its created state, a
+		// supervisor reporting it never started, or the exit code the
+		// capsule reserves for exactly that. Judged in evidence order,
+		// an aborted capsule settles as a job that started and the
+		// workload is never served again.
+		m.log.Warn("the authorized start never took effect; the attempt stays servable",
+			"attempt", attempt.ID, "lease", lease.ID)
+		return m.requeueProven(tx, attempt, lease.ID)
 	case attempt.Evidence == store.EvidenceExitObserved:
 		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionCompletedObserved)
 	case attempt.Evidence == store.EvidenceRunningObserved:
@@ -219,16 +237,6 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	case attempt.Evidence.Retriable():
 		m.log.Warn("delivery failed before any start was authorized; the attempt stays servable",
 			"attempt", attempt.ID, "lease", lease.ID)
-		return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
-	case startObs == assignment.ObservedCreated:
-		// Authorized, and the daemon proved the start never took effect:
-		// the work was not consumed, and this is the one path allowed
-		// back to ready past the authorization.
-		m.log.Warn("the authorized start never took effect; the attempt stays servable",
-			"attempt", attempt.ID, "lease", lease.ID)
-		if attempt.State == "starting" {
-			return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), lease.ID)
-		}
 		return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
 	default:
 		m.log.Warn("start outcome is unproven; the attempt is held for review",
@@ -249,6 +257,24 @@ func (m *Manager) HoldAttempt(ctx context.Context, leaseID, reason string) {
 			"lease", leaseID, "reason", reason)
 		return tx.HoldForReview(attempt.ID, reason)
 	})
+}
+
+// requeueProven returns an attempt whose start provably never took
+// effect to the queue, choosing the requeue its state allows.
+//
+// The two exist because the plain requeue refuses everything past the
+// start authorization — that refusal is the at-most-once rule — while
+// this disposition arrives holding the one proof that outranks it. Which
+// state the attempt is in by then is not a property of the failure: the
+// walk advances it to `starting` and on to `running` optimistically, so
+// the proof can land at either. Naming only one leaves the other
+// matching no row, and a requeue that matches nothing rolls the whole
+// finalizing transaction back and pins the lease in cleaning.
+func (m *Manager) requeueProven(tx *store.Tx, attempt store.Attempt, leaseID string) error {
+	if attempt.State == "starting" || attempt.State == "running" {
+		return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), leaseID)
+	}
+	return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), leaseID)
 }
 
 // requeueOrReview turns a refused retry into a review rather than an
@@ -276,14 +302,7 @@ func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, eviden
 		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionStartedObserved)
 	case evidence.Retriable(), obs == assignment.ObservedCreated:
 		m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
-			// The same split disposeAttempt makes: a stranded attempt in
-			// starting is past the plain requeue's guard, and only the
-			// proven-inert path may bring it back. Without this the
-			// requeue matches zero rows and the attempt never converges.
-			if attempt.State == "starting" {
-				return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), lease.ID)
-			}
-			return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
+			return m.requeueProven(tx, attempt, lease.ID)
 		})
 	case obs == assignment.ObservedRunning:
 		// Running reaches here only when the binding is gone and

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -146,6 +147,28 @@ func (f *fixture) attemptState() store.Attempt {
 		return err
 	})
 	return a
+}
+
+// advanceAttemptTo walks the attempt through the real transitions the
+// serving path uses, so a test never writes a state the product cannot
+// reach.
+func (f *fixture) advanceAttemptTo(target string) {
+	f.t.Helper()
+	ladder := []string{"leased", "preparing", "prepared", "starting", "running"}
+	f.tx(func(tx *store.Tx) error {
+		for i := 1; i < len(ladder); i++ {
+			if err := tx.Advance(f.attempt, ladder[i-1], ladder[i]); err != nil {
+				return err
+			}
+			if ladder[i] == target {
+				return nil
+			}
+		}
+		return fmt.Errorf("no path defined to attempt state %q", target)
+	})
+	if got := f.attemptState().State; got != target {
+		f.t.Fatalf("wanted an attempt in %q but it is %q; the test would assert nothing", target, got)
+	}
 }
 
 func (f *fixture) recordEvidence(e store.Evidence) {
@@ -413,5 +436,34 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 			f.lease, err = tx.LeaseAttempt(f.attempt, attempt.BindingID, "standard")
 			return err
 		})
+	}
+}
+
+// TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning: the
+// walk to `running` is optimistic. It records that a start was
+// authorized and the capsule reported itself up — never that a runner
+// took the job — so a runtime that afterwards proves the start never
+// took effect must still return the workload to the queue.
+//
+// Judged in evidence order instead, this attempt settles as one that
+// started, and the workload is never served again. That is the shape of
+// a capsule whose inner daemon never came up: everything the controller
+// wrote is intention, and the only fact is the reserved exit code.
+func TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	f.driveTo(store.LeaseCleaning)
+	f.advanceAttemptTo("running")
+	f.recordEvidence(store.EvidenceRunningObserved)
+
+	if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.ObservedCreated); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+
+	if got := f.attemptState(); got.State != "ready" {
+		t.Errorf("attempt state = %s (resolution %q); want it back in the queue as ready",
+			got.State, got.Resolution)
+	}
+	if got := f.reload().State; got != store.LeaseReleased {
+		t.Errorf("lease = %s; want released in the same commit", got)
 	}
 }

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -122,9 +122,17 @@ WHERE id = @attempt_id AND state IN ('leased', 'preparing', 'prepared');
 -- runtime being prepared - a write that moves backwards, and every retry
 -- of this shape ends in review after burning a lease. What each serving
 -- observed is kept in attempt_events either way.
+--
+-- `running` is in the guard beside `starting` because the walk that
+-- advances an attempt is optimistic: it writes `running` when the start
+-- is authorized and the capsule reports itself up, which is before the
+-- wait that can prove the runner never took the job. The proof arrives
+-- with the attempt already past `starting`, and a guard naming only that
+-- state matches no row: the finalizing transaction then rolls back and
+-- the lease pins in cleaning holding its credit.
 UPDATE assignment_attempts
 SET state = 'ready', execution_evidence = 'not_started'
-WHERE id = @attempt_id AND state = 'starting';
+WHERE id = @attempt_id AND state IN ('starting', 'running');
 
 -- name: CancelReadyAttempt :execrows
 -- A remote cancellation may close an attempt that is not yet executing;

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -453,7 +453,7 @@ func (q *Queries) RequeueAttempt(ctx context.Context, attemptID string) (int64, 
 const requeueProvenInertAttempt = `-- name: RequeueProvenInertAttempt :execrows
 UPDATE assignment_attempts
 SET state = 'ready', execution_evidence = 'not_started'
-WHERE id = ?1 AND state = 'starting'
+WHERE id = ?1 AND state IN ('starting', 'running')
 `
 
 // The one legal requeue past the start authorization: the daemon proved
@@ -467,6 +467,14 @@ WHERE id = ?1 AND state = 'starting'
 // runtime being prepared - a write that moves backwards, and every retry
 // of this shape ends in review after burning a lease. What each serving
 // observed is kept in attempt_events either way.
+//
+// `running` is in the guard beside `starting` because the walk that
+// advances an attempt is optimistic: it writes `running` when the start
+// is authorized and the capsule reports itself up, which is before the
+// wait that can prove the runner never took the job. The proof arrives
+// with the attempt already past `starting`, and a guard naming only that
+// state matches no row: the finalizing transaction then rolls back and
+// the lease pins in cleaning holding its credit.
 func (q *Queries) RequeueProvenInertAttempt(ctx context.Context, attemptID string) (int64, error) {
 	result, err := q.db.ExecContext(ctx, requeueProvenInertAttempt, attemptID)
 	if err != nil {

--- a/test/contract/capsule/contract_test.go
+++ b/test/contract/capsule/contract_test.go
@@ -192,6 +192,24 @@ func TestCapsuleLifecycle(t *testing.T) {
 		t.Fatalf("post-start observation never reached running; last = %s", last)
 	}
 
+	// Running says the runner was forked, not that it has read anything:
+	// the supervisor writes that state immediately after fork/exec,
+	// which is the earliest moment at which the job can be said to be
+	// the runner's. The drain below has to reach a listener that is
+	// actually up, so wait for the listener's own first output rather
+	// than for the state that precedes it.
+	deadline = time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		tail, err := dock.TailLogs(ctx, prepared.RuntimeID, 200)
+		if err != nil {
+			t.Fatalf("logs: %v", err)
+		}
+		if strings.Contains(tail, "[RUNNER") {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+
 	// End the serving the way the platform ends one. PID 1 is the
 	// supervisor, and its TERM path drains the runner and the inner
 	// daemon before reporting the exit.

--- a/test/contract/capsule/outcome_test.go
+++ b/test/contract/capsule/outcome_test.go
@@ -1,0 +1,150 @@
+package capsulecontract
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
+	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// controlProtocolFile is where the supervisor declares what it speaks.
+// The path is written out rather than borrowed from the launcher because
+// it is the contract itself: the two sides meet at this location, and a
+// test that read the launcher's own constant would agree with it however
+// wrong it was.
+const controlProtocolFile = "/run/runpool/protocol"
+
+// innerDockerSocket is the daemon the job actually runs on. The launcher
+// never names it — the supervisor owns it — so a test that asks whether
+// the daemon is up has to address it directly.
+const innerDockerSocket = "unix:///run/runpool-docker/docker.sock"
+
+// prepared brings up one capsule and hands back what the tests here need
+// from it. Every one of them is about the moment prepare returns, so
+// none of them starts the runner.
+func prepared(t *testing.T) (*capsule.Launcher, *docker.Client, capsule.PreparedRuntime) {
+	t.Helper()
+	m, dock, leaseID := launcher(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 4*time.Minute)
+	defer cancel()
+
+	rec := &memRecorder{}
+	t.Cleanup(func() { rec.cleanup(t, dock) })
+
+	runtime, err := m.Prepare(ctx, capsule.Spec{
+		LeaseID:      leaseID,
+		InstanceID:   "contract",
+		CapsuleImage: image,
+		JITConfig:    fakeJITConfig,
+		Resources: config.Resources{
+			Memory: 2 << 30, Swap: 0, CPU: 2e9, PIDs: 512,
+		},
+		CgroupDriver: cgroupDriver(ctx, t, dock),
+	}, rec)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	return m, dock, runtime
+}
+
+// TestTheCapsuleDeclaresTheProtocolThisBuildSpeaks pins the constant
+// against the image rather than against itself.
+//
+// The launcher refuses a capsule whose declaration is not this build's,
+// so a bumped constant and a stale image already fail — but they fail as
+// "incompatible image", which is also what a genuinely foreign image
+// produces. This says which of the two happened, and it is the only
+// check that can: the declaration is baked into the image at build time,
+// and nothing hermetic can read it.
+func TestTheCapsuleDeclaresTheProtocolThisBuildSpeaks(t *testing.T) {
+	_, dock, runtime := prepared(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	code, out, err := dock.Exec(ctx, runtime.RuntimeID, []string{"cat", controlProtocolFile})
+	if err != nil || code != 0 {
+		t.Fatalf("read %s: exit %d, %v: %s", controlProtocolFile, code, err, out)
+	}
+	if got := strings.TrimSpace(out); got != protocol.Version {
+		t.Errorf("the capsule image declares protocol %q and this build speaks %q; "+
+			"the image was not rebuilt for the change that moved the version", got, protocol.Version)
+	}
+}
+
+// TestPrepareWaitsForAProvenDaemon: when prepare returns, the capsule
+// can run a job.
+//
+// The supervisor writes `waiting` and the launcher waits for it, so what
+// this proves is that the name means what the launcher reads it as. A
+// supervisor that writes it at boot satisfies the launcher just as well
+// and has no daemon behind it — and the credential is delivered and the
+// start authorized against that capsule anyway, which is the failure
+// this pins. Only the pair can demonstrate it: the state is written on
+// one side and waited on from the other.
+func TestPrepareWaitsForAProvenDaemon(t *testing.T) {
+	_, dock, runtime := prepared(t)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+
+	// Asked once, with no retry on purpose. A poll here would prove only
+	// that the daemon comes up eventually, which was never in doubt; the
+	// claim is that it is already up at the instant prepare returned.
+	code, out, err := dock.Exec(ctx, runtime.RuntimeID, []string{"docker", "--host=" + innerDockerSocket, "info"})
+	if err != nil {
+		t.Fatalf("probe the inner daemon: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("prepare returned while the inner daemon was not answering (exit %d): %s\n"+
+			"a job authorized against this capsule has nothing to run on", code, out)
+	}
+}
+
+// TestAbortBeforeStartExitsWithTheReservedCode: a capsule stopped before
+// its start is authorized reports that the runner never owned the job.
+//
+// This is the ordinary shutdown of an idle capsule — the platform stops
+// the controller, the daemon stops the container — and the only account
+// it can leave is its exit code: the state file is tmpfs and dies with
+// it. Reporting a clean exit here settles an attempt that never ran as
+// complete, and nothing requeues it afterwards.
+func TestAbortBeforeStartExitsWithTheReservedCode(t *testing.T) {
+	m, dock, runtime := prepared(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	// Nothing was started, and the capsule says so while it can still be
+	// asked. The same answer has to survive the stop.
+	if obs, err := m.InspectExecution(ctx, runtime); err != nil || obs != assignment.ObservedCreated {
+		t.Fatalf("pre-stop observation = %s, %v; want created", obs, err)
+	}
+
+	if code, out, err := dock.ExecWithInput(ctx, runtime.RuntimeID, []string{"kill", "-TERM", "1"}, nil); err != nil || code != 0 {
+		t.Fatalf("signal the supervisor: exit %d, %v: %s", code, err, out)
+	}
+
+	exit, err := dock.WaitExit(ctx, runtime.RuntimeID)
+	if err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if int(exit) != protocol.AbortedExitCode {
+		t.Errorf("a capsule stopped before its start exited %d; want the reserved %d, "+
+			"which is what tells the controller the job was never handed over",
+			exit, protocol.AbortedExitCode)
+	}
+
+	// And the controller's own reading of that code, through the seam
+	// recovery uses: any other answer settles the attempt as a run.
+	obs, err := m.InspectExecution(ctx, runtime)
+	if err != nil {
+		t.Fatalf("post-stop inspection: %v", err)
+	}
+	if obs != assignment.ObservedCreated {
+		t.Errorf("post-stop observation = %s; want created, so the workload returns to the queue", obs)
+	}
+}


### PR DESCRIPTION
## What changes

A capsule that stopped before its start was authorized now settles as
work that never ran, on both the path that awaited it and the path that
adopted it. `waiting` is written only once the capsule's own Docker
daemon answers, and the control protocol moves to version 2 with it. The
protocol version is read before readiness rather than after, and a
supervisor state the container can no longer leave ends the wait instead
of burning its deadline.

## What was found

**A capsule whose daemon never comes up is handed a job anyway.** The
supervisor wrote `waiting` in `boot()`, alongside creating the control
directory — before `startDockerd`, let alone `awaitDockerdReady`. That
state is exactly what the launcher waits for before delivering the
credential and authorizing the start, so "prepared" meant "the control
surface answers", not "the job has something to run on". The launcher
cannot fix this from outside: it was already waiting for the right name,
and any probe of its own would race the daemon's startup with a second
poll loop while the state file went on lying.

**The ordinary shutdown of an idle capsule was reported as a finished
job.** `run` returned `(0, nil)` when the wait for authorization was
cancelled, with a comment calling it clean. Everything downstream reads a
clean exit as a runner that ran: `supervise` never reached
`terminalFailure`, so nothing produced `aborted:` and nothing returned
the reserved status.

**The reserved exit code was honoured on one path of two.** The serving
path recorded `exit_observed` for any clean wait, code 79 included, and
the adoption path discarded the status with `_` before recording the
same. A capsule could therefore settle two different ways depending on
which path awaited it.

**The proof was outranked by the intention.** By the time a wait returns,
evidence is `running_observed` and the attempt is `running` — both
written when the start authorization was accepted and the capsule
reported itself up, neither of them a runner observed owning work.
`disposeAttempt` judged evidence first, so an attempt with a
proven-inert start settled as `started_observed` and was never requeued.

**The requeue that carries the proof matched no row.** Its guard named
`starting`, but the walk advances an attempt to `running` before the wait
that produces the proof. Zero rows affected rolls the finalizing
transaction back and pins the lease in `cleaning` holding its credit.

**A terminal state cost the whole deadline and lost its reason.**
`awaitState` fast-failed on `failed:` only, so a capsule reporting
`aborted: dockerd did not become ready in time` was polled for 90 seconds
and then reported as a timeout — the reason discarded, and it is the only
account of the failure that survives, since the state file is tmpfs and
dies with the container.

**An incompatible image cost a readiness deadline to discover.** The
version check ran after readiness, so an image that could never become
ready spent the full wait before anyone read the file that said so.

Version 2 is the consequence of the first finding, not a courtesy: a
version 1 supervisor writes `waiting` before its daemon, so a version 2
controller pairing with one would deliver a credential against a capsule
with no daemon — the same failure, silent instead of racy. Exact equality
is the contract `docs/adrs/2026-08-17-capsule-image-substitution.md`
already states, and skewed pairs are supported through
`tiers[].capsuleImage`.

The 30-second bound on `awaitProtocol` is chosen as "this is not a
Runpool capsule", not as a readiness budget: the supervisor writes that
file before any state, so a first-party capsule answers within
milliseconds of starting.

## Evidence

The hermetic fixes are covered in `internal/capsule` and
`internal/lease`, each checked by reverting the fix and watching the new
test fail. Readiness and the abort status are properties of the
controller and capsule as a pair, so they are pinned in the gated capsule
contract — which runs in CI on this pull request, not only at
qualification.

```text
mutation checks, local:
  drop AbortedPrefix from protocol.Terminal
    -> TestAwaitStateGivesUpOnEveryTerminalState/aborted_before_the_runner:
       done = false, want true
  move the ObservedCreated case back below the evidence cases
    -> TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning:
       attempt state = settled (resolution "started_observed"); want ready
  narrow RequeueProvenInertAttempt back to state = 'starting'
    -> Finalize: row state moved since it was observed: attempt ... is not starting

CI, "outer capsule, JIT and the egress sandbox" (real daemon, first-party image):
  TestTheCapsuleDeclaresTheProtocolThisBuildSpeaks   PASS
  TestPrepareWaitsForAProvenDaemon                   PASS
  TestAbortBeforeStartExitsWithTheReservedCode       PASS
  TestCapsuleLifecycle                               PASS
```

## What would notice this regressing

- `TestAwaitStateGivesUpOnEveryTerminalState` (internal/capsule) fails if
  a terminal prefix stops ending the wait.
- `TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning`
  (internal/lease) fails if evidence is judged ahead of the proof, and if
  the proven-inert guard narrows again.
- `TestPrepareWaitsForAProvenDaemon` (gated capsule contract) fails if
  `waiting` moves back ahead of the daemon. Nothing hermetic can catch
  that one: it is a property of the pair.
- `TestAbortBeforeStartExitsWithTheReservedCode` (gated) fails if the
  cancelled wait returns a clean exit again.
- `TestTheCapsuleDeclaresTheProtocolThisBuildSpeaks` (gated) fails if the
  constant moves without the image being rebuilt.
- `TestProtocolVerdict` derives its neighbouring versions from the one
  this build speaks; it previously named `"2"` by hand and would have
  started accepting it the day it shipped.

## Risk, compatibility and operations

**Protocol compatibility is the risk, and it is deliberate.** A version 1
capsule image meets a version 2 controller as `ErrIncompatibleImage`, is
held for review as `capsule_incompatible`, and is not retried. Pre-release,
so no image exists in the wild; an operator building on the published
capsule rebuilds against this release, which the existing `capsuleImage`
documentation already prescribes.

**Trust boundary: unchanged.** No credential path, capability, mount or
network surface is touched. The credential still travels over exec stdin
onto tmpfs; delivery now happens strictly later, after a proven daemon.

**Failure behaviour: strictly more conservative.** Two paths that
previously settled an attempt as complete now requeue it, which spends a
serving from the retry budget rather than losing the job. An attempt that
exhausts that budget goes to `retry_budget_exhausted` review as before.

**Operations:** no CLI, configuration, status API, schema or migration
change. No rollback step. `runpool status` already reports each tier's
capsule image, which is what an operator reads when an image is refused.

The decision record on capsule image substitution already states the
exact-equality rule this exercises, so it is applied rather than amended.

## Changelog

```text
Isolation and egress:
- A tier may name its own capsule image ... That version is read before
  readiness is waited on, so an image that is not this build's half of the
  protocol is refused in about a second rather than after a readiness
  deadline that was never going to be met.
- A prepared capsule has a daemon that answers. The state the controller
  delivers a credential on is written by the supervisor only once the
  job's own Docker daemon is up, so readiness is something the capsule
  proves rather than something it announces on the way to proving it.

State and operations:
- A capsule that never handed the job over returns it to the queue. The
  supervisor exits with a status it reserves for stopping before the start
  was authorized — the ordinary end of an idle capsule when a controller
  shuts down — and both the path that awaited a capsule and the one that
  adopted it read that status the same way. It outranks what was recorded
  when the start was authorized: that record is written when a capsule
  reports itself up, while this one is the capsule stating that nothing
  ever came after it. A job read the other way around is settled as one
  that ran and is never served again.
```

## Notes for your reviewer

`TestCapsuleLifecycle` needed a change and it is worth looking at. It
signalled the supervisor as soon as it observed `running` and then
asserted the listener had run — but `running` is written immediately
after the runner is forked, so the assertion was relying on how long the
observation happened to take. Making readiness real removed that slack
and the test failed. It now waits for the listener's own first output
before draining, which is the observable the assertion is actually about.

The second guard I drafted for `withAttemptOfLease` is not here: see the
next pull request, where I dropped it for the same reason.
