### PR TITLE
fix(gateway, app): a tightened policy is installed before it is in force, and no connection outlives its revocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,21 @@ by its public and operational effects.
 - **Policy changes are classified.** A restriction that cannot be
   installed closes the affected gateway; discovery failing at all
   closes every gateway. The previous policy is never treated as a safe
-  fallback.
+  fallback. A policy counts as in force only once it has reached every
+  gateway that could be named, so a pass that could not name one leaves
+  the books where they were and the next pass installs the change
+  instead of comparing it against itself.
+- **A revoked address stops being reachable.** A destination the policy
+  no longer allows is checked when a connection is dialled, and the pool
+  a job keeps warm never dials again — the kernel does not intervene
+  either, since the ruleset accepts established traffic ahead of every
+  reject. A policy that moves therefore retires the pool it authorised
+  rather than closing the connections that happen to be idle in it.
+- **The two policy installers cannot overwrite each other.** A reload
+  and an emergency close arrive as separate processes into the same
+  container, so the install is serialized by a lock the kernel holds and
+  publishes through a private temporary file: neither a lost close nor a
+  spliced document the relay would refuse to read.
 - The relay's CONNECT port set, header handling, parser strictness and
   every concurrency and size bound are explicit, tested and fuzzed.
 - **Containers a job starts take the same relay.** A daemon does not pass
@@ -64,7 +78,9 @@ by its public and operational effects.
 - **An operator allowance is bounded by what it reopens.**
   `network.allowPrivateCIDRs` punches holes through the built-in deny
   set, so an entry *broader* than a withheld range would reopen that
-  whole range as a side effect; the validator refuses exactly those.
+  whole range as a side effect; a policy carrying one is refused. The
+  rule belongs to the policy rather than to the configuration file, so
+  the live reload channel is held to it too.
   Public prefixes are accepted because the profile already permits the
   public internet — which is how a capsule reaches a service on the
   host's own public address, an address the runtime deny set withholds

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -297,8 +297,7 @@ func (n *networkSandbox) refresh(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	n.applyPolicy(ctx, next)
-	return nil
+	return n.applyPolicy(ctx, next)
 }
 
 // rediscover is one pass, separated so a test can drive it directly.
@@ -320,30 +319,44 @@ func (n *networkSandbox) rediscover(ctx context.Context) {
 
 // applyPolicy installs a rediscovered set, and decides what a failure
 // costs from what the change was.
-func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox) {
+//
+// It reports whether the install could be attempted at all, because the
+// caller's fail-closed paths turn on exactly that: a discovery pass that
+// cannot say what is installed anywhere closes every gateway, and a
+// launch under an unprovable policy is refused.
+func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox) error {
 	previous := n.state.snapshot()
 	change := ClassifyPolicy(previous.Deny, next.Deny)
 	uplinkChanged := previous.UplinkNetworkID != next.UplinkNetworkID
 	if change == PolicyUnchanged && !uplinkChanged {
-		return
+		return nil
 	}
 	n.log.Info("egress policy changed", "change", change.String(),
 		"was", len(previous.Deny), "now", len(next.Deny), "uplink_recreated", uplinkChanged)
-	n.state.replace(next)
 
 	failed, err := n.reloadGateways(ctx, next.Allow, next.Deny)
 	if err != nil {
-		n.log.Error("could not enumerate gateways to reload", "error", err)
+		// Nothing can be said about what is installed anywhere, so the
+		// snapshot stays where it was and the next pass sees this change
+		// again. Recorded first, that pass would compare the new set
+		// against itself, report it unchanged, and a restriction that
+		// landed nowhere would never be attempted again.
+		return fmt.Errorf("enumerate gateways: %w", err)
 	}
+	// Recorded only now: the set has reached every gateway that could be
+	// named, so this is what is in force rather than what was intended.
+	// The refresh lock is held across both, so no launch can observe the
+	// window between them.
+	n.state.replace(next)
 	if len(failed) == 0 {
-		return
+		return nil
 	}
 	if !change.restricts() {
 		// A relaxation that did not land leaves the capsule with the
 		// stricter policy it started under. Its work continues.
 		n.log.Warn("some gateways kept the previous, stricter policy",
 			"gateways", len(failed), "change", change.String())
-		return
+		return nil
 	}
 	// A restriction that did not land leaves a capsule able to reach
 	// something the policy now denies. Close those gateways.
@@ -355,6 +368,7 @@ func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox)
 				"container", id, "error", err)
 		}
 	}
