### PR TITLE
fix(gateway): the tunnel counts both directions, and a half-close is not a truncation

### DIFF
--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -23,6 +23,7 @@ on:
       - "internal/capsule/**"
       - "internal/cache/**"
       - "internal/egress/**"
+      - "internal/gateway/**"
       - "internal/disk/**"
       - "internal/store/**"
       - "cmd/capsule-supervisor/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ by its public and operational effects.
   spliced document the relay would refuse to read.
 - The relay's CONNECT port set, header handling, parser strictness and
   every concurrency and size bound are explicit, tested and fuzzed.
+- **A tunnel ends when both of its directions do.** A client that shuts
+  down its write side once its request is out has half-closed, not hung
+  up: the relay forwards that half-close and keeps carrying the reply,
+  so the response arrives whole. And the idle bound belongs to the
+  tunnel rather than to each direction, so a large upload or a slow
+  download — silent one way for its whole duration — is not cut off
+  while it is streaming.
 - **Containers a job starts take the same relay.** A daemon does not pass
   its own environment to what it runs, so the capsule's proxy did not
   reach a `docker build` or a `docker run` the job issued — and under the

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/netip"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -203,35 +204,88 @@ func (r *Relay) establishTunnel(w http.ResponseWriter, upstream net.Conn) {
 	tunnel(client, upstream)
 }
 
