### PR TITLE
refactor(store, command): the schema and the report carry only what something reads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,20 +83,24 @@ jobs:
             echo "staticcheck analyzed no packages:"; echo "$err"; exit 1
           fi
           go tool staticcheck ./...
-      - name: Test with the race detector
-        # Shuffled, so a test that depends on another's leftovers fails
-        # here rather than on the day the order happens to change. The
-        # contract suites are gated by environment and skip in this job:
-        # they need a Docker host and real targets, and release qualification
-        # runs them without skips before any release.
-        run: go test -race -shuffle=on -count=1 ./...
-      - name: Verify coverage meets the floor
+      - name: Test with the race detector and measure coverage
+        # One run, carrying every property both steps had. Shuffled, so a
+        # test that depends on another's leftovers fails here rather than
+        # on the day the order happens to change; raced, so a data race
+        # is a failure rather than a flake; and profiled, because running
+        # the whole suite twice to learn the same thing costs the slowest
+        # job in this workflow twice over.
+        #
         # The global floor protects the hermetic surface from regression;
-        # live contracts cover the Docker and provider adapters separately.
-        # Requiring covdata also rejects an incomplete Go distribution.
+        # live contracts cover the Docker and provider adapters
+        # separately. The contract suites are gated by environment and
+        # skip here: they need a Docker host and real targets, and
+        # release qualification runs them without skips before any
+        # release. Requiring covdata also rejects an incomplete Go
+        # distribution.
         run: |
           go tool -n covdata >/dev/null 2>&1 || { echo "toolchain has no covdata; it is not a complete distribution"; exit 1; }
-          go test -covermode=atomic -coverprofile=coverage.out -count=1 ./...
+          go test -race -shuffle=on -covermode=atomic -coverprofile=coverage.out -count=1 ./...
           scripts/verify/coverage.sh coverage.out
       - name: Keep the coverage baseline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,12 @@ by its public and operational effects.
 - **There are no down migrations.** Restoring the pre-migration backup
   is the rollback, because a down script claims every schema change is
   losslessly reversible and a dropped column is not.
+- **The status document drops `desired_state`.** The column admitted
+  `present` and `absent`, nothing ever wrote `absent`, and the only
+  query that could had no caller — so it described a capability the
+  product does not have. `bindings[].desired_state` is gone from the v1
+  document; `api_version` is unchanged, because a field nothing could
+  vary is not a contract a consumer can have depended on.
 - **A schema is identified by its contents.** The applied migrations'
   fingerprint is recorded with the schema, in the same transaction, and
   checked on every open. A version counter cannot tell two schemas apart

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -53,7 +53,7 @@ absent state, because the attempt it was asked about cannot exist.
 | `schema_version` | number | The state schema in use |
 | `scheduling` | object, optional | Present when status can read configuration: `mode`, `instance_parallelism`, `effective_parallelism`, `active`, `available`, `queued`, and `tiers[]` |
 | `disk_pressure` | object or null | `level`, `free_bytes`, `free_inodes`, `managed_bytes`, `measured_at` |
-| `bindings` | array | `target_id`, `provider_kind`, `source_binding_key`, `desired_state`, and the provider reach fields below |
+| `bindings` | array | `target_id`, `provider_kind`, `source_binding_key`, and the provider reach fields below |
 | `leases` | array | `id`, `state`, `terminal`, `attempt_id`, `project`, `runtime_name`, `evidence`, `created_at`, `resources[]`. Every live lease, plus recent finished ones — see below |
 | `released_total` | number | How many finished leases the store holds, which is more than the `leases` array carries |
 | `cache_lanes` | array | `id`, `source_project_key`, `generation`, `leased_by`, `last_used` |

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
 )
