### PR TITLE
fix(docker, app): the context reaches the I/O it cancels, and shutdown fits the margin it declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,10 +126,15 @@ by its public and operational effects.
   session cannot be reached retries on its own loop, so an outage or an
   expired token costs that binding its turn rather than ending the
   process while capsules are still running. The whole shutdown is sized
-  to end inside the deployment's stop grace period: the drain is spent
-  first, then every message session closes concurrently under one shared
-  budget, so the bound does not grow with the binding count and the
-  sessions are closed rather than left for the next start to wait out. A
+  to end inside the deployment's stop grace period, and the deployment is
+  sized against that whole number rather than a subset of its terms: the
+  serve loops are waited out, the drain is spent, then every message
+  session closes concurrently under one shared budget, so the bound does
+  not grow with the binding count and the sessions are closed rather than
+  left for the next start to wait out. The periodic reconciler's recovery
+  ends with that shutdown instead of running a budget of its own, because
+  its work is resumable — the next start finds each lease where the
+  shutdown left it. A
   drain window that elapses leaves live capsules exactly as they are for
   the next start's adoption — a dying controller never dismantles a
   running job on its way down.
@@ -189,6 +194,21 @@ by its public and operational effects.
   before the one effect that can begin execution is a compare-and-swap,
   so a launch whose attempt was resolved while its capsule was being
   prepared stops there, and the capsule is torn down without a job.
+- **A cancellation is durable before its message is given up.**
+  Everything a broker message carries is written down before the message
+  is acknowledged, for the same reason the assignment is: an acknowledged
+  message is never sent again and nothing re-derives a cancellation from
+  the provider, so one lost in that window costs a whole capsule on work
+  the provider already closed.
+- **Every call into a container is bounded.** The daemon's connection
+  for an exec is handed over once and stops consulting the caller's
+  context, so a container that accepts a command and answers nothing
+  held the call open indefinitely — including the gateway control calls
+  a policy refresh makes while holding the lock every launch waits on.
+  The connection now ends with the context, and each gateway call
+  carries its own bound. Inside a capsule the readiness probe is bounded
+  the same way, so a daemon that never answers cannot spend the whole
+  readiness budget in one call.
 - **A capsule that never handed the job over returns it to the queue.**
   The supervisor exits with a status it reserves for stopping before the
   start was authorized — the ordinary end of an idle capsule when a

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -69,6 +69,9 @@ const (
 	runnerHome = "/home/runner"
 
 	dockerdReadyTimeout = 60 * time.Second
+	// dockerdProbeTimeout bounds one readiness probe, so the budget above
+	// is spent on repeated asking rather than inside one call that hangs.
+	dockerdProbeTimeout = 5 * time.Second
 	startPollInterval   = 200 * time.Millisecond
 	drainTimeout        = 5 * time.Minute
 )