+	return nil
 }
 
 // reloadGateways hands the new sets to every running gateway this

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"reflect"
@@ -89,6 +90,9 @@ type fakeSandboxDaemon struct {
 	probeErr     error
 
 	containers []docker.OwnedContainer
+	// listErr is the daemon refusing to say which gateways exist, which
+	// is the one failure that makes the whole install unaccountable.
+	listErr error
 	// refuse names the containers whose exec fails, which is how a
 	// gateway that will not take a new policy is expressed.
 	refuse   map[string]bool
@@ -110,6 +114,9 @@ func (f *fakeSandboxDaemon) RunTask(context.Context, docker.ContainerSpec) (int6
 	return 0, f.probeOut, f.probeErr
 }
 func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, string) ([]docker.OwnedContainer, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
 	return f.containers, nil
 }
 func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, _ []string) (int, string, error) {
@@ -331,5 +338,53 @@ func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
 	}
 	if sb == nil || sb.UplinkNetworkID != "up-1" {
 		t.Errorf("the first launch would get %+v; want the policy just built", sb)
+	}
+}
+
+// TestARestrictionThatCouldNotBeEnumeratedIsRetried: a policy is
+// recorded as in force only once it has reached every gateway that
+// could be named.
+//
+// The snapshot is what the next pass compares against. Recorded before
+// the install, a pass whose enumeration failed leaves the new set in the
+// books while no gateway ever received it — and the pass after that
+// compares the new set against itself, reports it unchanged, and returns
+// without trying. A restriction that landed nowhere is then never
+// attempted again.
+func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
+	inForce := &capsule.Sandbox{
+		UplinkNetworkID: "uplink-1",
+		UplinkSubnet:    "172.30.0.0/24",
+		Deny:            []string{"10.0.0.0/8"},
+	}
+	daemon := &fakeSandboxDaemon{
+		refuse:  map[string]bool{},
+		listErr: errors.New("daemon unreachable"),
+		containers: []docker.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
+		},
+	}
+	n := newTestSandbox(t, daemon, inForce)
+
+	tightened := &capsule.Sandbox{
+		UplinkNetworkID: "uplink-1",
+		UplinkSubnet:    "172.30.0.0/24",
+		Deny:            []string{"10.0.0.0/8", "192.168.0.0/16"},
+	}
+	if err := n.applyPolicy(t.Context(), tightened); err == nil {
+		t.Fatal("an install that could not name a single gateway reported success")
+	}
+	if got := n.state.snapshot().Deny; len(got) != 1 {
+		t.Fatalf("the books record %v as in force; nothing was installed anywhere", got)
+	}
+
+	// The daemon recovers, and the pass that follows must see the change
+	// again rather than compare the new set against itself.
+	daemon.listErr = nil
+	if err := n.applyPolicy(t.Context(), tightened); err != nil {
+		t.Fatalf("the retry failed: %v", err)
+	}
+	if len(daemon.reloaded) != 1 || daemon.reloaded[0] != "gw-1" {
+		t.Errorf("gateways reloaded on the retry = %v; want the restriction to reach gw-1", daemon.reloaded)
 	}
 }

