### PR TITLE
fix(doctor, command): the diagnosis answers when the daemon does not, and the report does not depend on who asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,20 @@ by its public and operational effects.
   while the reviewed baseline is still edited in place, which is exactly
   when a database written by an earlier build would otherwise be accepted
   and then fail on a missing table.
+- **A diagnosis answers when the daemon does not.** `runpool doctor`
+  runs to completion against an unreachable daemon and reports every
+  check that could be made, which is the state an operator runs it in.
+- **A report answers its own question.** `runpool status` reports a
+  capsule image it cannot resolve as a finding beside the rest of the
+  document, rather than refusing to answer — so one unset environment
+  variable no longer takes the lease list and the daemon comparison down
+  with it.
+- **A binding is identified by what an operator configured.** Its
+  durable key is built from the target, runner group and scale set name,
+  never from a parsed form of the address, so a deployment that changed
+  nothing keeps the row its whole history hangs off. Bindings the
+  configuration no longer claims are forgotten on the next start, unless
+  they still own a delivery — that trail is kept.
 - **A schema this build cannot account for is refused, not repaired** —
   by reporting as well as by the controller. `status`, a `gc` dry run and
   a `cleanup` or `uninstall` preview apply no migrations, so each says

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -22,6 +22,7 @@ import (
 // result. Creating-or-adopting the scale set is the binding's own loop's
 // first act, where a failure is retried instead of ending the process.
 func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, environ func(string) string) error {
+	var claimed []int64
 	tiers := make(map[string]config.Tier, len(cfg.Tiers))
 	for _, t := range cfg.Tiers {
 		tiers[t.ID] = t
@@ -67,11 +68,8 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 			tier := tiers[tb.TierID]
 
 			// The neutral binding row comes first: it keys the delivery,
-			// attempt and lease machinery. Its source key is a versioned
-			// encoding of the provider identity, never an ambiguous
-			// concatenation.
-			sourceBindingKey := fmt.Sprintf("v1|%s|%s|%s|%s",
-				ref.Scope, ref.CanonicalURL, target.RunnerGroup, tb.ScaleSetName)
+			// attempt and lease machinery.
+			sourceBindingKey := sourceBindingKey(target, tb.ScaleSetName)
 			var bindingID, knownSetID int64
 			if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 				var err error
@@ -114,12 +112,42 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 			}
 			s.bindings = append(s.bindings, b)
 			s.byBinding[bindingID] = b
+			claimed = append(claimed, bindingID)
 		}
 	}
 	if len(s.bindings) == 0 {
 		return errors.New("no bindings configured")
 	}
+	// What configuration no longer claims is forgotten. A renamed scale
+	// set or a removed tier leaves a row nothing serves, and the report
+	// carries it forever with no command that removes it.
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		forgotten, err := tx.ForgetUnclaimedBindings(claimed)
+		if err != nil {
+			return err
+		}
+		if forgotten > 0 {
+			s.log.Info("forgot bindings configuration no longer claims", "count", forgotten)
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
 	return nil
+}
+
+// sourceBindingKey is a binding's durable identity: the row every
+// delivery, attempt and lease hangs off.
+//
+// It is built from what an operator configured and never from a parsed
+// form of the target's URL. A key carrying the parsed scope and the
+// canonical URL moves whenever the parser changes how it reads an
+// address a deployment did not touch — and a moved key is a second row
+// beside the first, with the original left in `status` for good and
+// nothing that removes it. Scope and canonical URL still travel, in the
+// adapter's own metadata, which is where provider identity belongs.
+func sourceBindingKey(target config.Target, scaleSetName string) string {
+	return fmt.Sprintf("v2|%s|%s|%s", target.ID, target.RunnerGroup, scaleSetName)
 }
 
 // ensureScaleSet creates or adopts this binding's scale set and records

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -406,3 +406,44 @@ func TestStartupSaysWhereEachCredentialTravels(t *testing.T) {
 		t.Errorf("a non-hosted target must warn naming host and credential:\n%s", logged)
 	}
 }