@@ -391,9 +394,7 @@ func stopDockerd(log *slog.Logger, dockerd *exec.Cmd, exit chan int) {
 func awaitDockerdReady(ctx context.Context) error {
 	deadline := time.Now().Add(dockerdReadyTimeout)
 	for {
-		probe := exec.Command("docker", "--host=unix://"+dockerSocket, "info")
-		probe.Stdout, probe.Stderr = io.Discard, io.Discard
-		if probe.Run() == nil {
+		if probeDockerd(ctx) == nil {
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -405,6 +406,23 @@ func awaitDockerdReady(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// probeDockerd asks the inner daemon once, under a bound of its own. A
+// daemon that accepts the socket and then never answers would otherwise
+// spend the whole readiness budget inside a single call, and PID 1 has
+// nobody outside it to cut that short.
+func probeDockerd(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, dockerdProbeTimeout)
+	defer cancel()
+	probe := exec.CommandContext(ctx, "docker", "--host=unix://"+dockerSocket, "info")
+	// The null device, not a discarding writer. A writer that is not an
+	// *os.File makes Cmd build a pipe and copy from it, and Wait then
+	// waits for that copy to finish — which a process the kill orphaned
+	// keeps open. The probe would return only when the orphan did,
+	// leaving the bound above describing nothing.
+	probe.Stdout, probe.Stderr = nil, nil
+	return probe.Run()
 }
 
 // awaitStart blocks until the controller authorizes the start. The

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func encodedBundle(t *testing.T, body string) string {
@@ -203,4 +204,34 @@ func TestWriteDockerProxyConfig(t *testing.T) {
 			t.Errorf("stat: %v; want no file at all", err)
 		}
 	})
+}
+
+// TestTheReadinessProbeIsBounded: one probe cannot spend the whole
+// readiness budget.
+//
+// A daemon that accepts the socket and then never answers leaves the
+// probe blocked, and this process is PID 1 — there is nothing outside it
+// to cut the call short. Without a bound of its own the budget is spent
+// inside a single call, and the capsule reports neither ready nor
+// failed until something kills the container.
+func TestTheReadinessProbeIsBounded(t *testing.T) {
+	// A `docker` on PATH that answers nothing, ever.
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "docker")
+	if err := os.WriteFile(shim, []byte("#!/bin/sh\nsleep 60\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	start := time.Now()
+	err := probeDockerd(t.Context())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a probe that never answered reported the daemon ready")
+	}
+	if elapsed > dockerdProbeTimeout+5*time.Second {
+		t.Errorf("one probe took %s against a %s bound; the readiness budget is spent inside a single call",
+			elapsed.Round(time.Second), dockerdProbeTimeout)
+	}
 }

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -63,7 +63,7 @@ services:
     # message sessions close before the platform kills the container. A
     # session left open is one the next start waits out as a conflict.
     # Anything still running is adopted on the next start.
-    stop_grace_period: 2m
+    stop_grace_period: 150s
 
 volumes:
   # State holds the lease and ownership records: back this up. Cache

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -192,6 +192,15 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 			}
 			continue
 		}
+		// Durable before the acknowledgement, for the same reason the
+		// delivery is: an acknowledged message is never sent again, and
+		// nothing re-derives a cancellation from the provider. One lost
+		// here is a whole capsule spent on work the provider already
+		// closed. It also has to land before anything schedules, or a
+		// cancellation arrives after the attempt it was meant to close
+		// has already been leased.
+		s.recordLifecycleEvents(ctx, b, msg)
+
 		advanced := s.acknowledgeDelivery(ctx, b, delivery, msg.ID)
 
 		if msg.Statistics != nil {
@@ -201,7 +210,6 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 			// them would overstate what this binding owes.
 			s.alloc.SetAssignedDemand(b.key, msg.Statistics.Assigned)
 		}
-		s.recordLifecycleEvents(ctx, b, msg)
 
 		s.scheduleReadyAttempts(ctx, b)
 

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -363,7 +363,7 @@ func TestPeriodicReconcileConvergesQuarantine(t *testing.T) {
 	// The removal fails: the lease parks in quarantine with backoff
 	// booked on the intent, and the attempt stays leased — unresolved,
 	// visible, waiting.
-	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err == nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err == nil {
 		t.Fatal("recoverCapsuleFailure with a wedged daemon succeeded")
 	}
 	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseQuarantined {
@@ -682,5 +682,67 @@ func TestASupersededAttemptIsNeverStarted(t *testing.T) {
 	}
 	if !h.srv.alloc.TryReserve(h.bind.key) {
 		t.Error("the lease's admission credit was never returned")
+	}
+}
+
+// blockingRemover holds every removal until its context ends — a daemon
+// that accepted the call and is answering nothing.
+type blockingRemover struct{}
+
+func (blockingRemover) block(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (b blockingRemover) RemoveOwnedContainer(ctx context.Context, _, _, _ string) error {
+	return b.block(ctx)
+}
+func (b blockingRemover) RemoveOwnedNetwork(ctx context.Context, _, _, _ string) error {
+	return b.block(ctx)
+}
+func (b blockingRemover) RemoveOwnedVolume(ctx context.Context, _, _, _ string) error {
+	return b.block(ctx)
+}
+
+// TestTheReconcilerStopsRecoveringWhenTheShutdownBegins: the periodic
+// pass's recovery ends when the loop's context does.
+//
+// Its work is resumable by definition — the next pass, or the next
+// start, finds the lease exactly where this left it — so there is
+// nothing to protect by detaching it, and a recovery detached from
+// everything runs its own two-minute budget against a wedged daemon
+// while the platform's grace period expires around it. The shutdown
+// bound the deployment is sized against has to be one the process
+// actually keeps.
+func TestTheReconcilerStopsRecoveringWhenTheShutdownBegins(t *testing.T) {
+	h := newHarness(t, 1)
+	h.useRemover(blockingRemover{})
+	if err := h.deliver(demand("job-blocked", "app", 81)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-blocked")
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		id, err := tx.PlanResource(lease.ID, store.ResourceContainer, "runner", "runpool-runner-blocked")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "blocked-1")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	h.srv.retryStranded(ctx)
+	elapsed := time.Since(start)
+
+	if elapsed > LoopStopBudget {
+		t.Errorf("the pass held the shutdown for %s against a %s budget; a recovery detached "+
+			"from the loop outlives the grace period the deployment is sized for",
+			elapsed.Round(time.Second), LoopStopBudget)
 	}
 }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -213,7 +213,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 		// recoverCapsuleFailure finishes with the same finalizing
 		// transaction, so release and disposition cannot come apart.
 		log.Info("releasing an interrupted lease")
-		if err := s.recoverCapsuleFailure(b, lease.ID, obs); err != nil {
+		if err := s.recoverCapsuleFailure(ctx, b, lease.ID, obs); err != nil {
 			log.Error("recovery could not resolve the lease; reconciliation will retry", "error", err)
 		}
 
@@ -244,7 +244,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		exit, err := s.wait.WaitExit(ctx, runnerContainer)
 		if err != nil {
 			s.log.Error("adopted capsule wait failed", "lease", lease.ID, "error", err)
-			if err := s.recoverCapsuleFailure(b, lease.ID, ""); err != nil {
+			if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}
@@ -257,7 +257,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		if obs := capsule.ClassifyExit(int(exit)); obs != assignment.ObservedExited {
 			s.log.Warn("the adopted capsule reports the runner never started; the attempt is returned to the queue",
 				"lease", lease.ID, "exit", exit)
-			if err := s.recoverCapsuleFailure(b, lease.ID, obs); err != nil {
+			if err := s.recoverCapsuleFailure(ctx, b, lease.ID, obs); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}
@@ -544,7 +544,7 @@ func (s *Controller) resolveStranded(ctx context.Context, lease store.Lease, ret
 	}
 	*retried++
 	b := s.byBinding[lease.BindingID] // may be nil if the target was removed
-	if err := s.recoverCapsuleFailure(b, lease.ID, ""); err != nil {
+	if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
 		s.log.Warn("stranded lease still unresolved",
 			"lease", lease.ID, "state", string(lease.State), "error", err)
 		return

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -109,7 +109,7 @@ func TestCapsuleFailureRecoverySurvivesAMissingBinding(t *testing.T) {
 			t.Fatalf("recoverCapsuleFailure panicked with a missing binding: %v", r)
 		}
 	}()
-	if err := h.srv.recoverCapsuleFailure(nil, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), nil, lease.ID, ""); err != nil {
 		t.Fatalf("recoverCapsuleFailure with a missing binding: %v", err)
 	}
 }

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -438,3 +438,107 @@ func (s *replaySession) Acknowledge(context.Context, int) error { return nil }
 func (s *replaySession) SetCapacity(int)                        {}
 func (s *replaySession) Initial() *githubactions.Statistics     { return nil }
 func (s *replaySession) Close(context.Context) error            { return nil }
+
+// cancellingSession hands over one message and cancels the loop from
+// inside the acknowledgement — the shape of a shutdown that lands
+// exactly there. It is the worst honest moment: the message is gone from
+// the broker's queue and this process is stopping.
+type cancellingSession struct {
+	msg    *githubactions.Message
+	cancel context.CancelFunc
+
+	mu     sync.Mutex
+	served bool
+}
+
+func (s *cancellingSession) Receive(ctx context.Context) (*githubactions.Message, error) {
+	s.mu.Lock()
+	first := !s.served
+	s.served = true
+	s.mu.Unlock()
+	if first {
+		return s.msg, nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *cancellingSession) Acknowledge(context.Context, int) error {
+	s.cancel()
+	return nil
+}
+func (s *cancellingSession) SetCapacity(int)                    {}
+func (s *cancellingSession) Initial() *githubactions.Statistics { return nil }
+func (s *cancellingSession) Close(context.Context) error        { return nil }
+
+// TestACancellationIsDurableBeforeTheMessageIsAcknowledged: everything a
+// message carries is written down before the message is given up.
+//
+// An acknowledged message is never sent again, and nothing re-derives a
+// cancellation from the provider — so one lost between the
+// acknowledgement and the write is lost for good, and the workload it
+// closed goes on to spend a whole capsule on work the provider already
+// finished with. Recorded first, a shutdown in that window leaves the
+// message unacknowledged and the broker redelivers it.
+func TestACancellationIsDurableBeforeTheMessageIsAcknowledged(t *testing.T) {
+	h := newHarness(t, 1)
+
+	// One message carrying the assignment and the cancellation that
+	// closes it — the shape the provider actually sends when a run is
+	// cancelled while its jobs are being handed out. Delivering the two
+	// separately would not reach this: the loop drains ready work at the
+	// top of every turn, so the attempt is leased before any later
+	// message can close it, and a cancellation correctly refuses to
+	// touch a serving attempt.
+	ctx, cancel := context.WithCancel(t.Context())
+	msg := &githubactions.Message{
+		ID:       901,
+		Assigned: []assignment.WorkloadAssignment{demand("job-closed", "app", 44)},
+		Completed: []assignment.WorkloadLifecycleEvent{{
+			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-closed",
+			Result: "canceled",
+		}},
+	}
+	h.bind.session = &cancellingSession{msg: msg, cancel: cancel}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		cancel()
+		t.Fatal("the loop never returned after its context was cancelled")
+	}
+
+	// The state, not the queue: an attempt also leaves the ready list by
+	// being leased, which is the very outcome the cancellation exists to
+	// prevent.
+	var got store.Attempt
+	h.inStore(func(tx *store.Tx) error {
+		open, err := tx.OpenAttemptByWorkload(h.bind.bindingID, "job-closed")
+		if err == nil {
+			got = open
+			return nil
+		}
+		if !errors.Is(err, store.ErrNotFound) {
+			return err
+		}
+		attempts, err := tx.AttemptsOfDelivery(1)
+		if err != nil {
+			return err
+		}
+		for _, a := range attempts {
+			if a.SourceWorkloadKey == "job-closed" {
+				got = a
+			}
+		}
+		return nil
+	})
+	if got.State != "canceled" {
+		t.Errorf("the cancelled workload is %q; want canceled — the cancellation was lost "+
+			"with the message that carried it", got.State)
+	}
+}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -95,7 +95,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	jit, err := b.gh.GenerateJITConfig(prepCtx, b.scaleSetID, runnerName, workFolder)
 	if err != nil {
 		log.Error("jit generation failed", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	// The runtime's name is the lease's correlation handle; the runner id
@@ -111,7 +111,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return tx.TransitionLease(lease.ID, store.LeaseProvisioning, store.LeaseRuntimeRegistered)
 	}); err != nil {
 		log.Error("registering runner in state failed", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 
@@ -137,7 +137,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	sandbox, err := s.netSandbox.forLaunch(prepCtx)
 	if err != nil {
 		log.Error("network sandbox refresh failed", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	prepared, err := s.caps.Prepare(prepCtx, capsule.Spec{
@@ -164,14 +164,14 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		if errors.Is(err, capsule.ErrIncompatibleImage) {
 			s.leases.HoldAttempt(ctx, lease.ID, store.ReviewReasonIncompatibleCapsule)
 		}
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	// Recorded after the preparation exists — evidence names what
 	// happened, never what was about to be attempted.
 	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceRuntimePrepared); err != nil {
 		log.Error("cannot record that the runtime is prepared", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	s.advanceAttempt(ctx, attemptID, "preparing", "prepared")
@@ -194,7 +194,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	}); err != nil {
 		log.Warn("the attempt moved before the start was authorized; nothing is started",
 			"attempt", attemptID, "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, assignment.ObservedCreated)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, assignment.ObservedCreated)
 		return
 	}
 	// The authorization is durable immediately before the one effect
@@ -203,7 +203,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// inspecting the runtime, never by guessing.
 	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceStartAuthorized); err != nil {
 		log.Error("cannot record the start authorization", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	if startErr := s.caps.Start(prepCtx, prepared); startErr != nil {
@@ -223,11 +223,11 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 			if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
 				log.Error("cannot record the observed exit", "error", err)
 			}
-			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 			return
 		case assignment.ObservedCreated:
 			log.Info("the runtime was never started; the assignment stays servable", "error", startErr)
-			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 			return
 		default:
 			// Absent or unavailable: neither retry nor settlement can be
@@ -235,7 +235,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 			// assignment for a person.
 			log.Error("start outcome is unobservable; the assignment needs an operator",
 				"observation", string(obs), "error", startErr)
-			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 			return
 		}
 	}
@@ -245,7 +245,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	s.advanceAttempt(ctx, attemptID, "starting", "running")
 	if err := s.leases.Transition(ctx, lease.ID, store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning); err != nil {
 		log.Error("transition to running failed", "error", err)
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	runnerContainer := prepared.RuntimeID
@@ -268,7 +268,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		if startObs = capsule.ClassifyExit(int(exit)); startObs != assignment.ObservedExited {
 			log.Warn("the capsule reports the runner never started; the attempt is returned to the queue",
 				"exit", exit)
-			s.recoverCapsuleFailure(b, lease.ID, startObs)
+			s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 			return
 		}
 		if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
@@ -286,7 +286,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		} else {
 			log.Error("waiting on runner failed", "error", err)
 		}
-		s.recoverCapsuleFailure(b, lease.ID, startObs)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
 	if exit != 0 {
@@ -346,8 +346,21 @@ func (s *Controller) releaseCreditIfDone(b *binding, leaseID string) {
 // its Docker resources still need removing, and logging must not
 // dereference it — a panic here takes down startup reconciliation for
 // every other lease.
-func (s *Controller) recoverCapsuleFailure(b *binding, leaseID string, startObs assignment.ExecutionObservation) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+// recoverCapsuleFailure unwinds one lease after a failure, and disposes
+// of its attempt.
+//
+// ctx bounds the recovery, and which context a caller passes is a
+// statement about who else can finish this work. The serving path passes
+// one of its own, detached from the job's: a recovery interrupted
+// halfway leaves a lease nothing in this process will pick up again. The
+// periodic reconciler passes the loop's, because its work is resumable
+// by definition — the next pass, or the next start, finds the lease
+// exactly where this left it — and a recovery that outlived the
+// shutdown budget would have the platform kill the process inside one.
+func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leaseID string,
+	startObs assignment.ExecutionObservation) error {
+
+	ctx, cancel := context.WithTimeout(ctx, recoveryBudget)
 	defer cancel()
 	bindingKey := "(unconfigured)"
 	if b != nil {

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -389,8 +389,10 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 		if c.Role != capsule.RoleGateway || !c.Running {
 			continue
 		}
-		code, out, err := n.daemon.ExecWithInput(ctx, c.ID,
-			[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
+		code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
+			return n.daemon.ExecWithInput(ctx, c.ID,
+				[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
+		})
 		if err != nil || code != 0 {
 			failed = append(failed, c.ID)
 			n.log.Error("gateway policy reload failed", "container", c.Name, "exit", code, "error", err, "output", out)
@@ -401,6 +403,21 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 	return failed, nil
 }
 
+// gatewayExecTimeout bounds one gateway control exec, so a refresh pass
+// costs at most one of these per gateway rather than an unknown amount.
+// The pass holds the refresh lock and every launch waits on that lock
+// with a plain mutex, which takes no context of its own.
+const gatewayExecTimeout = 30 * time.Second
+
+// execGateway runs one gateway control command under its own bound.
+func (n *networkSandbox) execGateway(ctx context.Context,
+	call func(context.Context) (int, string, error)) (int, string, error) {
+
+	ctx, cancel := context.WithTimeout(ctx, gatewayExecTimeout)
+	defer cancel()
+	return call(ctx)
+}
+
 // closeGateway revokes a live gateway's egress: every destination
 // denied, in the kernel ruleset and in the relay's own check.
 //
@@ -409,8 +426,10 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 // which takes its connections with it. A capsule whose gateway is gone
 // has no egress at all, which is the state this is trying to reach.
 func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) error {
-	code, out, err := n.daemon.Exec(ctx, containerID,
-		[]string{capsule.SupervisorPath, "gateway-deny-all"})
+	code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
+		return n.daemon.Exec(ctx, containerID,
+			[]string{capsule.SupervisorPath, "gateway-deny-all"})
+	})
 	if err != nil || code != 0 {
 		// The policy could not be closed from inside; removing the
 		// container is the remaining way to stop it relaying.

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -46,7 +46,29 @@ const (
 	// hold drain plus this, and a bound that grew with the binding count
 	// would outgrow any grace period an operator chose.
 	SessionCloseBudget = 15 * time.Second
-	pollBackoff        = 5 * time.Second
+	// LoopStopBudget is how long waiting for the serve loops may take
+	// once their context is cancelled. Each loop stops on that context;
+	// what can outlive one is a write deliberately detached so it would
+	// survive cancellation, and the longest of those is the interrupted
+	// lease recovery at thirty seconds.
+	//
+	// Unlike its two neighbours this is a claim rather than a timer.
+	// Racing the wait against one would abandon a loop that is still
+	// running, which falsifies what closing the sessions afterwards
+	// assumes — that each binding's session field is quiescent — and
+	// puts a data race on it. So the wait stays unbounded and this
+	// number states what the loops must cost; the reconciler test is
+	// what keeps that true.
+	LoopStopBudget = 45 * time.Second
+	// ShutdownBudget is the whole of it, and the number the deployment's
+	// stop grace period is sized against — not a subset of its terms. A
+	// grace period shorter than this ends in SIGKILL partway through,
+	// which leaves every message session open for the next start to wait
+	// out as a conflict.
+	ShutdownBudget = LoopStopBudget + DrainTimeout + SessionCloseBudget
+	// recoveryBudget bounds unwinding one lease after a failure.
+	recoveryBudget = 2 * time.Minute
+	pollBackoff    = 5 * time.Second
 
 	// capsulePrepTimeout bounds getting a capsule to the point of running:
 	// minting a credential, acquiring a lane, building the sandbox,

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -122,7 +122,7 @@ func TestDrainExpiryAbandonsRecovery(t *testing.T) {
 	before := reloadLease(t, h, lease.ID).State
 
 	h.srv.abandoning.Store(true)
-	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err != nil {
 		t.Fatalf("abandoned recovery reported an error: %v", err)
 	}
 	if got := reloadLease(t, h, lease.ID).State; got != before {
@@ -135,7 +135,7 @@ func TestDrainExpiryAbandonsRecovery(t *testing.T) {
 	// The mutation half: the same call without the abandonment is the
 	// destructive path, so the assertions above are proven able to fail.
 	h.srv.abandoning.Store(false)
-	if err := h.srv.recoverCapsuleFailure(h.bind, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err != nil {
 		t.Fatalf("live recovery failed: %v", err)
 	}
 	if got := reloadLease(t, h, lease.ID).State; got == before {

--- a/internal/platform/docker/exec.go
+++ b/internal/platform/docker/exec.go
@@ -8,6 +8,42 @@ import (
 	"github.com/moby/moby/client"
 )
 
+// closeOnDone closes a hijacked connection when ctx ends, and returns
+// the function that stops watching.
+//
+// The client's context governs the dial and the protocol upgrade and
+// stops there: once the connection is hijacked nothing consults ctx
+// again, so a read blocks for as long as the container takes to answer,
+// and the deferred close cannot help — it is deferred inside the call
+// that is blocked. An exec into a wedged container is otherwise
+// unbounded, and one of those is held across the sandbox's refresh
+// lock, which every launch waits on with a mutex that takes no context.
+func closeOnDone(ctx context.Context, attach client.ExecAttachResult) func() {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			attach.Close()
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
+}
+
+// demux drains the multiplexed stream, reporting the context's error
+// when the context is what ended the read. Without that the caller sees
+// "use of closed network connection" and cannot tell a timeout it set
+// from a daemon that broke.
+func demux(ctx context.Context, attach client.ExecAttachResult, buf *bytes.Buffer) error {
+	if _, err := stdcopy.StdCopy(buf, buf, attach.Reader); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return err
+	}
+	return nil
+}
+
 // Exec runs a command inside a running container and returns its exit
 // code and combined output. The capsule uses it to read the dind socket
 // gid and to probe daemon readiness.
@@ -25,9 +61,12 @@ func (c *Client) Exec(ctx context.Context, containerID string, cmd []string) (in
 		return -1, "", err
 	}
 	defer attach.Close()
+	// Deferred after the close so it unwinds first: stop watching, then
+	// close.
+	defer closeOnDone(ctx, attach)()
 
 	var buf bytes.Buffer
-	if _, err := stdcopy.StdCopy(&buf, &buf, attach.Reader); err != nil {
+	if err := demux(ctx, attach, &buf); err != nil {
 		return -1, buf.String(), err
 	}
 	inspect, err := c.cli.ExecInspect(ctx, created.ID, client.ExecInspectOptions{})
@@ -64,6 +103,7 @@ func (c *Client) ExecWithInput(ctx context.Context, containerID string, cmd []st
 		return -1, "", err
 	}
 	defer attach.Close()
+	defer closeOnDone(ctx, attach)()
 
 	// Write, then half-close so the process sees EOF; the demux drains
 	// until the process exits.
@@ -74,7 +114,7 @@ func (c *Client) ExecWithInput(ctx context.Context, containerID string, cmd []st
 		return -1, "", err
 	}
 	var buf bytes.Buffer
-	if _, err := stdcopy.StdCopy(&buf, &buf, attach.Reader); err != nil {
+	if err := demux(ctx, attach, &buf); err != nil {
 		return -1, buf.String(), err
 	}
 	inspect, err := c.cli.ExecInspect(ctx, created.ID, client.ExecInspectOptions{})

--- a/internal/platform/docker/exec_test.go
+++ b/internal/platform/docker/exec_test.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"context"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/moby/moby/client"
+)
+
+// TestCloseOnDoneClosesTheConnection: cancelling the context has to
+// reach the hijacked connection itself.
+//
+// The client's context governs the dial and the protocol upgrade and
+// stops there — once the connection is hijacked, a read on it blocks for
+// as long as the container takes, and the deferred close cannot help
+// because it is deferred inside the call that is blocked. An exec into a
+// wedged container is unbounded without this, and one of those is held
+// across the lock every launch waits on.
+func TestCloseOnDoneClosesTheConnection(t *testing.T) {
+	ours, theirs := net.Pipe()
+	defer theirs.Close()
+	attach := client.ExecAttachResult{HijackedResponse: client.NewHijackedResponse(ours, "")}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stop := closeOnDone(ctx, attach)
+	defer stop()
+
+	read := make(chan error, 1)
+	go func() {
+		buf := make([]byte, 1)
+		_, err := theirs.Read(buf)
+		read <- err
+	}()
+
+	select {
+	case <-read:
+		t.Fatal("the read returned before the context was cancelled")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-read:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the context did not reach the connection; the read is unbounded")
+	}
+}
+
+// TestCloseOnDoneStopsWatching: the watcher must not outlive the call
+// it belongs to.
+//
+// It exists only for the duration of one exec, and its context can be a
+// long one — the tier's ceiling, or a launch budget of minutes. A
+// watcher left running holds a goroutine and a connection reference for
+// all of it, on every exec the controller makes.
+//
+// What it does at the moment it stops is deliberately not asserted: the
+// only thing it ever does is close a connection its own call closes on
+// the next deferred line, so a close that races the stop costs nothing.
+func TestCloseOnDoneStopsWatching(t *testing.T) {
+	// A context nothing cancels, so only the stop can end a watcher.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	before := runtime.NumGoroutine()
+	for range 64 {
+		ours, theirs := net.Pipe()
+		attach := client.ExecAttachResult{HijackedResponse: client.NewHijackedResponse(ours, "")}
+		closeOnDone(ctx, attach)()
+		ours.Close()
+		theirs.Close()
+	}
+
+	// Goroutines end asynchronously, so this settles rather than reads
+	// once; what it must not do is settle above the baseline.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if runtime.NumGoroutine() <= before+8 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("goroutines went from %d to %d after 64 stopped watchers; each exec leaks one "+
+		"until its context expires", before, runtime.NumGoroutine())
+}

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -29,10 +29,12 @@ func repoPath(parts ...string) string {
 	return filepath.Join(append([]string{"..", ".."}, parts...)...)
 }
 
-// TestStopGracePeriodHoldsTheWholeShutdown: shutdown spends the drain
-// window in full whenever work is in flight and then closes every
-// message session under one shared budget, so the deployment's stop
-// grace period must exceed the sum. When it does not, the platform's
+// TestStopGracePeriodHoldsTheWholeShutdown: shutdown waits out the serve
+// loops, spends the drain window in full whenever work is in flight, and
+// then closes every message session under one shared budget — so the
+// deployment's stop grace period must exceed all three. Comparing
+// against a subset of the terms is how a bound comes to describe less
+// than the process actually does. When it does not, the platform's
 // SIGKILL lands first, the deferred closes never run, and every restart
 // with a live job leaves the broker holding a session the next start
 // waits out as a conflict.
@@ -59,11 +61,11 @@ func TestStopGracePeriodHoldsTheWholeShutdown(t *testing.T) {
 		// must not pass with a grace period of no seconds.
 		t.Fatalf("stop_grace_period %q is not a duration: %v", controller.StopGracePeriod, err)
 	}
-	shutdown := app.DrainTimeout + app.SessionCloseBudget
-	if grace <= shutdown {
-		t.Fatalf("stop_grace_period %s does not hold the %s shutdown (%s drain + %s session close); "+
+	if grace <= app.ShutdownBudget {
+		t.Fatalf("stop_grace_period %s does not hold the %s shutdown "+
+			"(%s waiting for the loops + %s drain + %s session close); "+
 			"the platform kills the controller before it closes its sessions",
-			grace, shutdown, app.DrainTimeout, app.SessionCloseBudget)
+			grace, app.ShutdownBudget, app.LoopStopBudget, app.DrainTimeout, app.SessionCloseBudget)
 	}
 }
 


### PR DESCRIPTION
## What changes

An exec into a container ends when its context does, and reports the
context's error. Each gateway control call carries a bound, and so does
the capsule's dockerd readiness probe. Lifecycle events are made durable
before the message carrying them is acknowledged. `recoverCapsuleFailure`
takes a context from its caller, and `ShutdownBudget` states the whole
stop the reference deployment is sized against.

## What was found

**The context did not reach the I/O it was supposed to cancel.** Verified
in `moby/client@v0.5.1`: `postHijacked` uses the context for
`dialer(ctx)` and the upgrade round-trip, and once the connection is
hijacked nothing consults it again. So `stdcopy.StdCopy` blocks for as
long as the container takes, and `defer attach.Close()` cannot fire — it
is deferred inside the call that is blocked. Wrapping call sites in
`context.WithTimeout` does not help for the same reason: the timeout
fires and the read stays blocked on a connection nobody closed.

The call that makes this expensive is `gateway-reload`: the sandbox
refresh holds `refreshMu` across every gateway it reloads, and
`forLaunch` waits on that mutex with no context of its own. One
unresponsive gateway held every launch on the instance.

**The readiness probe could hang PID 1.** `exec.Command` with no context
meant one probe could spend the whole 60-second readiness budget, and
inside a capsule there is nothing outside the process to cut it short.

**The first bound did not bound.** With `io.Discard`, `exec.Cmd` builds a
pipe and copies from it, and `Wait` waits for that copy — which the
`sleep` orphaned by the kill kept open. Measured: 60s against a 5s bound.
Writing to the null device removes the pipe entirely.

**A cancellation could be lost with the message that carried it.**
`recordLifecycleEvents` ran after `acknowledgeDelivery`. An acknowledged
message is never sent again and nothing re-derives a cancellation from
the provider, so a shutdown in that window loses it for good and the
workload spends a whole capsule on work already closed. It also ran after
`scheduleReadyAttempts` could have leased the attempt it was meant to
close.

**The shutdown could take three minutes against a two-minute grace.**
`recoverCapsuleFailure` built `context.WithTimeout(context.Background(),
2*time.Minute)` — detached from every caller — and is reachable from
`periodicReconcile → retryStranded → resolveStranded`, which the shutdown
waits on through `loops.Wait()`. Measured: with the recovery detached,
the pass holds the shutdown for 2m0s against a 45s budget.

**What decided the constants.** `LoopStopBudget` is 45s, not 30s: the
longest detached write reachable inside a loop is `resolveInterrupted`'s
at 30s — not the 15s every other detached write uses — so 30s would leave
no margin at all. `ShutdownBudget` is therefore `45 + 60 + 15 = 120s`,
and the consistency test requires the grace period to exceed it strictly,
so `stop_grace_period` goes from `2m` to `150s`. `gatewayExecTimeout` is
30s so a refresh pass costs at most one of those per gateway rather than
an unknown amount.

**What deliberately did not change:** `loops.Wait()` stays unbounded, so
`LoopStopBudget` is a claim rather than a timer, and says so in its
comment. Racing the wait against a timer would abandon a live loop, which
falsifies what `closeSessions` states about `b.session` being quiescent
and puts a data race on it. The reconciler test is what keeps the claim
true.

## Evidence

Hermetic, plus one gated docker contract for the exec seam. Each fix was
checked by reverting it and watching the new test fail.

```text
mutation checks, local:
  delete the ctx.Done watcher in closeOnDone
    -> TestCloseOnDoneClosesTheConnection:
       cancelling the context did not reach the connection; the read is unbounded
  make the stop a no-op
    -> TestCloseOnDoneStopsWatching:
       goroutines went from 2 to 66 after 64 stopped watchers
  revert exec.CommandContext to exec.Command
    -> TestTheReadinessProbeIsBounded: 60s against a 5s bound
  move recordLifecycleEvents back below the acknowledgement
    -> TestACancellationIsDurableBeforeTheMessageIsAcknowledged:
       the cancelled workload is "ready"; want canceled
  detach the recovery from its caller again
    -> TestTheReconcilerStopsRecoveringWhenTheShutdownBegins:
       the pass held the shutdown for 2m0s against a 45s budget
```

## What would notice this regressing

- `TestCloseOnDoneClosesTheConnection` and `TestCloseOnDoneStopsWatching`
  (internal/platform/docker) cover both halves of the watcher.
- `TestExecHonoursItsContext` (gated docker contract) covers the same
  property against a real daemon.
- `TestTheReadinessProbeIsBounded` (cmd/capsule-supervisor) fails if the
  probe loses its context — and, because it measures wall clock, if the
  bound stops bounding for the pipe reason above.
- `TestACancellationIsDurableBeforeTheMessageIsAcknowledged`
  (internal/app) fails if the ordering reverts.
- `TestTheReconcilerStopsRecoveringWhenTheShutdownBegins` (internal/app)
  fails if the reconciler's recovery detaches again.
- `TestStopGracePeriodHoldsTheWholeShutdown` (test/consistency) fails if
  the deployment's grace period stops holding the whole bound. It
  previously summed two of the three terms, which is what let the
  omission stand.

## Risk, compatibility and operations

**Deployment change, and it needs saying:** `stop_grace_period` in
`deploy/compose/compose.yaml` rises from `2m` to `150s`. An operator
running their own compose file or another orchestrator has to raise
theirs to match, or a shutdown with work in flight is killed partway and
every message session is left for the next start to wait out as a
conflict. `TestStopGracePeriodHoldsTheWholeShutdown` enforces this for
the reference deployment only; nothing can enforce it for a file we do
not ship.

**Failure behaviour: more interruptible, in one direction only.** The
periodic reconciler's recovery now stops when the process is stopping.
That is safe because its work is resumable by construction — the next
pass or the next start finds each lease exactly where the shutdown left
it — and it is why the serving path keeps a context of its own, where an
interrupted recovery would leave a lease nothing in this process retries.

**Trust boundary: unchanged.** The credential still travels over exec
stdin; `ExecWithInput` gains the same watcher as `Exec`, so a delivery
whose context expires now ends rather than hanging.

**Operations:** no CLI, configuration, status API, schema or migration
change. Two exported constants are added (`LoopStopBudget`,
`ShutdownBudget`); `DrainTimeout` and `SessionCloseBudget` keep their
values. Rollback is the previous image plus the previous grace period.

## Changelog

```text
Isolation and egress / State and operations:
- A cancellation is durable before its message is given up. Everything a
  broker message carries is written down before the message is
  acknowledged, for the same reason the assignment is: an acknowledged
  message is never sent again and nothing re-derives a cancellation from
  the provider, so one lost in that window costs a whole capsule on work
  the provider already closed.
- Every call into a container is bounded. The daemon's connection for an
  exec is handed over once and stops consulting the caller's context, so a
  container that accepts a command and answers nothing held the call open
  indefinitely — including the gateway control calls a policy refresh
  makes while holding the lock every launch waits on. The connection now
  ends with the context, and each gateway call carries its own bound.
  Inside a capsule the readiness probe is bounded the same way, so a
  daemon that never answers cannot spend the whole readiness budget in one
  call.
- (amended) A restart is not a provider dependency ... The whole shutdown
  is sized to end inside the deployment's stop grace period, and the
  deployment is sized against that whole number rather than a subset of
  its terms ... The periodic reconciler's recovery ends with that shutdown
  instead of running a budget of its own, because its work is resumable —
  the next start finds each lease where the shutdown left it.
```

## Notes for your reviewer

Three things failed *with* the fix in place, which is the part worth
reading.

The first bound did not bound: `exec.CommandContext` kills the shim, but
`Run` still waits on the pipe the orphaned `sleep` inherited. Without a
test that measures wall clock I would have shipped a decorative timeout.

The cancellation test first delivered the workload and its cancellation
as separate messages — but the loop drains ready work at the top of every
turn, so the attempt was leased before the cancellation arrived, and a
cancellation correctly refuses to touch a serving attempt. The message
now carries both, which is the shape the provider actually sends. It also
asserted on the ready queue, which an attempt leaves by being leased too;
it now reads the attempt's state.

`TestCloseOnDoneStopsWatching` originally asserted that a stopped watcher
never closes the connection. That is unachievable — `select` with two
ready cases picks at random — and it is not a property worth having: the
only thing the watcher closes is a connection its own call closes on the
next deferred line. It now asserts what does matter, that the goroutine
does not outlive the call.
