### PR TITLE
fix(store, app): only an attempt that consumed nothing is superseded, and its lease is claimed inside the transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,18 @@ by its public and operational effects.
   evidence rung and the provider's own identifiers for the run, so the
   external check the command's help prescribes can be carried out from
   the tool that prescribes it.
+- **A workload the provider reassigns is served under its new
+  delivery.** The redelivery replaces the predecessor's attempt when that
+  attempt provably consumed nothing — including one held for review,
+  which is an open state and would otherwise stall the binding's whole
+  ordered queue — and refuses when a start was authorized, where the
+  redelivery waits for the predecessor's own lifecycle instead. A
+  replacement never reaches the attempts the same delivery just
+  recorded.
+- **An attempt replaced mid-preparation is not started.** The edge
+  before the one effect that can begin execution is a compare-and-swap,
+  so a launch whose attempt was resolved while its capsule was being
+  prepared stops there, and the capsule is torn down without a job.
 - **A capsule that never handed the job over returns it to the queue.**
   The supervisor exits with a status it reserves for stopping before the
   start was authorized — the ordinary end of an idle capsule when a

--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/rhobuild/runpool/internal/allocator"
 	"github.com/rhobuild/runpool/internal/assignment"
@@ -93,6 +94,11 @@ func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness 
 		alloc:     allocator.New(),
 		bindings:  []*binding{b},
 		byBinding: map[int64]*binding{bindingID: b},