@@ -91,7 +92,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 
-	runnerName := "runpool-" + shortID(lease.ID)
+	runnerName := "runpool-" + docker.ShortID(lease.ID)
 	jit, err := b.gh.GenerateJITConfig(prepCtx, b.scaleSetID, runnerName, workFolder)
 	if err != nil {
 		log.Error("jit generation failed", "error", err)
@@ -249,7 +250,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 	runnerContainer := prepared.RuntimeID
-	log.Info("capsule running", "runner", jit.RunnerName, "container", shortID(runnerContainer))
+	log.Info("capsule running", "runner", jit.RunnerName, "container", docker.ShortID(runnerContainer))
 
 	// From here the tier's ceiling governs, and only here: this is the
 	// wait for work the provider owns, and the ceiling is the backstop
@@ -301,15 +302,6 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 	log.Info("lease released")
-}
-
-// shortID trims an id for log lines, tolerating ids shorter than the
-// display width — test fixtures and future id formats included.
-func shortID(id string) string {
-	if len(id) > 12 {
-		return id[:12]
-	}
-	return id
 }
 
 // releaseCreditIfDone returns the binding's admission credit only when the lease has

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -255,10 +255,7 @@ func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
 }
 
 func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (string, error) {
-	short := spec.LeaseID
-	if len(short) > 12 {
-		short = short[:12]
-	}
+	short := docker.ShortID(spec.LeaseID)
 	name := func(role string) string { return "runpool-" + role + "-" + short }
 	labels := func(kind, role string) map[string]string {
 		return map[string]string{
@@ -581,7 +578,7 @@ func (m *Launcher) awaitState(ctx context.Context, containerID, want string) err
 			return verdict
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("container %s did not reach %q within %s", containerID[:12], want, readyTimeout)
+			return fmt.Errorf("container %s did not reach %q within %s", docker.ShortID(containerID), want, readyTimeout)
 		}
 		select {
 		case <-time.After(readyPollInterval):

--- a/internal/command/attempts.go
+++ b/internal/command/attempts.go
@@ -94,7 +94,7 @@ func runAttemptsList(streams IO, stateFilter string, asJSON bool) error {
 		for _, v := range views {
 			fmt.Fprintf(streams.Out, "%-22s %-28s %-24s %-24s %s\n",
 				v.ID, v.Workload, v.Project, v.ReviewReason,
-				(time.Duration(v.AgeSeconds) * time.Second).String())
+				age(time.Duration(v.AgeSeconds)*time.Second))
 		}
 		return nil
 	})

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -132,8 +132,8 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	fmt.Fprintf(streams.Out, "\nbindings (%d)\n", len(snap.Bindings))
 	now := time.Now()
 	for _, b := range snap.Bindings {
-		fmt.Fprintf(streams.Out, "  %-14s %-16s %-8s %s\n",
-			b.TargetID, b.ProviderKind, b.DesiredState, b.SourceBindingKey)
+		fmt.Fprintf(streams.Out, "  %-14s %-16s %s\n",
+			b.TargetID, b.ProviderKind, b.SourceBindingKey)
 		fmt.Fprintf(streams.Out, "  %-14s %s\n", "", providerReach(b.Contact, now))
 	}
 
@@ -270,23 +270,32 @@ func providerReach(c store.ProviderContact, now time.Time) string {
 
 // ago renders a gap the way an operator reads one: the size of the wait,
 // not a timestamp to subtract from the current time by hand.
-func ago(now, then time.Time) string {
-	d := now.Sub(then).Round(time.Second)
+func ago(now, then time.Time) string { return age(now.Sub(then)) + " ago" }
+
+// age renders a span the way an operator reads one: the size of the
+// wait, not a timestamp to subtract by hand.
+//
+// A negative span reads as zero. Two clocks disagree, and a record
+// written a moment ahead of the reader is ordinary rather than
+// remarkable — but "-1m0s ago" reads as a bug in the thing being
+// diagnosed, which is the last place to send someone looking.
+func age(d time.Duration) string {
+	d = d.Round(time.Second)
 	if d < 0 {
 		d = 0
 	}
-	return d.String() + " ago"
+	return d.String()
 }
 
 // reportNoState answers the one state every command can meet before the
 // controller has ever run, in whichever form the caller asked for.
 func reportNoState(streams IO, asJSON bool) error {
 	if asJSON {
-		return json.NewEncoder(streams.Out).Encode(map[string]any{
-			"api_version": statusAPIVersion,
-			"state_dir":   stateDir(),
-			"served":      false,
-			"detail":      "this instance has not run yet",
+		return json.NewEncoder(streams.Out).Encode(statusDoc{
+			APIVersion: statusAPIVersion,
+			Served:     false,
+			StateDir:   stateDir(),
+			Detail:     "this instance has not run yet",
 		})
 	}
 	fmt.Fprintf(streams.Out, "no state in %s: this instance has not run yet\n", stateDir())

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -22,7 +22,13 @@ type statusDoc struct {
 	// Served discriminates v1's two forms: true carries the document
 	// below, false is the pre-serve form with only state_dir and detail.
 	// A consumer branches on this, not on which fields happen to exist.
-	Served        bool           `json:"served"`
+	Served bool `json:"served"`
+	// StateDir and Detail are the pre-serve form's whole payload, and
+	// they are fields rather than a map the other branch builds by hand:
+	// a map re-spells every tag, so the two forms of one document could
+	// drift under a rename with nothing to notice.
+	StateDir      string         `json:"state_dir,omitempty"`
+	Detail        string         `json:"detail,omitempty"`
 	Instance      string         `json:"instance"`
 	HostTopology  string         `json:"host_topology"`
 	SchemaVersion int            `json:"schema_version"`
@@ -97,7 +103,6 @@ type bindingDTO struct {
 	TargetID         string `json:"target_id"`
 	ProviderKind     string `json:"provider_kind"`
 	SourceBindingKey string `json:"source_binding_key"`
-	DesiredState     string `json:"desired_state"`
 	// LastContactAt is when a provider call for this binding last
 	// succeeded, and LastError what it cannot do now. Both are reported
 	// because neither answers alone: an instance holding no leases is
@@ -184,10 +189,10 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	for _, b := range snap.Bindings {
 		doc.Bindings = append(doc.Bindings, bindingDTO{
 			TargetID: b.TargetID, ProviderKind: b.ProviderKind,
-			SourceBindingKey: b.SourceBindingKey, DesiredState: b.DesiredState,
-			LastContactAt: rfc3339(b.Contact.LastContact),
-			LastError:     b.Contact.LastError,
-			LastErrorAt:   rfc3339(b.Contact.LastErrorAt),
+			SourceBindingKey: b.SourceBindingKey,
+			LastContactAt:    rfc3339(b.Contact.LastContact),
+			LastError:        b.Contact.LastError,
+			LastErrorAt:      rfc3339(b.Contact.LastErrorAt),
 		})
 	}
 	for _, l := range snap.Leases {

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -261,3 +261,53 @@ func TestStatusReportsWithoutAResolvableCapsuleImage(t *testing.T) {
 			"for what a launch would run")
 	}
 }
+
+// TestBothStatusAnswersShareOneEnvelope: the two forms of a v1 status
+// document are the same document.
+//
+// The pre-serve form used to be a hand-built map that re-spelled every
+// tag, so a rename on the struct could leave the two disagreeing with
+// nothing to notice — and a consumer branching on `served`, which the
+// document tells it to do, would then meet fields it had no name for.
+func TestBothStatusAnswersShareOneEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNPOOL_STATE_DIR", dir)
+
+	decode := func(t *testing.T, raw []byte) statusDoc {
+		t.Helper()
+		dec := json.NewDecoder(bytes.NewReader(raw))
+		dec.DisallowUnknownFields()
+		var doc statusDoc
+		if err := dec.Decode(&doc); err != nil {
+			t.Fatalf("the document carries a field statusDoc does not name: %v\n%s", err, raw)
+		}
+		return doc
+	}
+
+	// Pre-serve: no state directory has been written yet.
+	var out bytes.Buffer
+	if err := runStatus(IO{Out: &out, Err: &bytes.Buffer{}}, true, ""); err != nil {
+		t.Fatal(err)
+	}
+	pre := decode(t, out.Bytes())
+	if pre.Served {
+		t.Error("the pre-serve form claims to be served")
+	}
+	if pre.StateDir != dir || pre.Detail == "" {
+		t.Errorf("the pre-serve form lost its payload: state_dir %q, detail %q", pre.StateDir, pre.Detail)
+	}
+
+	// Served: the same envelope, the other branch.
+	st, err := store.Open(dir, store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+	out.Reset()
+	if err := runStatus(IO{Out: &out, Err: &bytes.Buffer{}}, true, ""); err != nil {
+		t.Fatal(err)
+	}
+	if served := decode(t, out.Bytes()); !served.Served {
+		t.Error("the served form does not say so")
+	}
+}

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -61,7 +61,7 @@ func (c *Client) ContainerIPOn(ctx context.Context, containerID, networkID strin
 			continue
 		}
 		if !es.IPAddress.IsValid() {
-			return "", "", fmt.Errorf("container %s has no IPv4 address on network %s", containerID[:12], networkID[:12])
+			return "", "", fmt.Errorf("container %s has no IPv4 address on network %s", ShortID(containerID), ShortID(networkID))
 		}
 		prefix, err := es.IPAddress.Prefix(es.IPPrefixLen)
 		if err != nil {
@@ -69,7 +69,7 @@ func (c *Client) ContainerIPOn(ctx context.Context, containerID, networkID strin
 		}
 		return es.IPAddress.String(), prefix.Masked().String(), nil
 	}
-	return "", "", fmt.Errorf("container %s is not attached to network %s", containerID[:12], networkID[:12])
+	return "", "", fmt.Errorf("container %s is not attached to network %s", ShortID(containerID), ShortID(networkID))
 }
 
 // RemoveNetwork removes a network; one that is already gone is success.
@@ -110,7 +110,7 @@ func (c *Client) NetworkSubnet(ctx context.Context, id string) (string, error) {
 			return cfg.Subnet.String(), nil
 		}
 	}
-	return "", fmt.Errorf("network %s has no IPv4 subnet", id[:12])
+	return "", fmt.Errorf("network %s has no IPv4 subnet", ShortID(id))
 }
 
 // AllNetworkSubnets lists every subnet the daemon knows, whoever owns
@@ -174,3 +174,17 @@ func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID string) ([]Ow
 // role added later would be swept away as garbage by everything that
 // spelled the rule that way.
 func (r OwnedResource) InstanceInfrastructure() bool { return r.LeaseID == "" }
+
+// ShortID trims an object id to the width daemon tooling displays,
+// tolerating an id shorter than that width. Test fixtures use short
+// ids, and so would any future id format — and an unguarded slice
+// panics inside an error path, which is the least welcome place for
+// one: the message that would have said what went wrong is replaced by
+// a crash.
+func ShortID(id string) string {
+	const width = 12
+	if len(id) > width {
+		return id[:width]
+	}
+	return id
+}

--- a/internal/platform/docker/network_test.go
+++ b/internal/platform/docker/network_test.go
@@ -30,3 +30,22 @@ func TestInstanceInfrastructureIsDecidedByTheLeaseID(t *testing.T) {
 		}
 	}
 }
+
+// TestShortIDToleratesAShortID: the trim is used inside error paths, and
+// an unguarded slice there replaces the message that would have said
+// what went wrong with a crash.
+func TestShortIDToleratesAShortID(t *testing.T) {
+	for name, tc := range map[string]struct{ in, want string }{
+		"a full docker id": {
+			"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "0123456789ab"},
+		"exactly the display width": {"0123456789ab", "0123456789ab"},
+		"a test fixture":            {"fake-runner", "fake-runner"},
+		"empty":                     {"", ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := ShortID(tc.in); got != tc.want {
+				t.Errorf("ShortID(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/store/migrations/000001_initial.up.sql
+++ b/internal/store/migrations/000001_initial.up.sql
@@ -25,8 +25,6 @@ CREATE TABLE provider_bindings (
 	target_id           TEXT NOT NULL,
 	provider_kind       TEXT NOT NULL CHECK (length(provider_kind) > 0),
 	source_binding_key  TEXT NOT NULL CHECK (length(source_binding_key) > 0),
-	desired_state       TEXT NOT NULL DEFAULT 'present'
-		CHECK (desired_state IN ('present', 'absent')),
 	created_at          INTEGER NOT NULL DEFAULT (unixepoch()),
 	UNIQUE (provider_kind, source_binding_key)
 );
@@ -268,6 +266,14 @@ ON capsule_leases (attempt_id)
 WHERE state <> 'released';
 
 CREATE INDEX capsule_leases_by_state ON capsule_leases (state);
+
+-- Every lease an attempt ever had, released ones included: that count is
+-- the retry budget, and it is read inside the write transaction that
+-- decides whether a workload is served again. The partial index above
+-- cannot answer it - it excludes exactly the released rows the count is
+-- about - so without this the check is a full scan of every lease the
+-- host has ever recorded, taken while the single writer is held.
+CREATE INDEX capsule_leases_by_attempt ON capsule_leases (attempt_id);
 
 -- Not partial: attribution asks which attempt a runtime ran for, and a
 -- late report's lease is released by the time it arrives. An index that

--- a/internal/store/query/attempt_events.sql
+++ b/internal/store/query/attempt_events.sql
@@ -9,12 +9,6 @@ INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
 VALUES (@attempt_id, @idempotency_key, @kind, @detail_json)
 ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
 
--- name: GetAttemptEventByKey :one
-SELECT id, attempt_id, idempotency_key, kind, detail_json, created_at
-FROM attempt_events
-WHERE attempt_id = @attempt_id
-  AND idempotency_key = @idempotency_key;
-
 -- name: ListAttemptEvents :many
 SELECT id, attempt_id, idempotency_key, kind, detail_json, created_at
 FROM attempt_events

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -24,14 +24,6 @@ SELECT id, delivery_id, binding_id, source_workload_key, tenant_key, project_key
 FROM assignment_attempts
 WHERE id = @id;
 
--- name: GetAttemptByDeliveryAndWorkload :one
-SELECT id, delivery_id, binding_id, source_workload_key, tenant_key, project_key,
-       state, execution_evidence, resolution, review_reason, reviewed_at,
-       reviewed_by, received_at, settled_at
-FROM assignment_attempts
-WHERE delivery_id = @delivery_id
-  AND source_workload_key = @source_workload_key;
-
 -- name: GetOpenAttemptByWorkload :one
 SELECT id, delivery_id, binding_id, source_workload_key, tenant_key, project_key,
        state, execution_evidence, resolution, review_reason, reviewed_at,

--- a/internal/store/query/bindings.sql
+++ b/internal/store/query/bindings.sql
@@ -6,23 +6,7 @@
 INSERT INTO provider_bindings (target_id, provider_kind, source_binding_key)
 VALUES (@target_id, @provider_kind, @source_binding_key)
 ON CONFLICT (provider_kind, source_binding_key) DO UPDATE SET target_id = excluded.target_id
-RETURNING id, target_id, provider_kind, source_binding_key, desired_state, created_at;
-
--- name: GetProviderBinding :one
-SELECT id, target_id, provider_kind, source_binding_key, desired_state, created_at
-FROM provider_bindings
-WHERE provider_kind = @provider_kind
-  AND source_binding_key = @source_binding_key;
-
--- name: ListProviderBindings :many
-SELECT id, target_id, provider_kind, source_binding_key, desired_state, created_at
-FROM provider_bindings
-ORDER BY target_id, source_binding_key;
-
--- name: SetBindingDesiredState :execrows
-UPDATE provider_bindings
-SET desired_state = @desired_state
-WHERE id = @binding_id;
+RETURNING id, target_id, provider_kind, source_binding_key, created_at;
 
 -- name: RecordProviderContact :exec
 -- A success clears the failure: what is reported is the current state of
@@ -46,7 +30,7 @@ SET last_error = excluded.last_error, last_error_at_ms = excluded.last_error_at_
 -- database's job. A binding that has never run reports zeroes, which is
 -- not the same as failing: the first has nothing to say, the second has
 -- a reason.
-SELECT b.id, b.target_id, b.provider_kind, b.source_binding_key, b.desired_state, b.created_at,
+SELECT b.id, b.target_id, b.provider_kind, b.source_binding_key, b.created_at,
        coalesce(c.last_contact_at_ms, 0) AS last_contact_at_ms,
        coalesce(c.last_error, '')        AS last_error,
        coalesce(c.last_error_at_ms, 0)   AS last_error_at_ms

--- a/internal/store/query/deliveries.sql
+++ b/internal/store/query/deliveries.sql
@@ -36,9 +36,3 @@ UPDATE broker_deliveries
 SET ack_state = 'uncertain', ack_updated_at = unixepoch()
 WHERE id = @delivery_id AND ack_state IN ('pending', 'requested');
 
--- name: ListUnconfirmedDeliveries :many
-SELECT id, binding_id, source_delivery_key, payload_sha256, ack_state,
-       received_at, ack_updated_at, acknowledged_at
-FROM broker_deliveries
-WHERE binding_id = @binding_id AND ack_state <> 'confirmed'
-ORDER BY received_at, id;

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -1,6 +1,11 @@
 package store
 
-import "context"
+import (
+	"context"
+	"strings"
+
+	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+)
 
 // Snapshot is everything an operator needs to answer "what does this
 // instance own and why is it in this shape" without opening SQLite.
@@ -42,7 +47,6 @@ type BindingInfo struct {
 	TargetID         string
 	ProviderKind     string
 	SourceBindingKey string
-	DesiredState     string
 	// Contact is what this binding's loop last managed with its provider.
 	// A binding that has never run carries the zero value, which is not
 	// the same as one that is failing: the first has nothing to report,
@@ -62,8 +66,8 @@ func (t *Tx) Bindings() ([]BindingInfo, error) {
 	for i, r := range rows {
 		out[i] = BindingInfo{
 			ID: r.ID, TargetID: r.TargetID, ProviderKind: r.ProviderKind,
-			SourceBindingKey: r.SourceBindingKey, DesiredState: r.DesiredState,
-			Contact: providerContactFromRow(r.ID, r.LastContactAtMs, r.LastError, r.LastErrorAtMs),
+			SourceBindingKey: r.SourceBindingKey,
+			Contact:          providerContactFromRow(r.ID, r.LastContactAtMs, r.LastError, r.LastErrorAtMs),
 		}
 	}
 	return out, nil
@@ -114,20 +118,13 @@ func (s *Store) Snapshot() (Snapshot, error) {
 		}
 		snap.Leases = append(snap.Leases, recent...)
 		snap.ReleasedTotal = total
-		for _, lease := range snap.Leases {
-			attempt, err := tx.Get(lease.AttemptID)
-			if err != nil {
-				return err
-			}
-			snap.Attempts[lease.ID] = attempt
-
-			resources, err := tx.Resources(lease.ID)
-			if err != nil {
-				return err
-			}
-			if len(resources) > 0 {
-				snap.Resources[lease.ID] = resources
-			}
+		// Two set reads rather than two per lease: this runs on the one
+		// connection every lease transition also needs.
+		if snap.Attempts, err = tx.attemptsOfLeases(snap.Leases); err != nil {
+			return err
+		}
+		if snap.Resources, err = tx.resourcesOfLeases(snap.Leases); err != nil {
+			return err
 		}
 		for _, b := range snap.Bindings {
 			queued, err := tx.CountReadyAttempts(b.ID)
@@ -167,4 +164,79 @@ func (t *Tx) CacheLanes() ([]CacheLaneInfo, error) {
 		out = append(out, c)
 	}
 	return out, rows.Err()
+}
+
+// selectAttempt is the attempt column list this file's set read scans.
+// It matches the generated GetAttempt query's projection; the schema
+// parity test is what keeps the two in step.
+const selectAttempt = `SELECT id, delivery_id, binding_id, source_workload_key, tenant_key,
+       project_key, state, execution_evidence, resolution, review_reason, reviewed_at,
+       reviewed_by, received_at, settled_at FROM assignment_attempts `
+
+// attemptsOfLeases reads the attempt each lease serves in one query.
+//
+// One read per lease made `runpool status` cost two round trips per row
+// on the single connection every lease transition also waits for, and a
+// snapshot carries up to a hundred leases.
+func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
+	out := make(map[string]Attempt, len(leases))
+	if len(leases) == 0 {
+		return out, nil
+	}
+	byAttempt := make(map[string]string, len(leases)) // attempt id -> lease id
+	args := make([]any, 0, len(leases))
+	for _, l := range leases {
+		byAttempt[l.AttemptID] = l.ID
+		args = append(args, l.AttemptID)
+	}
+	rows, err := t.tx.Query(selectAttempt+
+		`WHERE id IN (`+placeholders(len(args))+`)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var r sqlitedb.AssignmentAttempt
+		if err := rows.Scan(&r.ID, &r.DeliveryID, &r.BindingID, &r.SourceWorkloadKey,
+			&r.TenantKey, &r.ProjectKey, &r.State, &r.ExecutionEvidence, &r.Resolution,
+			&r.ReviewReason, &r.ReviewedAt, &r.ReviewedBy, &r.ReceivedAt, &r.SettledAt); err != nil {
+			return nil, err
+		}
+		out[byAttempt[r.ID]] = fromRow(r)
+	}
+	return out, rows.Err()
+}
+
+// resourcesOfLeases reads every lease's resource intents in one query,
+// for the same reason attemptsOfLeases exists.
+func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, error) {
+	out := make(map[string][]ResourceIntent, len(leases))
+	if len(leases) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(leases))
+	for _, l := range leases {
+		args = append(args, l.ID)
+	}
+	rows, err := t.tx.Query(selectIntent+
+		`WHERE lease_id IN (`+placeholders(len(args))+`) ORDER BY lease_id, id`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		in, err := t.scanIntent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out[in.LeaseID] = append(out[in.LeaseID], in)
+	}
+	return out, rows.Err()
+}
+
+// placeholders builds the `?,?,?` list a set read needs. sqlc's sqlite
+// engine has no slice parameter, and the values are always ids the
+// caller already holds, never input.
+func placeholders(n int) string {
+	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
 }

--- a/internal/store/schema/current.sql
+++ b/internal/store/schema/current.sql
@@ -145,8 +145,6 @@ CREATE TABLE provider_bindings (
 	target_id           TEXT NOT NULL,
 	provider_kind       TEXT NOT NULL CHECK (length(provider_kind) > 0),
 	source_binding_key  TEXT NOT NULL CHECK (length(source_binding_key) > 0),
-	desired_state       TEXT NOT NULL DEFAULT 'present'
-		CHECK (desired_state IN ('present', 'absent')),
 	created_at          INTEGER NOT NULL DEFAULT (unixepoch()),
 	UNIQUE (provider_kind, source_binding_key)
 );
@@ -177,6 +175,8 @@ ON assignment_attempts (binding_id, received_at, id)
 WHERE state = 'ready';
 
 CREATE INDEX cache_lanes_pool ON cache_lanes (project_id, generation, leased_by);
+
+CREATE INDEX capsule_leases_by_attempt ON capsule_leases (attempt_id);
 
 CREATE INDEX capsule_leases_by_runtime_name ON capsule_leases (runtime_name);
 

--- a/internal/store/sqlitedb/attempt_events.sql.go
+++ b/internal/store/sqlitedb/attempt_events.sql.go
@@ -9,32 +9,6 @@ import (
 	"context"
 )
 
-const getAttemptEventByKey = `-- name: GetAttemptEventByKey :one
-SELECT id, attempt_id, idempotency_key, kind, detail_json, created_at
-FROM attempt_events
-WHERE attempt_id = ?1
-  AND idempotency_key = ?2
-`
-
-type GetAttemptEventByKeyParams struct {
-	AttemptID      string
-	IdempotencyKey string
-}
-
-func (q *Queries) GetAttemptEventByKey(ctx context.Context, arg GetAttemptEventByKeyParams) (AttemptEvent, error) {
-	row := q.db.QueryRowContext(ctx, getAttemptEventByKey, arg.AttemptID, arg.IdempotencyKey)
-	var i AttemptEvent
-	err := row.Scan(
-		&i.ID,
-		&i.AttemptID,
-		&i.IdempotencyKey,
-		&i.Kind,
-		&i.DetailJson,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const insertAttemptEvent = `-- name: InsertAttemptEvent :execrows
 
 INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -93,42 +93,6 @@ func (q *Queries) GetAttempt(ctx context.Context, id string) (AssignmentAttempt,
 	return i, err
 }
 
-const getAttemptByDeliveryAndWorkload = `-- name: GetAttemptByDeliveryAndWorkload :one
-SELECT id, delivery_id, binding_id, source_workload_key, tenant_key, project_key,
-       state, execution_evidence, resolution, review_reason, reviewed_at,
-       reviewed_by, received_at, settled_at
-FROM assignment_attempts
-WHERE delivery_id = ?1
-  AND source_workload_key = ?2
-`
-
-type GetAttemptByDeliveryAndWorkloadParams struct {
-	DeliveryID        int64
-	SourceWorkloadKey string
-}
-
-func (q *Queries) GetAttemptByDeliveryAndWorkload(ctx context.Context, arg GetAttemptByDeliveryAndWorkloadParams) (AssignmentAttempt, error) {
-	row := q.db.QueryRowContext(ctx, getAttemptByDeliveryAndWorkload, arg.DeliveryID, arg.SourceWorkloadKey)
-	var i AssignmentAttempt
-	err := row.Scan(
-		&i.ID,
-		&i.DeliveryID,
-		&i.BindingID,
-		&i.SourceWorkloadKey,
-		&i.TenantKey,
-		&i.ProjectKey,
-		&i.State,
-		&i.ExecutionEvidence,
-		&i.Resolution,
-		&i.ReviewReason,
-		&i.ReviewedAt,
-		&i.ReviewedBy,
-		&i.ReceivedAt,
-		&i.SettledAt,
-	)
-	return i, err
-}
-
 const getAttemptByLease = `-- name: GetAttemptByLease :one
 SELECT a.id, a.delivery_id, a.binding_id, a.source_workload_key, a.tenant_key,
        a.project_key, a.state, a.execution_evidence, a.resolution,

--- a/internal/store/sqlitedb/bindings.sql.go
+++ b/internal/store/sqlitedb/bindings.sql.go
@@ -9,38 +9,12 @@ import (
 	"context"
 )
 
-const getProviderBinding = `-- name: GetProviderBinding :one
-SELECT id, target_id, provider_kind, source_binding_key, desired_state, created_at
-FROM provider_bindings
-WHERE provider_kind = ?1
-  AND source_binding_key = ?2
-`
-
-type GetProviderBindingParams struct {
-	ProviderKind     string
-	SourceBindingKey string
-}
-
-func (q *Queries) GetProviderBinding(ctx context.Context, arg GetProviderBindingParams) (ProviderBinding, error) {
-	row := q.db.QueryRowContext(ctx, getProviderBinding, arg.ProviderKind, arg.SourceBindingKey)
-	var i ProviderBinding
-	err := row.Scan(
-		&i.ID,
-		&i.TargetID,
-		&i.ProviderKind,
-		&i.SourceBindingKey,
-		&i.DesiredState,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const insertProviderBinding = `-- name: InsertProviderBinding :one
 
 INSERT INTO provider_bindings (target_id, provider_kind, source_binding_key)
 VALUES (?1, ?2, ?3)
 ON CONFLICT (provider_kind, source_binding_key) DO UPDATE SET target_id = excluded.target_id
-RETURNING id, target_id, provider_kind, source_binding_key, desired_state, created_at
+RETURNING id, target_id, provider_kind, source_binding_key, created_at
 `
 
 type InsertProviderBindingParams struct {
@@ -60,50 +34,13 @@ func (q *Queries) InsertProviderBinding(ctx context.Context, arg InsertProviderB
 		&i.TargetID,
 		&i.ProviderKind,
 		&i.SourceBindingKey,
-		&i.DesiredState,
 		&i.CreatedAt,
 	)
 	return i, err
 }
 
-const listProviderBindings = `-- name: ListProviderBindings :many
-SELECT id, target_id, provider_kind, source_binding_key, desired_state, created_at
-FROM provider_bindings
-ORDER BY target_id, source_binding_key
-`
-
-func (q *Queries) ListProviderBindings(ctx context.Context) ([]ProviderBinding, error) {
-	rows, err := q.db.QueryContext(ctx, listProviderBindings)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ProviderBinding{}
-	for rows.Next() {
-		var i ProviderBinding
-		if err := rows.Scan(
-			&i.ID,
-			&i.TargetID,
-			&i.ProviderKind,
-			&i.SourceBindingKey,
-			&i.DesiredState,
-			&i.CreatedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listProviderBindingsWithContact = `-- name: ListProviderBindingsWithContact :many
-SELECT b.id, b.target_id, b.provider_kind, b.source_binding_key, b.desired_state, b.created_at,
+SELECT b.id, b.target_id, b.provider_kind, b.source_binding_key, b.created_at,
        coalesce(c.last_contact_at_ms, 0) AS last_contact_at_ms,
        coalesce(c.last_error, '')        AS last_error,
        coalesce(c.last_error_at_ms, 0)   AS last_error_at_ms
@@ -117,7 +54,6 @@ type ListProviderBindingsWithContactRow struct {
 	TargetID         string
 	ProviderKind     string
 	SourceBindingKey string
-	DesiredState     string
 	CreatedAt        int64
 	LastContactAtMs  int64
 	LastError        string
@@ -143,7 +79,6 @@ func (q *Queries) ListProviderBindingsWithContact(ctx context.Context) ([]ListPr
 			&i.TargetID,
 			&i.ProviderKind,
 			&i.SourceBindingKey,
-			&i.DesiredState,
 			&i.CreatedAt,
 			&i.LastContactAtMs,
 			&i.LastError,
@@ -199,23 +134,4 @@ type RecordProviderFailureParams struct {
 func (q *Queries) RecordProviderFailure(ctx context.Context, arg RecordProviderFailureParams) error {
 	_, err := q.db.ExecContext(ctx, recordProviderFailure, arg.BindingID, arg.LastError, arg.At)
 	return err
-}
-
-const setBindingDesiredState = `-- name: SetBindingDesiredState :execrows
-UPDATE provider_bindings
-SET desired_state = ?1
-WHERE id = ?2
-`
-
-type SetBindingDesiredStateParams struct {
-	DesiredState string
-	BindingID    int64
-}
-
-func (q *Queries) SetBindingDesiredState(ctx context.Context, arg SetBindingDesiredStateParams) (int64, error) {
-	result, err := q.db.ExecContext(ctx, setBindingDesiredState, arg.DesiredState, arg.BindingID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected()
 }

--- a/internal/store/sqlitedb/deliveries.sql.go
+++ b/internal/store/sqlitedb/deliveries.sql.go
@@ -73,46 +73,6 @@ func (q *Queries) InsertDelivery(ctx context.Context, arg InsertDeliveryParams) 
 	return i, err
 }
 
-const listUnconfirmedDeliveries = `-- name: ListUnconfirmedDeliveries :many
-SELECT id, binding_id, source_delivery_key, payload_sha256, ack_state,
-       received_at, ack_updated_at, acknowledged_at
-FROM broker_deliveries
-WHERE binding_id = ?1 AND ack_state <> 'confirmed'
-ORDER BY received_at, id
-`
-
-func (q *Queries) ListUnconfirmedDeliveries(ctx context.Context, bindingID int64) ([]BrokerDelivery, error) {
-	rows, err := q.db.QueryContext(ctx, listUnconfirmedDeliveries, bindingID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []BrokerDelivery{}
-	for rows.Next() {
-		var i BrokerDelivery
-		if err := rows.Scan(
-			&i.ID,
-			&i.BindingID,
-			&i.SourceDeliveryKey,
-			&i.PayloadSha256,
-			&i.AckState,
-			&i.ReceivedAt,
-			&i.AckUpdatedAt,
-			&i.AcknowledgedAt,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const markAckConfirmed = `-- name: MarkAckConfirmed :execrows
 UPDATE broker_deliveries
 SET ack_state = 'confirmed', ack_updated_at = unixepoch(), acknowledged_at = unixepoch()

--- a/internal/store/sqlitedb/models.go
+++ b/internal/store/sqlitedb/models.go
@@ -115,7 +115,6 @@ type ProviderBinding struct {
 	TargetID         string
 	ProviderKind     string
 	SourceBindingKey string
-	DesiredState     string
 	CreatedAt        int64
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1449,3 +1449,38 @@ func TestABindingConfigurationNoLongerClaimsIsForgotten(t *testing.T) {
 		return nil
 	})
 }
+
+// TestTheRetryCountIsIndexed: the count that decides whether a workload
+// is served again is answered from an index, not a scan.
+//
+// It runs inside the write transaction that decides a requeue, on the
+// one connection every other writer waits for, and it counts released
+// leases too — so the partial unique index cannot serve it, since that
+// one excludes exactly the rows the count is about. Without an index of
+// its own the check scans every lease the host has ever recorded, and
+// that cost grows with history rather than with live work.
+func TestTheRetryCountIsIndexed(t *testing.T) {
+	s := newStore(t)
+	var plan []string
+	inTx(t, s, func(tx *Tx) error {
+		rows, err := tx.tx.Query(
+			`EXPLAIN QUERY PLAN SELECT count(*) FROM capsule_leases WHERE attempt_id = ?`, "att-x")
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var id, parent, notUsed int
+			var detail string
+			if err := rows.Scan(&id, &parent, &notUsed, &detail); err != nil {
+				return err
+			}
+			plan = append(plan, detail)
+		}
+		return rows.Err()
+	})
+	joined := strings.Join(plan, "; ")
+	if !strings.Contains(joined, "USING INDEX") && !strings.Contains(joined, "USING COVERING INDEX") {
+		t.Errorf("the retry count plans as %q; want an index, not a scan of every lease ever recorded", joined)
+	}
+}

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -113,6 +113,13 @@ func TestRemoveIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
+	// Registered here rather than left to the removals below: this suite
+	// runs against a daemon it does not own, and any t.Fatalf between
+	// the create and the last remove leaves a container behind that
+	// nothing else will ever collect. It cannot mask what is being
+	// tested — that removing what is already gone is success is the
+	// assertion two lines down.
+	t.Cleanup(func() { _ = c.RemoveContainer(context.Background(), id) })
 	if err := c.RemoveContainer(ctx, id); err != nil {
 		t.Fatalf("first remove: %v", err)
 	}
@@ -840,6 +847,7 @@ func TestContainerRemovalSparesNamedVolumes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create container: %v", err)
 	}
+	t.Cleanup(func() { _ = c.RemoveContainer(context.Background(), id) })
 	if err := c.RemoveContainer(ctx, id); err != nil {
 		t.Fatalf("remove container: %v", err)
 	}

--- a/test/contract/sqlite/durability_test.go
+++ b/test/contract/sqlite/durability_test.go
@@ -1,6 +1,7 @@
 package sqlitecontract
 
 import (
+	"bytes"
 	"database/sql"
 	"fmt"
 	"math/rand"
@@ -190,20 +191,47 @@ func TestBackupRestore(t *testing.T) {
 		t.Fatalf("seed writer: %v: %s", err, out)
 	}
 
+	// Started explicitly rather than through CombinedOutput, so the
+	// process exists before the cleanup can reference it: every
+	// t.Fatalf below this point returns without receiving from `done`,
+	// and an unreaped writer goes on writing into a directory the
+	// harness is already removing.
+	writer := writerCmd(dbPath, "", 100)
+	var writerOut bytes.Buffer
+	writer.Stdout, writer.Stderr = &writerOut, &writerOut
+	if err := writer.Start(); err != nil {
+		t.Fatalf("start the concurrent writer: %v", err)
+	}
 	done := make(chan error, 1)
 	go func() {
-		out, err := writerCmd(dbPath, "", 100).CombinedOutput()
+		err := writer.Wait()
 		if err != nil {
-			err = fmt.Errorf("concurrent writer: %v: %s", err, out)
+			err = fmt.Errorf("concurrent writer: %v: %s", err, writerOut.String())
 		}
 		done <- err
 	}()
+	// Reaped exactly once, whether the body gets there or a t.Fatalf
+	// jumps past it. The channel carries one value, so a cleanup that
+	// read it unconditionally would block forever on the path where the
+	// body already did.
+	var (
+		reapOnce  sync.Once
+		writerErr error
+	)
+	reap := func() error {
+		reapOnce.Do(func() { writerErr = <-done })
+		return writerErr
+	}
+	t.Cleanup(func() {
+		_ = writer.Process.Kill()
+		_ = reap()
+	})
 
 	db := open(t, dbPath)
 	if _, err := db.Exec(`VACUUM INTO '` + backupPath + `'`); err != nil {
 		t.Fatalf("VACUUM INTO: %v", err)
 	}
-	if err := <-done; err != nil {
+	if err := reap(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -228,11 +256,26 @@ func TestDiskFull(t *testing.T) {
 	if small == "" {
 		t.Skipf("%s not set; disk-full runs inside the qualification container", envSmallDir)
 	}
+	// The capped filesystem is somebody else's directory: this test is
+	// pointed at it and fills it deliberately. The shipped harness gives
+	// a fresh tmpfs per run, so nothing accumulates there — but the gate
+	// invites pointing it at a real directory, and leftovers make the
+	// next run unable to fill anything. Cleared before, removed after.
+	dbPath := filepath.Join(small, "full.db")
 	ballast := filepath.Join(small, "ballast")
+	leftovers := []string{dbPath, dbPath + "-wal", dbPath + "-shm", ballast}
+	for _, f := range leftovers {
+		_ = os.Remove(f)
+	}
+	t.Cleanup(func() {
+		for _, f := range leftovers {
+			_ = os.Remove(f)
+		}
+	})
 	if err := os.WriteFile(ballast, make([]byte, 1<<20), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	db := open(t, filepath.Join(small, "full.db"))
+	db := open(t, dbPath)
 	mustExec(t, db, `CREATE TABLE IF NOT EXISTS big (id INTEGER PRIMARY KEY, blob TEXT NOT NULL)`)
 
 	blob := strings.Repeat("x", 64<<10)


### PR DESCRIPTION
## What changes

Six generated queries with no caller are removed, and `desired_state`
with them. `Snapshot` reads its attempts and resource intents as two set
reads instead of two per lease. The retry count gains the index it needs.
CI runs the suite once rather than twice. `ShortID`, the pre-serve status
answer and the duration renderer each collapse to one declaration. Three
test fixtures are cleaned up after.

No behaviour changes except the two the changelog names: the status
document loses a field, and the schema fingerprint moves.

## What was found

**Six queries nothing calls.** `GetProviderBinding`,
`ListProviderBindings`, `SetBindingDesiredState`,
`GetAttemptByDeliveryAndWorkload`, `GetAttemptEventByKey`,
`ListUnconfirmedDeliveries`. Each verified to have zero callers outside
the generated package before removal.

**A column that can only hold one value.** `desired_state`'s CHECK
admits `present` and `absent`; nothing anywhere writes `absent`, and the
one query that could is `SetBindingDesiredState`, which is in the list
above. It described a capability the product does not have — there is no
path that marks a binding for removal and no reader that acts on one.
The reviewed baseline is edited in place rather than given a `000002`,
so the schema fingerprint moves; that is the break, and it costs nothing
before a release.

**`Snapshot` cost two round trips per lease.** `tx.Get` and
`tx.Resources` inside the loop, on up to a hundred leases, on the single
connection every lease transition also waits for. Its own comment
already noted the per-lease reads as the reason the lease set is
bounded; bounding the set did not make the reads cheaper.

**The retry count had no index.** `servingsSoFar` counts every lease an
attempt ever had — released ones included — and runs inside the write
transaction that decides a requeue. `one_live_lease_per_attempt` is
partial on `state <> 'released'`, so it excludes exactly the rows the
count is about. Measured with `EXPLAIN QUERY PLAN`: `SCAN
capsule_leases`, i.e. every lease the host has ever recorded, taken
while the single writer is held.

**CI ran the whole suite twice.** One raced and shuffled, one profiled —
two runs of the slowest job in the workflow to learn two things about
one run.

**Three duplications.** `shortID` in `internal/app` guarded its slice;
the four sites in `internal/platform/docker` and `internal/capsule` did
not, and an unguarded slice panics inside an error path — the least
welcome place, since the message that would have said what went wrong is
replaced by a crash. `reportNoState` hand-built a map re-spelling tags
`statusDoc` already declares, so the two forms of one v1 document could
drift under a rename with nothing to notice. And the two surfaces that
print a span rendered it differently, only one of them clamping a
negative one — two clocks disagree, and `-1m0s ago` reads as a bug in
the thing being diagnosed.

**Three fixtures outlived their tests.** The disk-full test fills a
directory it is pointed at and left its database and ballast there. The
backup test launched a writer subprocess through `CombinedOutput` with
no path that reaped it, so any `t.Fatalf` between the launch and the
receive left it writing into a directory the harness was deleting. And
the Docker contract left containers in a daemon it does not own whenever
an assertion fired between a create and its removal.

**Two justifications I was given did not survive checking, and the fixes
are kept on narrower grounds.** The disk-full leak was said to matter
because the qualification container runs that test twice;
`test/contract/sqlite/testdata/remote-harness.sh` runs the suite once
with `-test.count=1` against a fresh tmpfs, so nothing accumulates
there. The Docker leak was said to collide with the next run's name;
`client(t)` draws a random instance id per test, so it does not. Both
are still worth fixing — one fills a directory it does not own, the
other leaves containers in a daemon it does not own — and the comments
now say that instead.

**And one item was dropped.** The duration renderer was to move to
`internal/platform`. Both callers are in `internal/command`, so a shared
helper there is the whole fix; moving it would have added a dependency
edge for nothing.

## Evidence

Hermetic, plus the gated sqlite contract run locally with both gates
set. The two behaviour-preserving claims are carried by the existing
suites: the snapshot's output is unchanged, and its tests are the
contract for that.

```text
mutation checks, local:
  drop capsule_leases_by_attempt
    -> TestTheRetryCountIsIndexed: the retry count plans as "SCAN capsule_leases"
  remove the guard from ShortID
    -> TestShortIDToleratesAShortID: panic: slice bounds out of range
       [:12] with length 11
  return reportNoState to a hand-built map with one renamed key
    -> TestBothStatusAnswersShareOneEnvelope: the document carries a field
       statusDoc does not name: json: unknown field "stateDir"

gates that carried the rest:
  TestSchemaSnapshotMatchesMigrations caught the stale snapshot after the
    column was dropped, before anything else could
  sqlc diff / vet, and the generated-layer CI step, cover the six removals

sqlite durability contract, run locally with both gates set:
  PASS Pragmas, CrashRecovery, Contention, SingletonLock, BackupRestore,
       MigrationMechanics
  FAIL DiskFull — "cap not effective": the gate was pointed at an
       uncapped temp directory, which is the test refusing to pass rather
       than a regression. The capped directory it is designed for is the
       harness's 8 MiB tmpfs.
  after that failing run, the capped directory was empty: the new
  cleanup runs on the failure path too, which is the path it exists for
```

## What would notice this regressing

- `TestTheRetryCountIsIndexed` (internal/store) reads `EXPLAIN QUERY
  PLAN` and fails on a scan.
- `TestShortIDToleratesAShortID` (internal/platform/docker) panics
  without the guard.
- `TestBothStatusAnswersShareOneEnvelope` (internal/command) decodes both
  forms with `DisallowUnknownFields`.
- `TestSchemaSnapshotMatchesMigrations` and the CI `sqlc diff` step fail
  if the generated layer or the snapshot drifts from the migrations.
- Nothing would notice the six query removals regressing, because
  re-adding an unused query is not a regression — the CI step only
  requires the generated code to match the `.sql` files.
- Nothing hermetic notices the fixture cleanups. They are exercised by
  the gated suites, and the disk-full one was verified by inspecting the
  directory after a deliberately failing run.

## Risk, compatibility and operations

**The schema fingerprint moves, and that is the operationally
significant change.** A state directory written by an earlier build is
refused on open — by the controller and by every reporting surface,
each of which says which build wrote it. That refusal is the designed
behaviour for a baseline still being edited in place, and it is why
`CHANGELOG` records the removal. Pre-release: no tagged build exists, so
only a development state directory can be holding the old schema, and
removing it is the resolution.

**Status API: a field is removed, and `api_version` does not move.**
`bindings[].desired_state` is gone from the v1 document. A consumer
reading it gets nothing — but the field could only ever be `"present"`,
so no consumer can have branched on it, and v1's stated contract is the
two forms discriminated by `served`, which is unchanged. Bumping the
version for a field that could not vary would spend the discriminator a
real break will need.

**Trust boundary, credentials, networking, resource limits: untouched.**
No capability, mount, credential path or policy decision is in this
change.

**Performance is the point of two items and is measurable in neither
direction hermetically.** The set reads and the index both reduce work
on the single writer's connection; neither changes output, which is why
the existing snapshot tests are the contract for them.

**CI runtime falls** by one full suite run on every pull request. The
merged step keeps the race detector, the shuffle, `-count=1`, atomic
coverage mode and the covdata check.

**No CLI flags, configuration keys, deployment or rollback changes.**

## Changelog

```text
State and operations:
- The status document drops `desired_state`. The column admitted `present`
  and `absent`, nothing ever wrote `absent`, and the only query that could
  had no caller — so it described a capability the product does not have.
  `bindings[].desired_state` is gone from the v1 document; `api_version`
  is unchanged, because a field nothing could vary is not a contract a
  consumer can have depended on.
```

## Notes for your reviewer

This is the widest diff of the remediation and the one with the least
behaviour in it, so the thing to check is that the two behavioural
statements above are the only two.

The schema parity test is worth watching work: dropping the column left
`internal/store/schema/current.sql` stale, and that test named the
regeneration command before anything else could go wrong. It is the
mechanism that makes editing the reviewed baseline in place safe.

The `-count=2` behaviour of the sqlite contract is worth knowing about
and is not addressed here: run twice against one contract directory,
`TestBackupRestore` sees the previous run's rows and fails on its own
bounds. The shipped harness gives a fresh directory per run, so it is a
property of a mode nothing uses — I mention it because I hit it while
verifying the writer reap, and it looks like a leak until you see why it
is not one.