+
+// TestTheDurableBindingKeyDoesNotMoveWithTheURLParser: a binding's
+// durable identity is what an operator configured, not a parsed form of
+// the address they wrote.
+//
+// The key was built from the parsed scope and the canonical URL, so a
+// change to how a URL is read moves the key of a deployment that changed
+// nothing: the next start inserts a second binding beside the first, and
+// the original is left in `status` for good with no command that removes
+// it. Every delivery, attempt and lease hangs off that row, so the
+// history goes with it.
+func TestTheDurableBindingKeyDoesNotMoveWithTheURLParser(t *testing.T) {
+	base := config.Target{ID: "app", RunnerGroup: "default"}
+	want := sourceBindingKey(base, "runpool-standard")
+
+	for name, url := range map[string]string{
+		"a plain repository URL": "https://github.com/acme/app",
+		"the clone form":         "https://github.com/acme/app.git",
+		"a trailing slash":       "https://github.com/acme/app/",
+		"a different host":       "https://ghe.example.com/acme/app",
+	} {
+		t.Run(name, func(t *testing.T) {
+			target := base
+			target.URL = url
+			if got := sourceBindingKey(target, "runpool-standard"); got != want {
+				t.Errorf("key = %q for %s; want %q — the identity moved with the address form",
+					got, url, want)
+			}
+		})
+	}
+
+	// And it still separates what genuinely differs.
+	other := base
+	other.RunnerGroup = "isolated"
+	if sourceBindingKey(other, "runpool-standard") == want {
+		t.Error("two runner groups share one binding key")
+	}
+	if sourceBindingKey(base, "runpool-large") == want {
+		t.Error("two scale sets share one binding key")
+	}
+}

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -3,12 +3,9 @@ package command
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"runtime"
 
 	"github.com/spf13/cobra"
-
-	"github.com/rhobuild/runpool/internal/app"
 )
 
 // Each constructor declares its positional-argument contract with Cobra.