--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -61,9 +61,25 @@ func (p Policy) Validate() error {
 	if len(p.Deny) == 0 {
 		return fmt.Errorf("deny set is empty; a policy that denies nothing is not a policy")
 	}
-	for _, c := range append(append([]string{}, p.Allow...), p.Deny...) {
+	for _, c := range p.Deny {
 		if _, err := netip.ParsePrefix(c); err != nil {
 			return fmt.Errorf("cidr %q: %w", c, err)
+		}
+	}
+	for _, c := range p.Allow {
+		prefix, err := netip.ParsePrefix(c)
+		if err != nil {
+			return fmt.Errorf("cidr %q: %w", c, err)
+		}
+		// Allow is consulted before deny, so an allow broader than a
+		// range the baseline withholds reopens that whole range as a
+		// side effect. The rule belongs to the policy rather than to any
+		// one of the paths that produce one: a gateway takes a policy
+		// from its reload channel as well as from configuration, and a
+		// check at a single entry point is not a rule.
+		if WidensBaselineDeny(prefix) {
+			return fmt.Errorf("allow %s is broader than a range the restricted profile withholds, "+
+				"so allowing it would reopen that whole range", prefix)
 		}
 	}
 	return nil

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -165,9 +165,25 @@ func ClassifyLegs(p egress.Policy) (Legs, error) {
 // writeFileAtomic replaces a control file by rename, so a reader never
 // observes a half-written policy.
 func writeFileAtomic(path string, data []byte) error {
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	// A unique temp name, not a fixed one. The rename is atomic, but the
+	// write into a shared name is not: two writers truncate and fill the
+	// same file, and the rename then publishes whatever interleaving
+	// won — a document the reader refuses, after which every dial fails.
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	defer os.Remove(tmp.Name())
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
 }

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/rhobuild/runpool/internal/egress"
 )
@@ -14,6 +16,11 @@ import (
 // MaxPolicyBytes bounds a policy document. The real one is a few
 // kilobytes of CIDRs; anything larger is a mistake or an attempt.
 const MaxPolicyBytes = 1 << 20
+
+// policyLockFile serializes the installers against each other. It lives
+// beside the policy on the same tmpfs, so it is created with the control
+// surface and dies with the container.
+const policyLockFile = "policy.lock"
 
 // ParsePolicy decodes and validates a policy document.
 func ParsePolicy(raw string) (egress.Policy, error) {
@@ -123,10 +130,11 @@ func Reload(controlDir string, r io.Reader) error {
 			Allow:          incoming.Allow,
 			Deny:           incoming.Deny,
 		}
-		// Validated here, not in installPolicy: these prefixes arrived
-		// from outside this process, and this is the trust boundary they
-		// cross. DenyAll's do not, so hoisting the check into the shared
-		// path would misread why it is here.
+		// Validated here because these prefixes arrived from outside
+		// this process, and this is the boundary they cross. What
+		// counts as valid — including that no allow may be broader than
+		// a range the baseline withholds — belongs to the policy, so
+		// this channel and the configuration file are held to one rule.
 		return next, next.Validate()
 	})
 }
@@ -161,6 +169,50 @@ func DenyAll(controlDir string) error {
 // gateway bridges is a fact of its own creation, not something a later
 // discovery pass may redefine.
 func installPolicy(controlDir string, build func(current egress.Policy) (egress.Policy, error)) error {
+	return installPolicyWith(controlDir, build, applyToKernel)
+}
+
+// applyToKernel identifies this container's two legs and installs the
+// ruleset for the policy about to take effect.
+//
+// It is a parameter of the install rather than a step inside it because
+// what the install owns — the lock, the read-modify-write, the order of
+// kernel before file — is only observable on a host that has both legs
+// and NET_ADMIN. Named here, those properties can be exercised
+// anywhere, and the step that genuinely needs a gateway container is
+// the one the live contract covers.
+func applyToKernel(next egress.Policy) error {
+	legs, err := ClassifyLegs(next)
+	if err != nil {
+		return err
+	}
+	return ApplyFirewall(next, legs)
+}
+
+func installPolicyWith(controlDir string,
+	build func(current egress.Policy) (egress.Policy, error),
+	apply func(next egress.Policy) error) error {
+
+	// The two callers reach this from separate `docker exec` processes
+	// into the same container, so the lock has to be one the kernel
+	// holds. Without it both read the same policy in force, build two
+	// successors from it and race the write: the stricter one is lost —
+	// a deny-all overwritten by a reload that was already in flight —
+	// or the file the relay reads is two documents spliced together,
+	// which ParsePolicy refuses and which then fails every dial.
+	//
+	// It blocks rather than trying: an emergency close must wait its
+	// turn and then win, not give up because a reload held the lock.
+	lock, err := os.OpenFile(filepath.Join(controlDir, policyLockFile), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("policy lock: %w", err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("policy lock: %w", err)
+	}
+	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
+
 	path := PolicyPath(controlDir)
 	inForce, err := os.ReadFile(path)
 	if err != nil {
@@ -174,11 +226,7 @@ func installPolicy(controlDir string, build func(current egress.Policy) (egress.
 	if err != nil {
 		return err
 	}
-	legs, err := ClassifyLegs(next)
-	if err != nil {
-		return err
-	}
-	if err := ApplyFirewall(next, legs); err != nil {
+	if err := apply(next); err != nil {
 		return err
 	}
 	encoded, err := json.Marshal(next)

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -3,7 +3,11 @@ package gateway
 import (
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/rhobuild/runpool/internal/egress"
 	"time"
 )
 
@@ -94,5 +98,177 @@ func TestRelayNoticesAPolicyChangeWithoutDialing(t *testing.T) {
 	r.expireStaleConnections()
 	if got := r.policyGen.Load(); got == baseline {
 		t.Error("the relay did not notice a new policy without dialing; pooled connections would keep the old one")
+	}
+}
+
+// TestAWideningAllowIsRefusedOnTheReloadChannel: the rule that an allow
+// may not be broader than a range the baseline withholds is a property
+// of the policy, not of the configuration file.
+//
+// Allow is consulted before deny, so such an entry reopens the whole
+// withheld range. A gateway takes a policy from this channel as well as
+// from configuration, and a check that lived only at the configuration
+// entry point left this one open.
+func TestAWideningAllowIsRefusedOnTheReloadChannel(t *testing.T) {
+	dir := t.TempDir()
+	path := PolicyPath(dir)
+	inForce := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+		`"allow":[],"deny":["10.0.0.0/8"]}`
+	if err := os.WriteFile(path, []byte(inForce), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	incoming := `{"allow":["0.0.0.0/0"],"deny":["10.0.0.0/8"]}`
+	err := Reload(dir, strings.NewReader(incoming))
+	if err == nil {
+		t.Fatal("the reload channel accepted an allow that reopens the whole space")
+	}
+	// The reason matters, not just the refusal: this host has no legs
+	// and no NET_ADMIN, so the kernel step refuses everything that
+	// reaches it. A test satisfied by any error would pass with the rule
+	// removed.
+	if !strings.Contains(err.Error(), "broader than a range") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != inForce {
+		t.Errorf("the refused policy was written anyway:\n%s", got)
+	}
+}
+
+// TestConcurrentInstallsDoNotLoseTheStricterPolicy: the two installers
+// are separate exec processes into the same container, so what
+// serializes them has to be a lock the kernel holds.
+//
+// Without one they read the same policy in force, build two successors
+// and race the write: an emergency close is overwritten by a reload that
+// was already in flight, or the file is two documents spliced together —
+// which the reader refuses, after which every dial fails.
+func TestConcurrentInstallsDoNotLoseTheStricterPolicy(t *testing.T) {
+	dir := t.TempDir()
+	path := PolicyPath(dir)
+	inForce := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+		`"allow":[],"deny":["10.0.0.0/8"]}`
+	if err := os.WriteFile(path, []byte(inForce), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A reader racing the writers: every intermediate state it observes
+	// must be a policy, never a splice.
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				continue // the rename is atomic; a missing file is not
+			}
+			if _, err := ParsePolicy(string(raw)); err != nil {
+				select {
+				case bad <- string(raw):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	// The kernel step is stubbed: this host has neither leg nor
+	// NET_ADMIN, and with the real one every install would refuse before
+	// writing anything — leaving the test passing over a file nobody
+	// ever touched.
+	noKernel := func(egress.Policy) error { return nil }
+	reload := func() error {
+		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+			next := current
+			next.Deny = []string{"10.0.0.0/8", "192.168.0.0/16"}
+			return next, next.Validate()
+		}, noKernel)
+	}
+	denyAll := func() error {
+		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+			next := current
+			next.Allow, next.Deny = nil, []string{"0.0.0.0/0"}
+			return next, nil
+		}, noKernel)
+	}
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if i%2 == 0 {
+				_ = reload()
+				return
+			}
+			_ = denyAll()
+		}()
+	}
+	wg.Wait()
+	close(stop)
+
+	select {
+	case raw := <-bad:
+		t.Fatalf("a reader observed a policy it could not parse:\n%s", raw)
+	default:
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParsePolicy(string(raw)); err != nil {
+		t.Fatalf("the policy left in force does not parse: %v\n%s", err, raw)
+	}
+}
+
+// TestAPolicyMoveRetiresTheTransport: when the policy moves, the pool
+// that was authorised under the old one must stop being reachable.
+//
+// Closing the idle connections is not that. By contract it leaves a
+// connection carrying a request alone, and that connection goes back
+// into the pool afterwards, where the next request reuses it without
+// reaching the dialer — which is where the address is checked. The
+// kernel does not catch it either: the ruleset accepts established
+// traffic ahead of every reject. Replacing the transport is what makes
+// the old pool unreachable whatever state its connections are in.
+func TestAPolicyMoveRetiresTheTransport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "policy.json")
+	write := func(deny string) {
+		body := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("10.0.0.0/8")
+
+	r := &Relay{Policy: &PolicyStore{Path: path}, Log: discardLogger()}
+	first := r.roundTripper()
+
+	// Two observations settle the baseline; neither is a policy move.
+	r.expireStaleConnections()
+	r.expireStaleConnections()
+	if got := r.roundTripper(); got != first {
+		t.Fatal("the transport was replaced without the policy moving; every request would start a new pool")
+	}
+
+	time.Sleep(10 * time.Millisecond) // distinct mtime
+	write("192.168.0.0/16")
+	r.expireStaleConnections()
+	if got := r.roundTripper(); got == first {
+		t.Error("the transport survived a policy move; a connection pooled under the old one " +
+			"still carries the next request past the dialer, where the address is checked")
 	}
 }

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -91,7 +91,7 @@ type Relay struct {
 	Log    *slog.Logger
 
 	once      sync.Once
-	transport *http.Transport
+	transport atomic.Pointer[http.Transport]
 	// policyGen is the policy generation the pooled connections were
 	// authorised under.
 	policyGen atomic.Uint64
@@ -251,9 +251,11 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 	outbound.RequestURI = ""
 	stripHopByHop(outbound.Header)
 
-	rt := r.roundTripper()
+	// The check runs first and the transport is read after it: the check
+	// can replace the transport, and reading it beforehand sends this
+	// request through the pool that was just retired.
 	r.expireStaleConnections()
-	resp, err := rt.RoundTrip(outbound)
+	resp, err := r.roundTripper().RoundTrip(outbound)
 	if err != nil {
 		r.refuse(w, err)
 		return
@@ -269,14 +271,22 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 	_, _ = io.Copy(w, resp.Body)
 }
 
-// expireStaleConnections drops pooled connections once the policy moves.
+// expireStaleConnections retires the pool once the policy moves.
+//
 // The address check lives in the transport's dialer, and http.Transport
-// only dials when no idle connection exists for the destination — so a
-// restriction installed while a job kept a connection warm would not bind
-// to its next request until IdleConnTimeout expired. Closing idle
-// connections forces the next request back through the dialer, where the
-// check is. Connections mid-request are left alone, which is the
-// documented "established ones are unaffected".
+// only dials when it has no connection for the destination — so a
+// restriction installed while a job kept a connection warm would not
+// bind to its next request. Closing the idle connections is not enough
+// to fix that: by contract it leaves a connection carrying a request
+// alone, and that connection returns to the pool afterwards, where the
+// next request reuses it without ever reaching the dialer. The kernel
+// does not catch it either, because the ruleset accepts established
+// traffic ahead of every reject. A revoked address therefore stayed
+// reachable for as long as a job kept using it.
+//
+// Replacing the transport is what makes the old pool unreachable:
+// nothing routes through it again, whatever state its connections were
+// in. The ones already carrying a request finish it and go with it.
 func (r *Relay) expireStaleConnections() {
 	if r.Policy == nil {
 		return
@@ -286,42 +296,58 @@ func (r *Relay) expireStaleConnections() {
 	// here is the whole point: without it the generation could not move in
 	// exactly the case this function exists for. A cached hit is one stat.
 	if _, err := r.Policy.Current(); err != nil {
-		// An unreadable policy is not in force. Drop the pool so the next
-		// request must dial, where that error refuses the connection.
-		r.transport.CloseIdleConnections()
+		// An unreadable policy is not in force. Retire the pool so the
+		// next request must dial, where that error refuses it.
+		r.retireTransport()
 		return
 	}
 	gen := r.Policy.Generation()
 	// The first observation only records where the policy started; there is
 	// nothing pooled under an older one yet.
 	if prev := r.policyGen.Swap(gen); prev != 0 && prev != gen {
-		r.transport.CloseIdleConnections()
+		r.retireTransport()
 	}
 }
 
-// roundTripper is built once. A transport per request — the shape this
-// replaces — leaks a connection pool and its idle goroutines on every
-// call, which is unbounded growth driven by the workload.
+// retireTransport puts a fresh pool in place and releases what the old
+// one still holds idle.
+func (r *Relay) retireTransport() {
+	if old := r.transport.Swap(r.newTransport()); old != nil {
+		old.CloseIdleConnections()
+	}
+}
+
+// roundTripper returns the transport in force, building the first one on
+// demand. A transport per request — the shape this replaces — leaks a
+// connection pool and its idle goroutines on every call, which is
+// unbounded growth driven by the workload.
 func (r *Relay) roundTripper() http.RoundTripper {
+	// CompareAndSwap rather than Store: a policy that moved before the
+	// first request has already installed one through retireTransport,
+	// and storing over it would discard the pool in force.
 	r.once.Do(func() {
-		r.transport = &http.Transport{
-			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
-				host, port, err := parseAuthority(addr)
-				if err != nil {
-					return nil, err
-				}
-				return r.dial(ctx, host, port)
-			},
-			MaxConnsPerHost:        MaxUpstreamConns,
-			MaxIdleConns:           MaxUpstreamConns,
-			IdleConnTimeout:        90 * time.Second,
-			TLSHandshakeTimeout:    15 * time.Second,
-			ExpectContinueTimeout:  5 * time.Second,
-			ResponseHeaderTimeout:  60 * time.Second,
-			MaxResponseHeaderBytes: MaxHeaderBytes,
-		}
+		r.transport.CompareAndSwap(nil, r.newTransport())
 	})
-	return r.transport
+	return r.transport.Load()
+}
+
+func (r *Relay) newTransport() *http.Transport {
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+			host, port, err := parseAuthority(addr)
+			if err != nil {
+				return nil, err
+			}
+			return r.dial(ctx, host, port)
+		},
+		MaxConnsPerHost:        MaxUpstreamConns,
+		MaxIdleConns:           MaxUpstreamConns,
+		IdleConnTimeout:        90 * time.Second,
+		TLSHandshakeTimeout:    15 * time.Second,
+		ExpectContinueTimeout:  5 * time.Second,
+		ResponseHeaderTimeout:  60 * time.Second,
+		MaxResponseHeaderBytes: MaxHeaderBytes,
+	}
 }
 
 func stripHopByHop(h http.Header) {


### PR DESCRIPTION
## What changes

The rule that an allow may not be broader than a range the baseline
withholds moves onto `egress.Policy`, so the live reload channel is held
to it. The shared policy install serializes on a lock the kernel holds
and publishes through a private temporary file. The relay replaces its
transport when the policy moves instead of closing idle connections. And
a policy is recorded as in force only once the install has been
enumerated.

## What was found

**The reload channel was not held to the widening rule.** Allow is
consulted before deny, so an allow broader than a range the baseline
withholds reopens that whole range. The check lived only in
`config/validate.go`, and a live gateway takes a policy from
`gateway-reload` as well — a check at one entry point is not a rule.

**Two installers could lose the stricter policy or corrupt it outright.**
`gateway-reload` and `gateway-deny-all` are separate `docker exec`
processes into the same container, so no in-process lock reaches both.
They read the same policy in force, build two successors and race the
write; `writeFileAtomic` used a fixed `path + ".tmp"`, so the two writes
interleave into one file and the rename publishes whatever won. Either an
emergency close is silently overwritten, or the relay is left a document
it refuses to parse, after which every dial fails.

**A revoked address stayed reachable.** `expireStaleConnections` called
`CloseIdleConnections`, which by contract leaves a connection carrying a
request alone. That connection returns to the pool, and `RoundTrip`
reuses it without calling `DialContext` — where the address check is. The
kernel is no backstop: `RenderIPTables` accepts `ESTABLISHED,RELATED`
ahead of every REJECT. So a job holding a connection to a newly-denied
host kept reaching it for as long as it kept using it.

**A policy landed in the books before it landed anywhere.**
`applyPolicy` called `n.state.replace(next)` above `reloadGateways`, and
the enumeration failure was only logged. The next pass then compared the
new set against itself, found `PolicyUnchanged` and returned — so a
restriction installed on no gateway at all was never attempted again.
Making `applyPolicy` report also reconnects two fail-closed paths that
could not fire while `refresh` was infallible: `rediscover`'s
`closeGateways`, and `forLaunch`'s refusal.

`forward` also reads the transport after the check rather than before it.
Captured first, the retirement arrived one request late.

## Evidence

Hermetic. `internal/gateway` is exercised in full on every pull request,
and this change adds a seam so the parts that need a real gateway
container can be exercised too — see the note below, because without it
two of these tests passed while proving nothing.

```text
mutation checks, local:
  remove the flock and restore the fixed temp name
    -> TestConcurrentInstallsDoNotLoseTheStricterPolicy:
       a reader observed a policy it could not parse:
       {"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",
        "deny":["0.0.0.0/0"]}"192.168.0.0/16"]}
  remove the widening rule from Policy.Validate
    -> TestAWideningAllowIsRefusedOnTheReloadChannel:
       refused for the wrong reason: not attached to both networks
  restore CloseIdleConnections in place of retiring the transport
    -> TestAPolicyMoveRetiresTheTransport:
       the transport survived a policy move
  record the snapshot before the enumeration
    -> TestARestrictionThatCouldNotBeEnumeratedIsRetried:
       the books record [10.0.0.0/8 192.168.0.0/16] as in force;
       nothing was installed anywhere
```

## What would notice this regressing

- `TestAWideningAllowIsRefusedOnTheReloadChannel` (internal/gateway)
  fails if the rule leaves `Policy.Validate`. It asserts the *reason*,
  not the refusal, because on a host with no legs every install refuses
  anyway.
- `TestConcurrentInstallsDoNotLoseTheStricterPolicy` runs sixteen
  concurrent installers against a reader and fails without the lock or
  the private temp name.
- `TestAPolicyMoveRetiresTheTransport` fails if the pool survives a
  policy move.
- `TestARestrictionThatCouldNotBeEnumeratedIsRetried` (internal/app)
  fails if the snapshot advances on an intention.
- The bypass contract (`test/contract/capsule`) still drives a real
  gateway container and tries to leave it; it runs on this pull request.

## Risk, compatibility and operations

**This is the security group of the remediation, and every change here
fails closed.** The widening rule refuses a policy rather than accepting
it; the lock blocks rather than skipping, so an emergency close waits its
turn and then wins; the snapshot lags the install rather than leading it,
so a change is retried rather than forgotten.

**Trust boundary: this is the trust boundary.** The relay's own address
check now genuinely binds the next request after a policy moves, which it
did not before. No new capability, mount or credential path; the gateway
still runs with `NET_ADMIN` and nothing else.

**Operator-visible:** an `allow` entry broader than a withheld range is
now refused on the live reload channel as well as in configuration.
`network.allowPrivateCIDRs` was already validated at startup, so a
running deployment cannot be holding one — but a policy assembled at
runtime that would have widened is refused where it previously was not.
That is the point of the change.

**Performance:** retiring the transport discards a warm pool on every
policy change, so the requests after one pay a dial and a TLS handshake.
Policy changes are rare (a rediscovery pass, an emergency close) and the
alternative is a revoked address staying reachable.

**No CLI, configuration, status API, schema, migration or deployment
change.** No rollback step.

## Changelog

```text
Isolation and egress:
- Policy changes are classified ... A policy counts as in force only once
  it has reached every gateway that could be named, so a pass that could
  not name one leaves the books where they were and the next pass installs
  the change instead of comparing it against itself.
- A revoked address stops being reachable. A destination the policy no
  longer allows is checked when a connection is dialled, and the pool a job
  keeps warm never dials again — the kernel does not intervene either,
  since the ruleset accepts established traffic ahead of every reject. A
  policy that moves therefore retires the pool it authorised rather than
  closing the connections that happen to be idle in it.
- The two policy installers cannot overwrite each other. A reload and an
  emergency close arrive as separate processes into the same container, so
  the install is serialized by a lock the kernel holds and publishes
  through a private temporary file: neither a lost close nor a spliced
  document the relay would refuse to read.
- An operator allowance is bounded by what it reopens ... The rule belongs
  to the policy rather than to the configuration file, so the live reload
  channel is held to it too.
```

## Notes for your reviewer

The seam is the part I would look at, because it exists for a reason
worth stating. `installPolicy` now takes the kernel application as a
parameter.

Without it, two of these tests passed while proving nothing.
`ClassifyLegs` refuses on any host without both network legs and
`NET_ADMIN`, so every install returned before `writeFileAtomic` — the
concurrency test was watching a file nobody ever wrote, and the widening
test asserted only that `Reload` failed, which it did for the wrong
reason. Naming the kernel step makes the properties the shared install
actually owns — the lock, the read-modify-write, kernel before file —
exercisable anywhere, and leaves the step that genuinely needs a gateway
container to the live contract.

I found both by mutating, not by reading. It is the argument for checking
every test against its own mutation rather than trusting a green run.