-// tunnel copies both directions and returns when either ends. Each side
-// carries an idle deadline, so a tunnel nobody is using releases its
-// connection slot instead of holding it until the job ends.
+// closeWriter is the half-close a tunnel propagates. Every connection a
+// tunnel joins has it; naming the interface is what lets a wrapper that
+// hides the method be given one back rather than silently falling
+// through to a full close.
+type closeWriter interface{ CloseWrite() error }
+
+// tunnelPollInterval is how often a quiet direction re-checks the
+// tunnel's shared activity clock. It also bounds how far past the idle
+// timeout a genuinely silent tunnel can live.
+const tunnelPollInterval = 30 * time.Second
+
+// tunnel copies both directions and returns when both of them have
+// ended.
+//
+// A clean EOF on one direction is a half-close, not the end of the
+// tunnel. Propagating it as CloseWrite is what lets the peer finish its
+// own reply; returning there truncated the response of every client
+// that shuts down its write side once its request is out — an ordinary
+// thing for an HTTP client to do, and the reason both directions are
+// now waited on: the deferred closes around this call fire when it
+// returns, so ending early closes the connection the peer was still
+// answering on.
+//
+// The idle bound is the tunnel's, not each direction's. A long one-way
+// transfer is silent in the other direction for its whole duration, so
+// a per-direction deadline severed a large upload or a slow download
+// while it was actively streaming. Each direction now reads in short
+// intervals and consults a clock both of them write.
 func tunnel(client, upstream net.Conn) {
-	done := make(chan struct{}, 2)
+	tunnelWith(client, upstream, TunnelIdleTimeout, tunnelPollInterval)
+}
+
+func tunnelWith(client, upstream net.Conn, idle, poll time.Duration) {
+	// One clock for the tunnel: activity in either direction is what
+	// keeps the other alive.
+	var lastActivity atomic.Int64
+	lastActivity.Store(time.Now().UnixNano())
+
+	var wg sync.WaitGroup
 	copyIdle := func(dst, src net.Conn) {
+		defer wg.Done()
 		buf := make([]byte, 32<<10)
 		for {
-			_ = src.SetReadDeadline(time.Now().Add(TunnelIdleTimeout))
+			_ = src.SetReadDeadline(time.Now().Add(poll))
 			n, err := src.Read(buf)
 			if n > 0 {
-				_ = dst.SetWriteDeadline(time.Now().Add(TunnelIdleTimeout))
+				lastActivity.Store(time.Now().UnixNano())
+				_ = dst.SetWriteDeadline(time.Now().Add(idle))
 				if _, werr := dst.Write(buf[:n]); werr != nil {
 					break
 				}
+				lastActivity.Store(time.Now().UnixNano())
 			}
-			if err != nil {
-				break
+			switch {
+			case err == nil:
+				continue
+			case errors.Is(err, os.ErrDeadlineExceeded):
+				// Quiet here. The tunnel is idle only if it is quiet
+				// both ways, which is what the shared clock answers.
+				if time.Since(time.Unix(0, lastActivity.Load())) < idle {
+					continue
+				}
+			case errors.Is(err, io.EOF):
+				// This side is done sending and says so, leaving the
+				// peer to finish. The tunnel ends when that one ends
+				// too.
+				if cw, ok := dst.(closeWriter); ok {
+					_ = cw.CloseWrite()
+					return
+				}
 			}
+			break
 		}
-		// Unblock the peer direction rather than leaving its goroutine
-		// parked on a read that will never return.
+		// The tunnel is over rather than half-closed: unblock the peer
+		// instead of leaving its goroutine parked on a read.
 		_ = src.SetReadDeadline(time.Now())
 		_ = dst.SetReadDeadline(time.Now())
-		done <- struct{}{}
 	}
+	wg.Add(2)
 	go copyIdle(upstream, client)
 	go copyIdle(client, upstream)
-	<-done
+	wg.Wait()
 }
 
 // forward relays a plain HTTP request through a shared, bounded
@@ -513,4 +567,17 @@ type limitConn struct {
 func (c *limitConn) Close() error {
 	c.once.Do(c.release)
 	return c.Conn.Close()
+}
+
+// CloseWrite forwards a half-close to the connection underneath.
+// net.Conn does not declare it, so embedding the interface hides the
+// method even though every connection this wraps has it — and a tunnel
+// propagating a half-close would find no closeWriter, close the whole
+// connection instead, and truncate the reply it was making room for.
+func (c *limitConn) CloseWrite() error {
+	cw, ok := c.Conn.(closeWriter)
+	if !ok {
+		return errors.New("the underlying connection cannot be half-closed")
+	}
+	return cw.CloseWrite()
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -293,3 +293,163 @@ func TestTunnelCarriesTheBytesTheServerAlreadyRead(t *testing.T) {
 	clientSide.Close()
 	<-done
 }
+
+// tcpPair dials a loopback listener and hands back both ends of one real
+// TCP connection. Real sockets, not net.Pipe: a half-close is a property
+// of the transport, and a pipe has no such thing.
+func tcpPair(t *testing.T) (client, server net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+	client, err = net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case server = <-accepted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the listener never accepted")
+	}
+	t.Cleanup(func() { client.Close(); server.Close() })
+	return client, server
+}
+
+// TestAHalfClosingClientStillReceivesItsWholeResponse: a client that
+// shuts down its write side once its request is out must still get the
+// whole reply.
+//
+// It is ordinary HTTP client behaviour and a clean EOF on one direction
+// only, not the end of the connection. Treating it as the end of the
+// tunnel closes the socket the upstream is still answering on, and the
+// client gets a truncated response with nothing to say why.
+func TestAHalfClosingClientStillReceivesItsWholeResponse(t *testing.T) {
+	const size = 1 << 20
+	clientEnd, clientSide := tcpPair(t)
+	upstreamSide, upstreamEnd := tcpPair(t)
+
+	go tunnelWith(clientSide, upstreamSide, 5*time.Second, 500*time.Millisecond)
+
+	// The request goes out, then the client is done sending.
+	if _, err := clientEnd.Write([]byte("request")); err != nil {
+		t.Fatal(err)
+	}
+	if err := clientEnd.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The upstream sees the request and its EOF, then answers at length.
+	go func() {
+		buf := make([]byte, 64)
+		for {
+			if _, err := upstreamEnd.Read(buf); err != nil {
+				break
+			}
+		}
+		payload := bytes.Repeat([]byte("x"), size)
+		_, _ = upstreamEnd.Write(payload)
+		_ = upstreamEnd.(*net.TCPConn).CloseWrite()
+	}()
+
+	if err := clientEnd.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(clientEnd)
+	if err != nil {
+		t.Fatalf("reading the response: %v (got %d of %d bytes)", err, len(got), size)
+	}
+	if len(got) != size {
+		t.Errorf("the client received %d bytes of a %d-byte response; the half-close was "+
+			"read as the end of the tunnel", len(got), size)
+	}
+}
+
+// TestALimitedConnectionForwardsAHalfClose: the wrapper the relay counts
+// connections with must not hide the half-close.
+//
+// It embeds net.Conn, which does not declare CloseWrite, so the method
+// is not promoted — a tunnel looking for one finds nothing and closes
+// the whole connection instead, which is the truncation above by another
+// route.
+func TestALimitedConnectionForwardsAHalfClose(t *testing.T) {
+	peer, raw := tcpPair(t)
+	limited := &limitConn{Conn: raw, release: func() {}}
+
+	var cw closeWriter = limited // fails to compile if the method is gone
+	if err := cw.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite: %v", err)
+	}
+
+	// The peer sees EOF on its read side...
+	if err := peer.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(peer); err != nil {
+		t.Fatalf("the peer could not read to EOF after the half-close: %v", err)
+	}
+	// ...and the half-closed side can still read what the peer sends.
+	if _, err := peer.Write([]byte("reply")); err != nil {
+		t.Fatal(err)
+	}
+	if err := limited.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 5)
+	if _, err := io.ReadFull(limited, buf); err != nil {
+		t.Fatalf("the half-closed connection lost its read side: %v", err)
+	}
+}
+
+// TestAOneWayTransferOutlivesTheIdleBound: a transfer that is silent in
+// one direction is not an idle tunnel.
+//
+// A large upload or a slow download says nothing back for its whole
+// duration, so a deadline applied per direction severed connections
+// that were actively streaming. The bound belongs to the tunnel, and
+// the tunnel is idle only when neither direction has moved.
+func TestAOneWayTransferOutlivesTheIdleBound(t *testing.T) {
+	const (
+		idle  = 200 * time.Millisecond
+		poll  = 20 * time.Millisecond
+		beats = 40
+	)
+	clientEnd, clientSide := tcpPair(t)
+	upstreamSide, upstreamEnd := tcpPair(t)
+
+	go tunnelWith(clientSide, upstreamSide, idle, poll)
+
+	// One direction streams steadily for well past the idle bound; the
+	// other says nothing at all.
+	go func() {
+		for range beats {
+			if _, err := upstreamEnd.Write([]byte("x")); err != nil {
+				return
+			}
+			time.Sleep(30 * time.Millisecond)
+		}
+		_ = upstreamEnd.(*net.TCPConn).CloseWrite()
+	}()
+
+	if err := clientEnd.SetReadDeadline(time.Now().Add(20 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(clientEnd)
+	if err != nil {
+		t.Fatalf("reading the stream: %v (got %d of %d bytes)", err, len(got), beats)
+	}
+	if len(got) != beats {
+		t.Errorf("the client received %d of %d bytes over %s with a %s idle bound; "+
+			"the quiet direction expired while the other was streaming",
+			len(got), beats, time.Duration(beats)*30*time.Millisecond, idle)
+	}
+}


### PR DESCRIPTION
## What changes

A CONNECT tunnel ends when both of its directions end. A clean EOF on one
side is propagated as a half-close instead of tearing the tunnel down, so
a client that shuts its write side still receives its whole reply. The
idle bound applies to the tunnel rather than to each direction, so a
one-way transfer is not cut off while it is streaming. `limitConn`
forwards `CloseWrite`. And a change under `internal/gateway` now selects
the Docker-backed suites that exercise a gateway.

## What was found

**A half-close was read as the end of the tunnel.** `tunnel` returned as
soon as either direction finished, and `establishTunnel`'s
`defer client.Close()` and the caller's `defer upstream.Close()` fire on
that return — so a client that shuts down its write side once its request
is out had the connection closed under the reply it was waiting for. That
is ordinary HTTP client behaviour, and the upstream never even saw the
EOF, so it had no reason to answer at all. Measured over a real TCP pair:
the client receives 0 of a 1 MiB response.

**The wrapper hid the half-close.** `limitConn` embeds `net.Conn`, and
`net.Conn` does not declare `CloseWrite` — so the method is not promoted
even though every connection it wraps has it. A tunnel asserting for a
`closeWriter` finds nothing and falls back to closing the whole
connection, which is the same truncation reached another way.

**A one-way transfer was cut off while it was streaming.** The idle
deadline was set per direction, and a large upload or a slow download is
silent the other way for its entire duration. Measured with a 200 ms
bound and one byte every 30 ms in a single direction: the client receives
7 of 40 bytes.

**A gateway change did not run the gateway suites.** The Docker-backed
workflow selects itself by path, and the list named `internal/egress` —
the policy vocabulary — but not `internal/gateway`, the relay and ruleset
that enforce it. This pull request's first run was six checks rather than
twelve: the capsule contract that drives a real gateway container, and
the bypass contract that tries to leave one, both sat out a change to the
relay's data path.

**What decided the constant.** `tunnelPollInterval` is 30s: it is how
often a quiet direction re-checks the shared clock, so it also bounds how
far past `TunnelIdleTimeout` a genuinely silent tunnel can live. Short
enough that a silent tunnel still releases its connection slot promptly,
long enough that an active tunnel is not re-arming deadlines constantly.

**What deliberately did not change.** Dropping the deadlines and using
`io.Copy` both ways fixes the truncation and the one-way transfer in far
less code — and reintroduces the unbounded connection slot the deadlines
exist for: a job could hold all 256 slots on abandoned tunnels inside a
128 MiB gateway. Raising `TunnelIdleTimeout` would only move the second
threshold, and a keepalive would put bytes on a stream the relay promises
not to inspect or modify.

## Evidence

Hermetic, over real loopback TCP rather than `net.Pipe` — a half-close is
a property of the transport, and a pipe has none. The Docker-backed
suites now run on this change too, which is the fourth finding above.

```text
mutation checks, local:
  return on the first EOF, as before
    -> TestAHalfClosingClientStillReceivesItsWholeResponse:
       reading the response: i/o timeout (got 0 of 1048576 bytes)
  remove limitConn.CloseWrite
    -> build failure: *limitConn does not implement closeWriter
       (missing method CloseWrite)
  restore per-direction idle deadlines
    -> TestAOneWayTransferOutlivesTheIdleBound:
       reading the stream: i/o timeout (got 7 of 40 bytes)
```

## What would notice this regressing

- `TestAHalfClosingClientStillReceivesItsWholeResponse` (internal/gateway)
  fails if a half-close ends the tunnel again.
- `TestALimitedConnectionForwardsAHalfClose` holds a `*limitConn` in a
  `closeWriter` variable, so removing the method fails the build rather
  than silently reverting the behaviour.
- `TestAOneWayTransferOutlivesTheIdleBound` fails if the idle bound goes
  back to being per-direction.
- The bypass and capsule contracts (`test/contract/capsule`) drive a real
  gateway container, and now run when `internal/gateway` changes.

## Risk, compatibility and operations

**Connection lifetime changes, in the safe direction and one unsafe one
worth naming.** A tunnel now outlives a single half-close, so a
connection slot is held until both directions finish rather than until
the first does. The bound that releases it is still there — the tunnel
expires when neither direction has moved for `TunnelIdleTimeout`, within
one 30-second poll — so the 256-slot ceiling is unchanged and no tunnel
is unbounded. The observable effect is that slots are held slightly
longer in the ordinary case, which is what makes responses arrive whole.

**Trust boundary: unchanged.** No policy decision moves: the address and
port checks happen before a tunnel exists, and this changes only how the
two established streams are joined. The relay still does not inspect or
modify what flows inside a tunnel — the half-close is propagated, not
synthesised.

**Operations:** no CLI, configuration, status API, schema, migration or
deployment change. No rollback step. `MaxProxyConnections`,
`TunnelIdleTimeout` and the gateway's memory envelope are untouched.

The CI path filter change means `internal/gateway` edits now cost the
Docker-backed workflow's runtime on every pull request that touches them,
which is the point.

## Changelog

```text
Isolation and egress:
- A tunnel ends when both of its directions do. A client that shuts down
  its write side once its request is out has half-closed, not hung up: the
  relay forwards that half-close and keeps carrying the reply, so the
  response arrives whole. And the idle bound belongs to the tunnel rather
  than to each direction, so a large upload or a slow download — silent
  one way for its whole duration — is not cut off while it is streaming.
```

## Notes for your reviewer

The path-filter commit is in this pull request rather than its own
because this is the change that revealed it: the relay's data path moved
and the suites that drive a real gateway did not run. Splitting it would
have meant merging a gateway change under the coverage that missed it.

`tunnelWith` is exported to the package only for the tests, so they can
use a 200 ms bound instead of ten minutes. `tunnel` remains the single
production entry point and fixes both constants.