@@ -109,13 +106,7 @@ func newStatusCommand(build BuildInfo) *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			operational(cmd)
-			// Resolved by the same rule serve resolves it with, so the
-			// image this reports is the image a launch would run.
-			img, err := app.CapsuleImage(os.Getenv, build.CapsuleImage)
-			if err != nil {
-				return err
-			}
-			return runStatus(streamsOf(cmd), asJSON, img)
+			return runStatus(streamsOf(cmd), asJSON, build.CapsuleImage)
 		},
 	}
 	cmd.Flags().BoolVar(&asJSON, "json", false, "emit the status as JSON")

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/rhobuild/runpool/internal/app"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
@@ -18,7 +19,11 @@ import (
 // operator to answer without reading SQLite: what this instance owns,
 // which leases are live, which cache lanes are held, and whether the
 // books agree with the daemon.
-func runStatus(streams IO, asJSON bool, shippedCapsule string) error {
+// runStatus takes the image this build ships rather than the image a
+// launch would run: resolving that is an observation like the daemon
+// read and the configuration read below, and it is made here so a
+// failure is reported rather than answered with nothing.
+func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -77,7 +82,21 @@ func runStatus(streams IO, asJSON bool, shippedCapsule string) error {
 	}
 
 	cfg := configuredStatusConfig(os.Getenv)
+	// Resolved the way serve resolves it, and best-effort like every
+	// other observation here: an environment this cannot resolve is a
+	// finding to report, not a reason to answer nothing. A --json caller
+	// that got a bare error and no document had no way to tell an
+	// unresolvable image from an unreachable host.
+	//
+	// It resolves from the environment of whoever ran this command,
+	// which in the reference deployment is the controller's own, so the
+	// answer is labelled with the failure rather than presented as the
+	// controller's view.
+	shippedCapsule, imageErr := app.CapsuleImage(os.Getenv, buildCapsule)
 	doc := statusDocument(snap, cfg, review, obs, shippedCapsule)
+	if imageErr != nil {
+		doc.CapsuleImageError = imageErr.Error()
+	}
 	if asJSON {
 		enc := json.NewEncoder(streams.Out)
 		enc.SetIndent("", "  ")
@@ -92,6 +111,13 @@ func runStatus(streams IO, asJSON bool, shippedCapsule string) error {
 			fmt.Fprintf(streams.Out, "  %-16s parallelism %-4d active %-4d available %d\n",
 				tier.ID, tier.Parallelism, tier.Active, tier.Available)
 		}
+	}
+
+	if doc.CapsuleImageError != "" {
+		// Said in the text form too: the tier lines above carry what
+		// this build ships, and without this a reader takes them for
+		// the images a launch would run.
+		fmt.Fprintf(streams.Out, "capsule image: unresolved (%s)\n", doc.CapsuleImageError)
 	}
 
 	if p := snap.Pressure; p != nil {

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -47,6 +47,12 @@ type statusDoc struct {
 	// must not report as a clean one.
 	Discrepancies []string `json:"discrepancies"`
 	DockerError   string   `json:"docker_error,omitempty"`
+	// CapsuleImageError explains a capsule image this command could not
+	// resolve. The tier entries then carry whatever the build ships, so
+	// this is what tells a reader those are not the images a launch would
+	// run — the alternative, refusing to answer at all, took every other
+	// fact in this document down with one unset environment variable.
+	CapsuleImageError string `json:"capsule_image_error,omitempty"`
 }
 
 type schedulingDTO struct {

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"strings"
@@ -215,5 +216,48 @@ func TestTierReportsTheImageItRuns(t *testing.T) {
 	}
 	if got.Tiers[1].CapsuleImage != operators {
 		t.Errorf("a tier naming an image reports %q, want its own", got.Tiers[1].CapsuleImage)
+	}
+}
+
+// TestStatusReportsWithoutAResolvableCapsuleImage: a capsule image this
+// command cannot resolve is a finding to report, not a reason to answer
+// nothing.
+//
+// Resolving it in the command wiring meant one unset or conflicting
+// environment variable returned an error and printed no document at all
+// — taking the daemon comparison, the lease list and every other fact
+// down with it, and answering a --json caller with prose on stderr and a
+// non-zero exit. That is the same parse failure the pre-serve form is
+// careful to avoid.
+func TestStatusReportsWithoutAResolvableCapsuleImage(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNPOOL_STATE_DIR", dir)
+	st, err := store.Open(dir, store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+
+	// A release build refuses an override that disagrees with it, which
+	// is the shape an operator meets after setting the variable by hand.
+	const release = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"1111111111111111111111111111111111111111111111111111111111111111"
+	t.Setenv("RUNPOOL_CAPSULE_IMAGE", "ghcr.io/example/other:latest")
+
+	var out, errOut bytes.Buffer
+	if err := runStatus(IO{Out: &out, Err: &errOut}, true, release); err != nil {
+		t.Fatalf("status refused to answer: %v", err)
+	}
+
+	var doc statusDoc
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("the document does not decode: %v\n%s", err, out.String())
+	}
+	if !doc.Served {
+		t.Fatal("the served document was not produced")
+	}
+	if doc.CapsuleImageError == "" {
+		t.Error("the document reports no capsule image error; a reader takes the tier images " +
+			"for what a launch would run")
 	}
 }

--- a/internal/doctor/capacity.go
+++ b/internal/doctor/capacity.go
@@ -67,7 +67,7 @@ func checkCapacity(cfg *config.Config) Result {
 
 // checkPhysicalCapacity fails before admission when the worst workload set
 // plus the configured host reserve cannot fit on the daemon host.
-func checkPhysicalCapacity(ctx context.Context, cfg *config.Config, d *docker.Client) Result {
+func checkPhysicalCapacity(ctx context.Context, cfg *config.Config, d daemonInfo) Result {
 	if d == nil {
 		return Result{"physical capacity", Fail, "daemon not connected", ""}
 	}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -117,15 +117,20 @@ func Run(ctx context.Context, opts Options) Report {
 	if opts.Config != nil {
 		add(checkHostTopology(opts.Config))
 	}
-	add(checkDaemon(ctx, opts.Docker))
-	add(checkIsolatedBridge(ctx, opts.Docker))
-	// A nil client must stay a nil interface: wrapped, it would be a
-	// non-nil daemonInfo holding nothing, and the guard inside would
-	// pass it to a method call.
-	var di daemonInfo
+	// A nil client must stay a nil interface. Wrapped, it is a non-nil
+	// value holding nothing, so every `d == nil` guard below it passes
+	// and the next line calls a method on nothing. The conversion is the
+	// trap, not the guard, so it is made once here rather than checked
+	// again at each seam.
+	var (
+		di daemonInfo
+		np networkProbeClient
+	)
 	if opts.Docker != nil {
-		di = opts.Docker
+		di, np = opts.Docker, opts.Docker
 	}
+	add(checkDaemon(ctx, di))
+	add(checkIsolatedBridge(ctx, np))
 	for _, res := range checkCgroups(ctx, di, opts.Config) {
 		add(res)
 	}
@@ -135,7 +140,7 @@ func Run(ctx context.Context, opts Options) Report {
 	add(checkStorage("state directory", opts.StateDir))
 	if opts.Config != nil {
 		add(checkCapacity(opts.Config))
-		add(checkPhysicalCapacity(ctx, opts.Config, opts.Docker))
+		add(checkPhysicalCapacity(ctx, opts.Config, di))
 		if opts.NewCredentialProbe != nil {
 			for _, res := range checkCredentials(ctx, opts) {
 				add(res)
@@ -169,7 +174,12 @@ func checkPlatform() Result {
 	return Result{"platform", Pass, runtime.GOOS + "/" + runtime.GOARCH, ""}
 }
 
-func checkDaemon(ctx context.Context, d *docker.Client) Result {
+// checkDaemon reads the one method it needs through the same seam
+// checkCgroups uses. Taking the concrete client instead left its three
+// refusals unreachable from any test: no live daemon can be asked to be
+// absent, rootless, or older than the floor on demand — and those are
+// precisely the verdicts that stop a host from serving.
+func checkDaemon(ctx context.Context, d daemonInfo) Result {
 	if d == nil {
 		return Result{"docker daemon", Fail, "not connected",
 			"mount the daemon socket at /var/run/docker.sock"}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -3,8 +3,10 @@ package doctor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -692,5 +694,73 @@ func TestCheckCgroupsRefusesWhatItCannotEnforce(t *testing.T) {
 
 	if res := checkCgroups(t.Context(), fakeDaemonInfo{info: good}, cfg); fails(res) {
 		t.Errorf("a conforming host failed: %+v", res)
+	}
+}
+
+// TestDoctorRunsWithoutADaemon is the panic guard, and it exists at the
+// level of Run rather than of any one check.
+//
+// A nil *docker.Client converted into an interface is a non-nil value
+// holding nothing, so every `d == nil` guard inside passes and the next
+// line calls a method on nothing. That is exactly the state doctor is
+// for — an operator whose daemon is not reachable runs it to be told so
+// — and the panic took the whole report with it, including the checks
+// that had already succeeded and would have said why.
+func TestDoctorRunsWithoutADaemon(t *testing.T) {
+	cfg := &config.Config{}
+	config.ApplyDefaults(cfg)
+
+	report := Run(t.Context(), Options{Config: cfg, StateDir: t.TempDir()})
+
+	if len(report.Results) == 0 {
+		t.Fatal("the report is empty; every check was lost with the daemon")
+	}
+	if report.OK() {
+		t.Error("a host with no reachable daemon reported healthy")
+	}
+	var named []string
+	for _, r := range report.Results {
+		named = append(named, r.Name)
+	}
+	for _, want := range []string{"docker daemon", "isolated bridge"} {
+		if !slices.Contains(named, want) {
+			t.Errorf("no %q result in %v; the check never ran", want, named)
+		}
+	}
+}
+
+// TestCheckDaemonFailsClosed covers the three refusals that stop a host
+// from serving. None is reachable from a live daemon — it cannot be
+// asked to be absent, rootless, or older than the floor — so they were
+// untested while the check took the concrete client.
+func TestCheckDaemonFailsClosed(t *testing.T) {
+	current := fmt.Sprintf("%d.0.0", platform.MinimumEngineMajor)
+	tooOld := fmt.Sprintf("%d.9.9", platform.MinimumEngineMajor-1)
+
+	for name, tc := range map[string]struct {
+		d       daemonInfo
+		wantOK  bool
+		wantFix string
+	}{
+		"no daemon at all": {nil, false, "mount the daemon socket"},
+		"the daemon cannot be read": {
+			fakeDaemonInfo{err: errors.New("socket refused")}, false, "check the socket mount"},
+		"rootless": {
+			fakeDaemonInfo{info: docker.HostInfo{Rootless: true, ServerVersion: current}},
+			false, "requires rootful Docker"},
+		"below the engine floor": {
+			fakeDaemonInfo{info: docker.HostInfo{ServerVersion: tooOld}}, false, "upgrade to Docker Engine"},
+		"a daemon that serves": {
+			fakeDaemonInfo{info: docker.HostInfo{ServerVersion: current}}, true, ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := checkDaemon(t.Context(), tc.d)
+			if (got.Status != Fail) != tc.wantOK {
+				t.Fatalf("status = %v; want ok=%v (detail %q)", got.Status, tc.wantOK, got.Detail)
+			}
+			if tc.wantFix != "" && !strings.Contains(got.Fix+got.Detail, tc.wantFix) {
+				t.Errorf("fix/detail = %q / %q; want it to mention %q", got.Fix, got.Detail, tc.wantFix)
+			}
+		})
 	}
 }

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
@@ -451,4 +452,51 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 		c.LastErrorAt = time.UnixMilli(errorMs).UTC()
 	}
 	return c
+}
+
+// ForgetUnclaimedBindings removes the binding rows configuration no
+// longer claims, with the adapter metadata and reach records that hang
+// off them, and reports how many went.
+//
+// A binding whose scale set was renamed or whose tier was removed is a
+// row nothing serves: it holds no work, appears in every report, and
+// there is no command that removes it. A binding that still owns a
+// delivery is kept whatever configuration says — those rows are the
+// trail of work that ran, and a report that lost the binding could not
+// say whose work it was.
+//
+// The placeholder list is built here rather than through the generated
+// layer: sqlc's sqlite engine has no slice parameter, and the ids come
+// from the caller's own loop, never from input.
+func (t *Tx) ForgetUnclaimedBindings(claimed []int64) (int, error) {
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(claimed)), ",")
+	if placeholders == "" {
+		// No claim at all is a caller with no bindings, which serve
+		// refuses before reaching here. Deleting everything on an empty
+		// list would turn that mistake into data loss.
+		return 0, nil
+	}
+	args := make([]any, len(claimed))
+	for i, id := range claimed {
+		args[i] = id
+	}
+	unclaimed := `
+		SELECT id FROM provider_bindings
+		WHERE id NOT IN (` + placeholders + `)
+		  AND NOT EXISTS (SELECT 1 FROM broker_deliveries d WHERE d.binding_id = provider_bindings.id)`
+
+	// The dependents first: both reference the binding row, so the
+	// delete order is what the foreign keys allow.
+	for _, table := range []string{"github_actions_binding_metadata", "provider_binding_contact"} {
+		if _, err := t.tx.Exec(
+			`DELETE FROM `+table+` WHERE binding_id IN (`+unclaimed+`)`, args...); err != nil {
+			return 0, err
+		}
+	}
+	res, err := t.tx.Exec(`DELETE FROM provider_bindings WHERE id IN (`+unclaimed+`)`, args...)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	return int(n), err
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1375,3 +1375,77 @@ func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
 		})
 	}
 }
+
+// A binding configuration no longer claims is forgotten, unless it still
+// owns work.
+//
+// A renamed scale set or a removed tier leaves a row nothing serves: it
+// appears in every report and no command removes it. But a binding that
+// owns a delivery is the trail of work that ran, and a report that lost
+// it could not say whose work it was — so that one is kept whatever the
+// configuration says.
+func TestABindingConfigurationNoLongerClaimsIsForgotten(t *testing.T) {
+	s := newStore(t)
+
+	var kept, dropped, withWork int64
+	inTx(t, s, func(tx *Tx) error {
+		var err error
+		if kept, err = tx.EnsureBinding("app", "github_actions", "v2|app|default|runpool-standard"); err != nil {
+			return err
+		}
+		if dropped, err = tx.EnsureBinding("app", "github_actions", "v2|app|default|runpool-renamed"); err != nil {
+			return err
+		}
+		if withWork, err = tx.EnsureBinding("old", "github_actions", "v2|old|default|runpool-old"); err != nil {
+			return err
+		}
+		_, err = tx.RecordDelivery(withWork, "msg-old", fingerprint("old"),
+			[]WorkloadRow{{SourceWorkloadKey: "job-old", TenantKey: "acme", ProjectKey: "old"}})
+		return err
+	})
+
+	var forgotten int
+	inTx(t, s, func(tx *Tx) error {
+		var err error
+		forgotten, err = tx.ForgetUnclaimedBindings([]int64{kept})
+		return err
+	})
+	if forgotten != 1 {
+		t.Errorf("forgot %d bindings; want exactly the one that holds no work", forgotten)
+	}
+
+	var ids []int64
+	inTx(t, s, func(tx *Tx) error {
+		rows, err := tx.Bindings()
+		if err != nil {
+			return err
+		}
+		for _, b := range rows {
+			ids = append(ids, b.ID)
+		}
+		return nil
+	})
+	if !slices.Contains(ids, kept) {
+		t.Error("a claimed binding was forgotten")
+	}
+	if slices.Contains(ids, dropped) {
+		t.Error("a binding configuration no longer claims is still reported")
+	}
+	if !slices.Contains(ids, withWork) {
+		t.Error("a binding that still owns a delivery was forgotten with the work it explains")
+	}
+
+	// An empty claim is a caller with no bindings at all, which serve
+	// refuses before reaching here; deleting everything would turn that
+	// mistake into data loss.
+	inTx(t, s, func(tx *Tx) error {
+		n, err := tx.ForgetUnclaimedBindings(nil)
+		if err != nil {
+			return err
+		}
+		if n != 0 {
+			t.Errorf("an empty claim forgot %d bindings", n)
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## What changes

`runpool doctor` runs to completion against an unreachable daemon
instead of panicking, and `checkDaemon` reads through the same one-method
seam `checkCgroups` uses. `runpool status` resolves the capsule image
where it makes every other observation and reports a failure as a field.
A binding's durable key is built from configured values, and bindings
configuration no longer claims are forgotten unless they own work.

## What was found

**`runpool doctor` panicked on the host it exists to diagnose.** `Run`
passed `opts.Docker` — a `*docker.Client` — straight into
`checkIsolatedBridge`, which takes the `networkProbeClient` interface. A
nil pointer converted into an interface is a non-nil value holding
nothing, so the `if d == nil` guard passed and `d.CreateNetwork(...)`
dereferenced nothing. An operator whose daemon is not reachable runs
`doctor` to be told so, and lost the whole report — including the checks
that had already succeeded and would have said why.

The conversion is the trap, not the guard. `Run` already did the dance
correctly for `checkCgroups` three lines below, which is what makes the
shape worth fixing once at the top rather than guarding again at each
seam.

**Three refusals were unreachable from any test.** `checkDaemon` took the
concrete client, and no live daemon can be asked to be absent, rootless,
or older than the engine floor on demand — so the verdicts that stop a
host from serving were the untested ones. It now takes `daemonInfo`,
which is exactly its only call.

**`status` refused to answer when one variable disagreed.** The capsule
image was resolved in `newStatusCommand`'s `RunE`, so
`RUNPOOL_CAPSULE_IMAGE` conflicting with a release build returned an
error and printed no document at all. Every other observation in that
command — the daemon read, the configuration read — is best-effort and
reported; this one took the lease list, the cache lanes and the
discrepancy comparison down with it, and answered a `--json` caller with
prose on stderr and a non-zero exit. That is the same parse failure
`reportNoState` exists to avoid for the pre-serve form.

**A binding's identity moved with the URL parser.** The key was
`v1|<scope>|<canonicalURL>|<group>|<scaleSet>`, and both scope and
canonical URL come from parsing the target's address. A change to that
parser moves the key of a deployment that changed nothing: `EnsureBinding`
inserts a second row, and the original stays in every report with every
delivery, attempt and lease still hanging off it, and no command that
removes it. The key is now `v2|<targetID>|<group>|<scaleSet>` — what an
operator wrote. Scope and canonical URL still travel, in
`github_actions_binding_metadata`, which is where provider identity
belongs.

**And nothing removed a binding the configuration dropped.** A renamed
scale set or a removed tier leaves a row nothing serves. `buildBindings`
now forgets what it did not claim — except a binding that still owns a
delivery, which is the trail of work that ran and which a report losing
the binding could not attribute.

**What decided the shape of the prune.** The placeholder list is built in
Go rather than through the generated layer because sqlc's sqlite engine
has no slice parameter; the ids come from the caller's own loop and never
from input. An empty claim returns without deleting: `NOT IN ()` is true
for every row in SQLite, so the guard is what stops a caller with no
bindings — which `serve` refuses before reaching here — from turning that
mistake into data loss.

## Evidence

Hermetic. `internal/doctor`, `internal/command`, `internal/app` and
`internal/store` all run in full on every pull request. Each fix was
checked by reverting it and watching the new test fail.

```text
mutation checks, local:
  pass opts.Docker straight into checkIsolatedBridge again
    -> TestDoctorRunsWithoutADaemon: panic, with the stack through
       doctor_test.go:713 — the defect reproduced
  invert the rootless guard in checkDaemon
    -> TestCheckDaemonFailsClosed/rootless and /a_daemon_that_serves both fail
  resolve the capsule image in the command wiring again
    -> TestStatusReportsWithoutAResolvableCapsuleImage:
       the document reports no capsule image error
  drop the NOT EXISTS clause from the prune
    -> TestABindingConfigurationNoLongerClaimsIsForgotten:
       constraint failed: FOREIGN KEY constraint failed (787)
  remove the empty-claim guard
    -> same test: an empty claim forgot 1 bindings
```

## What would notice this regressing

- `TestDoctorRunsWithoutADaemon` (internal/doctor) fails — by panicking —
  if any seam takes the concrete client again. It asserts at the level of
  `Run` rather than of one check, because the trap is the conversion and
  it can reappear at any seam.
- `TestCheckDaemonFailsClosed` covers the absent, unreadable, rootless
  and below-floor verdicts, plus the daemon that serves.
- `TestStatusReportsWithoutAResolvableCapsuleImage` (internal/command)
  decodes the `--json` document and requires the error field.
- `TestTheDurableBindingKeyDoesNotMoveWithTheURLParser` (internal/app)
  fixes the key across four address forms and checks that a different
  runner group or scale set still separates.
- `TestABindingConfigurationNoLongerClaimsIsForgotten` (internal/store)
  covers all three: what is forgotten, what is kept because it owns work,
  and the empty claim.

## Risk, compatibility and operations

**The binding key change is a data break, and it is the one to weigh.**
Every existing `provider_bindings` row keyed `v1|…` stops matching, so
the next start inserts a `v2|…` row beside it and the old one is then
unclaimed. If it owns no delivery it is forgotten in the same pass; if it
owns deliveries it is kept, and an operator sees both rows in `runpool
status` — the old one with its history, the new one serving. Pre-release,
so no deployment has such a row yet; a development state directory that
does is resolved by removing it or by accepting the duplicate.

**Deleting binding rows is the operationally significant new behaviour.**
It runs at every start, inside one transaction, and removes
`github_actions_binding_metadata` and `provider_binding_contact` before
the binding itself — the order the foreign keys allow. The delivery
clause is what bounds the blast radius, and the mutation above shows the
foreign key catching it independently if that clause ever goes.

**Trust boundary: unchanged.** No credential path, capability, mount or
network surface. `doctor`'s network probe still creates and removes a
labeled disposable network and nothing else.

**Status API: additive.** `capsule_image_error` is `omitempty`, so a
document from a host that resolves its image is byte-identical to before.
`statusAPIVersion` is unchanged: a field added under `omitempty` breaks
no consumer of v1.

**No CLI flags, configuration keys, schema or migration change.** No
rollback step beyond the previous image.

## Changelog

```text
State and operations:
- A diagnosis answers when the daemon does not. `runpool doctor` runs to
  completion against an unreachable daemon and reports every check that
  could be made, which is the state an operator runs it in.
- A report answers its own question. `runpool status` reports a capsule
  image it cannot resolve as a finding beside the rest of the document,
  rather than refusing to answer — so one unset environment variable no
  longer takes the lease list and the daemon comparison down with it.
- A binding is identified by what an operator configured. Its durable key
  is built from the target, runner group and scale set name, never from a
  parsed form of the address, so a deployment that changed nothing keeps
  the row its whole history hangs off. Bindings the configuration no
  longer claims are forgotten on the next start, unless they still own a
  delivery — that trail is kept.
```

## Notes for your reviewer

The doctor panic is worth reproducing before reading the fix: revert the
`np` seam and `TestDoctorRunsWithoutADaemon` crashes rather than failing.
It is the clearest statement of why the conversion, not the guard, is the
thing to fix — the guard was there and correct, and it passed.

The prune is the change I would scrutinise. It deletes rows, which
nothing else in the startup path does. The two clauses that bound it —
`NOT IN (claimed)` and `NOT EXISTS (delivery)` — are both covered, and
the empty-claim guard exists because `NOT IN ()` is true for every row in
SQLite rather than an error, which I confirmed by removing the guard and
watching a binding disappear.