+		// A lease this harness calls stranded was written moments ago,
+		// because no test here simulates the passage of time. The grace
+		// exists for a real gap between a lease committing and its owner
+		// registering, and a test whose subject is that gap sets its own.
+		strandedGrace: time.Nanosecond,
 	}
 	if err := h.srv.alloc.Register(b.tier.ID, b.key, parallelism); err != nil {
 		t.Fatal(err)

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -323,29 +323,36 @@ func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githu
 
 	var deliveryID int64
 	err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		delivery, err := tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
+		id, err := tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
 		if errors.Is(err, store.ErrOpenAttemptExists) {
-			// Supersede a ready predecessor and record again, in this
-			// same transaction. Anything beyond ready is left to resolve
-			// itself; the error propagates and the message waits as a
-			// redelivery.
+			// Supersede the predecessor and record again, in this same
+			// transaction. Only a predecessor that provably consumed
+			// nothing gives way; anything further along refuses, the
+			// error propagates, and the message waits as a redelivery.
+			//
+			// The sweep covers every workload the delivery carries
+			// because any of them may hold the conflict, and the ones
+			// that do not are no-ops. It cannot include this delivery's
+			// own attempts: those were inserted moments ago, above,
+			// before the conflicting workload was reached.
 			for _, a := range admitted {
-				serr := tx.SupersedeOpenAttempt(b.bindingID, a.SourceWorkloadKey, assignment.ResolutionSuperseded)
+				serr := tx.SupersedeOpenAttempt(b.bindingID, a.SourceWorkloadKey,
+					assignment.ResolutionSuperseded, id)
 				if serr != nil && !errors.Is(serr, store.ErrNotFound) {
 					return serr
 				}
 			}
-			delivery, err = tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
+			id, err = tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
 		}
 		if err != nil {
 			return err
 		}
-		deliveryID = delivery.ID
+		deliveryID = id
 
 		// The provider's identifiers ride along per attempt, in the
 		// adapter-owned metadata table. Zero request ids are stored as
 		// observed — they are diagnostics, never identity.
-		attempts, err := tx.AttemptsOfDelivery(delivery.ID)
+		attempts, err := tx.AttemptsOfDelivery(id)
 		if err != nil {
 			return err
 		}

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -29,10 +29,19 @@ type fakeCapsule struct {
 	// spec is what the controller asked for, which is the only place the
 	// image decisions are observable.
 	spec capsule.Spec
+	// onPrepare runs inside the preparation, which is the window a real
+	// redelivery lands in: preparing a capsule takes minutes and the
+	// attempt is out of the launching goroutine's sight for all of it.
+	onPrepare func()
+	// starts counts the one effect that can begin execution.
+	starts int
 }
 
 func (f *fakeCapsule) Prepare(_ context.Context, spec capsule.Spec, rec capsule.ResourceRecorder) (capsule.PreparedRuntime, error) {
 	f.spec = spec
+	if f.onPrepare != nil {
+		f.onPrepare()
+	}
 	if f.prepareErr != nil {
 		return capsule.PreparedRuntime{}, f.prepareErr
 	}
@@ -52,7 +61,10 @@ func (f *fakeCapsule) Prepare(_ context.Context, spec capsule.Spec, rec capsule.
 	return capsule.PreparedRuntime{RuntimeID: "fake-runner"}, nil
 }
 
-func (f *fakeCapsule) Start(context.Context, capsule.PreparedRuntime) error { return f.startErr }
+func (f *fakeCapsule) Start(context.Context, capsule.PreparedRuntime) error {
+	f.starts++
+	return f.startErr
+}
 
 func (f *fakeCapsule) InspectExecution(context.Context, capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
 	return f.obs, f.obsErr
@@ -558,4 +570,117 @@ func TestTheWaitInheritsWhatTheLeaseHasLeft(t *testing.T) {
 func ptrDuration(d time.Duration) *config.Duration {
 	cd := config.Duration(d)
 	return &cd
+}
+
+// TestARedeliveryNeverSupersedesItsOwnAttempts: resolving an
+// open-attempt conflict must not close the attempts the same delivery
+// just inserted.
+//
+// RecordDelivery inserts the workloads it reaches before the conflicting
+// one, so a caller that sweeps every workload the delivery carries finds
+// those first. Superseding one and retrying leaves the retry reporting
+// it as already inserted — the row is there, superseded — and the
+// workload is never served, under a delivery that did land and a
+// message that is acknowledged.
+func TestARedeliveryNeverSupersedesItsOwnAttempts(t *testing.T) {
+	h := newHarness(t, 2)
+
+	// A predecessor for the second workload only. The order is the
+	// point: the new delivery inserts job-a, then conflicts on job-b,
+	// so by the time the conflict is resolved this delivery already owns
+	// an open attempt of its own for a workload the sweep will visit.
+	if err := h.deliver(demand("job-b", "app", 2)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := h.deliver(demand("job-a", "app", 3), demand("job-b", "app", 4)); err != nil {
+		t.Fatalf("the redelivery did not persist: %v", err)
+	}
+
+	ready := h.ready()
+	if len(ready) != 2 {
+		var got []string
+		for _, a := range ready {
+			got = append(got, a.SourceWorkloadKey)
+		}
+		t.Fatalf("servable workloads = %v; want both job-a and job-b under the new delivery", got)
+	}
+	seen := map[string]bool{}
+	for _, a := range ready {
+		seen[a.SourceWorkloadKey] = true
+	}
+	if !seen["job-a"] || !seen["job-b"] {
+		t.Errorf("servable workloads = %v; want both", seen)
+	}
+}
+
+// TestAFreshLeaseIsNotStranded closes the window the in-memory claim
+// cannot cover. The claim is taken just after the lease row commits, so
+// a pass landing in between finds the lease unclaimed — and tearing down
+// a capsule that is starting ends with both owners releasing the same
+// admission credit.
+func TestAFreshLeaseIsNotStranded(t *testing.T) {
+	h := newHarness(t, 1)
+	// The production grace, against a lease this test just created: the
+	// harness shortens it, and shortening it is what would make this
+	// assert nothing.
+	h.srv.strandedGrace = defaultStrandedGrace
+	if err := h.deliver(demand("job-fresh", "app", 90)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-fresh")
+	h.srv.alloc.Adopt(h.bind.key)
+
+	before := reloadLease(t, h, lease.ID).State
+	h.srv.retryStranded(t.Context())
+
+	if got := reloadLease(t, h, lease.ID).State; got != before {
+		t.Errorf("a lease committed moments ago moved %s -> %s; its owner had not registered yet", before, got)
+	}
+	if h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the pass released the credit of a lease whose owner was still starting")
+	}
+}
+
+// TestASupersededAttemptIsNeverStarted: superseding an attempt that a
+// goroutine is already preparing must stop that goroutine before the
+// start, not after it.
+//
+// Preparing a capsule takes minutes, and the attempt is out of the
+// launching goroutine's sight for all of them: the walk logs a lost
+// transition and carries on. So the edge into `starting` is made
+// authoritative — a compare-and-swap that matches no row means something
+// else resolved this attempt, and the successor is already serving the
+// workload. Starting anyway runs it twice.
+func TestASupersededAttemptIsNeverStarted(t *testing.T) {
+	h := newHarness(t, 1)
+	caps := &fakeCapsule{}
+	h.srv.caps = caps
+	h.srv.wait = &fakeWaiter{}
+	h.bind.gh = &fakeRegistry{}
+	if err := h.deliver(demand("job-raced", "app", 42)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-raced")
+
+	// The redelivery lands while the capsule is being prepared.
+	caps.onPrepare = func() {
+		h.inStore(func(tx *store.Tx) error {
+			return tx.SupersedeOpenAttempt(h.bind.bindingID, "job-raced",
+				assignment.ResolutionSuperseded, 0)
+		})
+	}
+
+	h.srv.wg.Add(1)
+	h.srv.runCapsule(h.bind, lease)
+
+	if caps.starts != 0 {
+		t.Errorf("the capsule was started %d time(s) for an attempt its successor owns", caps.starts)
+	}
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseReleased {
+		t.Errorf("lease = %s; want released — a superseded attempt must not pin the lease serving it", got)
+	}
+	if !h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the lease's admission credit was never returned")
+	}
 }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -12,6 +12,18 @@ import (
 	"github.com/rhobuild/runpool/internal/store"
 )
 
+// strandedGrace is how long a live lease is left alone before the
+// periodic pass may consider it ownerless.
+//
+// It is keyed on the last transition rather than on creation, so it also
+// keeps the pass off a lease a goroutine is actively moving: every
+// transition is a sign of an owner, and a lease that stops moving for
+// this long has genuinely lost one. Long enough to cover the gap between
+// a lease row committing and its owner registering in memory; short
+// enough that a lease a crash really did strand is still recovered
+// within one pass of noticing.
+const defaultStrandedGrace = 2 * time.Minute
+
 // reconcile aligns the books with the daemon at startup, across every
 // binding. A lease whose capsule still runs is adopted, awaited
 // and cleaned; every other live lease is released, and the resource
@@ -489,6 +501,17 @@ func (s *Controller) retryStranded(ctx context.Context) {
 	for _, lease := range live {
 		if retried >= perPass {
 			break
+		}
+		if time.Since(lease.UpdatedAt) < s.strandedAfter() {
+			// Recently touched, so its owner is either running or about
+			// to register. The claim that marks a lease owned is taken
+			// in memory just after the row commits, and a pass that ran
+			// inside that gap would find the lease unclaimed, call it
+			// stranded, and tear down a capsule that is starting — after
+			// which both owners conclude the lease is done and release
+			// its credit twice. Elapsed time is the only evidence of the
+			// gap that exists here, so it is what the pass waits on.
+			continue
 		}
 		if !s.claimLease(lease.ID) {
 			continue // a goroutine is driving it; not this pass's business

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -175,6 +175,28 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 	s.advanceAttempt(ctx, attemptID, "preparing", "prepared")
+	// This one edge is authoritative, unlike every other in the walk. It
+	// is the last point before an effect that can begin execution, and
+	// by here the attempt has been out of this goroutine's sight for the
+	// whole preparation: a redelivery of the same workload can have
+	// superseded it, and nothing between `prepared` and the start
+	// consults it again. A compare-and-swap that matches no row means
+	// something else resolved this attempt, and no start may be
+	// authorized against it.
+	//
+	// It runs before the authorization is recorded rather than after,
+	// which narrows the ambiguous window instead of widening it: a
+	// compare-and-swap is not an effect, and an authorization recorded
+	// for a start that will not be attempted is a claim that never
+	// became true.
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.Advance(attemptID, "prepared", "starting")
+	}); err != nil {
+		log.Warn("the attempt moved before the start was authorized; nothing is started",
+			"attempt", attemptID, "error", err)
+		s.recoverCapsuleFailure(b, lease.ID, assignment.ObservedCreated)
+		return
+	}
 	// The authorization is durable immediately before the one effect
 	// that can begin execution, so the ambiguous window is exactly one
 	// Docker request wide and a crash inside it is classified by
@@ -184,7 +206,6 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		s.recoverCapsuleFailure(b, lease.ID, startObs)
 		return
 	}
-	s.advanceAttempt(ctx, attemptID, "prepared", "starting")
 	if startErr := s.caps.Start(prepCtx, prepared); startErr != nil {
 		// A failed Start call does not prove no start: the request may
 		// have taken effect before the error. Classify from the daemon

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -493,6 +493,21 @@ type Controller struct {
 	// default. Held for the same reason as pollBackoff: a minute is not
 	// something a test waits.
 	drainWindow time.Duration
+
+	// strandedGrace overrides defaultStrandedGrace in tests; zero means
+	// the default. A test that fabricates a stranded lease writes it in
+	// the same instant it sweeps for one, and the production window is
+	// two minutes.
+	strandedGrace time.Duration
+}
+
+// strandedAfter is how long a live lease must have gone untouched
+// before the periodic pass may claim it as ownerless.
+func (s *Controller) strandedAfter() time.Duration {
+	if s.strandedGrace > 0 {
+		return s.strandedGrace
+	}
+	return defaultStrandedGrace
 }
 
 func (s *Controller) drain() error {

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -211,6 +211,20 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+lease.ID, "cleanup_completed"); err != nil {
 		return err
 	}
+	// A redelivery of the same workload supersedes the attempt this
+	// lease was serving. The serving still ends — the capsule is
+	// destroyed and the lease released — but the attempt is already
+	// resolved, and forcing a disposition onto it would match no row,
+	// fail, and roll the release back with it: the lease would pin in
+	// cleaning holding its credit, for a workload that is being served
+	// by its successor.
+	//
+	// Only superseded. A settled attempt arriving here would be a second
+	// finalize, which the lease transition already refuses, and papering
+	// over that would hide it.
+	if attempt.State == "superseded" {
+		return nil
+	}
 	switch {
 	case startObs == assignment.ObservedCreated:
 		// Authorized, and the runtime proved the start never took

--- a/internal/store/assignment_repository.go
+++ b/internal/store/assignment_repository.go
@@ -50,14 +50,14 @@ type WorkloadRow struct {
 //     delivery returns ErrOpenAttemptExists: the caller supersedes or
 //     resolves the predecessor first, in the same transaction, and
 //     retries.
-func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerprint [32]byte, workloads []WorkloadRow) (sqlitedb.BrokerDelivery, error) {
+func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerprint [32]byte, workloads []WorkloadRow) (int64, error) {
 	delivery, err := t.q.GetDeliveryByKey(t.ctx, sqlitedb.GetDeliveryByKeyParams{
 		BindingID: bindingID, SourceDeliveryKey: sourceDeliveryKey,
 	})
 	switch {
 	case err == nil:
 		if !bytes.Equal(delivery.PayloadSha256, fingerprint[:]) {
-			return sqlitedb.BrokerDelivery{}, fmt.Errorf("%w: delivery %s of binding %d",
+			return 0, fmt.Errorf("%w: delivery %s of binding %d",
 				ErrContractDrift, sourceDeliveryKey, bindingID)
 		}
 		// Exact redelivery. The attempts are ensured below rather than
@@ -72,21 +72,27 @@ func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerpri
 			PayloadSha256:     fingerprint[:],
 		})
 		if err != nil {
-			return sqlitedb.BrokerDelivery{}, err
+			return 0, err
 		}
 	default:
-		return sqlitedb.BrokerDelivery{}, err
+		return 0, err
 	}
 
 	for _, w := range workloads {
 		if w.SourceWorkloadKey == "" {
-			return sqlitedb.BrokerDelivery{}, fmt.Errorf("workload with no key in delivery %s cannot be made durable", sourceDeliveryKey)
+			return delivery.ID, fmt.Errorf("workload with no key in delivery %s cannot be made durable", sourceDeliveryKey)
 		}
 		if err := t.insertAttempt(delivery, w); err != nil {
-			return sqlitedb.BrokerDelivery{}, err
+			// The id travels with the error on purpose. The delivery row
+			// exists in this transaction by now, and a caller resolving
+			// an open-attempt conflict needs to know which delivery is
+			// asking - without it, the only way to resolve the conflict
+			// is to supersede blindly, including the attempts this very
+			// delivery just inserted.
+			return delivery.ID, err
 		}
 	}
-	return delivery, nil
+	return delivery.ID, nil
 }
 
 func (t *Tx) insertAttempt(delivery sqlitedb.BrokerDelivery, w WorkloadRow) error {
@@ -129,9 +135,10 @@ func (t *Tx) insertAttempt(delivery sqlitedb.BrokerDelivery, w WorkloadRow) erro
 // SupersedeOpenAttempt resolves the open predecessor of a workload so a
 // new delivery's attempt can be recorded — in the caller's transaction,
 // so old-to-superseded and new-to-ready commit together or not at all.
-// Only an attempt that never had a start authorized may be superseded;
-// anything further along is settled or reviewed through its own path.
-func (t *Tx) SupersedeOpenAttempt(bindingID int64, sourceWorkloadKey, resolution string) error {
+// Only an attempt that provably consumed nothing may be superseded;
+// anything further along is settled or reviewed through its own path,
+// and the redelivery waits for that to happen.
+func (t *Tx) SupersedeOpenAttempt(bindingID int64, sourceWorkloadKey, resolution string, exceptDelivery int64) error {
 	open, err := t.q.GetOpenAttemptByWorkload(t.ctx, sqlitedb.GetOpenAttemptByWorkloadParams{
 		BindingID: bindingID, SourceWorkloadKey: sourceWorkloadKey,
 	})
@@ -140,6 +147,17 @@ func (t *Tx) SupersedeOpenAttempt(bindingID int64, sourceWorkloadKey, resolution
 	}
 	if err != nil {
 		return err
+	}
+	// A delivery never supersedes its own attempts. RecordDelivery
+	// inserts the workloads it reaches before the conflicting one, so a
+	// caller resolving that conflict by looping over the delivery's
+	// workloads finds those first: superseding one and retrying leaves
+	// the retry's ON CONFLICT DO NOTHING reporting it as already
+	// inserted, and the workload stays superseded, unserved, with its
+	// message acknowledged. Nothing afterwards notices, because the
+	// delivery did land.
+	if open.DeliveryID == exceptDelivery {
+		return ErrNotFound
 	}
 	affected, err := t.q.SupersedeAttempt(t.ctx, sqlitedb.SupersedeAttemptParams{
 		Resolution: resolution, AttemptID: open.ID,

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -148,10 +148,37 @@ SET state = 'settled', resolution = @resolution, settled_at = unixepoch()
 WHERE id = @attempt_id AND state = @current;
 
 -- name: SupersedeAttempt :execrows
+-- Every open state that provably consumed nothing, and no other.
+--
+-- `starting` and `running` are absent and must stay absent: a start was
+-- authorized there, and replacing such an attempt is how one workload
+-- comes to run twice. A redelivery that meets one leaves its message
+-- unacknowledged and waits for the predecessor's own lifecycle to end
+-- it, which is the correct stall.
+--
+-- `preparing` belongs here for the opposite reason - it precedes the
+-- authorization exactly as `leased` and `prepared` do - and leaving it
+-- out stalled a binding's whole ordered queue on an attempt that had
+-- consumed nothing.
+--
+-- `manual_review` belongs here too. It is an open state, so an attempt
+-- held in it blocks every redelivery of that workload, and the provider
+-- reassigning the work is precisely what makes a pending human decision
+-- moot. The superseded resolution keeps the trail.
+--
+-- But a review is reachable from `starting` and `running`, and
+-- `start_outcome_unknown` is exactly the review of an attempt whose
+-- start was authorized and whose outcome nobody could prove. Replacing
+-- that one is a second execution of work that may have run. So the
+-- evidence has to agree with the state: nothing beyond a prepared
+-- runtime was ever consumed. It also closes the same question for the
+-- pre-authorization states, none of which can be trusted to imply their
+-- own evidence forever.
 UPDATE assignment_attempts
 SET state = 'superseded', resolution = @resolution, settled_at = unixepoch()
 WHERE id = @attempt_id
-  AND state IN ('ready', 'leased', 'prepared');
+  AND state IN ('ready', 'leased', 'preparing', 'prepared', 'manual_review')
+  AND execution_evidence IN ('not_started', 'runtime_prepared');
 
 -- name: MarkAttemptManualReview :execrows
 UPDATE assignment_attempts

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -555,7 +555,8 @@ const supersedeAttempt = `-- name: SupersedeAttempt :execrows
 UPDATE assignment_attempts
 SET state = 'superseded', resolution = ?1, settled_at = unixepoch()
 WHERE id = ?2
-  AND state IN ('ready', 'leased', 'prepared')
+  AND state IN ('ready', 'leased', 'preparing', 'prepared', 'manual_review')
+  AND execution_evidence IN ('not_started', 'runtime_prepared')
 `
 
 type SupersedeAttemptParams struct {
@@ -563,6 +564,32 @@ type SupersedeAttemptParams struct {
 	AttemptID  string
 }
 
+// Every open state that provably consumed nothing, and no other.
+//
+// `starting` and `running` are absent and must stay absent: a start was
+// authorized there, and replacing such an attempt is how one workload
+// comes to run twice. A redelivery that meets one leaves its message
+// unacknowledged and waits for the predecessor's own lifecycle to end
+// it, which is the correct stall.
+//
+// `preparing` belongs here for the opposite reason - it precedes the
+// authorization exactly as `leased` and `prepared` do - and leaving it
+// out stalled a binding's whole ordered queue on an attempt that had
+// consumed nothing.
+//
+// `manual_review` belongs here too. It is an open state, so an attempt
+// held in it blocks every redelivery of that workload, and the provider
+// reassigning the work is precisely what makes a pending human decision
+// moot. The superseded resolution keeps the trail.
+//
+// But a review is reachable from `starting` and `running`, and
+// `start_outcome_unknown` is exactly the review of an attempt whose
+// start was authorized and whose outcome nobody could prove. Replacing
+// that one is a second execution of work that may have run. So the
+// evidence has to agree with the state: nothing beyond a prepared
+// runtime was ever consumed. It also closes the same question for the
+// pre-authorization states, none of which can be trusted to imply their
+// own evidence forever.
 func (q *Queries) SupersedeAttempt(ctx context.Context, arg SupersedeAttemptParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, supersedeAttempt, arg.Resolution, arg.AttemptID)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -79,7 +79,7 @@ func TestRedeliveryIsIdempotentAndDriftFailsClosed(t *testing.T) {
 	binding := seedBinding(t, s)
 	workloads := []WorkloadRow{{SourceWorkloadKey: "job-1", TenantKey: "acme", ProjectKey: "app"}}
 
-	var first sqlitedb.BrokerDelivery
+	var first int64
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		first, err = tx.RecordDelivery(binding, "msg-7", fingerprint("payload-a"), workloads)
@@ -92,8 +92,8 @@ func TestRedeliveryIsIdempotentAndDriftFailsClosed(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if again.ID != first.ID {
-			t.Errorf("redelivery produced delivery %d; want the original %d", again.ID, first.ID)
+		if again != first {
+			t.Errorf("redelivery produced delivery %d; want the original %d", again, first)
 		}
 		n, err := tx.q.CountOpenAttempts(tx.ctx, binding)
 		if err != nil {
@@ -142,7 +142,7 @@ func TestReassignmentNeedsThePredecessorResolved(t *testing.T) {
 	// Supersede-then-record commits together: the partial index admits
 	// the new attempt in the same transaction that closes the old one.
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.SupersedeOpenAttempt(binding, "job-r", "reassigned_by_provider"); err != nil {
+		if err := tx.SupersedeOpenAttempt(binding, "job-r", "reassigned_by_provider", 0); err != nil {
 			return err
 		}
 		_, err := tx.RecordDelivery(binding, "msg-2", fingerprint("second"), workloads)
@@ -238,9 +238,9 @@ func TestAckStateMachineConvergesAfterUncertainty(t *testing.T) {
 
 	var deliveryID int64
 	inTx(t, s, func(tx *Tx) error {
-		d, err := tx.RecordDelivery(binding, "msg-ack", fingerprint("ack"),
+		var err error
+		deliveryID, err = tx.RecordDelivery(binding, "msg-ack", fingerprint("ack"),
 			[]WorkloadRow{{SourceWorkloadKey: "job-ack", TenantKey: "acme", ProjectKey: "app"}})
-		deliveryID = d.ID
 		return err
 	})
 
@@ -497,9 +497,9 @@ func TestAckRequestedIsRetriedAfterACrashInFlight(t *testing.T) {
 
 	var deliveryID int64
 	inTx(t, s, func(tx *Tx) error {
-		d, err := tx.RecordDelivery(binding, "msg-wedge", fingerprint("wedge"),
+		var err error
+		deliveryID, err = tx.RecordDelivery(binding, "msg-wedge", fingerprint("wedge"),
 			[]WorkloadRow{{SourceWorkloadKey: "job-wedge", TenantKey: "acme", ProjectKey: "app"}})
-		deliveryID = d.ID
 		return err
 	})
 
@@ -1294,4 +1294,84 @@ func TestAttemptProviderReferences(t *testing.T) {
 		}
 		return nil
 	})
+}
+
+// A held attempt must not stall its binding's whole ordered queue, and a
+// held attempt whose start was authorized must not be replaced.
+//
+// manual_review is an open state, so the partial unique index refuses
+// every redelivery of that workload while one sits there — the queue is
+// ordered, so the binding stops. The provider reassigning the workload
+// is what makes a pending human decision moot, so the review gives way.
+//
+// Except when it cannot: a review is reachable from `starting` and
+// `running`, and `start_outcome_unknown` is precisely the review of an
+// attempt whose start was authorized and whose outcome nobody could
+// prove. Replacing that one runs work that may already have run, which
+// no queue property is worth. The evidence is what separates the two.
+func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		evidence       Evidence
+		reason         string
+		wantSuperseded bool
+	}{
+		{"nothing was prepared", EvidenceNotStarted, ReviewReasonIncompatibleCapsule, true},
+		{"a runtime was prepared", EvidenceRuntimePrepared, ReviewReasonRetryBudgetExhausted, true},
+		{"a start was authorized", EvidenceStartAuthorized, ReviewReasonStartOutcomeUnknown, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newStore(t)
+			binding := seedBinding(t, s)
+			workloads := []WorkloadRow{{SourceWorkloadKey: "job-held", TenantKey: "acme", ProjectKey: "app"}}
+
+			var attemptID string
+			inTx(t, s, func(tx *Tx) error {
+				if _, err := tx.RecordDelivery(binding, "msg-1", fingerprint("first"), workloads); err != nil {
+					return err
+				}
+				ready, err := tx.ReadyAttempts(binding)
+				if err != nil {
+					return err
+				}
+				attemptID = ready[0].ID
+				if err := tx.RecordEvidence(attemptID, tc.evidence); err != nil {
+					return err
+				}
+				return tx.HoldForReview(attemptID, tc.reason)
+			})
+
+			err := s.Tx(t.Context(), func(tx *Tx) error {
+				serr := tx.SupersedeOpenAttempt(binding, "job-held", "reassigned_by_provider", 0)
+				if serr != nil {
+					return serr
+				}
+				_, rerr := tx.RecordDelivery(binding, "msg-2", fingerprint("second"), workloads)
+				return rerr
+			})
+
+			var got Attempt
+			inTx(t, s, func(tx *Tx) error {
+				var err error
+				got, err = tx.Get(attemptID)
+				return err
+			})
+
+			if tc.wantSuperseded {
+				if err != nil {
+					t.Fatalf("the redelivery was refused: %v", err)
+				}
+				if got.State != "superseded" {
+					t.Errorf("held attempt = %s; want superseded so the queue moves", got.State)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("the redelivery replaced an attempt whose start was authorized")
+			}
+			if got.State != "manual_review" {
+				t.Errorf("held attempt = %s; want it left in manual_review", got.State)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## What changes

A redelivery replaces a predecessor attempt only when that attempt
provably consumed nothing, and never one of its own. The supersede set
moves into SQL and gains `preparing` and `manual_review`, gated on
evidence. The walk's edge into `starting` becomes an authoritative
compare-and-swap, so an attempt resolved during preparation is not
started. A superseded attempt no longer pins its lease, and the periodic
pass leaves a recently transitioned lease alone.

## What was found

**A delivery superseded its own attempts.** `RecordDelivery` inserts the
workloads it reaches before the conflicting one, then returned
`sqlitedb.BrokerDelivery{}` with `ErrOpenAttemptExists` — so the caller
could not tell its own attempts from a predecessor's and swept every
workload the delivery carried. The sweep found one just inserted,
superseded it, and the retry's `ON CONFLICT (delivery_id,
source_workload_key) DO NOTHING` reported it as already inserted. That
workload is then superseded, unserved, under a delivery that landed and a
message that was acknowledged, and nothing afterwards looks again.

**The supersede set was narrower than the states that consumed
nothing.** `preparing` was missing, so a redelivery meeting an attempt in
it failed the whole transaction; the queue is ordered, so the binding
stopped. `manual_review` was missing for the same practical effect — it
is in the open set the partial unique index enforces, so one held attempt
blocked every redelivery of that workload indefinitely.

**And wider than at-most-once allows, once `manual_review` is added.** A
review is reachable from `starting` and `running`, and
`start_outcome_unknown` is exactly the review of an attempt whose start
was authorized and whose outcome could not be proven. Superseding that
one lets a successor run work that may already be running. The guard is
therefore on evidence — `not_started` or `runtime_prepared` — which
states the actual rule and closes the same question for the
pre-authorization states rather than trusting them to imply their own
evidence forever. `starting` and `running` stay out of the set entirely:
a redelivery meeting one leaves its message unacknowledged and waits for
the predecessor's lifecycle, which is the correct stall.

**A superseded attempt could still be started.** Superseding an attempt
in `leased`, `preparing` or `prepared` leaves a goroutine preparing a
capsule for it, and that goroutine does not consult the attempt again
between `prepared` and `Start` — `advanceAttempt` logs a lost transition
and continues. Preparing takes minutes, which is the whole window.

**A superseded attempt pinned its lease.** `disposeAttempt` forced a
disposition onto it, every compare-and-swap matched no row, the error
rolled back the release in the same transaction, and the lease stayed in
`cleaning` holding its admission credit — for a workload its successor
was already serving.

**A lease had two owners for the length of one gap.** The claim that
marks a lease owned is taken in memory just after the row commits, and
the periodic pass lists `reserved` as live. A pass landing in the gap
found the lease unclaimed, called it stranded, and drove it through
recovery — destroying the capsule, network and volume of a job that was
starting, after which both owners released the same credit.

Two constants, and what decided them. `strandedGrace` is two minutes and
is keyed on the last transition rather than on creation: every transition
is a sign of an owner, so this also keeps the pass off a lease a
goroutine is actively moving, and two minutes is long enough to cover a
commit-to-claim gap while still recovering a genuinely stranded lease
within one pass of noticing. The compare-and-swap is placed *before*
`RecordEvidence` rather than after: a compare-and-swap is not an effect,
so this narrows the ambiguous window rather than widening it, and an
authorization recorded for a start that will not be attempted is a claim
that never became true.

## Evidence

Hermetic throughout — this is the assignment machine and SQLite, and both
run in full on every pull request. Each fix was checked by reverting it
and watching the new test fail.

```text
mutation checks, local:
  drop the exceptDelivery filter
    -> TestARedeliveryNeverSupersedesItsOwnAttempts:
       servable workloads = [job-b]; want both job-a and job-b
  remove 'manual_review' from the supersede set
    -> TestSupersedingAHeldAttemptTurnsOnWhatItConsumed/a_runtime_was_prepared:
       row state moved since it was observed: attempt ... is manual_review
  remove the evidence guard
    -> .../a_start_was_authorized:
       the redelivery replaced an attempt whose start was authorized
  return the prepared->starting edge to the best-effort walk
    -> TestASupersededAttemptIsNeverStarted:
       the capsule was started 1 time(s) for an attempt its successor owns
  remove the superseded guard in disposeAttempt
    -> TestASupersededAttemptIsNeverStarted:
       lease = cleaning; want released
  remove the stranded grace
    -> TestAFreshLeaseIsNotStranded:
       a lease committed moments ago moved reserved -> released
```

## What would notice this regressing

- `TestARedeliveryNeverSupersedesItsOwnAttempts` (internal/app) fails if
  the exclusion goes. Its first version passed with and without the fix —
  the conflict fell on the first workload, so the delivery had inserted
  nothing yet; it now orders the workloads so the delivery owns an open
  attempt by the time the sweep runs.
- `TestSupersedingAHeldAttemptTurnsOnWhatItConsumed` (internal/store)
  covers both halves: the queue stalls again without `manual_review`, and
  at-most-once breaks without the evidence guard.
- `TestASupersededAttemptIsNeverStarted` (internal/app) fails if the edge
  stops being authoritative, and separately if the lease guard goes.
- `TestAFreshLeaseIsNotStranded` (internal/app) fails without the grace.

## Risk, compatibility and operations

**At-most-once is the boundary this change moves against, and it is
tightened, not relaxed.** Two attempts for one workload is how a job runs
twice; the evidence guard is what makes adding `manual_review` safe, and
`starting`/`running` remain outside the set.

**A deliberate behaviour change for operators:** an attempt held as
`capsule_incompatible` or `retry_budget_exhausted` is now superseded when
the provider reassigns that workload, rather than blocking its binding's
queue. The trail is kept — the attempt resolves as `superseded` with its
`attempt_superseded` event — so a review an operator was looking at can
disappear from `runpool attempts` under them. A review of
`start_outcome_unknown` is never superseded, which is the case where the
human decision still matters.

**Trust boundary: unchanged.** No credential, capability, mount or
network surface. **Schema: unchanged** — the supersede guard is a `WHERE`
clause, not a migration.

**A store signature narrowed:** `RecordDelivery` returns `(int64, error)`
instead of a generated `sqlitedb` row type. That type crossing the store
boundary was coupling the architecture suite only misses because the app
infers it with `:=`. Internal API, no operator effect.

**Failure behaviour:** a launch whose attempt was resolved mid-preparation
now tears its capsule down without starting it, which spends admission
capacity and no job. Previously it started the job twice.

## Changelog

```text
State and operations:
- A workload the provider reassigns is served under its new delivery. The
  redelivery replaces the predecessor's attempt when that attempt provably
  consumed nothing — including one held for review, which is an open state
  and would otherwise stall the binding's whole ordered queue — and refuses
  when a start was authorized, where the redelivery waits for the
  predecessor's own lifecycle instead. A replacement never reaches the
  attempts the same delivery just recorded.
- An attempt replaced mid-preparation is not started. The edge before the
  one effect that can begin execution is a compare-and-swap, so a launch
  whose attempt was resolved while its capsule was being prepared stops
  there, and the capsule is torn down without a job.
```

## Notes for your reviewer

The `manual_review` question is the one I would look at first. Adding it
to the supersede set is what unblocks the queue, and doing so
unconditionally would let a workload whose execution is unknown run
again. The evidence guard is the whole answer to that, and it is why the
guard is on `execution_evidence` rather than on `review_reason`: the
reason is a label, the evidence is the fact.

I drafted a second guard for `withAttemptOfLease` and removed it before
committing. Nothing broke when I mutated it away, and reading its callers
the only difference it makes is one log line — the transaction that can
actually lose a lease is the finalizing one, which is guarded and
covered. It seemed better to drop an unproven guard than to keep a
plausible one.

The app harness sets a one-nanosecond stranded grace, because no test
there simulates the passage of time and every existing stranded-lease
test is about the ownership claim rather than the window. The test whose
subject is the window sets the production value explicitly.
