### PR TITLE
refactor: an identifier cannot pass for another

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -19,13 +19,15 @@ package allocator
 import (
 	"fmt"
 	"sync"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // pool is one tier's parallelism budget and the bindings sharing it.
 type pool struct {
 	parallelism int
-	order       []string // binding keys, registration order, stable
-	state       map[string]*binding
+	order       []assignment.BindingKey // binding keys, registration order, stable
+	state       map[assignment.BindingKey]*binding
 	// discovery is the index in order of the binding currently holding
 	// the discovery credit. Rotate advances it.
 	discovery int
@@ -47,10 +49,10 @@ type Allocator struct {
 	mu sync.Mutex
 	// globalParallelism is zero when tiers are intentionally independent.
 	globalParallelism int
-	pools             map[string]*pool
-	tierOf            map[string]string
-	order             []string // all binding keys, registration order
-	discovery         int      // instance-wide cursor when a global limit is set
+	pools             map[assignment.TierID]*pool
+	tierOf            map[assignment.BindingKey]assignment.TierID
+	order             []assignment.BindingKey // all binding keys, registration order
+	discovery         int                     // instance-wide cursor when a global limit is set
 	// held is the instance-wide hold. It is kept here, not only on the
 	// bindings, because a hold is a statement about the instance and
 	// outlives the set of bindings that existed when it was applied:
@@ -69,8 +71,8 @@ func New() *Allocator { return NewWithGlobalParallelism(0) }
 func NewWithGlobalParallelism(globalParallelism int) *Allocator {
 	return &Allocator{
 		globalParallelism: globalParallelism,
-		pools:             map[string]*pool{},
-		tierOf:            map[string]string{},
+		pools:             map[assignment.TierID]*pool{},
+		tierOf:            map[assignment.BindingKey]assignment.TierID{},
 	}
 }
 
@@ -78,13 +80,13 @@ func NewWithGlobalParallelism(globalParallelism int) *Allocator {
 // tier; every binding in a tier must pass the same value. More bindings
 // than the limit is legal: they share the tier's credits and take turns at
 // discovery rather than each reserving one.
-func (a *Allocator) Register(tierID, key string, parallelism int) error {
+func (a *Allocator) Register(tierID assignment.TierID, key assignment.BindingKey, parallelism int) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	p := a.pools[tierID]
 	if p == nil {
-		p = &pool{parallelism: parallelism, state: map[string]*binding{}}
+		p = &pool{parallelism: parallelism, state: map[assignment.BindingKey]*binding{}}
 		a.pools[tierID] = p
 	}
 	if p.parallelism != parallelism {
@@ -103,7 +105,7 @@ func (a *Allocator) Register(tierID, key string, parallelism int) error {
 // SetAssignedDemand records what the provider has committed to a
 // binding — running plus waiting workloads, from its latest statistics
 // — which is what the free credits are shared by.
-func (a *Allocator) SetAssignedDemand(key string, demand int) {
+func (a *Allocator) SetAssignedDemand(key assignment.BindingKey, demand int) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if b := a.binding(key); b != nil {
@@ -134,7 +136,7 @@ func (a *Allocator) Hold(held bool) {
 // both have capacity, counting active capsules across the whole pool. It
 // returns false when the pool is full, in which case the job waits in the
 // caller's local pending queue. A successful reserve must be paired with Release.
-func (a *Allocator) TryReserve(key string) bool {
+func (a *Allocator) TryReserve(key assignment.BindingKey) bool {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p := a.poolOf(key)
@@ -164,7 +166,7 @@ func (a *Allocator) TryReserve(key string) bool {
 // leaving an operator to meet it as a capacity figure that makes no
 // sense. Reporting rather than logging keeps the decision here and the
 // logger where the wiring is.
-func (a *Allocator) Adopt(key string) (overBudget bool) {
+func (a *Allocator) Adopt(key assignment.BindingKey) (overBudget bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	b := a.binding(key)
@@ -184,7 +186,7 @@ func (a *Allocator) Adopt(key string) (overBudget bool) {
 }
 
 // Release frees admission capacity when cleanup releases the lease.
-func (a *Allocator) Release(key string) {
+func (a *Allocator) Release(key assignment.BindingKey) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if b := a.binding(key); b != nil && b.active > 0 {
@@ -193,7 +195,7 @@ func (a *Allocator) Release(key string) {
 }
 
 // Active reports a binding's current reserved/running capsule count.
-func (a *Allocator) Active(key string) int {
+func (a *Allocator) Active(key assignment.BindingKey) int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if b := a.binding(key); b != nil {
@@ -225,7 +227,7 @@ func (a *Allocator) Rotate() {
 // DiscoveryHolder reports which binding currently holds the tier's
 // discovery credit — the one datum an operator needs to answer "why is
 // that binding announcing zero".
-func (a *Allocator) DiscoveryHolder(tierID string) string {
+func (a *Allocator) DiscoveryHolder(tierID assignment.TierID) assignment.BindingKey {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p := a.pools[tierID]
@@ -255,7 +257,7 @@ func (a *Allocator) DiscoveryHolder(tierID string) string {
 // shared max-min fairly among bindings whose demand exceeds what they
 // hold. Whatever is still unclaimed can fund the discovery credit, so a
 // silent binding gets sight only out of genuinely idle capacity.
-func (a *Allocator) Advertised(key string) int {
+func (a *Allocator) Advertised(key assignment.BindingKey) int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p := a.poolOf(key)
@@ -269,7 +271,7 @@ func (a *Allocator) Advertised(key string) int {
 // per-binding call is what a session announces, but the invariant is a
 // statement about the pool, and reading it one binding at a time
 // samples four different instants rather than one state.
-func (a *Allocator) AdvertisedAll(tierID string) map[string]int {
+func (a *Allocator) AdvertisedAll(tierID assignment.TierID) map[assignment.BindingKey]int {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p := a.pools[tierID]
@@ -277,7 +279,7 @@ func (a *Allocator) AdvertisedAll(tierID string) map[string]int {
 		return nil
 	}
 	all := a.distributeAll()
-	out := make(map[string]int, len(p.order))
+	out := make(map[assignment.BindingKey]int, len(p.order))
 	for _, key := range p.order {
 		out[key] = all[key]
 	}
@@ -287,7 +289,7 @@ func (a *Allocator) AdvertisedAll(tierID string) map[string]int {
 // BindingCredit is one binding's line in the pool report: the demand it
 // reported, the credits it holds, and what it would announce now.
 type BindingCredit struct {
-	Key            string
+	Key            assignment.BindingKey
 	AssignedDemand int
 	Reserved       int
 	Advertised     int
@@ -296,7 +298,7 @@ type BindingCredit struct {
 
 // PoolReport is the tier's credit accounting, for operators and for the
 // log line that explains why a binding announces what it does.
-func (a *Allocator) PoolReport(tierID string) (parallelism int, rows []BindingCredit) {
+func (a *Allocator) PoolReport(tierID assignment.TierID) (parallelism int, rows []BindingCredit) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	p := a.pools[tierID]
@@ -304,7 +306,7 @@ func (a *Allocator) PoolReport(tierID string) (parallelism int, rows []BindingCr
 		return 0, nil
 	}
 	adv := a.distributeAll()
-	discovery := ""
+	var discovery assignment.BindingKey
 	if a.globalParallelism > 0 {
 		if len(a.order) > 0 && a.tierOf[a.order[a.discovery]] == tierID {
 			discovery = a.order[a.discovery]
@@ -360,11 +362,11 @@ func (a *Allocator) CapacityReport() CapacityReport {
 	}
 }
 
-func (a *Allocator) distributeAll() map[string]int {
+func (a *Allocator) distributeAll() map[assignment.BindingKey]int {
 	if a.globalParallelism > 0 {
 		return a.distributeGlobal()
 	}
-	out := make(map[string]int, len(a.order))
+	out := make(map[assignment.BindingKey]int, len(a.order))
 	for _, p := range a.pools {
 		for key, credit := range a.distributeTier(p) {
 			out[key] = credit
@@ -373,8 +375,8 @@ func (a *Allocator) distributeAll() map[string]int {
 	return out
 }
 
-func (a *Allocator) distributeTier(p *pool) map[string]int {
-	adv := make(map[string]int, len(p.order))
+func (a *Allocator) distributeTier(p *pool) map[assignment.BindingKey]int {
+	adv := make(map[assignment.BindingKey]int, len(p.order))
 	for _, k := range p.order {
 		adv[k] = p.state[k].active
 	}
@@ -388,7 +390,8 @@ func (a *Allocator) distributeTier(p *pool) map[string]int {
 	// fair and deterministic — no cursor to make two callers disagree
 	// about who got the credit.
 	for remaining > 0 {
-		pick, best := "", int(^uint(0)>>1)
+		var pick assignment.BindingKey
+		best := int(^uint(0) >> 1)
 		for _, k := range p.order {
 			b := p.state[k]
 			if !b.held && adv[k] < b.assignedDemand && adv[k] < best {
@@ -414,9 +417,9 @@ func (a *Allocator) distributeTier(p *pool) map[string]int {
 	return adv
 }
 
-func (a *Allocator) distributeGlobal() map[string]int {
-	adv := make(map[string]int, len(a.order))
-	tierAdvertised := make(map[string]int, len(a.pools))
+func (a *Allocator) distributeGlobal() map[assignment.BindingKey]int {
+	adv := make(map[assignment.BindingKey]int, len(a.order))
+	tierAdvertised := make(map[assignment.TierID]int, len(a.pools))
 	for _, key := range a.order {
 		active := a.binding(key).active
 		adv[key] = active
@@ -428,7 +431,8 @@ func (a *Allocator) distributeGlobal() map[string]int {
 	}
 
 	for remaining > 0 {
-		pick, best := "", int(^uint(0)>>1)
+		var pick assignment.BindingKey
+		best := int(^uint(0) >> 1)
 		for _, key := range a.order {
 			b := a.binding(key)
 			tierID := a.tierOf[key]
@@ -457,7 +461,7 @@ func (a *Allocator) distributeGlobal() map[string]int {
 	return adv
 }
 
-func (a *Allocator) nextDiscovery(order []string, current int) int {
+func (a *Allocator) nextDiscovery(order []assignment.BindingKey, current int) int {
 	if len(order) == 0 {
 		return 0
 	}
@@ -471,14 +475,14 @@ func (a *Allocator) nextDiscovery(order []string, current int) int {
 	return current
 }
 
-func (a *Allocator) binding(key string) *binding {
+func (a *Allocator) binding(key assignment.BindingKey) *binding {
 	if p := a.poolOf(key); p != nil {
 		return p.state[key]
 	}
 	return nil
 }
 
-func (a *Allocator) poolOf(key string) *pool { return a.pools[a.tierOf[key]] }
+func (a *Allocator) poolOf(key assignment.BindingKey) *pool { return a.pools[a.tierOf[key]] }
 
 func (a *Allocator) poolActive(p *pool) int {
 	total := 0

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -3,11 +3,13 @@ package allocator
 import (
 	"sync"
 	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
-func mustRegister(t *testing.T, a *Allocator, tier, key string, parallelism int) {
+func mustRegister(t *testing.T, a *Allocator, tier, key assignment.SourceWorkloadKey, parallelism int) {
 	t.Helper()
-	if err := a.Register(tier, key, parallelism); err != nil {
+	if err := a.Register(assignment.TierID(tier), assignment.BindingKey(key), parallelism); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -30,7 +32,7 @@ func advertisedSum(a *Allocator, _ ...string) int {
 func TestMoreBindingsThanParallelism(t *testing.T) {
 	a := New()
 	for _, key := range []string{"a", "b", "c"} {
-		mustRegister(t, a, "std", key, 2)
+		mustRegister(t, a, "std", assignment.SourceWorkloadKey(key), 2)
 	}
 	if got := advertisedSum(a, "a", "b", "c"); got > 2 {
 		t.Errorf("sum(advertised) = %d; the tier parallelism is 2", got)
@@ -66,12 +68,12 @@ func TestInvariantHoldsAcrossStates(t *testing.T) {
 	} {
 		a := New()
 		for _, k := range keys {
-			mustRegister(t, a, "std", k, tc.parallelism)
+			mustRegister(t, a, "std", assignment.SourceWorkloadKey(k), tc.parallelism)
 		}
 		for i, k := range keys {
-			a.SetAssignedDemand(k, tc.wants[i])
+			a.SetAssignedDemand(assignment.BindingKey(k), tc.wants[i])
 			for range tc.holds[i] {
-				if !a.TryReserve(k) {
+				if !a.TryReserve(assignment.BindingKey(k)) {
 					t.Fatalf("%s: %s could not reserve within budget", tc.name, k)
 				}
 			}
@@ -175,7 +177,7 @@ func TestDiscoveryCreditMakesASilentBindingVisible(t *testing.T) {
 	// safe.
 	for range 3 {
 		for _, k := range []string{"a", "b", "c"} {
-			if a.Advertised(k) > 0 {
+			if a.Advertised(assignment.BindingKey(k)) > 0 {
 				seen[k] = true
 			}
 		}
@@ -195,11 +197,11 @@ func TestDiscoveryIsNotOfferedToEveryoneAtOnce(t *testing.T) {
 	a := New()
 	keys := []string{"a", "b", "c", "d"}
 	for _, k := range keys {
-		mustRegister(t, a, "std", k, 2)
+		mustRegister(t, a, "std", assignment.SourceWorkloadKey(k), 2)
 	}
 	holders := 0
 	for _, k := range keys {
-		if a.Advertised(k) > 0 {
+		if a.Advertised(assignment.BindingKey(k)) > 0 {
 			holders++
 		}
 	}
@@ -214,14 +216,14 @@ func TestDiscoveryIsNotOfferedToEveryoneAtOnce(t *testing.T) {
 func TestRotationSkipsBindingsThatCanAlreadySee(t *testing.T) {
 	a := New()
 	for _, k := range []string{"a", "b", "c"} {
-		mustRegister(t, a, "std", k, 3)
+		mustRegister(t, a, "std", assignment.SourceWorkloadKey(k), 3)
 	}
 	a.SetAssignedDemand("b", 5) // b has demand: it is visible without the credit
 
 	held := map[string]int{}
 	for range 6 {
 		a.Rotate()
-		held[a.DiscoveryHolder("std")]++
+		held[string(a.DiscoveryHolder("std"))]++
 	}
 	if held["b"] != 0 {
 		t.Errorf("rotation gave the discovery credit to a binding with demand %d times", held["b"])
@@ -336,7 +338,7 @@ func TestNoOvershootUnderConcurrentTraffic(t *testing.T) {
 	keys := []string{"a", "b", "c", "d"}
 	const parallelism = 3
 	for _, k := range keys {
-		mustRegister(t, a, "std", k, parallelism)
+		mustRegister(t, a, "std", assignment.SourceWorkloadKey(k), parallelism)
 	}
 
 	var workers sync.WaitGroup
@@ -351,9 +353,9 @@ func TestNoOvershootUnderConcurrentTraffic(t *testing.T) {
 					return
 				default:
 				}
-				a.SetAssignedDemand(k, i%5)
-				if a.TryReserve(k) {
-					a.Release(k)
+				a.SetAssignedDemand(assignment.BindingKey(k), i%5)
+				if a.TryReserve(assignment.BindingKey(k)) {
+					a.Release(assignment.BindingKey(k))
 				}
 				a.Rotate()
 			}
@@ -405,7 +407,7 @@ func TestGlobalDiscoveryRotatesAcrossTiers(t *testing.T) {
 	seen := map[string]bool{}
 	for range 2 {
 		for _, key := range []string{"small-a", "large-a"} {
-			if a.Advertised(key) == 1 {
+			if a.Advertised(assignment.BindingKey(key)) == 1 {
 				seen[key] = true
 			}
 		}
@@ -512,9 +514,9 @@ func TestNoGlobalOvershootUnderConcurrentTraffic(t *testing.T) {
 					return
 				default:
 				}
-				a.SetAssignedDemand(key, i%5)
-				if a.TryReserve(key) {
-					a.Release(key)
+				a.SetAssignedDemand(assignment.BindingKey(key), i%5)
+				if a.TryReserve(assignment.BindingKey(key)) {
+					a.Release(assignment.BindingKey(key))
 				}
 				a.Rotate()
 			}
@@ -623,14 +625,14 @@ func TestPoolReportUnderAGlobalLimit(t *testing.T) {
 
 	flagged := map[string]bool{}
 	for _, tier := range []string{"small", "large"} {
-		_, rows := a.PoolReport(tier)
+		_, rows := a.PoolReport(assignment.TierID(tier))
 		for _, r := range rows {
 			if r.Discovery {
-				flagged[r.Key] = true
+				flagged[string(r.Key)] = true
 			}
 		}
-		holder := a.DiscoveryHolder(tier)
-		if holder != "" && !flagged[holder] {
+		holder := a.DiscoveryHolder(assignment.TierID(tier))
+		if holder != "" && !flagged[string(holder)] {
 			t.Errorf("tier %s reports holder %q that its own rows do not flag", tier, holder)
 		}
 	}
@@ -689,7 +691,7 @@ func TestAdoptionOverBudgetIsReportedAndConverges(t *testing.T) {
 	a := New()
 	keys := []string{"a", "b"}
 	for _, k := range keys {
-		mustRegister(t, a, "std", k, 1) // the tier shrank to one
+		mustRegister(t, a, "std", assignment.SourceWorkloadKey(k), 1) // the tier shrank to one
 	}
 
 	// Two capsules survived the restart; the tier now allows one.

--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -42,8 +42,8 @@ type harness struct {
 	objects *fakeObjects
 
 	mu       sync.Mutex
-	launched []string
-	leases   map[string]store.Lease // attempt id -> lease, captured at launch
+	launched []assignment.AttemptID
+	leases   map[assignment.AttemptID]store.Lease // attempt id -> lease, captured at launch
 
 	msgSeq int
 }
@@ -62,7 +62,7 @@ func newHarness(t *testing.T, parallelism int) *harness {
 // restart path: the same binding identity resolves to the same rows.
 func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness {
 	t.Helper()
-	var bindingID int64
+	var bindingID assignment.BindingID
 	if err := st.Tx(context.Background(), func(tx *store.Tx) error {
 		var err error
 		bindingID, err = tx.EnsureBinding("app", "github_actions",
@@ -72,7 +72,7 @@ func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness 
 		t.Fatal(err)
 	}
 
-	h := &harness{t: t, store: st, leases: map[string]store.Lease{}}
+	h := &harness{t: t, store: st, leases: map[assignment.AttemptID]store.Lease{}}
 	b := &binding{
 		key:       "app/standard",
 		tier:      config.Tier{ID: "standard", Parallelism: parallelism},
@@ -93,14 +93,14 @@ func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness 
 		cache:     cacheMgr,
 		alloc:     allocator.New(),
 		bindings:  []*binding{b},
-		byBinding: map[int64]*binding{bindingID: b},
+		byBinding: map[int64]*binding{int64(bindingID): b},
 		// A lease this harness calls stranded was written moments ago,
 		// because no test here simulates the passage of time. The grace
 		// exists for a real gap between a lease committing and its owner
 		// registering, and a test whose subject is that gap sets its own.
 		strandedGrace: time.Nanosecond,
 	}
-	if err := h.srv.alloc.Register(b.tier.ID, b.key, parallelism); err != nil {
+	if err := h.srv.alloc.Register(assignment.TierID(b.tier.ID), b.key, parallelism); err != nil {
 		t.Fatal(err)
 	}
 	// The monitor is real, on a defaulted policy and a probe that reports
@@ -142,10 +142,10 @@ func (h *harness) serve() {
 	h.srv.wg.Wait()
 }
 
-func (h *harness) launchedAttempts() []string {
+func (h *harness) launchedAttempts() []assignment.AttemptID {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return append([]string(nil), h.launched...)
+	return append([]assignment.AttemptID(nil), h.launched...)
 }
 
 // useRemover rebuilds the lease manager over a faulted daemon, so a test
@@ -154,7 +154,7 @@ func (h *harness) useRemover(r lease.Remover) {
 	h.srv.leases = lease.NewManager(h.store, r, h.srv.log)
 }
 
-func (h *harness) recordEvidence(leaseID string, e store.Evidence) {
+func (h *harness) recordEvidence(leaseID assignment.LeaseID, e store.Evidence) {
 	h.t.Helper()
 	if err := h.store.Tx(h.t.Context(), func(tx *store.Tx) error {
 		return tx.RecordEvidenceForLease(leaseID, e)
@@ -184,7 +184,7 @@ func (h *harness) ready() []store.Attempt {
 
 // attemptByLease resolves the attempt a lease serves, or a zero Attempt
 // when disposition already detached it.
-func (h *harness) attemptByLease(leaseID string) store.Attempt {
+func (h *harness) attemptByLease(leaseID assignment.LeaseID) store.Attempt {
 	h.t.Helper()
 	var out store.Attempt
 	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
@@ -220,9 +220,15 @@ func demand(workloadKey, project string, run int64) assignment.WorkloadAssignmen
 // success, exactly the contract the real client honours.
 type nopRemover struct{}
 
-func (nopRemover) RemoveOwnedContainer(context.Context, string, string, string) error { return nil }
-func (nopRemover) RemoveOwnedNetwork(context.Context, string, string, string) error   { return nil }
-func (nopRemover) RemoveOwnedVolume(context.Context, string, string, string) error    { return nil }
+func (nopRemover) RemoveOwnedContainer(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
+func (nopRemover) RemoveOwnedNetwork(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
+func (nopRemover) RemoveOwnedVolume(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
 
 var errDaemon = errors.New("daemon unreachable")
 
@@ -243,13 +249,13 @@ type fakeObjects struct {
 	removed []string
 }
 
-func (f *fakeObjects) ListOwnedContainers(context.Context, string) ([]docker.OwnedContainer, error) {
+func (f *fakeObjects) ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error) {
 	return f.containers, f.listErr
 }
-func (f *fakeObjects) ListOwnedNetworks(context.Context, string) ([]docker.OwnedResource, error) {
+func (f *fakeObjects) ListOwnedNetworks(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error) {
 	return f.networks, nil
 }
-func (f *fakeObjects) ListOwnedVolumes(context.Context, string) ([]docker.OwnedResource, error) {
+func (f *fakeObjects) ListOwnedVolumes(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error) {
 	return f.volumes, nil
 }
 func (f *fakeObjects) RemoveContainer(_ context.Context, id string) error { return f.remove(id) }
@@ -274,11 +280,11 @@ type fakeProbe struct {
 	usageErr error
 }
 
-func (f *fakeProbe) ProbeFilesystemFree(context.Context, string, string) (docker.FilesystemFree, error) {
+func (f *fakeProbe) ProbeFilesystemFree(context.Context, string, assignment.InstanceID) (docker.FilesystemFree, error) {
 	return f.free, f.freeErr
 }
 
-func (f *fakeProbe) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+func (f *fakeProbe) OwnedVolumeUsage(context.Context, assignment.InstanceID) ([]docker.VolumeUsage, error) {
 	return f.usage, f.usageErr
 }
 
@@ -288,11 +294,11 @@ func (f *fakeProbe) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUs
 type nopVolumes struct{}
 
 func (nopVolumes) EnsureOwnedVolume(context.Context, string, map[string]string) error { return nil }
-func (nopVolumes) OwnedIDByName(_ context.Context, _, name, _, _ string) (string, error) {
+func (nopVolumes) OwnedIDByName(_ context.Context, _, name string, _ assignment.InstanceID, _ assignment.LeaseID) (string, error) {
 	return name, nil
 }
 func (nopVolumes) RemoveVolume(context.Context, string) error { return nil }
-func (nopVolumes) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+func (nopVolumes) OwnedVolumeUsage(context.Context, assignment.InstanceID) ([]docker.VolumeUsage, error) {
 	return nil, nil
 }
 
@@ -404,7 +410,7 @@ func TestReadyAttemptsResumeAfterRestart(t *testing.T) {
 }
 
 // attemptState reloads one attempt by id, wherever its state moved.
-func attemptState(t *testing.T, h *harness, attemptID string) store.Attempt {
+func attemptState(t *testing.T, h *harness, attemptID assignment.AttemptID) store.Attempt {
 	t.Helper()
 	var out store.Attempt
 	h.inStore(func(s *store.Tx) error {
@@ -420,10 +426,10 @@ func attemptState(t *testing.T, h *harness, attemptID string) store.Attempt {
 
 // leaseFor claims the open attempt of a workload through the production
 // transaction, returning the lease and the attempt id.
-func leaseFor(t *testing.T, h *harness, workloadKey string) (store.Lease, string) {
+func leaseFor(t *testing.T, h *harness, workloadKey assignment.SourceWorkloadKey) (store.Lease, assignment.AttemptID) {
 	t.Helper()
 	var lease store.Lease
-	var attemptID string
+	var attemptID assignment.AttemptID
 	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
 		ready, err := tx.ReadyAttempts(h.bind.bindingID)
 		if err != nil {
@@ -445,7 +451,7 @@ func leaseFor(t *testing.T, h *harness, workloadKey string) (store.Lease, string
 	return lease, attemptID
 }
 
-func driveLeaseTo(t *testing.T, h *harness, leaseID string, target store.LeaseState) {
+func driveLeaseTo(t *testing.T, h *harness, leaseID assignment.LeaseID, target store.LeaseState) {
 	t.Helper()
 	// A lease starts reserved; every other state is reached by walking the
 	// real machine, so a test never fabricates a state the product cannot

--- a/internal/app/attribution_test.go
+++ b/internal/app/attribution_test.go
@@ -14,14 +14,14 @@ import (
 func nameRuntime(t *testing.T, h *harness, lease store.Lease, runtimeName string) {
 	t.Helper()
 	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
-		return tx.SetLeaseRuntimeName(lease.ID, runtimeName)
+		return tx.SetLeaseRuntimeName(lease.ID, assignment.RuntimeName(runtimeName))
 	}); err != nil {
 		t.Fatal(err)
 	}
 }
 
 // eventsOf lists an attempt's recorded lifecycle.
-func eventsOf(t *testing.T, h *harness, attemptID string) []string {
+func eventsOf(t *testing.T, h *harness, attemptID assignment.AttemptID) []string {
 	t.Helper()
 	var kinds []string
 	if err := h.store.Tx(context.Background(), func(tx *store.Tx) error {
@@ -79,7 +79,7 @@ func TestExecutionIsRecordedAgainstTheWorkloadThatRan(t *testing.T) {
 	var requeuedAttempt string
 	for _, a := range h.ready() {
 		if a.SourceWorkloadKey == "job-requeued" {
-			requeuedAttempt = a.ID
+			requeuedAttempt = string(a.ID)
 		}
 	}
 	if requeuedAttempt == "" {
@@ -96,7 +96,7 @@ func TestExecutionIsRecordedAgainstTheWorkloadThatRan(t *testing.T) {
 		}},
 	})
 
-	if !contains(eventsOf(t, h, requeuedAttempt), "running_observed") {
+	if !contains(eventsOf(t, h, assignment.AttemptID(requeuedAttempt)), "running_observed") {
 		t.Error("the workload that ran has no record of running; its evidence went elsewhere")
 	}
 	if contains(eventsOf(t, h, lapsedAttempt), "running_observed") {
@@ -163,10 +163,10 @@ func TestALateObservationStaysWithTheAttemptThatRanIt(t *testing.T) {
 	var successor string
 	for _, a := range h.ready() {
 		if a.SourceWorkloadKey == "job-requeued" {
-			successor = a.ID
+			successor = string(a.ID)
 		}
 	}
-	if successor == "" || successor == firstAttempt {
+	if successor == "" || assignment.AttemptID(successor) == firstAttempt {
 		t.Fatalf("the requeue left no successor attempt (got %q against the first %q); "+
 			"this case needs two attempts for one workload", successor, firstAttempt)
 	}
@@ -183,7 +183,7 @@ func TestALateObservationStaysWithTheAttemptThatRanIt(t *testing.T) {
 	if !contains(eventsOf(t, h, firstAttempt), "exit_observed") {
 		t.Error("the attempt whose runner produced the observation has no record of it")
 	}
-	if contains(eventsOf(t, h, successor), "exit_observed") {
+	if contains(eventsOf(t, h, assignment.AttemptID(successor)), "exit_observed") {
 		t.Error("the successor is recorded as having exited; it holds no lease and has " +
 			"started nothing, so an operator reading its trail is told a run happened")
 	}
@@ -212,10 +212,10 @@ func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
 	var successor string
 	for _, a := range h.ready() {
 		if a.SourceWorkloadKey == "job-requeued" {
-			successor = a.ID
+			successor = string(a.ID)
 		}
 	}
-	if successor == "" || successor == firstAttempt {
+	if successor == "" || assignment.AttemptID(successor) == firstAttempt {
 		t.Fatalf("the requeue left no successor attempt (got %q against the first %q)",
 			successor, firstAttempt)
 	}
@@ -236,7 +236,7 @@ func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
 	var after store.Attempt
 	h.inStore(func(tx *store.Tx) error {
 		var err error
-		after, err = tx.Get(successor)
+		after, err = tx.Get(assignment.AttemptID(successor))
 		return err
 	})
 	if after.State != "ready" {
@@ -259,7 +259,7 @@ func TestASecondServingsHintsAreNotSwallowed(t *testing.T) {
 	firstLease, attemptID := leaseFor(t, h, "job-retried")
 	nameRuntime(t, h, firstLease, "runpool-first")
 
-	hint := func(runtime string) {
+	hint := func(runtime assignment.RuntimeName) {
 		h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 			ID: 910,
 			Started: []assignment.WorkloadLifecycleEvent{{

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rhobuild/runpool/internal/credential"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // buildBindings resolves every configured (target, tier) pair into a
@@ -22,7 +24,7 @@ import (
 // result. Creating-or-adopting the scale set is the binding's own loop's
 // first act, where a failure is retried instead of ending the process.
 func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, environ func(string) string) error {
-	var claimed []int64
+	var claimed []assignment.BindingID
 	tiers := make(map[string]config.Tier, len(cfg.Tiers))
 	for _, t := range cfg.Tiers {
 		tiers[t.ID] = t
@@ -70,10 +72,11 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 			// The neutral binding row comes first: it keys the delivery,
 			// attempt and lease machinery.
 			sourceBindingKey := sourceBindingKey(target, tb.ScaleSetName)
-			var bindingID, knownSetID int64
+			var bindingID assignment.BindingID
+			var knownSetID int64
 			if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 				var err error
-				if bindingID, err = tx.EnsureBinding(target.ID, "github_actions", sourceBindingKey); err != nil {
+				if bindingID, err = tx.EnsureBinding(assignment.TargetID(target.ID), "github_actions", assignment.SourceBindingKey(sourceBindingKey)); err != nil {
 					return err
 				}
 				// The scale set id recorded against this binding is the
@@ -86,7 +89,7 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 				return err
 			}
 			b := &binding{
-				key:    target.ID + "/" + tier.ID,
+				key:    assignment.BindingKey(target.ID + "/" + tier.ID),
 				target: target,
 				tier:   tier,
 				ref:    ref,
@@ -107,11 +110,11 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 				maxLanes:     laneCeiling(cfg, tier),
 				capsuleImage: tier.Image(s.shippedCapsuleImage),
 			}
-			if err := s.alloc.Register(tier.ID, b.key, tier.Parallelism); err != nil {
+			if err := s.alloc.Register(assignment.TierID(tier.ID), b.key, tier.Parallelism); err != nil {
 				return err
 			}
 			s.bindings = append(s.bindings, b)
-			s.byBinding[bindingID] = b
+			s.byBinding[int64(bindingID)] = b
 			claimed = append(claimed, bindingID)
 		}
 	}

--- a/internal/app/credits_test.go
+++ b/internal/app/credits_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/disk"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // TestCreditsRebuildFromAdoptedCapsules: after a restart the allocator
@@ -16,7 +18,7 @@ import (
 func TestCreditsRebuildFromAdoptedCapsules(t *testing.T) {
 	a := allocator.New()
 	for _, key := range []string{"a", "b"} {
-		if err := a.Register("std", key, 2); err != nil {
+		if err := a.Register("std", assignment.BindingKey(key), 2); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -80,14 +82,14 @@ func TestSilentBindingIsFoundByRotation(t *testing.T) {
 	a := allocator.New()
 	keys := []string{"repo-a", "repo-b", "repo-c", "repo-d"}
 	for _, k := range keys {
-		if err := a.Register("std", k, 2); err != nil {
+		if err := a.Register("std", assignment.BindingKey(k), 2); err != nil {
 			t.Fatal(err)
 		}
 	}
 	seen := map[string]bool{}
 	for range len(keys) {
 		for _, k := range keys {
-			if a.Advertised(k) > 0 {
+			if a.Advertised(assignment.BindingKey(k)) > 0 {
 				seen[k] = true
 			}
 		}

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -201,7 +201,7 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 		// has already been leased.
 		s.recordLifecycleEvents(ctx, b, msg)
 
-		advanced := s.acknowledgeDelivery(ctx, b, delivery, msg.ID)
+		advanced := s.acknowledgeDelivery(ctx, b, assignment.DeliveryID(delivery), msg.ID)
 
 		if msg.Statistics != nil {
 			// TotalAssignedJobs is the upstream scaling signal: what
@@ -238,7 +238,7 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 // delivery already confirmed, and an acknowledgement that failed - and on
 // both of them the next poll returns this same message with no long-poll
 // delay, so the caller has to wait rather than spin.
-func (s *Controller) acknowledgeDelivery(ctx context.Context, b *binding, deliveryID int64, messageID int) bool {
+func (s *Controller) acknowledgeDelivery(ctx context.Context, b *binding, deliveryID assignment.DeliveryID, messageID int) bool {
 	var proceed bool
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 		var err error
@@ -329,7 +329,7 @@ func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githu
 		}
 	}
 
-	var deliveryID int64
+	var deliveryID assignment.DeliveryID
 	err := s.store.Tx(ctx, func(tx *store.Tx) error {
 		id, err := tx.RecordDelivery(b.bindingID, key, fingerprint, workloads)
 		if errors.Is(err, store.ErrOpenAttemptExists) {
@@ -344,7 +344,7 @@ func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githu
 			// own attempts: those were inserted moments ago, above,
 			// before the conflicting workload was reached.
 			for _, a := range admitted {
-				serr := tx.SupersedeOpenAttempt(b.bindingID, a.SourceWorkloadKey,
+				serr := tx.SupersedeOpenAttempt(b.bindingID, assignment.SourceWorkloadKey(a.SourceWorkloadKey),
 					assignment.ResolutionSuperseded, id)
 				if serr != nil && !errors.Is(serr, store.ErrNotFound) {
 					return serr
@@ -369,7 +369,7 @@ func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githu
 			byKey[a.SourceWorkloadKey] = a
 		}
 		for _, attempt := range attempts {
-			a, ok := byKey[attempt.SourceWorkloadKey]
+			a, ok := byKey[string(attempt.SourceWorkloadKey)]
 			if !ok {
 				continue
 			}
@@ -383,7 +383,7 @@ func (s *Controller) persistDelivery(ctx context.Context, b *binding, msg *githu
 	if err != nil {
 		return 0, err
 	}
-	return deliveryID, nil
+	return int64(deliveryID), nil
 }
 
 // recordLifecycleEvents persists the provider's started/completed
@@ -404,11 +404,11 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 				// The cancellation and the event it explains commit
 				// together, so no row is closed without the trail that
 				// says what closed it.
-				if err := s.cancelIfReady(tx, attemptID); err != nil {
+				if err := s.cancelIfReady(tx, assignment.AttemptID(attemptID)); err != nil {
 					return err
 				}
 			}
-			return tx.RecordEvent(attemptID, idempotency, kind)
+			return tx.RecordEvent(assignment.AttemptID(attemptID), idempotency, kind)
 		}); err != nil {
 			s.log.Error("cannot record a lifecycle event",
 				"binding", b.key, "workload", ev.SourceWorkloadKey, "error", err)
@@ -423,7 +423,7 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 	for _, ev := range msg.Started {
 		s.log.Info("workload started",
 			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName)
-		record(ev, "running_observed", "remote_running_observed:"+ev.RuntimeName, false)
+		record(ev, "running_observed", "remote_running_observed:"+string(ev.RuntimeName), false)
 	}
 	for _, ev := range msg.Completed {
 		s.log.Info("workload completed (hint)",
@@ -432,7 +432,7 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 		if ev.Result == "canceled" {
 			kind, idempotency = "remote_canceled", "remote_canceled"
 		}
-		record(ev, kind, idempotency, ev.Result == "canceled")
+		record(ev, kind, string(idempotency), ev.Result == "canceled")
 	}
 }
 
@@ -445,7 +445,7 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 // It runs in the caller's transaction, on the attempt the caller
 // resolved. Resolving one of its own is how a cancellation of a run that
 // has already been superseded reached the successor instead.
-func (s *Controller) cancelIfReady(tx *store.Tx, attemptID string) error {
+func (s *Controller) cancelIfReady(tx *store.Tx, attemptID assignment.AttemptID) error {
 	err := tx.CancelReady(attemptID, assignment.ResolutionRemoteCanceled)
 	if errors.Is(err, store.ErrConflict) {
 		return nil // nothing ready to cancel; running work drains instead
@@ -531,8 +531,9 @@ func (s *Controller) backoff() time.Duration {
 // The runtime name stays as the fallback. An observation about a workload
 // this instance never recorded, or whose attempt is already settled, is
 // still worth keeping against the attempt whose lease owns that runner.
-func (s *Controller) attemptForObservation(tx *store.Tx, b *binding, ev assignment.WorkloadLifecycleEvent) (string, error) {
-	attempt, err := tx.OpenAttemptByWorkload(b.bindingID, ev.SourceWorkloadKey)
+func (s *Controller) attemptForObservation(tx *store.Tx, b *binding,
+	ev assignment.WorkloadLifecycleEvent) (assignment.AttemptID, error) {
+	attempt, err := tx.OpenAttemptByWorkload(b.bindingID, assignment.SourceWorkloadKey(ev.SourceWorkloadKey))
 	switch {
 	case err == nil:
 		if ev.RuntimeName == "" {
@@ -563,7 +564,7 @@ func (s *Controller) attemptForObservation(tx *store.Tx, b *binding, ev assignme
 			return "", nil
 		case perr != nil:
 			return "", perr
-		case provisioned.SourceWorkloadKey == ev.SourceWorkloadKey:
+		case string(provisioned.SourceWorkloadKey) == ev.SourceWorkloadKey:
 			// Same workload, earlier attempt: a report of the run that
 			// attempt made, arriving after a requeue opened this one in
 			// its place. The open attempt has started nothing, and
@@ -668,13 +669,13 @@ func (s *Controller) announce(b *binding) {
 		return
 	}
 	b.lastAdvertised = credit
-	parallelism, rows := s.alloc.PoolReport(b.tier.ID)
+	parallelism, rows := s.alloc.PoolReport(assignment.TierID(b.tier.ID))
 	total := 0
 	for _, r := range rows {
 		total += r.Advertised
 	}
 	s.log.Info("advertised capacity changed", "binding", b.key, "advertised", credit,
 		"tier", b.tier.ID, "tier_parallelism", parallelism, "tier_advertised", total,
-		"discovery", s.alloc.DiscoveryHolder(b.tier.ID), "instance_capacity", s.alloc.CapacityReport(),
+		"discovery", s.alloc.DiscoveryHolder(assignment.TierID(b.tier.ID)), "instance_capacity", s.alloc.CapacityReport(),
 		"credits", rows)
 }

--- a/internal/app/durability_test.go
+++ b/internal/app/durability_test.go
@@ -73,7 +73,7 @@ func TestFailedAndQuarantinedLeasesReachReleased(t *testing.T) {
 			if err := h.deliver(demand("probe-"+string(from), "app", 44)); err != nil {
 				t.Fatal(err)
 			}
-			lease, _ := leaseFor(t, h, "probe-"+string(from))
+			lease, _ := leaseFor(t, h, assignment.SourceWorkloadKey("probe-"+string(from)))
 			driveLeaseTo(t, h, lease.ID, from)
 
 			h.resolveWithoutRuntime(t.Context(), lease)
@@ -86,7 +86,7 @@ func TestFailedAndQuarantinedLeasesReachReleased(t *testing.T) {
 	}
 }
 
-func reloadLease(t *testing.T, h *harness, leaseID string) store.Lease {
+func reloadLease(t *testing.T, h *harness, leaseID assignment.LeaseID) store.Lease {
 	t.Helper()
 	var lease store.Lease
 	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -124,18 +124,18 @@ func (f *fakeWaiter) TailLogs(context.Context, string, int) (string, error) {
 
 // runFaulted claims one attempt and drives runCapsule synchronously
 // against the given fakes.
-func runFaulted(t *testing.T, h *harness, caps *fakeCapsule, reg *fakeRegistry, wait *fakeWaiter, workload string) (store.Lease, string) {
+func runFaulted(t *testing.T, h *harness, caps *fakeCapsule, reg *fakeRegistry, wait *fakeWaiter, workload assignment.SourceWorkloadKey) (store.Lease, string) {
 	t.Helper()
 	h.srv.caps = caps
 	h.srv.wait = wait
 	h.bind.gh = reg
-	if err := h.deliver(demand(workload, "app", 60)); err != nil {
+	if err := h.deliver(demand(string(workload), "app", 60)); err != nil {
 		t.Fatal(err)
 	}
 	lease, attemptID := leaseFor(t, h, workload)
 	h.srv.wg.Add(1)
 	h.srv.runCapsule(h.bind, lease)
-	return lease, attemptID
+	return lease, string(attemptID)
 }
 
 func TestStartFaultMatrix(t *testing.T) {
@@ -221,7 +221,7 @@ func TestStartFaultMatrix(t *testing.T) {
 			h := newHarness(t, 1)
 			lease, attemptID := runFaulted(t, h, tc.caps, tc.reg, tc.wait, "job-fault")
 
-			got := attemptState(t, h, attemptID)
+			got := attemptState(t, h, assignment.AttemptID(attemptID))
 			if got.State != tc.want {
 				t.Errorf("attempt = %s; want %s", got.State, tc.want)
 			}
@@ -264,19 +264,19 @@ func TestOperatorResolvesHeldAttempts(t *testing.T) {
 			_, attemptID := runFaulted(t, h,
 				&fakeCapsule{startErr: boom, obs: assignment.ObservedAbsent},
 				&fakeRegistry{}, &fakeWaiter{}, "job-held")
-			if got := attemptState(t, h, attemptID); got.State != "manual_review" {
+			if got := attemptState(t, h, assignment.AttemptID(attemptID)); got.State != "manual_review" {
 				t.Fatalf("attempt = %s; want manual_review", got.State)
 			}
 
 			h.inStore(func(s *store.Tx) error {
 				if decision == "retry" {
-					return s.ResolveReviewToReady(attemptID, "provider shows the job never started", "matias")
+					return s.ResolveReviewToReady(assignment.AttemptID(attemptID), "provider shows the job never started", "matias")
 				}
-				return s.ResolveReviewToSettled(attemptID, assignment.ResolutionMayHaveExecuted,
+				return s.ResolveReviewToSettled(assignment.AttemptID(attemptID), assignment.ResolutionMayHaveExecuted,
 					"cannot rule out execution", "matias")
 			})
 
-			got := attemptState(t, h, attemptID)
+			got := attemptState(t, h, assignment.AttemptID(attemptID))
 			switch decision {
 			case "retry":
 				if got.State != "ready" {
@@ -297,7 +297,7 @@ func TestOperatorResolvesHeldAttempts(t *testing.T) {
 			// audit reads them back.
 			var sawResolution bool
 			h.inStore(func(s *store.Tx) error {
-				events, err := s.Events(attemptID)
+				events, err := s.Events(assignment.AttemptID(attemptID))
 				if err != nil {
 					return err
 				}
@@ -327,13 +327,13 @@ func (f *faultyRemover) fail() error {
 	}
 	return errors.New("daemon wedged")
 }
-func (f *faultyRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+func (f *faultyRemover) RemoveOwnedContainer(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return f.fail()
 }
-func (f *faultyRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+func (f *faultyRemover) RemoveOwnedNetwork(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return f.fail()
 }
-func (f *faultyRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+func (f *faultyRemover) RemoveOwnedVolume(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return f.fail()
 }
 
@@ -601,13 +601,13 @@ func TestARedeliveryNeverSupersedesItsOwnAttempts(t *testing.T) {
 	if len(ready) != 2 {
 		var got []string
 		for _, a := range ready {
-			got = append(got, a.SourceWorkloadKey)
+			got = append(got, string(a.SourceWorkloadKey))
 		}
 		t.Fatalf("servable workloads = %v; want both job-a and job-b under the new delivery", got)
 	}
 	seen := map[string]bool{}
 	for _, a := range ready {
-		seen[a.SourceWorkloadKey] = true
+		seen[string(a.SourceWorkloadKey)] = true
 	}
 	if !seen["job-a"] || !seen["job-b"] {
 		t.Errorf("servable workloads = %v; want both", seen)
@@ -693,13 +693,13 @@ func (blockingRemover) block(ctx context.Context) error {
 	<-ctx.Done()
 	return ctx.Err()
 }
-func (b blockingRemover) RemoveOwnedContainer(ctx context.Context, _, _, _ string) error {
+func (b blockingRemover) RemoveOwnedContainer(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
 	return b.block(ctx)
 }
-func (b blockingRemover) RemoveOwnedNetwork(ctx context.Context, _, _, _ string) error {
+func (b blockingRemover) RemoveOwnedNetwork(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
 	return b.block(ctx)
 }
-func (b blockingRemover) RemoveOwnedVolume(ctx context.Context, _, _, _ string) error {
+func (b blockingRemover) RemoveOwnedVolume(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
 	return b.block(ctx)
 }
 

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rhobuild/runpool/internal/disk"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // The disk monitor measures once a minute. Pressure moves at the speed
@@ -24,8 +26,8 @@ const monitorInterval = time.Minute
 // because that is what lets a test present a filesystem with no room
 // left — the one state the daemon cannot be asked to be in.
 type diskProbe interface {
-	ProbeFilesystemFree(ctx context.Context, image, instanceID string) (docker.FilesystemFree, error)
-	OwnedVolumeUsage(ctx context.Context, instanceID string) ([]docker.VolumeUsage, error)
+	ProbeFilesystemFree(ctx context.Context, image string, instanceID assignment.InstanceID) (docker.FilesystemFree, error)
+	OwnedVolumeUsage(ctx context.Context, instanceID assignment.InstanceID) ([]docker.VolumeUsage, error)
 }
 
 // admissionGate is the half of the credit pool a verdict acts on.

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -76,7 +76,7 @@ func (s *Controller) reconcile(ctx context.Context) error {
 
 	adopted := make(map[string]bool)
 	for _, lease := range live {
-		b := s.byBinding[lease.BindingID] // may be nil if the target was removed
+		b := s.byBinding[int64(lease.BindingID)] // may be nil if the target was removed
 		// Adoption means "this lease is still executing; wait it out".
 		// A lease already past draining is not executing — it is being
 		// unwound, and adopting it would run WalkToRunning and then a
@@ -84,11 +84,11 @@ func (s *Controller) reconcile(ctx context.Context) error {
 		// returns before any cleanup. The lease would then hold its credit
 		// and its privileged container forever, because being marked
 		// adopted also exempts it from the orphan sweep.
-		if runner, ok := runnerByLease[lease.ID]; ok && runner.Running && b != nil && adoptable(lease.State) {
+		if runner, ok := runnerByLease[string(lease.ID)]; ok && runner.Running && b != nil && adoptable(lease.State) {
 			s.log.Info("adopting running capsule", "binding", b.key, "lease", lease.ID)
 			s.reportAdoption(b, s.alloc.Adopt(b.key))
 			s.adopt(b, lease, runner.ID)
-			adopted[lease.ID] = true
+			adopted[string(lease.ID)] = true
 			continue
 		}
 		// Every nonterminal lease holds a credit until it is resolved, even
@@ -99,7 +99,7 @@ func (s *Controller) reconcile(ctx context.Context) error {
 			s.reportAdoption(b, s.alloc.Adopt(b.key))
 			defer s.releaseCreditIfDone(b, lease.ID)
 		}
-		runner, hasRunner := runnerByLease[lease.ID]
+		runner, hasRunner := runnerByLease[string(lease.ID)]
 		s.resolveInterrupted(ctx, b, lease, runner, hasRunner)
 	}
 
@@ -170,7 +170,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	obs := assignment.ObservedAbsent
 	if evidence == store.EvidenceStartAuthorized && hasRunner {
 		var err error
-		obs, err = s.caps.InspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: runner.ID})
+		obs, err = s.caps.InspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: assignment.RuntimeID(runner.ID)})
 		if err != nil {
 			log.Error("cannot observe the runtime of an ambiguous start", "error", err)
 		}
@@ -474,7 +474,7 @@ func (s *Controller) sweepPeriodically(ctx context.Context) {
 	}
 	keep := make(map[string]bool, len(live))
 	for _, lease := range live {
-		keep[lease.ID] = true
+		keep[string(lease.ID)] = true
 	}
 	if err := s.sweepOrphans(ctx, keep); err != nil {
 		s.log.Error("periodic sweep failed", "error", err)
@@ -543,7 +543,7 @@ func (s *Controller) resolveStranded(ctx context.Context, lease store.Lease, ret
 		return // its backoff has not elapsed; let it breathe
 	}
 	*retried++
-	b := s.byBinding[lease.BindingID] // may be nil if the target was removed
+	b := s.byBinding[int64(lease.BindingID)] // may be nil if the target was removed
 	if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
 		s.log.Warn("stranded lease still unresolved",
 			"lease", lease.ID, "state", string(lease.State), "error", err)

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -60,7 +60,7 @@ func TestRecoveryMatrix(t *testing.T) {
 				if err := h.deliver(demand(workload, "app", 2)); err != nil {
 					t.Fatal(err)
 				}
-				lease, attemptID := leaseFor(t, h, workload)
+				lease, attemptID := leaseFor(t, h, assignment.SourceWorkloadKey(workload))
 				driveLeaseTo(t, h, lease.ID, from)
 				h.recordEvidence(lease.ID, evidence)
 

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -253,11 +253,11 @@ func TestRecordEvidenceClassifiesEveryOutcome(t *testing.T) {
 
 	record := func(id string, e store.Evidence) error {
 		return h.store.Tx(t.Context(), func(tx *store.Tx) error {
-			return tx.RecordEvidenceForLease(id, e)
+			return tx.RecordEvidenceForLease(assignment.LeaseID(id), e)
 		})
 	}
 
-	if err := record(lease.ID, store.Evidence("definitely-not-a-value")); !errors.Is(err, store.ErrInvalidExecutionObservation) {
+	if err := record(string(lease.ID), store.Evidence("definitely-not-a-value")); !errors.Is(err, store.ErrInvalidExecutionObservation) {
 		t.Errorf("an unknown value returned %v; want ErrInvalidExecutionObservation — "+
 			"a silent no-op tells the caller something was recorded when nothing was", err)
 	}
@@ -265,15 +265,15 @@ func TestRecordEvidenceClassifiesEveryOutcome(t *testing.T) {
 		t.Error("recording against a missing lease succeeded; the target's absence was swallowed")
 	}
 
-	if err := record(lease.ID, store.EvidenceRunningObserved); err != nil {
+	if err := record(string(lease.ID), store.EvidenceRunningObserved); err != nil {
 		t.Fatalf("recording a running observation: %v", err)
 	}
 	// Re-observing the same fact is not a fault.
-	if err := record(lease.ID, store.EvidenceRunningObserved); err != nil {
+	if err := record(string(lease.ID), store.EvidenceRunningObserved); err != nil {
 		t.Errorf("repeating an identical observation returned %v; want explicit idempotent success", err)
 	}
 	// A slower writer cannot unmake an observation.
-	if err := record(lease.ID, store.EvidenceRuntimePrepared); !errors.Is(err, store.ErrObservationConflict) {
+	if err := record(string(lease.ID), store.EvidenceRuntimePrepared); !errors.Is(err, store.ErrObservationConflict) {
 		t.Errorf("a backwards write returned %v; want ErrObservationConflict — a runner "+
 			"that was seen running cannot become one that never started", err)
 	}
@@ -355,10 +355,10 @@ func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
 		t.Fatal(err)
 	}
 	h.inStore(func(tx *store.Tx) error {
-		if _, err := tx.AckRequested(delivery); err != nil {
+		if _, err := tx.AckRequested(assignment.DeliveryID(delivery)); err != nil {
 			return err
 		}
-		return tx.AckConfirmed(delivery)
+		return tx.AckConfirmed(assignment.DeliveryID(delivery))
 	})
 
 	// The broker sends it again, now carrying the cancellation. One full
@@ -398,7 +398,7 @@ func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
 			return err
 		}
 		// Settled, then: fetch it through its delivery.
-		attempts, aerr := tx.AttemptsOfDelivery(delivery)
+		attempts, aerr := tx.AttemptsOfDelivery(assignment.DeliveryID(delivery))
 		if aerr != nil {
 			return aerr
 		}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -35,11 +35,11 @@ func (s *Controller) createLease(ctx context.Context, b *binding, attempt store.
 // walk is what an operator watches, while disposition rests on evidence
 // and the terminal transitions, so a conflict is logged rather than
 // fatal.
-func (s *Controller) advanceAttempt(ctx context.Context, attemptID, from, to string) {
+func (s *Controller) advanceAttempt(ctx context.Context, attemptID assignment.AttemptID, from, to string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		return tx.Advance(attemptID, from, to)
+		return tx.Advance(assignment.AttemptID(attemptID), from, to)
 	}); err != nil {
 		s.log.Warn("attempt did not advance", "attempt", attemptID,
 			"from", from, "to", to, "error", err)
@@ -92,7 +92,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 
-	runnerName := "runpool-" + docker.ShortID(lease.ID)
+	runnerName := "runpool-" + docker.ShortID(string(lease.ID))
 	jit, err := b.gh.GenerateJITConfig(prepCtx, b.scaleSetID, runnerName, workFolder)
 	if err != nil {
 		log.Error("jit generation failed", "error", err)
@@ -103,7 +103,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// GitHub assigned is the adapter's, and lands in the attempt's
 	// metadata table where deregistration reads it back.
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		if err := tx.SetLeaseRuntimeName(lease.ID, jit.RunnerName); err != nil {
+		if err := tx.SetLeaseRuntimeName(lease.ID, assignment.RuntimeName(jit.RunnerName)); err != nil {
 			return err
 		}
 		if err := tx.RecordGitHubRunnerID(attemptID, int64(jit.RunnerID)); err != nil {
@@ -145,8 +145,8 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		LeaseID:      lease.ID,
 		InstanceID:   s.store.InstanceID(),
 		AttemptID:    attemptID,
-		TargetID:     b.target.ID,
-		TierID:       b.tier.ID,
+		TargetID:     assignment.TargetID(b.target.ID),
+		TierID:       assignment.TierID(b.tier.ID),
 		CapsuleImage: b.capsuleImage,
 		JITConfig:    jit.Encoded,
 		Resources:    b.tier.Resources,
@@ -250,7 +250,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 	runnerContainer := prepared.RuntimeID
-	log.Info("capsule running", "runner", jit.RunnerName, "container", docker.ShortID(runnerContainer))
+	log.Info("capsule running", "runner", jit.RunnerName, "container", docker.ShortID(string(runnerContainer)))
 
 	// From here the tier's ceiling governs, and only here: this is the
 	// wait for work the provider owns, and the ceiling is the backstop
@@ -259,7 +259,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// budget, so a restart neither extends nor restarts it.
 	waitCtx, cancelWait := context.WithTimeout(ctx, remainingCeiling(b.tier, lease.CreatedAt))
 	defer cancelWait()
-	exit, err := s.wait.WaitExit(waitCtx, runnerContainer)
+	exit, err := s.wait.WaitExit(waitCtx, string(runnerContainer))
 	if err == nil {
 		// What the status proves, not that the wait returned. The
 		// supervisor reserves one code for "the runner never owned the
@@ -291,7 +291,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		return
 	}
 	if exit != 0 {
-		tail, _ := s.wait.TailLogs(ctx, runnerContainer, 40)
+		tail, _ := s.wait.TailLogs(ctx, string(runnerContainer), 40)
 		log.Warn("runner exited non-zero", "exit", exit, "log_tail", tail)
 	} else {
 		log.Info("runner exited cleanly")
@@ -307,7 +307,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 // releaseCreditIfDone returns the binding's admission credit only when the lease has
 // reached its terminal state. A quarantined or otherwise stuck lease
 // keeps consuming capacity until reconciliation or cleanup resolves it.
-func (s *Controller) releaseCreditIfDone(b *binding, leaseID string) {
+func (s *Controller) releaseCreditIfDone(b *binding, leaseID assignment.LeaseID) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	var lease store.Lease
@@ -349,14 +349,14 @@ func (s *Controller) releaseCreditIfDone(b *binding, leaseID string) {
 // by definition — the next pass, or the next start, finds the lease
 // exactly where this left it — and a recovery that outlived the
 // shutdown budget would have the platform kill the process inside one.
-func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leaseID string,
+func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leaseID assignment.LeaseID,
 	startObs assignment.ExecutionObservation) error {
 
 	ctx, cancel := context.WithTimeout(ctx, recoveryBudget)
 	defer cancel()
 	bindingKey := "(unconfigured)"
 	if b != nil {
-		bindingKey = b.key
+		bindingKey = string(b.key)
 	}
 	log := s.log.With("binding", bindingKey, "lease", leaseID)
 

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -16,6 +16,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/egress"
 	"github.com/rhobuild/runpool/internal/platform/docker"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // sandboxNetworks is what computing an egress policy needs from the
@@ -31,7 +33,7 @@ type sandboxNetworks interface {
 // sandboxGateways is what installing one needs: find the gateways, hand
 // each the new sets, and remove the ones that will not take them.
 type sandboxGateways interface {
-	ListOwnedContainers(ctx context.Context, instanceID string) ([]docker.OwnedContainer, error)
+	ListOwnedContainers(ctx context.Context, instanceID assignment.InstanceID) ([]docker.OwnedContainer, error)
 	Exec(ctx context.Context, id string, cmd []string) (int, string, error)
 	ExecWithInput(ctx context.Context, id string, cmd []string, input []byte) (int, string, error)
 	RemoveContainer(ctx context.Context, id string) error
@@ -93,7 +95,7 @@ func cloneSandbox(in *capsule.Sandbox) *capsule.Sandbox {
 type networkSandbox struct {
 	log        *slog.Logger
 	daemon     sandboxDaemon
-	instanceID string
+	instanceID assignment.InstanceID
 	probeImage string
 	// allow and denies are the operator's own two lists, read once. They
 	// extend the discovered set rather than replacing anything in it, and
@@ -108,10 +110,11 @@ type networkSandbox struct {
 // newNetworkSandbox assembles the initial policy and fails closed. Any
 // gap in the deny set is a hole in every capsule's egress, so serve does
 // not start without a complete one.
-func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon, instanceID, probeImage string,
+func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
+	instanceID assignment.InstanceID, probeImage string,
 	cfg *config.Config, log *slog.Logger) (*networkSandbox, error) {
 	n := &networkSandbox{
-		log: log, daemon: daemon, instanceID: instanceID, probeImage: probeImage,
+		log: log, daemon: daemon, instanceID: assignment.InstanceID(instanceID), probeImage: probeImage,
 	}
 	for _, c := range cfg.Network.AllowPrivateCIDRs {
 		n.allow = append(n.allow, c.String())
@@ -136,10 +139,10 @@ func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon, instanceID, pr
 // the uplink itself.
 func (n *networkSandbox) build(ctx context.Context) (*capsule.Sandbox, error) {
 	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, docker.NetworkSpec{
-		Name: "runpool-uplink-" + n.instanceID[:8],
+		Name: "runpool-uplink-" + string(n.instanceID)[:8],
 		Labels: map[string]string{
 			docker.LabelManaged:  "true",
-			docker.LabelInstance: n.instanceID,
+			docker.LabelInstance: string(n.instanceID),
 			docker.LabelRole:     capsule.RoleUplink,
 		},
 	})
@@ -472,14 +475,14 @@ func (n *networkSandbox) discoverHostCIDRs(ctx context.Context) ([]string, error
 		return nil, err
 	}
 	code, out, err := n.daemon.RunTask(ctx, docker.ContainerSpec{
-		Name:        "runpool-" + n.instanceID[:8] + "-hostnet-probe-" + hex.EncodeToString(nonce),
+		Name:        "runpool-" + string(n.instanceID)[:8] + "-hostnet-probe-" + hex.EncodeToString(nonce),
 		Image:       n.probeImage,
 		Entrypoint:  []string{"/bin/sh", "-c"},
 		Cmd:         []string{"ip -o -4 addr show scope global"},
 		NetworkMode: "host",
 		Labels: map[string]string{
 			docker.LabelManaged:  "true",
-			docker.LabelInstance: n.instanceID,
+			docker.LabelInstance: string(n.instanceID),
 			docker.LabelRole:     "probe",
 		},
 	})

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/docker"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 func TestSandboxStateSnapshotsAreIndependent(t *testing.T) {
@@ -113,7 +115,7 @@ func (f *fakeSandboxDaemon) AllNetworkSubnets(context.Context) ([]string, error)
 func (f *fakeSandboxDaemon) RunTask(context.Context, docker.ContainerSpec) (int64, string, error) {
 	return 0, f.probeOut, f.probeErr
 }
-func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, string) ([]docker.OwnedContainer, error) {
+func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error) {
 	if f.listErr != nil {
 		return nil, f.listErr
 	}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -112,7 +112,7 @@ type Options struct {
 // delivery and attempt identity live in the store, and claiming an
 // attempt is a compare-and-swap only one caller can win.
 type binding struct {
-	key    string
+	key    assignment.BindingKey
 	target config.Target
 	tier   config.Tier
 	ref    config.TargetRef
@@ -153,7 +153,7 @@ type binding struct {
 	// broker expires a session on is not, and only elapsed time tells the
 	// two apart. Owned by the binding's own loop.
 	conflictSince time.Time
-	bindingID     int64
+	bindingID     assignment.BindingID
 	cacheEnabled  bool
 	generation    string
 	// capsuleImage is what this binding launches: its tier's image where
@@ -324,7 +324,7 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 	owner := "runpool-" + st.InstanceID()[:8]
 	for _, b := range s.bindings {
 		b.newSession = func(ctx context.Context) (providerSession, error) {
-			return b.gh.OpenSession(ctx, b.scaleSetID, owner)
+			return b.gh.OpenSession(ctx, b.scaleSetID, string(owner))
 		}
 	}
 	// A session the broker still holds is one the next start has to wait
@@ -425,9 +425,9 @@ type providerSession interface {
 // this interface rather than the client itself, the whole startup and
 // sweep path becomes reachable from a test.
 type ownedObjects interface {
-	ListOwnedContainers(ctx context.Context, instanceID string) ([]docker.OwnedContainer, error)
-	ListOwnedNetworks(ctx context.Context, instanceID string) ([]docker.OwnedResource, error)
-	ListOwnedVolumes(ctx context.Context, instanceID string) ([]docker.OwnedResource, error)
+	ListOwnedContainers(ctx context.Context, instanceID assignment.InstanceID) ([]docker.OwnedContainer, error)
+	ListOwnedNetworks(ctx context.Context, instanceID assignment.InstanceID) ([]docker.OwnedResource, error)
+	ListOwnedVolumes(ctx context.Context, instanceID assignment.InstanceID) ([]docker.OwnedResource, error)
 	RemoveContainer(ctx context.Context, id string) error
 	RemoveNetwork(ctx context.Context, id string) error
 	RemoveVolume(ctx context.Context, name string) error
@@ -470,7 +470,14 @@ type Controller struct {
 	// are stranded — nobody's — and which are simply being worked on, and
 	// it is the mutual exclusion that keeps two owners from releasing the
 	// same admission credit twice.
-	inFlight sync.Map
+	//
+	// A typed map under a mutex rather than a sync.Map: a sync.Map keys on
+	// `any`, so a caller passing a plain string where the id type is
+	// meant compiles, misses every entry, and hands two owners the same
+	// lease. The type checker covers the key here, and the map is only
+	// ever as large as the live leases, so the lock is uncontended.
+	inFlightMu sync.Mutex
+	inFlight   map[assignment.LeaseID]struct{}
 
 	// disk owns the pressure level and everything that moves it. The
 	// controller reads the level in force on the admission path and does
@@ -583,9 +590,21 @@ func (s *Controller) closeSessions() {
 // another goroutine already holds it, which is what keeps the periodic
 // reconciler off a lease that is still being driven — and keeps two owners
 // from each concluding the lease is done and releasing its credit.
-func (s *Controller) claimLease(leaseID string) bool {
-	_, loaded := s.inFlight.LoadOrStore(leaseID, struct{}{})
-	return !loaded
+func (s *Controller) claimLease(leaseID assignment.LeaseID) bool {
+	s.inFlightMu.Lock()
+	defer s.inFlightMu.Unlock()
+	if _, held := s.inFlight[leaseID]; held {
+		return false
+	}
+	if s.inFlight == nil {
+		s.inFlight = map[assignment.LeaseID]struct{}{}
+	}
+	s.inFlight[leaseID] = struct{}{}
+	return true
 }
 
-func (s *Controller) releaseLease(leaseID string) { s.inFlight.Delete(leaseID) }
+func (s *Controller) releaseLease(leaseID assignment.LeaseID) {
+	s.inFlightMu.Lock()
+	defer s.inFlightMu.Unlock()
+	delete(s.inFlight, leaseID)
+}

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // stubSession is a message session a test can break on purpose. The
@@ -323,7 +325,7 @@ func TestAReopenedSessionPublishesItsBacklog(t *testing.T) {
 	// at zero demand it is left with the discovery credit, which this
 	// one's demand of 1 matches.
 	const rival = "other/standard"
-	if err := h.srv.alloc.Register(h.bind.tier.ID, rival, 4); err != nil {
+	if err := h.srv.alloc.Register(assignment.TierID(h.bind.tier.ID), rival, 4); err != nil {
 		t.Fatal(err)
 	}
 	h.srv.alloc.SetAssignedDemand(rival, 1)

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // gatedSession reports when its Close begins and then holds until the
@@ -48,10 +50,10 @@ func TestSessionsCloseTogether(t *testing.T) {
 	defer close(release)
 
 	s := &Controller{log: slog.New(slog.NewTextHandler(io.Discard, nil))}
-	for _, key := range []string{"a", "b", "c"} {
+	for _, key := range []assignment.BindingKey{"a", "b", "c"} {
 		s.bindings = append(s.bindings, &binding{
 			key:     key,
-			session: &gatedSession{started: started, release: release, key: key},
+			session: &gatedSession{started: started, release: release, key: string(key)},
 		})
 	}
 	// A binding whose loop never opened a session has nothing to close;
@@ -82,15 +84,15 @@ func TestSessionsCloseTogether(t *testing.T) {
 // mutation half needs to see some.
 type countingRemover struct{ calls atomic.Int64 }
 
-func (c *countingRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+func (c *countingRemover) RemoveOwnedContainer(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	c.calls.Add(1)
 	return nil
 }
-func (c *countingRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+func (c *countingRemover) RemoveOwnedNetwork(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	c.calls.Add(1)
 	return nil
 }
-func (c *countingRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+func (c *countingRemover) RemoveOwnedVolume(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	c.calls.Add(1)
 	return nil
 }

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -32,7 +32,7 @@ func TestReconcileAdoptsWhatIsStillRunning(t *testing.T) {
 	}
 
 	h.objects.containers = []docker.OwnedContainer{
-		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: alive.ID, Running: true},
+		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: string(alive.ID), Running: true},
 	}
 	h.srv.caps = &fakeCapsule{obs: assignment.ObservedAbsent}
 	h.srv.wait = &fakeWaiter{}
@@ -83,7 +83,7 @@ func TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn(t *testing.T) {
 	}
 	live, _ := leaseFor(t, h, "job-1")
 	h.objects.containers = []docker.OwnedContainer{
-		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: live.ID, Running: true},
+		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: string(live.ID), Running: true},
 		{ID: "runner-orphan", Role: capsule.RoleCapsule, LeaseID: "lse-vanished"},
 	}
 

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -125,7 +125,7 @@ type WorkloadLifecycleEvent struct {
 	ProjectKey        string
 	// RuntimeName and RuntimeID identify the provider-side runtime the
 	// observation names, opaque to the domain.
-	RuntimeName string
+	RuntimeName RuntimeName
 	RuntimeID   int64
 	// Result is the provider's stated outcome, populated on completed
 	// observations only.

--- a/internal/assignment/ids.go
+++ b/internal/assignment/ids.go
@@ -1,0 +1,62 @@
+package assignment
+
+// The identifiers the control plane keys on.
+//
+// They are distinct types because every one of them is a string or an
+// integer, and a function taking four of those accepts them in any
+// order. Nothing here changes what is stored or what travels: the point
+// is that a swap stops compiling, in signatures where it previously
+// produced a query that matched nothing and reported an empty result
+// rather than an error.
+//
+// They live in this package because it is the vocabulary both sides of
+// the control plane already share — the store writes these values and
+// the app reads them, and neither should have to import the other to
+// name one. `ExecutionObservation` is here for exactly that reason.
+//
+// No String methods. `%s` and slog already render a named string type,
+// and adding one invites `.String()` at call sites where a conversion is
+// what the reader needs to see.
+type (
+	// AttemptID identifies one attempt to serve a workload. It outlives
+	// the lease serving it: disposition happens after release.
+	AttemptID string
+	// LeaseID identifies the host resources one attempt consumes. It
+	// travels beside AttemptID through the disposition paths, which is
+	// where confusing the two costs the most.
+	LeaseID string
+	// BindingID is a binding's row id, the local key every delivery,
+	// attempt and lease hangs off.
+	BindingID int64
+	// DeliveryID is one provider message made durable.
+	DeliveryID int64
+	// InstanceID identifies this controller among any sharing a daemon.
+	// It is the ownership boundary every sweep respects.
+	InstanceID string
+	// TargetID is the operator's name for a place work arrives from.
+	TargetID string
+	// TierID is the operator's name for one envelope of resources.
+	TierID string
+	// SourceWorkloadKey is the provider's identity for a workload,
+	// opaque here.
+	SourceWorkloadKey string
+	// SourceBindingKey is a binding's durable identity — the value the
+	// binding row is keyed by. It survives the process.
+	SourceBindingKey string
+	// BindingKey is a binding's in-memory name, derived from
+	// configuration on every start and never written down. It is used
+	// for allocator accounting and log correlation.
+	//
+	// It and SourceBindingKey have shared one English name for long
+	// enough that separating them is half the reason this file exists:
+	// one keys rows that outlive the process, the other keys a map that
+	// does not.
+	BindingKey string
+	// RuntimeID is the daemon's id for a container.
+	RuntimeID string
+	// RuntimeName is the name a runtime was created under, which is the
+	// handle a late provider report correlates by.
+	RuntimeName string
+	// ResourceIntentID is one planned Docker object's row id.
+	ResourceIntentID int64
+)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Volume labels a cache lane carries, alongside the instance ownership
@@ -51,20 +53,21 @@ type LaneMount struct {
 // measure what this instance's volumes weigh, for the GC planner.
 type laneVolumes interface {
 	EnsureOwnedVolume(ctx context.Context, name string, labels map[string]string) error
-	OwnedIDByName(ctx context.Context, kind, name, instanceID, leaseID string) (string, error)
+	OwnedIDByName(ctx context.Context, kind, name string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error)
 	RemoveVolume(ctx context.Context, name string) error
-	OwnedVolumeUsage(ctx context.Context, instanceID string) ([]docker.VolumeUsage, error)
+	OwnedVolumeUsage(ctx context.Context, instanceID assignment.InstanceID) ([]docker.VolumeUsage, error)
 }
 
 type LaneManager struct {
 	store      *store.Store
 	volumes    laneVolumes
-	instanceID string
+	instanceID assignment.InstanceID
 }
 
 // New returns a cache manager. It touches no filesystem: lanes are
 // daemon-side volumes, and the store carries their exclusivity.
-func New(st *store.Store, volumes laneVolumes, instanceID string) *LaneManager {
+func New(st *store.Store, volumes laneVolumes, instanceID assignment.InstanceID) *LaneManager {
 	return &LaneManager{store: st, volumes: volumes, instanceID: instanceID}
 }
 
@@ -75,7 +78,8 @@ func VolumeName(laneID string) string { return volumePrefix + laneID }
 // volume exists. It returns ok=false with no error when the pool is
 // momentarily exhausted; the job then runs without a cache rather than
 // corrupting a shared one.
-func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation, leaseID string, maxLanes int) (LaneMount, bool, error) {
+func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation string,
+	leaseID assignment.LeaseID, maxLanes int) (LaneMount, bool, error) {
 	var lane store.CacheLane
 	err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		projectID, err := tx.EnsureCacheProject(sourceProjectKey)
@@ -95,7 +99,7 @@ func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation,
 	name := VolumeName(lane.ID)
 	labels := map[string]string{
 		docker.LabelManaged:  "true",
-		docker.LabelInstance: m.instanceID,
+		docker.LabelInstance: string(m.instanceID),
 		docker.LabelRole:     labelRoleValue,
 		LabelProject:         lane.ProjectID,
 		LabelGen:             lane.Generation,

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // fakeVolumes stands in for the daemon: it remembers what was ensured
@@ -33,7 +35,7 @@ func (f *fakeVolumes) EnsureOwnedVolume(_ context.Context, name string, labels m
 	return nil
 }
 
-func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind, name, instanceID, leaseID string) (string, error) {
+func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	if f.foreign {
 		return "", docker.ErrForeignResource
 	}
@@ -51,7 +53,7 @@ func (f *fakeVolumes) RemoveVolume(_ context.Context, name string) error {
 
 // sizes lets a GC test weigh volumes; unset names report unknown (-1),
 // like a daemon that could not compute a size.
-func (f *fakeVolumes) OwnedVolumeUsage(context.Context, string) ([]docker.VolumeUsage, error) {
+func (f *fakeVolumes) OwnedVolumeUsage(context.Context, assignment.InstanceID) ([]docker.VolumeUsage, error) {
 	var out []docker.VolumeUsage
 	for name, labels := range f.ensured {
 		size := int64(-1)
@@ -81,10 +83,10 @@ const repoURL = "https://github.com/acme/app"
 // release frees a lease's lane the way production does: inside a store
 // transaction, where the finalizing commit runs it alongside the lease's
 // own release.
-func release(t *testing.T, st *store.Store, leaseID string) error {
+func release(t *testing.T, st *store.Store, leaseID assignment.LeaseID) error {
 	t.Helper()
 	return st.Tx(t.Context(), func(tx *store.Tx) error {
-		return tx.ReleaseCacheLane(leaseID)
+		return tx.ReleaseCacheLane(assignment.LeaseID(leaseID))
 	})
 }
 

--- a/internal/cache/gc_test.go
+++ b/internal/cache/gc_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // gcFixture builds lanes with controlled ages and sizes. Ages are set
@@ -17,7 +19,7 @@ func gcFixture(t *testing.T) (*LaneManager, *store.Store, *fakeVolumes) {
 
 func addLane(t *testing.T, m *LaneManager, st *store.Store, vols *fakeVolumes, repo, gen, lease string, ageDays int, size int64) LaneMount {
 	t.Helper()
-	loc, ok, err := m.Acquire(t.Context(), repo, gen, lease, 10)
+	loc, ok, err := m.Acquire(t.Context(), repo, gen, assignment.LeaseID(lease), 10)
 	if err != nil || !ok {
 		t.Fatalf("acquire: ok=%v, %v", ok, err)
 	}
@@ -26,7 +28,7 @@ func addLane(t *testing.T, m *LaneManager, st *store.Store, vols *fakeVolumes, r
 		if err := tx.BackdateCacheLane(loc.LaneID, time.Duration(ageDays)*day); err != nil {
 			return err
 		}
-		return tx.ReleaseCacheLane(lease)
+		return tx.ReleaseCacheLane(assignment.LeaseID(lease))
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -27,6 +27,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/egress"
 	"github.com/rhobuild/runpool/internal/platform/docker"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 const (
@@ -93,14 +95,14 @@ const (
 )
 
 type Spec struct {
-	LeaseID    string
-	InstanceID string
+	LeaseID    assignment.LeaseID
+	InstanceID assignment.InstanceID
 	// AttemptID, TargetID and TierID are provider-neutral correlation
 	// labels. They make ephemeral resources intelligible in a shared
 	// daemon's container view without exposing credentials or source URLs.
-	AttemptID string
-	TargetID  string
-	TierID    string
+	AttemptID assignment.AttemptID
+	TargetID  assignment.TargetID
+	TierID    assignment.TierID
 	// CapsuleImage is the first-party outer image: supervisor, runner
 	// and engine in one filesystem.
 	CapsuleImage string
@@ -156,9 +158,9 @@ const CachePath = "/cache"
 // the object or proves its absence, which is why no compensation logic
 // lives here anymore: the record cannot be lost, only unconfirmed.
 type ResourceRecorder interface {
-	Plan(kind, role, name string) (int64, error)
-	Creating(intentID int64) error
-	Confirm(intentID int64, dockerID string) error
+	Plan(kind, role, name string) (assignment.ResourceIntentID, error)
+	Creating(intentID assignment.ResourceIntentID) error
+	Confirm(intentID assignment.ResourceIntentID, dockerID string) error
 }
 
 // create wraps one object creation in its intent lifecycle. When the
@@ -223,7 +225,7 @@ type PreparedRuntime struct {
 	// RuntimeID is the outer container: the one object whose state —
 	// and whose supervisor's state file — answers whether execution
 	// ever began.
-	RuntimeID string
+	RuntimeID assignment.RuntimeID
 }
 
 // Prepare builds the capsule and stops short of the one effect that can
@@ -236,7 +238,7 @@ func (m *Launcher) Prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	if err != nil {
 		return PreparedRuntime{}, err
 	}
-	return PreparedRuntime{RuntimeID: outerID}, nil
+	return PreparedRuntime{RuntimeID: assignment.RuntimeID(outerID)}, nil
 }
 
 // Start authorizes the runner. It is deliberately one exec that drops
@@ -244,7 +246,7 @@ func (m *Launcher) Prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 // the ambiguous window is exactly one request wide, and
 // InspectExecution can classify whatever a crash left behind.
 func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
-	code, out, err := m.dock.Exec(ctx, prepared.RuntimeID, []string{supervisorPath, "start"})
+	code, out, err := m.dock.Exec(ctx, string(prepared.RuntimeID), []string{supervisorPath, "start"})
 	if err != nil {
 		return err
 	}
@@ -255,18 +257,18 @@ func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
 }
 
 func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (string, error) {
-	short := docker.ShortID(spec.LeaseID)
+	short := docker.ShortID(string(spec.LeaseID))
 	name := func(role string) string { return "runpool-" + role + "-" + short }
 	labels := func(kind, role string) map[string]string {
 		return map[string]string{
 			docker.LabelManaged:  "true",
-			docker.LabelInstance: spec.InstanceID,
+			docker.LabelInstance: string(spec.InstanceID),
 			docker.LabelKind:     kind,
-			docker.LabelLease:    spec.LeaseID,
+			docker.LabelLease:    string(spec.LeaseID),
 			docker.LabelRole:     role,
-			docker.LabelAttempt:  spec.AttemptID,
-			docker.LabelTarget:   spec.TargetID,
-			docker.LabelTier:     spec.TierID,
+			docker.LabelAttempt:  string(spec.AttemptID),
+			docker.LabelTarget:   string(spec.TargetID),
+			docker.LabelTier:     string(spec.TierID),
 		}
 	}
 	resolve := func(kind, objName string) func() (string, error) {
@@ -283,7 +285,7 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 
 	// One envelope for the lease, split between the capsule and — when
 	// there is one — its gateway, and placed under one parent cgroup.
-	cgroupParent := LeaseCgroupParent(spec.CgroupDriver, spec.LeaseID)
+	cgroupParent := LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID))
 	capsuleShare := SplitEnvelope(spec.Resources, sandboxed)
 	netID, err := m.create(ctx, rec, KindNetwork, RoleNetwork, name(RoleNetwork),
 		func() (string, error) {
@@ -513,7 +515,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 				MemorySwapBytes: GatewayEnvelope().MemorySwapBytes,
 				NanoCPUs:        GatewayEnvelope().NanoCPUs,
 				PIDsLimit:       GatewayEnvelope().PIDsLimit,
-				CgroupParent:    LeaseCgroupParent(spec.CgroupDriver, spec.LeaseID),
+				CgroupParent:    LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID)),
 			})
 		}, resolve(KindContainer, name(RoleGateway)))
 	if err != nil {

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -14,7 +14,7 @@ import (
 // unknown. The result comes from the daemon and supervisor, never from the
 // controller's intended transition.
 func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntime) (assignment.ExecutionObservation, error) {
-	state, err := m.dock.ContainerStatus(ctx, prepared.RuntimeID)
+	state, err := m.dock.ContainerStatus(ctx, string(prepared.RuntimeID))
 	switch {
 	case err == nil:
 	case docker.IsNotFound(err):
@@ -22,12 +22,12 @@ func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntim
 	default:
 		return assignment.ObservedUnavailable, err
 	}
-	obs, askSupervisor, err := classifyContainerState(prepared.RuntimeID, state)
+	obs, askSupervisor, err := classifyContainerState(string(prepared.RuntimeID), state)
 	if !askSupervisor {
 		return obs, err
 	}
 
-	code, out, err := m.dock.Exec(ctx, prepared.RuntimeID, []string{supervisorPath, "state"})
+	code, out, err := m.dock.Exec(ctx, string(prepared.RuntimeID), []string{supervisorPath, "state"})
 	if err != nil || code != 0 {
 		return assignment.ObservedUnavailable, fmt.Errorf("capsule state unreadable (exit %d): %s", code, out)
 	}

--- a/internal/command/attempts.go
+++ b/internal/command/attempts.go
@@ -39,8 +39,8 @@ type attemptView struct {
 
 func viewOf(a store.Attempt, now time.Time) attemptView {
 	return attemptView{
-		ID:           a.ID,
-		Workload:     a.SourceWorkloadKey,
+		ID:           string(a.ID),
+		Workload:     string(a.SourceWorkloadKey),
 		Project:      a.TenantKey + "/" + a.ProjectKey,
 		State:        a.State,
 		ReviewReason: a.ReviewReason,
@@ -139,15 +139,15 @@ func listAttempts(s *store.Tx, stateFilter string) ([]store.Attempt, error) {
 
 func runAttemptsInspect(streams IO, id string, asJSON bool) error {
 	err := inReadOnlyStore(func(s *store.Tx) error {
-		attempt, err := s.Get(id)
+		attempt, err := s.Get(assignment.AttemptID(id))
 		if err != nil {
 			return err
 		}
-		events, err := s.Events(id)
+		events, err := s.Events(assignment.AttemptID(id))
 		if err != nil {
 			return err
 		}
-		refs, err := s.AttemptProviderReferences(id)
+		refs, err := s.AttemptProviderReferences(assignment.AttemptID(id))
 		if err != nil {
 			return err
 		}
@@ -235,9 +235,9 @@ func runAttemptsResolve(streams IO, id string, retry, settle bool, reason, actor
 
 	if err := st.Tx(ctx, func(tx *store.Tx) error {
 		if retry {
-			return tx.ResolveReviewToReady(id, reason, actor)
+			return tx.ResolveReviewToReady(assignment.AttemptID(id), reason, actor)
 		}
-		return tx.ResolveReviewToSettled(id, assignment.ResolutionMayHaveExecuted, reason, actor)
+		return tx.ResolveReviewToSettled(assignment.AttemptID(id), assignment.ResolutionMayHaveExecuted, reason, actor)
 	}); err != nil {
 		return err
 	}

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Destructive commands default to dry-run: the operator must ask for the
@@ -46,7 +48,7 @@ func runCleanup(streams IO, apply bool) error {
 	}
 	for _, l := range snap.Leases {
 		if !l.State.Terminal() {
-			keep[l.ID] = true
+			keep[string(l.ID)] = true
 		}
 	}
 	removable := plan.exclude(keep)
@@ -217,16 +219,16 @@ type ownedPlan struct {
 }
 
 func planOwnedResources(ctx context.Context, st *store.Store, dock *docker.Client) (ownedPlan, error) {
-	p := ownedPlan{instanceID: st.InstanceID()}
+	p := ownedPlan{instanceID: string(st.InstanceID())}
 	var err error
 	id := p.instanceID
-	if p.containers, err = dock.ListOwnedContainers(ctx, id); err != nil {
+	if p.containers, err = dock.ListOwnedContainers(ctx, assignment.InstanceID(id)); err != nil {
 		return p, err
 	}
-	if p.networks, err = dock.ListOwnedNetworks(ctx, id); err != nil {
+	if p.networks, err = dock.ListOwnedNetworks(ctx, assignment.InstanceID(id)); err != nil {
 		return p, err
 	}
-	p.volumes, err = dock.ListOwnedVolumes(ctx, id)
+	p.volumes, err = dock.ListOwnedVolumes(ctx, assignment.InstanceID(id))
 	return p, err
 }
 
@@ -295,17 +297,17 @@ func (p ownedPlan) describe(verb string, applying bool) string {
 // held open.
 func (p ownedPlan) remove(ctx context.Context, dock *docker.Client) error {
 	for _, c := range p.containers {
-		if err := dock.RemoveOwnedContainer(ctx, c.ID, p.instanceID, c.LeaseID); err != nil {
+		if err := dock.RemoveOwnedContainer(ctx, c.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(c.LeaseID)); err != nil {
 			return fmt.Errorf("remove container %s: %w", c.Name, err)
 		}
 	}
 	for _, n := range p.networks {
-		if err := dock.RemoveOwnedNetwork(ctx, n.ID, p.instanceID, n.LeaseID); err != nil {
+		if err := dock.RemoveOwnedNetwork(ctx, n.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(n.LeaseID)); err != nil {
 			return fmt.Errorf("remove network %.12s: %w", n.ID, err)
 		}
 	}
 	for _, v := range p.volumes {
-		if err := dock.RemoveOwnedVolume(ctx, v.ID, p.instanceID, v.LeaseID); err != nil {
+		if err := dock.RemoveOwnedVolume(ctx, v.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(v.LeaseID)); err != nil {
 			return fmt.Errorf("remove volume %s: %w", v.ID, err)
 		}
 	}

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -13,6 +13,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // runStatus answers the operability questions the design requires an
@@ -71,9 +73,9 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	var obs daemonObservation
 	if dock, err := docker.New(ctx); err == nil {
 		defer dock.Close()
-		if obs.containers, err = dock.ListOwnedContainers(ctx, snap.InstanceID); err == nil {
-			if obs.networks, err = dock.ListOwnedNetworks(ctx, snap.InstanceID); err == nil {
-				obs.volumes, err = dock.ListOwnedVolumes(ctx, snap.InstanceID)
+		if obs.containers, err = dock.ListOwnedContainers(ctx, assignment.InstanceID(snap.InstanceID)); err == nil {
+			if obs.networks, err = dock.ListOwnedNetworks(ctx, assignment.InstanceID(snap.InstanceID)); err == nil {
+				obs.volumes, err = dock.ListOwnedVolumes(ctx, assignment.InstanceID(snap.InstanceID))
 			}
 		}
 		obs.err = err
@@ -147,9 +149,9 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	}
 	fmt.Fprintln(streams.Out)
 	for _, l := range live {
-		resources := snap.Resources[l.ID]
+		resources := snap.Resources[string(l.ID)]
 		project := ""
-		if a, ok := snap.Attempts[l.ID]; ok {
+		if a, ok := snap.Attempts[string(l.ID)]; ok {
 			project = a.TenantKey + "/" + a.ProjectKey
 		}
 		fmt.Fprintf(streams.Out, "  %-16s %-18s %-28s %d resources\n", l.ID, l.State, project, len(resources))

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -188,33 +188,33 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	}
 	for _, b := range snap.Bindings {
 		doc.Bindings = append(doc.Bindings, bindingDTO{
-			TargetID: b.TargetID, ProviderKind: b.ProviderKind,
-			SourceBindingKey: b.SourceBindingKey,
+			TargetID: string(b.TargetID), ProviderKind: b.ProviderKind,
+			SourceBindingKey: string(b.SourceBindingKey),
 			LastContactAt:    rfc3339(b.Contact.LastContact),
 			LastError:        b.Contact.LastError,
 			LastErrorAt:      rfc3339(b.Contact.LastErrorAt),
 		})
 	}
 	for _, l := range snap.Leases {
-		attempt := snap.Attempts[l.ID]
+		attempt := snap.Attempts[string(l.ID)]
 		project := ""
 		if attempt.TenantKey != "" || attempt.ProjectKey != "" {
 			project = attempt.TenantKey + "/" + attempt.ProjectKey
 		}
 		lease := leaseDTO{
-			ID:          l.ID,
+			ID:          string(l.ID),
 			State:       string(l.State),
 			Terminal:    l.State.Terminal(),
-			AttemptID:   l.AttemptID,
+			AttemptID:   string(l.AttemptID),
 			Project:     project,
-			RuntimeName: l.RuntimeName,
+			RuntimeName: string(l.RuntimeName),
 			Evidence:    string(attempt.Evidence),
 			CreatedAt:   rfc3339(l.CreatedAt),
 			Resources:   []resourceDTO{},
 		}
-		for _, in := range snap.Resources[l.ID] {
+		for _, in := range snap.Resources[string(l.ID)] {
 			lease.Resources = append(lease.Resources, resourceDTO{
-				Kind: string(in.Kind), Role: in.Role, Name: in.Name, LeaseID: in.LeaseID, State: in.State,
+				Kind: string(in.Kind), Role: in.Role, Name: in.Name, LeaseID: string(in.LeaseID), State: in.State,
 			})
 		}
 		doc.Leases = append(doc.Leases, lease)
@@ -253,7 +253,7 @@ func schedulingStatus(cfg *config.Config, leases []store.Lease, queued map[int64
 			continue
 		}
 		active++
-		activeByTier[lease.TierID]++
+		activeByTier[string(lease.TierID)]++
 	}
 
 	mode := "independent-tiers"
@@ -310,7 +310,7 @@ func discrepancies(leases []store.Lease, obs daemonObservation) []string {
 	live := map[string]bool{}
 	for _, l := range leases {
 		if !l.State.Terminal() {
-			live[l.ID] = true
+			live[string(l.ID)] = true
 		}
 	}
 	out := []string{}
@@ -330,8 +330,8 @@ func discrepancies(leases []store.Lease, obs daemonObservation) []string {
 		}
 	}
 	for _, l := range leases {
-		if live[l.ID] && l.State == store.LeaseWorkloadRunning && !withContainer[l.ID] {
-			out = append(out, "lease "+l.ID+" claims to be running with no container")
+		if live[string(l.ID)] && l.State == store.LeaseWorkloadRunning && !withContainer[string(l.ID)] {
+			out = append(out, "lease "+string(l.ID)+" claims to be running with no container")
 		}
 	}
 

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -32,9 +32,12 @@ import (
 // absent through. Removal of an already-absent object is success — that
 // contract is what makes retrying a removal safe.
 type Remover interface {
-	RemoveOwnedContainer(ctx context.Context, reference, instanceID, leaseID string) error
-	RemoveOwnedNetwork(ctx context.Context, reference, instanceID, leaseID string) error
-	RemoveOwnedVolume(ctx context.Context, reference, instanceID, leaseID string) error
+	RemoveOwnedContainer(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
+	RemoveOwnedNetwork(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
+	RemoveOwnedVolume(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
 }
 
 // Manager drives leases. One per controller; it holds no per-lease
@@ -50,7 +53,7 @@ func NewManager(st *store.Store, remove Remover, log *slog.Logger) *Manager {
 }
 
 // Transition moves a lease along its state machine.
-func (m *Manager) Transition(ctx context.Context, leaseID string, from, to store.LeaseState) error {
+func (m *Manager) Transition(ctx context.Context, leaseID assignment.LeaseID, from, to store.LeaseState) error {
 	return m.store.Tx(ctx, func(tx *store.Tx) error {
 		return tx.TransitionLease(leaseID, from, to)
 	})
@@ -60,7 +63,7 @@ func (m *Manager) Transition(ctx context.Context, leaseID string, from, to store
 // the attempt the lease serves. It runs on a context detached from the
 // job's: the observation must outlive a cancelled job, because it is
 // what stops that job being run twice.
-func (m *Manager) RecordEvidence(ctx context.Context, leaseID string, e store.Evidence) error {
+func (m *Manager) RecordEvidence(ctx context.Context, leaseID assignment.LeaseID, e store.Evidence) error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
 	return m.store.Tx(ctx, func(tx *store.Tx) error {
@@ -86,7 +89,7 @@ func (m *Manager) EvidenceOf(ctx context.Context, lease store.Lease) (store.Evid
 // Release walks a live lease from `from` through cleaning to released,
 // removing every owned resource on the way. A removal failure parks the
 // lease in quarantined until a later reconciliation retries.
-func (m *Manager) Release(ctx context.Context, leaseID string, from store.LeaseState) error {
+func (m *Manager) Release(ctx context.Context, leaseID assignment.LeaseID, from store.LeaseState) error {
 	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		if err := tx.TransitionLease(leaseID, from, store.LeaseDraining); err != nil {
 			return err
@@ -107,7 +110,7 @@ func (m *Manager) Release(ctx context.Context, leaseID string, from store.LeaseS
 // lease's actual state is the point: a lease already failed or
 // quarantined cannot move to failed again, and attempting it once
 // aborted the very cleanup those states exist to retry.
-func (m *Manager) ToCleaning(ctx context.Context, leaseID string) (store.Lease, error) {
+func (m *Manager) ToCleaning(ctx context.Context, leaseID assignment.LeaseID) (store.Lease, error) {
 	var was store.Lease
 	err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		lease, err := tx.LeaseByID(leaseID)
@@ -155,7 +158,7 @@ func (m *Manager) FinishCleaning(ctx context.Context, lease store.Lease, obs ass
 // disposed of by evidence. One commit, so no crash can separate a
 // released lease from its attempt's disposition. Only after this commit
 // may the admission credit be released.
-func (m *Manager) Finalize(ctx context.Context, leaseID string, startObs assignment.ExecutionObservation) error {
+func (m *Manager) Finalize(ctx context.Context, leaseID assignment.LeaseID, startObs assignment.ExecutionObservation) error {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 	return m.store.Tx(ctx, func(tx *store.Tx) error {
@@ -208,7 +211,7 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	// Keyed by lease: an attempt is served once per lease, and a fixed key
 	// would have the second serving's cleanup swallowed as a replay of the
 	// first.
-	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+lease.ID, "cleanup_completed"); err != nil {
+	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), "cleanup_completed"); err != nil {
 		return err
 	}
 	// A redelivery of the same workload supersedes the attempt this
@@ -265,7 +268,7 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 // launch the same configured image, meet the same answer, and spend
 // another of the three servings finding out. Naming the reason is what
 // turns three identical failures per job into one thing to change.
-func (m *Manager) HoldAttempt(ctx context.Context, leaseID, reason string) {
+func (m *Manager) HoldAttempt(ctx context.Context, leaseID assignment.LeaseID, reason string) {
 	m.withAttemptOfLease(ctx, leaseID, func(tx *store.Tx, attempt store.Attempt) error {
 		m.log.Warn("holding the attempt for review", "attempt", attempt.ID,
 			"lease", leaseID, "reason", reason)
@@ -284,7 +287,7 @@ func (m *Manager) HoldAttempt(ctx context.Context, leaseID, reason string) {
 // the proof can land at either. Naming only one leaves the other
 // matching no row, and a requeue that matches nothing rolls the whole
 // finalizing transaction back and pins the lease in cleaning.
-func (m *Manager) requeueProven(tx *store.Tx, attempt store.Attempt, leaseID string) error {
+func (m *Manager) requeueProven(tx *store.Tx, attempt store.Attempt, leaseID assignment.LeaseID) error {
 	if attempt.State == "starting" || attempt.State == "running" {
 		return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), leaseID)
 	}
@@ -295,7 +298,7 @@ func (m *Manager) requeueProven(tx *store.Tx, attempt store.Attempt, leaseID str
 // error. The budget is not a safety rule - the work provably never began
 // either way - so the attempt is held for someone to look at, not
 // settled and not retried forever.
-func (m *Manager) requeueOrReview(tx *store.Tx, attemptID string, err error, leaseID string) error {
+func (m *Manager) requeueOrReview(tx *store.Tx, attemptID assignment.AttemptID, err error, leaseID assignment.LeaseID) error {
 	if !errors.Is(err, store.ErrRetryBudgetExhausted) {
 		return err
 	}
@@ -333,7 +336,7 @@ func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, eviden
 // withAttemptOfLease resolves the attempt a lease serves and runs one
 // disposition against it in the same transaction. A lease with no
 // attempt is quietly complete: disposition already happened.
-func (m *Manager) withAttemptOfLease(ctx context.Context, leaseID string, fn func(*store.Tx, store.Attempt) error) {
+func (m *Manager) withAttemptOfLease(ctx context.Context, leaseID assignment.LeaseID, fn func(*store.Tx, store.Attempt) error) {
 	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		attempt, err := tx.AttemptByLease(leaseID)
 		if errors.Is(err, store.ErrNotFound) {
@@ -349,7 +352,7 @@ func (m *Manager) withAttemptOfLease(ctx context.Context, leaseID string, fn fun
 	}
 }
 
-func (m *Manager) settleAttemptOfLease(ctx context.Context, leaseID, resolution string) {
+func (m *Manager) settleAttemptOfLease(ctx context.Context, leaseID assignment.LeaseID, resolution string) {
 	m.withAttemptOfLease(ctx, leaseID, func(tx *store.Tx, attempt store.Attempt) error {
 		return tx.Settle(attempt.ID, attempt.State, resolution)
 	})
@@ -358,7 +361,7 @@ func (m *Manager) settleAttemptOfLease(ctx context.Context, leaseID, resolution 
 // Quarantine parks a lease whose cleanup failed. It keeps consuming
 // capacity until a later pass resolves it, which is the honest shape of
 // "its privileged containers may still exist".
-func (m *Manager) Quarantine(leaseID string) {
+func (m *Manager) Quarantine(leaseID assignment.LeaseID) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
@@ -382,7 +385,7 @@ func (m *Manager) Quarantine(leaseID string) {
 // is proven. A failure is booked on the intent with backoff, so the
 // periodic reconciler retries that resource alone; the FK RESTRICT
 // means a surviving intent keeps the lease un-releasable.
-func (m *Manager) RemoveResources(ctx context.Context, leaseID string) error {
+func (m *Manager) RemoveResources(ctx context.Context, leaseID assignment.LeaseID) error {
 	if err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		return tx.MarkResourceCleanup(leaseID)
 	}); err != nil {
@@ -446,7 +449,8 @@ func removalBackoff(retries int64) time.Duration {
 	return backoff + jitter
 }
 
-func (m *Manager) removeObject(ctx context.Context, kind store.ResourceKind, handle, leaseID string) error {
+func (m *Manager) removeObject(ctx context.Context, kind store.ResourceKind,
+	handle string, leaseID assignment.LeaseID) error {
 	instanceID := m.store.InstanceID()
 	switch kind {
 	case store.ResourceContainer:
@@ -470,7 +474,7 @@ func (m *Manager) ForgetResource(ctx context.Context, leaseID, dockerID string) 
 		return nil // never recorded, so nothing to reconcile
 	}
 	return m.store.Tx(ctx, func(tx *store.Tx) error {
-		intents, err := tx.Resources(leaseID)
+		intents, err := tx.Resources(assignment.LeaseID(leaseID))
 		if err != nil {
 			return err
 		}
@@ -486,7 +490,7 @@ func (m *Manager) ForgetResource(ctx context.Context, leaseID, dockerID string) 
 // IntentsDue reports whether every booked backoff on the lease's intents
 // has elapsed. A lease with no intents is due by definition: only its
 // finalizing transaction remains.
-func (m *Manager) IntentsDue(ctx context.Context, leaseID string) (bool, error) {
+func (m *Manager) IntentsDue(ctx context.Context, leaseID assignment.LeaseID) (bool, error) {
 	var due bool
 	err := m.store.Tx(ctx, func(tx *store.Tx) error {
 		intents, err := tx.Resources(leaseID)
@@ -541,18 +545,18 @@ func (m *Manager) WalkToRunning(ctx context.Context, lease store.Lease) error {
 // consumer declares that interface — capsule.ResourceRecorder — and Go
 // satisfies it structurally at the call site, so this package produces a
 // recorder without linking a container runtime to do it.
-func (m *Manager) Recorder(ctx context.Context, leaseID string) *intentRecorder {
+func (m *Manager) Recorder(ctx context.Context, leaseID assignment.LeaseID) *intentRecorder {
 	return &intentRecorder{store: m.store, ctx: ctx, leaseID: leaseID}
 }
 
 type intentRecorder struct {
 	store   *store.Store
 	ctx     context.Context
-	leaseID string
+	leaseID assignment.LeaseID
 }
 
-func (r *intentRecorder) Plan(kind, role, name string) (int64, error) {
-	var id int64
+func (r *intentRecorder) Plan(kind, role, name string) (assignment.ResourceIntentID, error) {
+	var id assignment.ResourceIntentID
 	err := r.store.Tx(r.ctx, func(tx *store.Tx) error {
 		var err error
 		id, err = tx.PlanResource(r.leaseID, store.ResourceKind(kind), role, name)
@@ -561,14 +565,14 @@ func (r *intentRecorder) Plan(kind, role, name string) (int64, error) {
 	return id, err
 }
 
-func (r *intentRecorder) Creating(intentID int64) error {
+func (r *intentRecorder) Creating(intentID assignment.ResourceIntentID) error {
 	return r.store.Tx(r.ctx, func(tx *store.Tx) error {
 		return tx.MarkResourceCreating(intentID)
 	})
 }
 
-func (r *intentRecorder) Confirm(intentID int64, dockerID string) error {
+func (r *intentRecorder) Confirm(intentID assignment.ResourceIntentID, dockerID string) error {
 	return r.store.Tx(r.ctx, func(tx *store.Tx) error {
-		return tx.MarkResourcePresent(intentID, dockerID)
+		return tx.MarkResourcePresent(assignment.ResourceIntentID(intentID), dockerID)
 	})
 }

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -18,9 +18,15 @@ import (
 // success, exactly the contract the real client honours.
 type nopRemover struct{}
 
-func (nopRemover) RemoveOwnedContainer(context.Context, string, string, string) error { return nil }
-func (nopRemover) RemoveOwnedNetwork(context.Context, string, string, string) error   { return nil }
-func (nopRemover) RemoveOwnedVolume(context.Context, string, string, string) error    { return nil }
+func (nopRemover) RemoveOwnedContainer(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
+func (nopRemover) RemoveOwnedNetwork(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
+func (nopRemover) RemoveOwnedVolume(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
+	return nil
+}
 
 // wedgedRemover fails every removal until healed — the daemon a
 // quarantined lease is waiting on.
@@ -32,13 +38,13 @@ func (w *wedgedRemover) fail() error {
 	}
 	return errors.New("daemon wedged")
 }
-func (w *wedgedRemover) RemoveOwnedContainer(context.Context, string, string, string) error {
+func (w *wedgedRemover) RemoveOwnedContainer(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return w.fail()
 }
-func (w *wedgedRemover) RemoveOwnedNetwork(context.Context, string, string, string) error {
+func (w *wedgedRemover) RemoveOwnedNetwork(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return w.fail()
 }
-func (w *wedgedRemover) RemoveOwnedVolume(context.Context, string, string, string) error {
+func (w *wedgedRemover) RemoveOwnedVolume(context.Context, string, assignment.InstanceID, assignment.LeaseID) error {
 	return w.fail()
 }
 
@@ -76,8 +82,8 @@ func newFixture(t *testing.T, remove Remover) *fixture {
 		if err != nil {
 			return err
 		}
-		f.attempt = ready[0].ID
-		f.lease, err = tx.LeaseAttempt(f.attempt, binding, "standard")
+		f.attempt = string(ready[0].ID)
+		f.lease, err = tx.LeaseAttempt(assignment.AttemptID(f.attempt), binding, "standard")
 		return err
 	})
 	return f
@@ -143,7 +149,7 @@ func (f *fixture) attemptState() store.Attempt {
 	var a store.Attempt
 	f.tx(func(tx *store.Tx) error {
 		var err error
-		a, err = tx.Get(f.attempt)
+		a, err = tx.Get(assignment.AttemptID(f.attempt))
 		return err
 	})
 	return a
@@ -157,7 +163,7 @@ func (f *fixture) advanceAttemptTo(target string) {
 	ladder := []string{"leased", "preparing", "prepared", "starting", "running"}
 	f.tx(func(tx *store.Tx) error {
 		for i := 1; i < len(ladder); i++ {
-			if err := tx.Advance(f.attempt, ladder[i-1], ladder[i]); err != nil {
+			if err := tx.Advance(assignment.AttemptID(f.attempt), ladder[i-1], ladder[i]); err != nil {
 				return err
 			}
 			if ladder[i] == target {
@@ -244,7 +250,7 @@ func TestFinalizeIsAtomic(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return tx.MarkResourcePresent(id, "leftover")
+		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "leftover")
 	})
 
 	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err == nil {
@@ -269,7 +275,7 @@ func TestReleaseRemovesEverythingAndDisposes(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return tx.MarkResourcePresent(id, "runner-1")
+		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "runner-1")
 	})
 
 	if err := f.m.Release(t.Context(), f.lease.ID, store.LeaseWorkloadRunning); err != nil {
@@ -306,7 +312,7 @@ func TestReleaseQuarantinesOnAWedgedDaemon(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		return tx.MarkResourcePresent(id, "wedge-1")
+		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "wedge-1")
 	})
 
 	if err := f.m.Release(t.Context(), f.lease.ID, store.LeaseWorkloadRunning); err == nil {
@@ -413,7 +419,7 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 		var attempt store.Attempt
 		f.tx(func(tx *store.Tx) error {
 			var err error
-			attempt, err = tx.Get(f.attempt)
+			attempt, err = tx.Get(assignment.AttemptID(f.attempt))
 			return err
 		})
 		if attempt.State == "manual_review" {
@@ -433,7 +439,7 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 		// The next serving.
 		f.tx(func(tx *store.Tx) error {
 			var err error
-			f.lease, err = tx.LeaseAttempt(f.attempt, attempt.BindingID, "standard")
+			f.lease, err = tx.LeaseAttempt(assignment.AttemptID(f.attempt), attempt.BindingID, "standard")
 			return err
 		})
 	}

--- a/internal/platform/docker/diskusage.go
+++ b/internal/platform/docker/diskusage.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 
 	"github.com/moby/moby/client"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // VolumeUsage is one owned volume's measured size, as the daemon
@@ -24,14 +26,14 @@ type VolumeUsage struct {
 // disk-usage endpoint has no label filter, so the daemon's full answer
 // is filtered here; sizes come from the daemon's own accounting, which
 // is the only view that is correct wherever the controller runs.
-func (c *Client) OwnedVolumeUsage(ctx context.Context, instanceID string) ([]VolumeUsage, error) {
+func (c *Client) OwnedVolumeUsage(ctx context.Context, instanceID assignment.InstanceID) ([]VolumeUsage, error) {
 	du, err := c.cli.DiskUsage(ctx, client.DiskUsageOptions{Volumes: true, Verbose: true})
 	if err != nil {
 		return nil, err
 	}
 	var out []VolumeUsage
 	for _, v := range du.Volumes.Items {
-		if v.Labels[LabelManaged] != "true" || v.Labels[LabelInstance] != instanceID {
+		if v.Labels[LabelManaged] != "true" || v.Labels[LabelInstance] != string(instanceID) {
 			continue
 		}
 		size := int64(-1)
@@ -59,13 +61,13 @@ type FilesystemFree struct {
 // like every image the product runs; the probe container is labeled,
 // removed on exit, and mounts nothing. The name carries a nonce so a
 // monitor pass and a doctor run never collide on the daemon.
-func (c *Client) ProbeFilesystemFree(ctx context.Context, image, instanceID string) (FilesystemFree, error) {
+func (c *Client) ProbeFilesystemFree(ctx context.Context, image string, instanceID assignment.InstanceID) (FilesystemFree, error) {
 	nonce := make([]byte, 4)
 	if _, err := rand.Read(nonce); err != nil {
 		return FilesystemFree{}, err
 	}
 	code, out, err := c.RunTask(ctx, ContainerSpec{
-		Name:  "runpool-" + instanceID + "-df-probe-" + hex.EncodeToString(nonce),
+		Name:  "runpool-" + string(instanceID) + "-df-probe-" + hex.EncodeToString(nonce),
 		Image: image,
 		// The entrypoint is overridden so any pinned image works as the
 		// probe — production reuses the capsule image, whose entrypoint
@@ -74,7 +76,7 @@ func (c *Client) ProbeFilesystemFree(ctx context.Context, image, instanceID stri
 		Cmd:        []string{"df -Pk / && df -Pi /"},
 		Labels: map[string]string{
 			LabelManaged:  "true",
-			LabelInstance: instanceID,
+			LabelInstance: string(instanceID),
 			LabelKind:     "container",
 			LabelRole:     "probe",
 		},

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -18,6 +18,8 @@ import (
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/client"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Ownership labels: every resource Runpool creates is identifiable and
@@ -295,14 +297,14 @@ var ErrForeignResource = errors.New("an object with the expected name exists but
 // create-side conflict it means the conflict was transient, and for
 // recovery it proves the create never took effect. A name match with
 // foreign labels is ErrForeignResource — name equality is not ownership.
-func (c *Client) OwnedIDByName(ctx context.Context, kind, name, instanceID, leaseID string) (string, error) {
+func (c *Client) OwnedIDByName(ctx context.Context, kind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	return c.resolveOwnedID(ctx, kind, name, instanceID, leaseID)
 }
 
 // resolveOwnedID accepts either a deterministic name or an immutable daemon
 // id. Creation recovery calls it by name; destructive cleanup calls it by the
 // confirmed id when one was persisted.
-func (c *Client) resolveOwnedID(ctx context.Context, kind, reference, instanceID, leaseID string) (string, error) {
+func (c *Client) resolveOwnedID(ctx context.Context, kind, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	var id string
 	var labels map[string]string
 	switch kind {
@@ -336,7 +338,7 @@ func (c *Client) resolveOwnedID(ctx context.Context, kind, reference, instanceID
 	default:
 		return "", fmt.Errorf("unknown resource kind %q", kind)
 	}
-	if labels[LabelManaged] != "true" || labels[LabelInstance] != instanceID || labels[LabelLease] != leaseID {
+	if labels[LabelManaged] != "true" || labels[LabelInstance] != string(instanceID) || labels[LabelLease] != string(leaseID) {
 		return "", fmt.Errorf("%w: %s %q", ErrForeignResource, kind, reference)
 	}
 	return id, nil
@@ -346,7 +348,7 @@ func (c *Client) resolveOwnedID(ctx context.Context, kind, reference, instanceID
 // expected instance and lease, then removes the exact inspected id. This is
 // the destructive counterpart of OwnedIDByName: a stale intent must never
 // delete a foreign object that later reused its deterministic name.
-func (c *Client) RemoveOwnedContainer(ctx context.Context, reference, instanceID, leaseID string) error {
+func (c *Client) RemoveOwnedContainer(ctx context.Context, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) error {
 	id, err := c.resolveOwnedID(ctx, "container", reference, instanceID, leaseID)
 	if err != nil || id == "" {
 		return err
@@ -354,7 +356,7 @@ func (c *Client) RemoveOwnedContainer(ctx context.Context, reference, instanceID
 	return c.RemoveContainer(ctx, id)
 }
 
-func (c *Client) RemoveOwnedNetwork(ctx context.Context, reference, instanceID, leaseID string) error {
+func (c *Client) RemoveOwnedNetwork(ctx context.Context, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) error {
 	id, err := c.resolveOwnedID(ctx, "network", reference, instanceID, leaseID)
 	if err != nil || id == "" {
 		return err
@@ -362,7 +364,7 @@ func (c *Client) RemoveOwnedNetwork(ctx context.Context, reference, instanceID, 
 	return c.RemoveNetwork(ctx, id)
 }
 
-func (c *Client) RemoveOwnedVolume(ctx context.Context, reference, instanceID, leaseID string) error {
+func (c *Client) RemoveOwnedVolume(ctx context.Context, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) error {
 	name, err := c.resolveOwnedID(ctx, "volume", reference, instanceID, leaseID)
 	if err != nil || name == "" {
 		return err
@@ -438,7 +440,7 @@ func (c OwnedContainer) HelperInFlight() bool { return c.LeaseID == "" && c.Runn
 
 // ListOwnedContainers finds every container this instance stamped,
 // running or not — the reconciliation working set after a crash.
-func (c *Client) ListOwnedContainers(ctx context.Context, instanceID string) ([]OwnedContainer, error) {
+func (c *Client) ListOwnedContainers(ctx context.Context, instanceID assignment.InstanceID) ([]OwnedContainer, error) {
 	list, err := c.cli.ContainerList(ctx, client.ContainerListOptions{
 		All:     true,
 		Filters: ownedFilter(instanceID),
@@ -464,8 +466,8 @@ func (c *Client) ListOwnedContainers(ctx context.Context, instanceID string) ([]
 	return out, nil
 }
 
-func ownedFilter(instanceID string) client.Filters {
+func ownedFilter(instanceID assignment.InstanceID) client.Filters {
 	return client.Filters{}.
 		Add("label", LabelManaged+"=true").
-		Add("label", LabelInstance+"="+instanceID)
+		Add("label", LabelInstance+"="+string(instanceID))
 }

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -6,6 +6,8 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/client"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // NetworkSpec describes a user-defined bridge. Isolated is Engine 28's
@@ -150,7 +152,7 @@ type OwnedResource struct {
 	Role    string
 }
 
-func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID string) ([]OwnedResource, error) {
+func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID assignment.InstanceID) ([]OwnedResource, error) {
 	nets, err := c.cli.NetworkList(ctx, client.NetworkListOptions{Filters: ownedFilter(instanceID)})
 	if err != nil {
 		return nil, err

--- a/internal/platform/docker/volume.go
+++ b/internal/platform/docker/volume.go
@@ -6,6 +6,8 @@ import (
 
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/moby/moby/client"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // CreateVolume creates a named, labeled volume — an ephemeral capsule
@@ -49,7 +51,7 @@ func (c *Client) RemoveVolume(ctx context.Context, name string) error {
 	return ignoreNotFound(err)
 }
 
-func (c *Client) ListOwnedVolumes(ctx context.Context, instanceID string) ([]OwnedResource, error) {
+func (c *Client) ListOwnedVolumes(ctx context.Context, instanceID assignment.InstanceID) ([]OwnedResource, error) {
 	resp, err := c.cli.VolumeList(ctx, client.VolumeListOptions{Filters: ownedFilter(instanceID)})
 	if err != nil {
 		return nil, err

--- a/internal/platform/githubactions/message.go
+++ b/internal/platform/githubactions/message.go
@@ -119,7 +119,7 @@ func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runne
 		SourceWorkloadKey: b.JobID,
 		TenantKey:         b.OwnerName,
 		ProjectKey:        b.RepositoryName,
-		RuntimeName:       runnerName,
+		RuntimeName:       assignment.RuntimeName(runnerName),
 		RuntimeID:         int64(runnerID),
 		Result:            result,
 	}

--- a/internal/platform/githubactions/session_test.go
+++ b/internal/platform/githubactions/session_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 )
 
-func offer(key string, request int64) assignment.WorkloadAssignment {
+func offer(key assignment.SourceWorkloadKey, request int64) assignment.WorkloadAssignment {
 	return assignment.WorkloadAssignment{
-		SourceWorkloadKey: key, TenantKey: "acme", ProjectKey: "app",
+		SourceWorkloadKey: string(key), TenantKey: "acme", ProjectKey: "app",
 		SourceRequestID: request,
 	}
 }

--- a/internal/store/assignment_repository.go
+++ b/internal/store/assignment_repository.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 var (
@@ -50,9 +52,9 @@ type WorkloadRow struct {
 //     delivery returns ErrOpenAttemptExists: the caller supersedes or
 //     resolves the predecessor first, in the same transaction, and
 //     retries.
-func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerprint [32]byte, workloads []WorkloadRow) (int64, error) {
+func (t *Tx) RecordDelivery(bindingID assignment.BindingID, sourceDeliveryKey string, fingerprint [32]byte, workloads []WorkloadRow) (assignment.DeliveryID, error) {
 	delivery, err := t.q.GetDeliveryByKey(t.ctx, sqlitedb.GetDeliveryByKeyParams{
-		BindingID: bindingID, SourceDeliveryKey: sourceDeliveryKey,
+		BindingID: int64(bindingID), SourceDeliveryKey: sourceDeliveryKey,
 	})
 	switch {
 	case err == nil:
@@ -67,7 +69,7 @@ func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerpri
 		// a delivery whose work no query can ever find.
 	case errors.Is(err, sql.ErrNoRows):
 		delivery, err = t.q.InsertDelivery(t.ctx, sqlitedb.InsertDeliveryParams{
-			BindingID:         bindingID,
+			BindingID:         int64(bindingID),
 			SourceDeliveryKey: sourceDeliveryKey,
 			PayloadSha256:     fingerprint[:],
 		})
@@ -80,7 +82,7 @@ func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerpri
 
 	for _, w := range workloads {
 		if w.SourceWorkloadKey == "" {
-			return delivery.ID, fmt.Errorf("workload with no key in delivery %s cannot be made durable", sourceDeliveryKey)
+			return assignment.DeliveryID(delivery.ID), fmt.Errorf("workload with no key in delivery %s cannot be made durable", sourceDeliveryKey)
 		}
 		if err := t.insertAttempt(delivery, w); err != nil {
 			// The id travels with the error on purpose. The delivery row
@@ -89,10 +91,10 @@ func (t *Tx) RecordDelivery(bindingID int64, sourceDeliveryKey string, fingerpri
 			// asking - without it, the only way to resolve the conflict
 			// is to supersede blindly, including the attempts this very
 			// delivery just inserted.
-			return delivery.ID, err
+			return assignment.DeliveryID(delivery.ID), err
 		}
 	}
-	return delivery.ID, nil
+	return assignment.DeliveryID(delivery.ID), nil
 }
 
 func (t *Tx) insertAttempt(delivery sqlitedb.BrokerDelivery, w WorkloadRow) error {
@@ -138,9 +140,10 @@ func (t *Tx) insertAttempt(delivery sqlitedb.BrokerDelivery, w WorkloadRow) erro
 // Only an attempt that provably consumed nothing may be superseded;
 // anything further along is settled or reviewed through its own path,
 // and the redelivery waits for that to happen.
-func (t *Tx) SupersedeOpenAttempt(bindingID int64, sourceWorkloadKey, resolution string, exceptDelivery int64) error {
+func (t *Tx) SupersedeOpenAttempt(bindingID assignment.BindingID, sourceWorkloadKey assignment.SourceWorkloadKey,
+	resolution string, exceptDelivery assignment.DeliveryID) error {
 	open, err := t.q.GetOpenAttemptByWorkload(t.ctx, sqlitedb.GetOpenAttemptByWorkloadParams{
-		BindingID: bindingID, SourceWorkloadKey: sourceWorkloadKey,
+		BindingID: int64(bindingID), SourceWorkloadKey: string(sourceWorkloadKey),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return ErrNotFound
@@ -156,7 +159,7 @@ func (t *Tx) SupersedeOpenAttempt(bindingID int64, sourceWorkloadKey, resolution
 	// inserted, and the workload stays superseded, unserved, with its
 	// message acknowledged. Nothing afterwards notices, because the
 	// delivery did land.
-	if open.DeliveryID == exceptDelivery {
+	if assignment.DeliveryID(open.DeliveryID) == exceptDelivery {
 		return ErrNotFound
 	}
 	affected, err := t.q.SupersedeAttempt(t.ctx, sqlitedb.SupersedeAttemptParams{

--- a/internal/store/cache.go
+++ b/internal/store/cache.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // CacheLane identifies one exclusive lane: its opaque id and the opaque
@@ -40,7 +42,7 @@ func (t *Tx) EnsureCacheProject(sourceProjectKey string) (string, error) {
 // returns ErrNoLane when every lane is in use — the caller then runs
 // without a cache rather than sharing one, since concurrent writers
 // would corrupt it.
-func (t *Tx) LeaseCacheLane(projectID, generation, leaseID string, maxLanes int) (CacheLane, error) {
+func (t *Tx) LeaseCacheLane(projectID, generation string, leaseID assignment.LeaseID, maxLanes int) (CacheLane, error) {
 	var id string
 	err := t.tx.QueryRow(
 		`SELECT id FROM cache_lanes WHERE project_id = ? AND generation = ? AND leased_by IS NULL
@@ -87,7 +89,7 @@ func (t *Tx) BackdateCacheLane(laneID string, age time.Duration) error {
 
 // ReleaseCacheLane frees whatever lane a lease holds, leaving its data
 // for the next lease. Releasing a lease that holds none is a no-op.
-func (t *Tx) ReleaseCacheLane(leaseID string) error {
+func (t *Tx) ReleaseCacheLane(leaseID assignment.LeaseID) error {
 	_, err := t.tx.Exec(`UPDATE cache_lanes SET leased_by = NULL WHERE leased_by = ?`, leaseID)
 	return err
 }

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Evidence is what is durably known about whether an attempt's workload
@@ -108,7 +110,7 @@ const (
 //
 // A silent no-op is the one outcome this must never produce: the caller
 // would believe something was recorded when nothing was.
-func (t *Tx) RecordEvidence(attemptID string, e Evidence) error {
+func (t *Tx) RecordEvidence(attemptID assignment.AttemptID, e Evidence) error {
 	if !e.Valid() {
 		return fmt.Errorf("%w: %q", ErrInvalidExecutionObservation, string(e))
 	}
@@ -134,7 +136,7 @@ func (t *Tx) RecordEvidence(attemptID string, e Evidence) error {
 	// the row in between, nothing is written and the conflict is
 	// reported rather than resolved by overwriting.
 	affected, err := t.q.RecordAttemptEvidence(t.ctx, sqlitedb.RecordAttemptEvidenceParams{
-		Next: string(e), AttemptID: attemptID, Current: string(current),
+		Next: string(e), AttemptID: string(attemptID), Current: string(current),
 	})
 	if err != nil {
 		return err
@@ -149,7 +151,7 @@ func (t *Tx) RecordEvidence(attemptID string, e Evidence) error {
 // RecordEvidenceForLease advances the evidence of the attempt a lease is
 // serving. The runtime paths hold a lease and observe the capsule; the
 // record they are updating is the attempt's.
-func (t *Tx) RecordEvidenceForLease(leaseID string, e Evidence) error {
+func (t *Tx) RecordEvidenceForLease(leaseID assignment.LeaseID, e Evidence) error {
 	lease, err := t.LeaseByID(leaseID)
 	if err != nil {
 		return err

--- a/internal/store/github_actions.go
+++ b/internal/store/github_actions.go
@@ -7,13 +7,15 @@ import (
 	"strconv"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // RecordGitHubBindingMetadata stores the adapter's configuration for a
 // binding, one row per neutral binding.
-func (t *Tx) RecordGitHubBindingMetadata(bindingID int64, scope, canonicalURL, runnerGroup, scaleSetName string, scaleSetID int64) error {
+func (t *Tx) RecordGitHubBindingMetadata(bindingID assignment.BindingID, scope, canonicalURL, runnerGroup, scaleSetName string, scaleSetID int64) error {
 	return t.q.UpsertGitHubBindingMetadata(t.ctx, sqlitedb.UpsertGitHubBindingMetadataParams{
-		BindingID: bindingID, Scope: scope, CanonicalUrl: canonicalURL,
+		BindingID: int64(bindingID), Scope: scope, CanonicalUrl: canonicalURL,
 		RunnerGroup: runnerGroup, ScaleSetName: scaleSetName,
 		ScaleSetID: sql.NullInt64{Int64: scaleSetID, Valid: scaleSetID > 0},
 	})
@@ -21,9 +23,9 @@ func (t *Tx) RecordGitHubBindingMetadata(bindingID int64, scope, canonicalURL, r
 
 // RecordGitHubAttemptMetadata stores the provider identifiers observed for an
 // attempt. Runner request ids are diagnostic metadata and may be zero.
-func (t *Tx) RecordGitHubAttemptMetadata(attemptID, jobID string, runnerRequestID, workflowRunID int64) error {
+func (t *Tx) RecordGitHubAttemptMetadata(attemptID assignment.AttemptID, jobID string, runnerRequestID, workflowRunID int64) error {
 	return t.q.UpsertGitHubAttemptMetadata(t.ctx, sqlitedb.UpsertGitHubAttemptMetadataParams{
-		AttemptID: attemptID, JobID: jobID,
+		AttemptID: string(attemptID), JobID: jobID,
 		RunnerRequestID: runnerRequestID, WorkflowRunID: workflowRunID,
 	})
 }
@@ -59,7 +61,7 @@ func (t *Tx) GitHubBindings() ([]GitHubBinding, error) {
 
 // GitHubScaleSetID returns the recorded ownership identity for a binding. Zero
 // means that no scale set has been recorded.
-func (t *Tx) GitHubScaleSetID(bindingID int64) (int64, error) {
+func (t *Tx) GitHubScaleSetID(bindingID assignment.BindingID) (int64, error) {
 	id, _, err := t.GitHubScaleSet(bindingID)
 	return id, err
 }
@@ -73,8 +75,8 @@ func (t *Tx) GitHubScaleSetID(bindingID int64) (int64, error) {
 // create and then failed, or was killed, before the provider's id came
 // back. Only the second is grounds for taking over a set that already
 // carries that name.
-func (t *Tx) GitHubScaleSet(bindingID int64) (id int64, recorded bool, err error) {
-	row, err := t.q.GetGitHubBindingMetadata(t.ctx, bindingID)
+func (t *Tx) GitHubScaleSet(bindingID assignment.BindingID) (id int64, recorded bool, err error) {
+	row, err := t.q.GetGitHubBindingMetadata(t.ctx, int64(bindingID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, false, nil
 	}
@@ -86,9 +88,9 @@ func (t *Tx) GitHubScaleSet(bindingID int64) (id int64, recorded bool, err error
 
 // RecordGitHubRunnerID stores the ephemeral runner assigned to an attempt so
 // failure cleanup can deregister it.
-func (t *Tx) RecordGitHubRunnerID(attemptID string, runnerID int64) error {
+func (t *Tx) RecordGitHubRunnerID(attemptID assignment.AttemptID, runnerID int64) error {
 	affected, err := t.q.SetGitHubAttemptRunner(t.ctx, sqlitedb.SetGitHubAttemptRunnerParams{
-		RunnerID: runnerID, AttemptID: attemptID,
+		RunnerID: runnerID, AttemptID: string(attemptID),
 	})
 	if err != nil {
 		return err
@@ -107,8 +109,8 @@ func (t *Tx) RecordGitHubRunnerID(attemptID string, runnerID int64) error {
 // It is keyed by name rather than typed because its only consumer prints
 // it. Anything deciding on these identifiers reads them through the
 // accessors above, where they keep their meaning.
-func (t *Tx) AttemptProviderReferences(attemptID string) (map[string]string, error) {
-	row, err := t.q.GetGitHubAttemptMetadata(t.ctx, attemptID)
+func (t *Tx) AttemptProviderReferences(attemptID assignment.AttemptID) (map[string]string, error) {
+	row, err := t.q.GetGitHubAttemptMetadata(t.ctx, string(attemptID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -136,8 +138,8 @@ func (t *Tx) AttemptProviderReferences(attemptID string) (map[string]string, err
 
 // GitHubRunnerID returns the recorded ephemeral runner. A missing metadata row
 // reports zero because there is nothing to deregister.
-func (t *Tx) GitHubRunnerID(attemptID string) (int64, error) {
-	row, err := t.q.GetGitHubAttemptMetadata(t.ctx, attemptID)
+func (t *Tx) GitHubRunnerID(attemptID assignment.AttemptID) (int64, error) {
+	row, err := t.q.GetGitHubAttemptMetadata(t.ctx, string(attemptID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -3,6 +3,8 @@ package store
 import (
 	"slices"
 	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // LeaseState is one node of the capsule lease machine: the lifecycle of
@@ -89,12 +91,12 @@ const ReportedReleasedLeases = 50
 // so the reconciler can find a client to clean up with; AttemptID is the
 // link to the record of what the work actually did.
 type Lease struct {
-	ID          string
-	BindingID   int64
-	AttemptID   string
-	TierID      string
+	ID          assignment.LeaseID
+	BindingID   assignment.BindingID
+	AttemptID   assignment.AttemptID
+	TierID      assignment.TierID
 	State       LeaseState
-	RuntimeName string
+	RuntimeName assignment.RuntimeName
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
@@ -116,8 +118,8 @@ const (
 // object confirmed. Retries, LastError and NotBefore pace the periodic
 // reconciler per resource.
 type ResourceIntent struct {
-	ID        int64
-	LeaseID   string
+	ID        assignment.ResourceIntentID
+	LeaseID   assignment.LeaseID
 	Kind      ResourceKind
 	Role      string
 	Name      string

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // seedLease is the common starting point for the runtime-lifecycle
@@ -14,11 +16,11 @@ import (
 func seedLease(t *testing.T, s *Store, key string) Lease {
 	t.Helper()
 	binding := seedBinding(t, s)
-	attempt := seedAttempt(t, s, binding, "msg-"+key, "job-"+key)
+	attempt := seedAttempt(t, s, binding, "msg-"+key, assignment.SourceWorkloadKey("job-"+key))
 	var lease Lease
 	inTx(t, s, func(tx *Tx) error {
 		var err error
-		lease, err = tx.LeaseAttempt(attempt, binding, "standard")
+		lease, err = tx.LeaseAttempt(assignment.AttemptID(attempt), assignment.BindingID(binding), "standard")
 		return err
 	})
 	return lease
@@ -222,7 +224,7 @@ func TestAttemptOfRuntimeNameSurvivesTheLeaseEnding(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if got != lease.AttemptID {
+		if assignment.AttemptID(got) != lease.AttemptID {
 			t.Errorf("runtime name resolved to attempt %q; want %q", got, lease.AttemptID)
 		}
 		return nil
@@ -243,7 +245,7 @@ func TestAttemptOfRuntimeNameSurvivesTheLeaseEnding(t *testing.T) {
 			t.Errorf("a released lease stopped answering to its runtime name: %v", err)
 			return nil
 		}
-		if got != lease.AttemptID {
+		if assignment.AttemptID(got) != lease.AttemptID {
 			t.Errorf("after release the name resolved to attempt %q; want %q", got, lease.AttemptID)
 		}
 		return nil
@@ -269,7 +271,7 @@ func TestTxRollsBackOnError(t *testing.T) {
 
 	boom := errors.New("boom")
 	err := s.Tx(t.Context(), func(tx *Tx) error {
-		if _, err := tx.LeaseAttempt(attempt, binding, "standard"); err != nil {
+		if _, err := tx.LeaseAttempt(assignment.AttemptID(attempt), assignment.BindingID(binding), "standard"); err != nil {
 			return err
 		}
 		return boom
@@ -286,7 +288,7 @@ func TestTxRollsBackOnError(t *testing.T) {
 			t.Errorf("rolled-back lease persisted: %+v", leases)
 		}
 		// The claim rolled back with it, so the work is servable again.
-		ready, err := tx.ReadyAttempts(binding)
+		ready, err := tx.ReadyAttempts(assignment.BindingID(binding))
 		if err != nil {
 			return err
 		}
@@ -307,7 +309,7 @@ func TestResourceIntentLifecycleAndReleaseRule(t *testing.T) {
 	s := newStore(t)
 	lease := seedLease(t, s, "intents")
 
-	var netIntent, dindIntent int64
+	var netIntent, dindIntent assignment.ResourceIntentID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		if netIntent, err = tx.PlanResource(lease.ID, ResourceNetwork, "capsule-net", "runpool-net-x"); err != nil {
@@ -409,7 +411,7 @@ func TestPendingRemovalsHonourBackoff(t *testing.T) {
 	s := newStore(t)
 	lease := seedLease(t, s, "backoff")
 
-	var wedged, healthy int64
+	var wedged, healthy assignment.ResourceIntentID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		if wedged, err = tx.PlanResource(lease.ID, ResourceVolume, "work", "runpool-work-x"); err != nil {

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 var (
@@ -24,8 +26,8 @@ var (
 //
 // The claim runs first on purpose. Inserting the lease first would leave
 // an orphan runtime row behind whenever the claim lost the race.
-func (t *Tx) LeaseAttempt(attemptID string, bindingID int64, tierID string) (Lease, error) {
-	affected, err := t.q.ClaimReadyAttempt(t.ctx, attemptID)
+func (t *Tx) LeaseAttempt(attemptID assignment.AttemptID, bindingID assignment.BindingID, tierID string) (Lease, error) {
+	affected, err := t.q.ClaimReadyAttempt(t.ctx, string(attemptID))
 	if err != nil {
 		return Lease{}, err
 	}
@@ -41,13 +43,13 @@ func (t *Tx) LeaseAttempt(attemptID string, bindingID int64, tierID string) (Lea
 	if err := t.RecordEvent(attemptID, "lease_attached:"+id, "lease_attached"); err != nil {
 		return Lease{}, err
 	}
-	return t.LeaseByID(id)
+	return t.LeaseByID(assignment.LeaseID(id))
 }
 
 // TransitionLease moves a lease along the state machine. The write is
 // guarded by the expected current state: if the lease moved meanwhile,
 // nothing changes and ErrStateConflict reports where it actually is.
-func (t *Tx) TransitionLease(id string, from, to LeaseState) error {
+func (t *Tx) TransitionLease(id assignment.LeaseID, from, to LeaseState) error {
 	if !ValidTransition(from, to) {
 		return fmt.Errorf("%w: %s -> %s", ErrInvalidTransition, from, to)
 	}
@@ -72,13 +74,13 @@ func (t *Tx) TransitionLease(id string, from, to LeaseState) error {
 // SetLeaseRuntimeName records the name the runtime registered under. It
 // is the correlation handle for provider lifecycle events: each lease
 // registers its own, so the name cannot cross attempts.
-func (t *Tx) SetLeaseRuntimeName(id, runtimeName string) error {
+func (t *Tx) SetLeaseRuntimeName(id assignment.LeaseID, runtimeName assignment.RuntimeName) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE capsule_leases SET runtime_name = ?, updated_at = unixepoch() WHERE id = ?`,
 		runtimeName, id))
 }
 
-func (t *Tx) LeaseByID(id string) (Lease, error) {
+func (t *Tx) LeaseByID(id assignment.LeaseID) (Lease, error) {
 	l, err := t.scanLease(t.tx.QueryRow(selectLease+`WHERE id = ?`, id))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Lease{}, fmt.Errorf("%w: lease %s", ErrNotFound, id)
@@ -93,11 +95,11 @@ func (t *Tx) LeaseByID(id string) (Lease, error) {
 // lease is released - so unlike everything else that reads a lease, this
 // does not exclude terminal ones. The name is minted per lease, so it
 // resolves to one attempt or to none.
-func (t *Tx) AttemptOfRuntimeName(runtimeName string) (string, error) {
+func (t *Tx) AttemptOfRuntimeName(runtimeName assignment.RuntimeName) (assignment.AttemptID, error) {
 	if runtimeName == "" {
 		return "", fmt.Errorf("%w: no runtime name to resolve", ErrNotFound)
 	}
-	var attemptID string
+	var attemptID assignment.AttemptID
 	err := t.tx.QueryRow(
 		`SELECT attempt_id FROM capsule_leases WHERE runtime_name = ? ORDER BY rowid DESC LIMIT 1`,
 		runtimeName).Scan(&attemptID)
@@ -116,7 +118,7 @@ func (t *Tx) AttemptOfRuntimeName(runtimeName string) (string, error) {
 // a second, and a tie broken by a random id would answer this with either
 // of them. Insertion order is what "newest" means here and rowid is what
 // records it.
-func (t *Tx) LeaseByAttempt(attemptID string) (Lease, error) {
+func (t *Tx) LeaseByAttempt(attemptID assignment.AttemptID) (Lease, error) {
 	l, err := t.scanLease(t.tx.QueryRow(
 		selectLease+`WHERE attempt_id = ? ORDER BY rowid DESC LIMIT 1`, attemptID))
 	if errors.Is(err, sql.ErrNoRows) {
@@ -282,7 +284,7 @@ func (t *Tx) LeasesInStates(states ...LeaseState) ([]Lease, error) {
 // the runtime record of live work leaves an attempt nothing can finish
 // or explain. Resolve the attempt first — settle it, or hold it for
 // review — and the lease becomes purgeable.
-func (t *Tx) PurgeLease(id string) error {
+func (t *Tx) PurgeLease(id assignment.LeaseID) error {
 	res, err := t.tx.Exec(`
 		DELETE FROM capsule_leases
 		WHERE id = ? AND attempt_id NOT IN (
@@ -296,7 +298,7 @@ func (t *Tx) PurgeLease(id string) error {
 		return err
 	}
 	if n == 0 {
-		if _, err := t.LeaseByID(id); err != nil {
+		if _, err := t.LeaseByID(assignment.LeaseID(id)); err != nil {
 			return err
 		}
 		return fmt.Errorf("%w: lease %s still serves an unresolved attempt", ErrConflict, id)
@@ -333,26 +335,27 @@ func (t *Tx) scanIntent(r rowScanner) (ResourceIntent, error) {
 // external effect. The deterministic name is the recovery handle: a
 // crash after the create call finds the object — or proves its absence
 // — by the name this row already carries.
-func (t *Tx) PlanResource(leaseID string, kind ResourceKind, role, name string) (int64, error) {
+func (t *Tx) PlanResource(leaseID assignment.LeaseID, kind ResourceKind, role, name string) (assignment.ResourceIntentID, error) {
 	res, err := t.tx.Exec(
 		`INSERT INTO resource_intents (lease_id, kind, role, name) VALUES (?, ?, ?, ?)`,
 		leaseID, kind, role, name)
 	if err != nil {
 		return 0, err
 	}
-	return res.LastInsertId()
+	id, err := res.LastInsertId()
+	return assignment.ResourceIntentID(id), err
 }
 
 // MarkResourceCreating records that the create call is about to run: the
 // window in which existence is ambiguous, resolved by the name.
-func (t *Tx) MarkResourceCreating(id int64) error {
+func (t *Tx) MarkResourceCreating(id assignment.ResourceIntentID) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE resource_intents SET state = 'creating', updated_at = unixepoch()
 		 WHERE id = ? AND state = 'planned'`, id))
 }
 
 // MarkResourcePresent confirms the object exists under this id.
-func (t *Tx) MarkResourcePresent(id int64, dockerID string) error {
+func (t *Tx) MarkResourcePresent(id assignment.ResourceIntentID, dockerID string) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE resource_intents SET state = 'present', docker_id = ?, updated_at = unixepoch()
 		 WHERE id = ? AND state IN ('planned', 'creating')`, dockerID, id))
@@ -361,7 +364,7 @@ func (t *Tx) MarkResourcePresent(id int64, dockerID string) error {
 // MarkResourceCleanup queues every one of a lease's intents for
 // removal. Objects that never confirmed are queued too: a creating
 // intent's object may exist, and only the delete path proves otherwise.
-func (t *Tx) MarkResourceCleanup(leaseID string) error {
+func (t *Tx) MarkResourceCleanup(leaseID assignment.LeaseID) error {
 	_, err := t.tx.Exec(
 		`UPDATE resource_intents SET state = 'cleanup_pending', updated_at = unixepoch()
 		 WHERE lease_id = ? AND state IN ('planned', 'creating', 'present')`, leaseID)
@@ -369,7 +372,7 @@ func (t *Tx) MarkResourceCleanup(leaseID string) error {
 }
 
 // MarkResourceDeleting records that the delete call is about to run.
-func (t *Tx) MarkResourceDeleting(id int64) error {
+func (t *Tx) MarkResourceDeleting(id assignment.ResourceIntentID) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE resource_intents SET state = 'deleting', updated_at = unixepoch()
 		 WHERE id = ? AND state IN ('cleanup_pending', 'deleting')`, id))
@@ -377,7 +380,7 @@ func (t *Tx) MarkResourceDeleting(id int64) error {
 
 // ForgetResource is the intent reaching absent: the object is proven
 // gone, so the row goes with it.
-func (t *Tx) ForgetResource(id int64) error {
+func (t *Tx) ForgetResource(id assignment.ResourceIntentID) error {
 	return t.mustAffect(t.tx.Exec(`DELETE FROM resource_intents WHERE id = ?`, id))
 }
 
@@ -385,7 +388,7 @@ func (t *Tx) ForgetResource(id int64) error {
 // bounded retries with exponential backoff and jitter live on the row,
 // so the periodic reconciler paces each resource instead of hammering
 // the daemon.
-func (t *Tx) RecordResourceError(id int64, attemptErr error, notBefore time.Time) error {
+func (t *Tx) RecordResourceError(id assignment.ResourceIntentID, attemptErr error, notBefore time.Time) error {
 	msg := ""
 	if attemptErr != nil {
 		msg = attemptErr.Error()
@@ -396,7 +399,7 @@ func (t *Tx) RecordResourceError(id int64, attemptErr error, notBefore time.Time
 }
 
 // Resources lists a lease's intents, oldest first.
-func (t *Tx) Resources(leaseID string) ([]ResourceIntent, error) {
+func (t *Tx) Resources(leaseID assignment.LeaseID) ([]ResourceIntent, error) {
 	rows, err := t.tx.Query(selectIntent+`WHERE lease_id = ? ORDER BY id`, leaseID)
 	if err != nil {
 		return nil, err

--- a/internal/store/open.go
+++ b/internal/store/open.go
@@ -32,6 +32,8 @@ import (
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // dsn is the connection contract the durability suite in
@@ -188,7 +190,7 @@ func (s *Store) Close() error { return s.db.Close() }
 
 // InstanceID is the stable opaque identity stamped on every owned Docker
 // resource (io.runpool.instance); it is generated once per state volume.
-func (s *Store) InstanceID() string { return s.instanceID }
+func (s *Store) InstanceID() assignment.InstanceID { return assignment.InstanceID(s.instanceID) }
 
 // SchemaVersion exposes the migration level for diagnostics.
 func (s *Store) SchemaVersion() (int, error) {

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Snapshot is everything an operator needs to answer "what does this
@@ -43,10 +45,10 @@ type Snapshot struct {
 // group and scale set name, which is enough for an operator to tell two
 // bindings apart without the adapter's table being consulted.
 type BindingInfo struct {
-	ID               int64
-	TargetID         string
+	ID               assignment.BindingID
+	TargetID         assignment.TargetID
 	ProviderKind     string
-	SourceBindingKey string
+	SourceBindingKey assignment.SourceBindingKey
 	// Contact is what this binding's loop last managed with its provider.
 	// A binding that has never run carries the zero value, which is not
 	// the same as one that is failing: the first has nothing to report,
@@ -65,8 +67,8 @@ func (t *Tx) Bindings() ([]BindingInfo, error) {
 	out := make([]BindingInfo, len(rows))
 	for i, r := range rows {
 		out[i] = BindingInfo{
-			ID: r.ID, TargetID: r.TargetID, ProviderKind: r.ProviderKind,
-			SourceBindingKey: r.SourceBindingKey,
+			ID: assignment.BindingID(r.ID), TargetID: assignment.TargetID(r.TargetID), ProviderKind: r.ProviderKind,
+			SourceBindingKey: assignment.SourceBindingKey(r.SourceBindingKey),
 			Contact:          providerContactFromRow(r.ID, r.LastContactAtMs, r.LastError, r.LastErrorAtMs),
 		}
 	}
@@ -132,7 +134,7 @@ func (s *Store) Snapshot() (Snapshot, error) {
 				return err
 			}
 			if queued > 0 {
-				snap.Queued[b.ID] = int(queued)
+				snap.Queued[int64(b.ID)] = int(queued)
 			}
 		}
 		if snap.CacheLanes, err = tx.CacheLanes(); err != nil {
@@ -186,7 +188,7 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 	byAttempt := make(map[string]string, len(leases)) // attempt id -> lease id
 	args := make([]any, 0, len(leases))
 	for _, l := range leases {
-		byAttempt[l.AttemptID] = l.ID
+		byAttempt[string(l.AttemptID)] = string(l.ID)
 		args = append(args, l.AttemptID)
 	}
 	rows, err := t.tx.Query(selectAttempt+
@@ -229,7 +231,7 @@ func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, err
 		if err != nil {
 			return nil, err
 		}
-		out[in.LeaseID] = append(out[in.LeaseID], in)
+		out[string(in.LeaseID)] = append(out[string(in.LeaseID)], in)
 	}
 	return out, rows.Err()
 }

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -9,16 +9,18 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // Attempt is the store's domain-facing view of one attempt row. It is a
 // translation, not the generated row: consumers never see table types,
 // so a schema change stops at this boundary.
 type Attempt struct {
-	ID                string
-	DeliveryID        int64
-	BindingID         int64
-	SourceWorkloadKey string
+	ID                assignment.AttemptID
+	DeliveryID        assignment.DeliveryID
+	BindingID         assignment.BindingID
+	SourceWorkloadKey assignment.SourceWorkloadKey
 	TenantKey         string
 	ProjectKey        string
 	State             string
@@ -32,11 +34,14 @@ type Attempt struct {
 }
 
 func fromRow(r sqlitedb.AssignmentAttempt) Attempt {
+	// The one place a generated row becomes a domain value. Every
+	// conversion below is here so no caller has to make one, which is
+	// what keeps a swap outside this file a compile error.
 	return Attempt{
-		ID:                r.ID,
-		DeliveryID:        r.DeliveryID,
-		BindingID:         r.BindingID,
-		SourceWorkloadKey: r.SourceWorkloadKey,
+		ID:                assignment.AttemptID(r.ID),
+		DeliveryID:        assignment.DeliveryID(r.DeliveryID),
+		BindingID:         assignment.BindingID(r.BindingID),
+		SourceWorkloadKey: assignment.SourceWorkloadKey(r.SourceWorkloadKey),
 		TenantKey:         r.TenantKey,
 		ProjectKey:        r.ProjectKey,
 		State:             r.State,
@@ -59,8 +64,8 @@ type Event struct {
 }
 
 // Events lists an attempt's lifecycle, oldest first.
-func (t *Tx) Events(attemptID string) ([]Event, error) {
-	rows, err := t.q.ListAttemptEvents(t.ctx, attemptID)
+func (t *Tx) Events(attemptID assignment.AttemptID) ([]Event, error) {
+	rows, err := t.q.ListAttemptEvents(t.ctx, string(attemptID))
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +85,8 @@ func fromRows(rows []sqlitedb.AssignmentAttempt) []Attempt {
 }
 
 // ReadyAttempts lists a binding's servable work, oldest first.
-func (t *Tx) ReadyAttempts(bindingID int64) ([]Attempt, error) {
-	rows, err := t.q.ListReadyAttempts(t.ctx, bindingID)
+func (t *Tx) ReadyAttempts(bindingID assignment.BindingID) ([]Attempt, error) {
+	rows, err := t.q.ListReadyAttempts(t.ctx, int64(bindingID))
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +103,8 @@ func (t *Tx) ManualReviewAttempts() ([]Attempt, error) {
 }
 
 // Get reloads one attempt by id, whatever state it moved to.
-func (t *Tx) Get(attemptID string) (Attempt, error) {
-	row, err := t.q.GetAttempt(t.ctx, attemptID)
+func (t *Tx) Get(attemptID assignment.AttemptID) (Attempt, error) {
+	row, err := t.q.GetAttempt(t.ctx, string(attemptID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Attempt{}, ErrNotFound
 	}
@@ -110,8 +115,8 @@ func (t *Tx) Get(attemptID string) (Attempt, error) {
 }
 
 // AttemptByLease resolves the attempt a lease is serving.
-func (t *Tx) AttemptByLease(leaseID string) (Attempt, error) {
-	row, err := t.q.GetAttemptByLease(t.ctx, leaseID)
+func (t *Tx) AttemptByLease(leaseID assignment.LeaseID) (Attempt, error) {
+	row, err := t.q.GetAttemptByLease(t.ctx, string(leaseID))
 	if errors.Is(err, sql.ErrNoRows) {
 		return Attempt{}, ErrNotFound
 	}
@@ -122,8 +127,8 @@ func (t *Tx) AttemptByLease(leaseID string) (Attempt, error) {
 }
 
 // AttemptsOfDelivery lists the attempts one delivery carries.
-func (t *Tx) AttemptsOfDelivery(deliveryID int64) ([]Attempt, error) {
-	rows, err := t.q.ListAttemptsByDelivery(t.ctx, deliveryID)
+func (t *Tx) AttemptsOfDelivery(deliveryID assignment.DeliveryID) ([]Attempt, error) {
+	rows, err := t.q.ListAttemptsByDelivery(t.ctx, int64(deliveryID))
 	if err != nil {
 		return nil, err
 	}
@@ -145,9 +150,9 @@ func (t *Tx) StrandedAttempts() ([]Attempt, error) {
 // Advance walks the attempt state machine one edge, compare-and-swap.
 // The walk is observability — disposition rests on evidence and the
 // terminal transitions — so a conflict here reports rather than blocks.
-func (t *Tx) Advance(attemptID, from, to string) error {
+func (t *Tx) Advance(attemptID assignment.AttemptID, from, to string) error {
 	affected, err := t.q.TransitionAttempt(t.ctx, sqlitedb.TransitionAttemptParams{
-		Next: to, AttemptID: attemptID, Current: from,
+		Next: to, AttemptID: string(attemptID), Current: from,
 	})
 	if err != nil {
 		return err
@@ -187,7 +192,7 @@ const DefaultRetryBudget = 3
 // whose attempt is still open (prunableReleasedLeases). GC forgetting
 // those rows would silently reset this to zero and reopen the unbounded
 // retry it exists to close.
-func (t *Tx) servingsSoFar(attemptID string) (int, error) {
+func (t *Tx) servingsSoFar(attemptID assignment.AttemptID) (int, error) {
 	var n int
 	err := t.tx.QueryRow(
 		`SELECT count(*) FROM capsule_leases WHERE attempt_id = ?`, attemptID).Scan(&n)
@@ -197,7 +202,7 @@ func (t *Tx) servingsSoFar(attemptID string) (int, error) {
 // withinRetryBudget refuses a requeue that would exceed the budget. It
 // guards the automatic paths only: an operator resolving a review has
 // established something the counter has not, and is not overruled by it.
-func (t *Tx) withinRetryBudget(attemptID string) error {
+func (t *Tx) withinRetryBudget(attemptID assignment.AttemptID) error {
 	n, err := t.servingsSoFar(attemptID)
 	if err != nil {
 		return err
@@ -213,11 +218,11 @@ func (t *Tx) withinRetryBudget(attemptID string) error {
 // servable queue. Only leased, preparing and prepared qualify: they all
 // precede the start authorization, and from starting onward
 // at-most-once rules.
-func (t *Tx) Requeue(attemptID string) error {
+func (t *Tx) Requeue(attemptID assignment.AttemptID) error {
 	if err := t.withinRetryBudget(attemptID); err != nil {
 		return err
 	}
-	affected, err := t.q.RequeueAttempt(t.ctx, attemptID)
+	affected, err := t.q.RequeueAttempt(t.ctx, string(attemptID))
 	if err != nil {
 		return err
 	}
@@ -230,11 +235,11 @@ func (t *Tx) Requeue(attemptID string) error {
 // RequeueProvenInert is the one legal requeue past the start
 // authorization: the daemon proved the start never took effect, so the
 // at-most-once rule has nothing to protect.
-func (t *Tx) RequeueProvenInert(attemptID string) error {
+func (t *Tx) RequeueProvenInert(attemptID assignment.AttemptID) error {
 	if err := t.withinRetryBudget(attemptID); err != nil {
 		return err
 	}
-	affected, err := t.q.RequeueProvenInertAttempt(t.ctx, attemptID)
+	affected, err := t.q.RequeueProvenInertAttempt(t.ctx, string(attemptID))
 	if err != nil {
 		return err
 	}
@@ -252,9 +257,9 @@ func (t *Tx) RequeueProvenInert(attemptID string) error {
 // It takes the attempt rather than the workload because a workload can
 // hold more than one attempt over its life, and only the caller that
 // correlated the event knows which of them the cancellation is about.
-func (t *Tx) CancelReady(attemptID, resolution string) error {
+func (t *Tx) CancelReady(attemptID assignment.AttemptID, resolution string) error {
 	affected, err := t.q.CancelReadyAttempt(t.ctx, sqlitedb.CancelReadyAttemptParams{
-		Resolution: resolution, AttemptID: attemptID,
+		Resolution: resolution, AttemptID: string(attemptID),
 	})
 	if err != nil {
 		return err
@@ -269,9 +274,9 @@ func (t *Tx) CancelReady(attemptID, resolution string) error {
 // or ErrNotFound when the workload has none open. A workload holds at
 // most one open attempt at a time, which the partial unique index
 // enforces, so the answer is unambiguous when there is one.
-func (t *Tx) OpenAttemptByWorkload(bindingID int64, workloadKey string) (Attempt, error) {
+func (t *Tx) OpenAttemptByWorkload(bindingID assignment.BindingID, workloadKey assignment.SourceWorkloadKey) (Attempt, error) {
 	row, err := t.q.GetOpenAttemptByWorkload(t.ctx, sqlitedb.GetOpenAttemptByWorkloadParams{
-		BindingID: bindingID, SourceWorkloadKey: workloadKey,
+		BindingID: int64(bindingID), SourceWorkloadKey: string(workloadKey),
 	})
 	if errors.Is(err, sql.ErrNoRows) {
 		return Attempt{}, ErrNotFound
@@ -285,8 +290,8 @@ func (t *Tx) OpenAttemptByWorkload(bindingID int64, workloadKey string) (Attempt
 // CountReadyAttempts is how many attempts wait for admission on this
 // binding. Reported so a queue that stops draining is visible before it
 // is diagnosed.
-func (t *Tx) CountReadyAttempts(bindingID int64) (int64, error) {
-	return t.q.CountReadyAttempts(t.ctx, bindingID)
+func (t *Tx) CountReadyAttempts(bindingID assignment.BindingID) (int64, error) {
+	return t.q.CountReadyAttempts(t.ctx, int64(bindingID))
 }
 
 // ResolveReviewToReady is the operator deciding a held attempt may run
@@ -294,9 +299,9 @@ func (t *Tx) CountReadyAttempts(bindingID int64) (int64, error) {
 // executed, because the row itself holds no proof either way. The
 // decision is audited: actor and timestamp on the row, actor and reason
 // in the event.
-func (t *Tx) ResolveReviewToReady(attemptID, reason, actor string) error {
+func (t *Tx) ResolveReviewToReady(attemptID assignment.AttemptID, reason, actor string) error {
 	affected, err := t.q.ResolveManualReviewToReady(t.ctx, sqlitedb.ResolveManualReviewToReadyParams{
-		Resolution: "", ReviewedBy: actor, AttemptID: attemptID,
+		Resolution: "", ReviewedBy: actor, AttemptID: string(attemptID),
 	})
 	if err != nil {
 		return err
@@ -312,9 +317,9 @@ func (t *Tx) ResolveReviewToReady(attemptID, reason, actor string) error {
 // have run and must never run again. Audited the same way; the row's
 // resolution keeps the vocabulary value, and the operator's words live
 // in the event.
-func (t *Tx) ResolveReviewToSettled(attemptID, resolution, reason, actor string) error {
+func (t *Tx) ResolveReviewToSettled(attemptID assignment.AttemptID, resolution, reason, actor string) error {
 	affected, err := t.q.ResolveManualReviewToSettled(t.ctx, sqlitedb.ResolveManualReviewToSettledParams{
-		Resolution: resolution, ReviewedBy: actor, AttemptID: attemptID,
+		Resolution: resolution, ReviewedBy: actor, AttemptID: string(attemptID),
 	})
 	if err != nil {
 		return err
@@ -327,9 +332,9 @@ func (t *Tx) ResolveReviewToSettled(attemptID, resolution, reason, actor string)
 }
 
 // Settle closes an attempt with an evidence-accurate resolution.
-func (t *Tx) Settle(attemptID, currentState, resolution string) error {
+func (t *Tx) Settle(attemptID assignment.AttemptID, currentState, resolution string) error {
 	affected, err := t.q.SettleAttempt(t.ctx, sqlitedb.SettleAttemptParams{
-		Resolution: resolution, AttemptID: attemptID, Current: currentState,
+		Resolution: resolution, AttemptID: string(attemptID), Current: currentState,
 	})
 	if err != nil {
 		return err
@@ -342,9 +347,9 @@ func (t *Tx) Settle(attemptID, currentState, resolution string) error {
 
 // HoldForReview parks an attempt for an operator with the reason the
 // queue will show.
-func (t *Tx) HoldForReview(attemptID, reason string) error {
+func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason string) error {
 	affected, err := t.q.MarkAttemptManualReview(t.ctx, sqlitedb.MarkAttemptManualReviewParams{
-		ReviewReason: reason, AttemptID: attemptID,
+		ReviewReason: reason, AttemptID: string(attemptID),
 	})
 	if err != nil {
 		return err
@@ -356,9 +361,9 @@ func (t *Tx) HoldForReview(attemptID, reason string) error {
 }
 
 // RecordEvent appends one lifecycle event, idempotently per key.
-func (t *Tx) RecordEvent(attemptID, idempotencyKey, kind string) error {
+func (t *Tx) RecordEvent(attemptID assignment.AttemptID, idempotencyKey, kind string) error {
 	_, err := t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
-		AttemptID: attemptID, IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: "{}",
+		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: "{}",
 	})
 	return err
 }
@@ -367,13 +372,13 @@ func (t *Tx) RecordEvent(attemptID, idempotencyKey, kind string) error {
 // detail. The detail is marshalled here so nothing unvalidated reaches
 // the column, and it must never contain secrets — it is what an
 // operator reads back.
-func (t *Tx) RecordEventDetail(attemptID, idempotencyKey, kind string, detail map[string]string) error {
+func (t *Tx) RecordEventDetail(attemptID assignment.AttemptID, idempotencyKey, kind string, detail map[string]string) error {
 	encoded, err := json.Marshal(detail)
 	if err != nil {
 		return err
 	}
 	_, err = t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
-		AttemptID: attemptID, IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: string(encoded),
+		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: string(encoded),
 	})
 	return err
 }
@@ -381,35 +386,36 @@ func (t *Tx) RecordEventDetail(attemptID, idempotencyKey, kind string, detail ma
 // AckRequested marks a delivery's acknowledgement as in flight,
 // immediately before the network call. It reports false when the
 // delivery is already confirmed, so the caller skips the call.
-func (t *Tx) AckRequested(deliveryID int64) (bool, error) {
-	affected, err := t.q.MarkAckRequested(t.ctx, deliveryID)
+func (t *Tx) AckRequested(deliveryID assignment.DeliveryID) (bool, error) {
+	affected, err := t.q.MarkAckRequested(t.ctx, int64(deliveryID))
 	return affected > 0, err
 }
 
 // AckConfirmed records an unambiguous acknowledgement. Already
 // confirmed is idempotent success.
-func (t *Tx) AckConfirmed(deliveryID int64) error {
-	_, err := t.q.MarkAckConfirmed(t.ctx, deliveryID)
+func (t *Tx) AckConfirmed(deliveryID assignment.DeliveryID) error {
+	_, err := t.q.MarkAckConfirmed(t.ctx, int64(deliveryID))
 	return err
 }
 
 // AckUncertain records an acknowledgement whose result is unknown — a
 // timeout, an ambiguous error. The delivery stays retriable; the
 // broker's redelivery plus idempotent recording converge it.
-func (t *Tx) AckUncertain(deliveryID int64) error {
-	_, err := t.q.MarkAckUncertain(t.ctx, deliveryID)
+func (t *Tx) AckUncertain(deliveryID assignment.DeliveryID) error {
+	_, err := t.q.MarkAckUncertain(t.ctx, int64(deliveryID))
 	return err
 }
 
 // EnsureBinding records the neutral binding identity and returns its id.
-func (t *Tx) EnsureBinding(targetID, providerKind, sourceBindingKey string) (int64, error) {
+func (t *Tx) EnsureBinding(targetID assignment.TargetID, providerKind string,
+	sourceBindingKey assignment.SourceBindingKey) (assignment.BindingID, error) {
 	b, err := t.q.InsertProviderBinding(t.ctx, sqlitedb.InsertProviderBindingParams{
-		TargetID: targetID, ProviderKind: providerKind, SourceBindingKey: sourceBindingKey,
+		TargetID: string(targetID), ProviderKind: providerKind, SourceBindingKey: string(sourceBindingKey),
 	})
 	if err != nil {
 		return 0, err
 	}
-	return b.ID, nil
+	return assignment.BindingID(b.ID), nil
 }
 
 // ProviderContact is what one binding's loop last managed with its
@@ -425,17 +431,17 @@ type ProviderContact struct {
 
 // RecordProviderContact marks a provider call for this binding as having
 // succeeded, and clears whatever was failing.
-func (t *Tx) RecordProviderContact(bindingID int64, at time.Time) error {
+func (t *Tx) RecordProviderContact(bindingID assignment.BindingID, at time.Time) error {
 	return t.q.RecordProviderContact(t.ctx, sqlitedb.RecordProviderContactParams{
-		BindingID: bindingID, At: at.UnixMilli(),
+		BindingID: int64(bindingID), At: at.UnixMilli(),
 	})
 }
 
 // RecordProviderFailure records what this binding cannot currently do
 // with its provider, without disturbing when it last could.
-func (t *Tx) RecordProviderFailure(bindingID int64, at time.Time, reason string) error {
+func (t *Tx) RecordProviderFailure(bindingID assignment.BindingID, at time.Time, reason string) error {
 	return t.q.RecordProviderFailure(t.ctx, sqlitedb.RecordProviderFailureParams{
-		BindingID: bindingID, LastError: reason, At: at.UnixMilli(),
+		BindingID: int64(bindingID), LastError: reason, At: at.UnixMilli(),
 	})
 }
 
@@ -468,7 +474,7 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 // The placeholder list is built here rather than through the generated
 // layer: sqlc's sqlite engine has no slice parameter, and the ids come
 // from the caller's own loop, never from input.
-func (t *Tx) ForgetUnclaimedBindings(claimed []int64) (int, error) {
+func (t *Tx) ForgetUnclaimedBindings(claimed []assignment.BindingID) (int, error) {
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(claimed)), ",")
 	if placeholders == "" {
 		// No claim at all is a caller with no bindings, which serve

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 func openStore(t *testing.T, dir string) *Store {
@@ -36,9 +38,9 @@ func inTx(t *testing.T, s *Store, fn func(*Tx) error) {
 	}
 }
 
-func seedBinding(t *testing.T, s *Store) int64 {
+func seedBinding(t *testing.T, s *Store) assignment.BindingID {
 	t.Helper()
-	var id int64
+	var id assignment.BindingID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		id, err = tx.EnsureBinding("default", "github_actions",
@@ -51,21 +53,22 @@ func seedBinding(t *testing.T, s *Store) int64 {
 // seedAttempt records one delivery carrying one workload and returns the
 // ready attempt it produced — the starting point for anything that needs
 // work to lease.
-func seedAttempt(t *testing.T, s *Store, binding int64, deliveryKey, workloadKey string) string {
+func seedAttempt(t *testing.T, s *Store, binding assignment.BindingID,
+	deliveryKey string, workloadKey assignment.SourceWorkloadKey) assignment.AttemptID {
 	t.Helper()
 	var id string
 	inTx(t, s, func(tx *Tx) error {
 		if _, err := tx.RecordDelivery(binding, deliveryKey, fingerprint(deliveryKey),
-			[]WorkloadRow{{SourceWorkloadKey: workloadKey, TenantKey: "acme", ProjectKey: "app"}}); err != nil {
+			[]WorkloadRow{{SourceWorkloadKey: string(workloadKey), TenantKey: "acme", ProjectKey: "app"}}); err != nil {
 			return err
 		}
 		attempt, err := tx.q.GetOpenAttemptByWorkload(tx.ctx, sqlitedb.GetOpenAttemptByWorkloadParams{
-			BindingID: binding, SourceWorkloadKey: workloadKey,
+			BindingID: int64(binding), SourceWorkloadKey: string(workloadKey),
 		})
 		id = attempt.ID
 		return err
 	})
-	return id
+	return assignment.AttemptID(id)
 }
 
 func fingerprint(s string) [32]byte { return sha256.Sum256([]byte(s)) }
@@ -79,7 +82,7 @@ func TestRedeliveryIsIdempotentAndDriftFailsClosed(t *testing.T) {
 	binding := seedBinding(t, s)
 	workloads := []WorkloadRow{{SourceWorkloadKey: "job-1", TenantKey: "acme", ProjectKey: "app"}}
 
-	var first int64
+	var first assignment.DeliveryID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		first, err = tx.RecordDelivery(binding, "msg-7", fingerprint("payload-a"), workloads)
@@ -95,7 +98,7 @@ func TestRedeliveryIsIdempotentAndDriftFailsClosed(t *testing.T) {
 		if again != first {
 			t.Errorf("redelivery produced delivery %d; want the original %d", again, first)
 		}
-		n, err := tx.q.CountOpenAttempts(tx.ctx, binding)
+		n, err := tx.q.CountOpenAttempts(tx.ctx, int64(binding))
 		if err != nil {
 			return err
 		}
@@ -157,7 +160,7 @@ func TestReassignmentNeedsThePredecessorResolved(t *testing.T) {
 		if len(ready) != 1 || ready[0].SourceWorkloadKey != "job-r" {
 			t.Errorf("ready attempts = %+v; want exactly the reassigned workload", ready)
 		}
-		n, err := tx.q.CountOpenAttempts(tx.ctx, binding)
+		n, err := tx.q.CountOpenAttempts(tx.ctx, int64(binding))
 		if err != nil {
 			return err
 		}
@@ -236,7 +239,7 @@ func TestAckStateMachineConvergesAfterUncertainty(t *testing.T) {
 	s := newStore(t)
 	binding := seedBinding(t, s)
 
-	var deliveryID int64
+	var deliveryID assignment.DeliveryID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		deliveryID, err = tx.RecordDelivery(binding, "msg-ack", fingerprint("ack"),
@@ -381,7 +384,7 @@ func TestPurgeLeaseRefusesWhileItsAttemptIsUnresolved(t *testing.T) {
 	binding := seedBinding(t, s)
 	attempt := seedAttempt(t, s, binding, "msg-fk", "job-fk")
 
-	var leaseID string
+	var leaseID assignment.LeaseID
 	inTx(t, s, func(tx *Tx) error {
 		lease, err := tx.LeaseAttempt(attempt, binding, "standard")
 		leaseID = lease.ID
@@ -495,7 +498,7 @@ func TestAckRequestedIsRetriedAfterACrashInFlight(t *testing.T) {
 	s := newStore(t)
 	binding := seedBinding(t, s)
 
-	var deliveryID int64
+	var deliveryID assignment.DeliveryID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		deliveryID, err = tx.RecordDelivery(binding, "msg-wedge", fingerprint("wedge"),
@@ -594,9 +597,9 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	// the random id tiebreak — which is how an order assertion passes
 	// whichever way the query is written.
 	base := time.Now().Add(-released * time.Hour)
-	finishOrder := make([]string, released)
+	finishOrder := make([]assignment.LeaseID, released)
 	for i := range released {
-		id, _ := releasedLease(t, s, binding, fmt.Sprintf("done-%03d", i))
+		id, _ := releasedLease(t, s, binding, assignment.SourceWorkloadKey(fmt.Sprintf("done-%03d", i)))
 		backdateLease(t, s, id, base, base.Add(time.Duration(i)*time.Hour))
 		finishOrder[i] = id
 	}
@@ -604,14 +607,14 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	// Three live leases, each in a different state.
 	live := map[string]bool{}
 	for i, state := range []LeaseState{LeaseReserved, LeaseProvisioning, LeaseRuntimeRegistered} {
-		key := fmt.Sprintf("live-%d", i)
-		attempt := seedAttempt(t, s, binding, "msg-"+key, "job-"+key)
+		key := assignment.SourceWorkloadKey(fmt.Sprintf("live-%d", i))
+		attempt := seedAttempt(t, s, binding, "msg-"+string(key), "job-"+key)
 		inTx(t, s, func(tx *Tx) error {
 			lease, err := tx.LeaseAttempt(attempt, binding, "standard")
 			if err != nil {
 				return err
 			}
-			live[lease.ID] = true
+			live[string(lease.ID)] = true
 			if state == LeaseReserved {
 				return nil
 			}
@@ -633,7 +636,7 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	var gotLive, gotReleased int
 	seen := map[string]bool{}
 	for _, l := range snap.Leases {
-		seen[l.ID] = true
+		seen[string(l.ID)] = true
 		if l.State.Terminal() {
 			gotReleased++
 		} else {
@@ -664,7 +667,7 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	// — selection order and emission order are opposite, so both halves are
 	// named here rather than left to a monotonicity check that a reversed
 	// query would also satisfy.
-	var carried []string
+	var carried []assignment.LeaseID
 	for _, l := range snap.Leases {
 		if l.State.Terminal() {
 			carried = append(carried, l.ID)
@@ -681,7 +684,7 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 // waiting for one. Start and finish are separate arguments because the two
 // are the whole question: a lease that ran for months finished once, and
 // only the second of those times says whether its record is still wanted.
-func backdateLease(t *testing.T, s *Store, leaseID string, started, finished time.Time) {
+func backdateLease(t *testing.T, s *Store, leaseID assignment.LeaseID, started, finished time.Time) {
 	t.Helper()
 	inTx(t, s, func(tx *Tx) error {
 		_, err := tx.tx.Exec(
@@ -692,9 +695,9 @@ func backdateLease(t *testing.T, s *Store, leaseID string, started, finished tim
 }
 
 // releasedLease drives one attempt to a released lease and returns both ids.
-func releasedLease(t *testing.T, s *Store, binding int64, key string) (leaseID, attemptID string) {
+func releasedLease(t *testing.T, s *Store, binding assignment.BindingID, key assignment.SourceWorkloadKey) (leaseID assignment.LeaseID, attemptID assignment.AttemptID) {
 	t.Helper()
-	attemptID = seedAttempt(t, s, binding, "msg-"+key, "job-"+key)
+	attemptID = seedAttempt(t, s, binding, "msg-"+string(key), "job-"+key)
 	inTx(t, s, func(tx *Tx) error {
 		lease, err := tx.LeaseAttempt(attemptID, binding, "standard")
 		if err != nil {
@@ -881,7 +884,7 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 // backdateAttempt ages an attempt's arrival without waiting for it.
 // received_at is what the ready queue is ordered by, so moving it is the
 // whole of what growing old means for an attempt.
-func backdateAttempt(t *testing.T, s *Store, attemptID string, arrived time.Time) {
+func backdateAttempt(t *testing.T, s *Store, attemptID assignment.AttemptID, arrived time.Time) {
 	t.Helper()
 	inTx(t, s, func(tx *Tx) error {
 		_, err := tx.tx.Exec(
@@ -924,7 +927,7 @@ func TestReadyAttemptsAreServedOldestFirst(t *testing.T) {
 
 	got := make([]string, len(ready))
 	for i, a := range ready {
-		got[i] = a.SourceWorkloadKey
+		got[i] = string(a.SourceWorkloadKey)
 	}
 	want := []string{"job-oldest", "job-middle", "job-newest"}
 	if !slices.Equal(got, want) {
@@ -936,12 +939,12 @@ func TestReadyAttemptsAreServedOldestFirst(t *testing.T) {
 // one serving of an attempt costs. Requeue happens in the same commit as
 // the release, so the next serving always starts with the predecessor
 // already terminal.
-func serve(t *testing.T, s *Store, binding int64, attemptID string) Lease {
+func serve(t *testing.T, s *Store, binding int64, attemptID assignment.AttemptID) Lease {
 	t.Helper()
 	var lease Lease
 	inTx(t, s, func(tx *Tx) error {
 		var err error
-		lease, err = tx.LeaseAttempt(attemptID, binding, "standard")
+		lease, err = tx.LeaseAttempt(attemptID, assignment.BindingID(binding), "standard")
 		return err
 	})
 	for _, step := range [][2]LeaseState{
@@ -966,7 +969,7 @@ func TestARequeuedAttemptIsServedAgain(t *testing.T) {
 	binding := seedBinding(t, s)
 	attemptID := seedAttempt(t, s, binding, "msg-1", "job-1")
 
-	first := serve(t, s, binding, attemptID)
+	first := serve(t, s, int64(binding), attemptID)
 	inTx(t, s, func(tx *Tx) error { return tx.Requeue(attemptID) })
 
 	var second Lease
@@ -1039,7 +1042,7 @@ func TestTheRetryBudgetEndsInReviewRatherThanForever(t *testing.T) {
 	attemptID := seedAttempt(t, s, binding, "msg-1", "job-1")
 
 	for i := 1; i < DefaultRetryBudget; i++ {
-		serve(t, s, binding, attemptID)
+		serve(t, s, int64(binding), attemptID)
 		inTx(t, s, func(tx *Tx) error {
 			if err := tx.Requeue(attemptID); err != nil {
 				t.Fatalf("serving %d was refused within the budget: %v", i, err)
@@ -1047,7 +1050,7 @@ func TestTheRetryBudgetEndsInReviewRatherThanForever(t *testing.T) {
 			return nil
 		})
 	}
-	serve(t, s, binding, attemptID)
+	serve(t, s, int64(binding), attemptID)
 
 	err := s.Tx(t.Context(), func(tx *Tx) error { return tx.Requeue(attemptID) })
 	if !errors.Is(err, ErrRetryBudgetExhausted) {
@@ -1066,7 +1069,7 @@ func TestAnOperatorRetryIsNotOverruledByTheBudget(t *testing.T) {
 	attemptID := seedAttempt(t, s, binding, "msg-1", "job-1")
 
 	for i := 0; i < DefaultRetryBudget; i++ {
-		serve(t, s, binding, attemptID)
+		serve(t, s, int64(binding), attemptID)
 		if i < DefaultRetryBudget-1 {
 			inTx(t, s, func(tx *Tx) error { return tx.Requeue(attemptID) })
 		}
@@ -1111,7 +1114,7 @@ func TestARetryInFlightIsNotStranded(t *testing.T) {
 	binding := seedBinding(t, s)
 	attemptID := seedAttempt(t, s, binding, "msg-1", "job-1")
 
-	serve(t, s, binding, attemptID)
+	serve(t, s, int64(binding), attemptID)
 	inTx(t, s, func(tx *Tx) error { return tx.Requeue(attemptID) })
 	inTx(t, s, func(tx *Tx) error {
 		_, err := tx.LeaseAttempt(attemptID, binding, "standard")
@@ -1182,23 +1185,23 @@ func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 		requeue func(*Tx, string) error
 	}{
 		{"plain requeue from prepared", "prepared", func(tx *Tx, id string) error {
-			if err := tx.Advance(id, "leased", "preparing"); err != nil {
+			if err := tx.Advance(assignment.AttemptID(id), "leased", "preparing"); err != nil {
 				return err
 			}
-			if err := tx.Advance(id, "preparing", "prepared"); err != nil {
+			if err := tx.Advance(assignment.AttemptID(id), "preparing", "prepared"); err != nil {
 				return err
 			}
-			return tx.Requeue(id)
+			return tx.Requeue(assignment.AttemptID(id))
 		}},
 		{"proven inert from starting", "starting", func(tx *Tx, id string) error {
 			for _, step := range [][2]string{
 				{"leased", "preparing"}, {"preparing", "prepared"}, {"prepared", "starting"},
 			} {
-				if err := tx.Advance(id, step[0], step[1]); err != nil {
+				if err := tx.Advance(assignment.AttemptID(id), step[0], step[1]); err != nil {
 					return err
 				}
 			}
-			return tx.RequeueProvenInert(id)
+			return tx.RequeueProvenInert(assignment.AttemptID(id))
 		}},
 	}
 	for _, tc := range cases {
@@ -1215,7 +1218,7 @@ func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 						return err
 					}
 				}
-				return tc.requeue(tx, attemptID)
+				return tc.requeue(tx, string(attemptID))
 			})
 			inTx(t, s, func(tx *Tx) error {
 				if err := tx.RecordEvidence(attemptID, EvidenceRuntimePrepared); err != nil {
@@ -1325,7 +1328,7 @@ func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
 			binding := seedBinding(t, s)
 			workloads := []WorkloadRow{{SourceWorkloadKey: "job-held", TenantKey: "acme", ProjectKey: "app"}}
 
-			var attemptID string
+			var attemptID assignment.AttemptID
 			inTx(t, s, func(tx *Tx) error {
 				if _, err := tx.RecordDelivery(binding, "msg-1", fingerprint("first"), workloads); err != nil {
 					return err
@@ -1387,7 +1390,7 @@ func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
 func TestABindingConfigurationNoLongerClaimsIsForgotten(t *testing.T) {
 	s := newStore(t)
 
-	var kept, dropped, withWork int64
+	var kept, dropped, withWork assignment.BindingID
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		if kept, err = tx.EnsureBinding("app", "github_actions", "v2|app|default|runpool-standard"); err != nil {
@@ -1407,14 +1410,14 @@ func TestABindingConfigurationNoLongerClaimsIsForgotten(t *testing.T) {
 	var forgotten int
 	inTx(t, s, func(tx *Tx) error {
 		var err error
-		forgotten, err = tx.ForgetUnclaimedBindings([]int64{kept})
+		forgotten, err = tx.ForgetUnclaimedBindings([]assignment.BindingID{kept})
 		return err
 	})
 	if forgotten != 1 {
 		t.Errorf("forgot %d bindings; want exactly the one that holds no work", forgotten)
 	}
 
-	var ids []int64
+	var ids []assignment.BindingID
 	inTx(t, s, func(tx *Tx) error {
 		rows, err := tx.Bindings()
 		if err != nil {

--- a/test/contract/capsule/budget_test.go
+++ b/test/contract/capsule/budget_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/egress"
 	"github.com/rhobuild/runpool/internal/platform/docker"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // TestLeaseResourceBudget proves on a real kernel what the threat model
@@ -55,7 +57,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 		PIDs:   512,
 	}
 	prepared, err := m.Prepare(ctx, capsule.Spec{
-		LeaseID:      leaseID,
+		LeaseID:      assignment.LeaseID(leaseID),
 		InstanceID:   "contract",
 		CapsuleImage: image,
 		JITConfig:    fakeJITConfig,
@@ -75,7 +77,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}
@@ -83,7 +85,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 	// Both containers report the same parent cgroup, so the kernel
 	// accounts them as one aggregate and one path reports the lease.
 	wantParent := capsule.LeaseCgroupParent(info.CgroupDriver, leaseID)
-	for name, id := range map[string]string{"capsule": prepared.RuntimeID, "gateway": gwID} {
+	for name, id := range map[string]string{"capsule": string(prepared.RuntimeID), "gateway": gwID} {
 		got, err := dock.ContainerCgroupParent(ctx, id)
 		if err != nil {
 			t.Fatalf("%s cgroup parent: %v", name, err)
@@ -96,7 +98,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 	// The kernel's own numbers, read from inside each container's
 	// cgroup: what the daemon was asked for is not evidence, what the
 	// kernel enforces is.
-	capsuleLimits := readCgroupLimits(ctx, t, dock, prepared.RuntimeID)
+	capsuleLimits := readCgroupLimits(ctx, t, dock, string(prepared.RuntimeID))
 	gatewayLimits := readCgroupLimits(ctx, t, dock, gwID)
 
 	if got := capsuleLimits.memory + gatewayLimits.memory; got != int64(tier.Memory) {

--- a/test/contract/capsule/bypass_test.go
+++ b/test/contract/capsule/bypass_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/egress"
 	"github.com/rhobuild/runpool/internal/platform/docker"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // TestNetworkSandboxBypass is the egress bypass suite, run against a
@@ -30,7 +32,8 @@ import (
 //
 // Then the gateway is removed, and egress must go with it.
 func TestNetworkSandboxBypass(t *testing.T) {
-	m, dock, leaseID := launcher(t)
+	m, dock, name := launcher(t)
+	leaseID := assignment.LeaseID(name)
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	defer cancel()
 
@@ -38,7 +41,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 
 	// The uplink stands in for the instance's shared egress network.
 	uplinkID, err := dock.CreateNetwork(ctx, docker.NetworkSpec{
-		Name:   leaseID + "-uplink",
+		Name:   string(string(leaseID) + "-uplink"),
 		Labels: map[string]string{docker.LabelManaged: "true", docker.LabelInstance: "contract", docker.LabelRole: capsule.RoleUplink},
 	})
 	if err != nil {
@@ -57,7 +60,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 		[]string{"172.30.0.0/16"})  // stand-in other Docker network
 
 	prepared, err := m.Prepare(ctx, capsule.Spec{
-		LeaseID:      leaseID,
+		LeaseID:      assignment.LeaseID(leaseID),
 		InstanceID:   "contract",
 		CapsuleImage: image,
 		JITConfig:    fakeJITConfig,
@@ -77,7 +80,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	// direct opens a raw TCP connection from the capsule, with no
 	// proxy: the path the host must refuse in every case.
 	direct := func(host string, port int) bool {
-		code, _, err := dock.Exec(ctx, capsuleID, []string{
+		code, _, err := dock.Exec(ctx, string(capsuleID), []string{
 			"bash", "-c", fmt.Sprintf("timeout 5 bash -c 'echo > /dev/tcp/%s/%d' 2>/dev/null", host, port),
 		})
 		return err == nil && code == 0
@@ -85,7 +88,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	// relayed asks the gateway to reach a URL. Exit 0 means the relay
 	// connected; the body is irrelevant.
 	relayed := func(url string) (bool, string) {
-		code, out, err := dock.Exec(ctx, capsuleID, []string{
+		code, out, err := dock.Exec(ctx, string(capsuleID), []string{
 			"bash", "-c", fmt.Sprintf(
 				"curl -sS -o /dev/null -w '%%{http_code}' --max-time 20 %s 2>&1", url),
 		})
@@ -116,7 +119,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 
 	// DNS resolves — through the gateway's relay, the only resolver the
 	// capsule can reach.
-	if code, out, err := dock.Exec(ctx, capsuleID, []string{"getent", "hosts", "example.com"}); err != nil || code != 0 {
+	if code, out, err := dock.Exec(ctx, string(capsuleID), []string{"getent", "hosts", "example.com"}); err != nil || code != 0 {
 		t.Errorf("DNS through the gateway failed: exit %d, %v, %s", code, err, out)
 		dumpSandboxDiag(ctx, t, dock, capsuleID, leaseID)
 	}
@@ -149,7 +152,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}
@@ -167,21 +170,22 @@ func TestNetworkSandboxBypass(t *testing.T) {
 // dumpSandboxDiag prints the sandbox's live state when an assertion
 // fails, so a failure is diagnosed from the actual routes and rules
 // rather than guessed at.
-func dumpSandboxDiag(ctx context.Context, t *testing.T, dock *docker.Client, capsuleID, leaseID string) {
+func dumpSandboxDiag(ctx context.Context, t *testing.T, dock *docker.Client,
+	capsuleID assignment.RuntimeID, leaseID assignment.LeaseID) {
 	t.Helper()
 	show := func(container, label string, cmd ...string) {
 		code, out, err := dock.Exec(ctx, container, cmd)
 		t.Logf("--- %s (exit %d, err %v) ---\n%s", label, code, err, out)
 	}
-	show(capsuleID, "capsule: ip route", "ip", "route")
-	show(capsuleID, "capsule: resolv.conf", "cat", "/etc/resolv.conf")
-	show(capsuleID, "capsule: proxy env", "bash", "-c", "env | grep -i proxy | sort")
+	show(string(capsuleID), "capsule: ip route", "ip", "route")
+	show(string(capsuleID), "capsule: resolv.conf", "cat", "/etc/resolv.conf")
+	show(string(capsuleID), "capsule: proxy env", "bash", "-c", "env | grep -i proxy | sort")
 
 	short := leaseID
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", leaseID)
+	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Logf("could not resolve gateway for diagnostics: %v", err)
 		return

--- a/test/contract/capsule/contract_test.go
+++ b/test/contract/capsule/contract_test.go
@@ -74,14 +74,14 @@ type memRecorder struct {
 	objects []struct{ kind, id string }
 }
 
-func (r *memRecorder) Plan(kind, role, name string) (int64, error) {
+func (r *memRecorder) Plan(kind, role, name string) (assignment.ResourceIntentID, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.objects = append(r.objects, struct{ kind, id string }{kind, name})
-	return int64(len(r.objects)), nil
+	return assignment.ResourceIntentID(len(r.objects)), nil
 }
-func (r *memRecorder) Creating(int64) error { return nil }
-func (r *memRecorder) Confirm(id int64, dockerID string) error {
+func (r *memRecorder) Creating(assignment.ResourceIntentID) error { return nil }
+func (r *memRecorder) Confirm(id assignment.ResourceIntentID, dockerID string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.objects[id-1].id = dockerID
@@ -149,7 +149,7 @@ func TestCapsuleLifecycle(t *testing.T) {
 	t.Cleanup(func() { rec.cleanup(t, dock) })
 
 	prepared, err := m.Prepare(ctx, capsule.Spec{
-		LeaseID:      leaseID,
+		LeaseID:      assignment.LeaseID(leaseID),
 		InstanceID:   "contract",
 		CapsuleImage: image,
 		JITConfig:    fakeJITConfig,
@@ -200,7 +200,7 @@ func TestCapsuleLifecycle(t *testing.T) {
 	// than for the state that precedes it.
 	deadline = time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
-		tail, err := dock.TailLogs(ctx, prepared.RuntimeID, 200)
+		tail, err := dock.TailLogs(ctx, string(prepared.RuntimeID), 200)
 		if err != nil {
 			t.Fatalf("logs: %v", err)
 		}
@@ -213,7 +213,7 @@ func TestCapsuleLifecycle(t *testing.T) {
 	// End the serving the way the platform ends one. PID 1 is the
 	// supervisor, and its TERM path drains the runner and the inner
 	// daemon before reporting the exit.
-	if code, out, err := dock.ExecWithInput(ctx, prepared.RuntimeID,
+	if code, out, err := dock.ExecWithInput(ctx, string(prepared.RuntimeID),
 		[]string{"kill", "-TERM", "1"}, nil); err != nil || code != 0 {
 		t.Fatalf("signal the supervisor: exit %d, %v: %s", code, err, out)
 	}
@@ -235,14 +235,14 @@ func TestCapsuleLifecycle(t *testing.T) {
 
 	// The capsule's exit is the job's exit: the daemon-side wait must
 	// agree with the observation.
-	exit, err := dock.WaitExit(ctx, prepared.RuntimeID)
+	exit, err := dock.WaitExit(ctx, string(prepared.RuntimeID))
 	if err != nil {
 		t.Fatalf("wait: %v", err)
 	}
 	t.Logf("capsule exited %d after the drain ended the runner", exit)
 
 	// The JIT bundle must not have reached the container log driver.
-	tail, err := dock.TailLogs(ctx, prepared.RuntimeID, 200)
+	tail, err := dock.TailLogs(ctx, string(prepared.RuntimeID), 200)
 	if err != nil {
 		t.Fatalf("logs: %v", err)
 	}

--- a/test/contract/capsule/outcome_test.go
+++ b/test/contract/capsule/outcome_test.go
@@ -38,7 +38,7 @@ func prepared(t *testing.T) (*capsule.Launcher, *docker.Client, capsule.Prepared
 	t.Cleanup(func() { rec.cleanup(t, dock) })
 
 	runtime, err := m.Prepare(ctx, capsule.Spec{
-		LeaseID:      leaseID,
+		LeaseID:      assignment.LeaseID(leaseID),
 		InstanceID:   "contract",
 		CapsuleImage: image,
 		JITConfig:    fakeJITConfig,
@@ -67,7 +67,7 @@ func TestTheCapsuleDeclaresTheProtocolThisBuildSpeaks(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 
-	code, out, err := dock.Exec(ctx, runtime.RuntimeID, []string{"cat", controlProtocolFile})
+	code, out, err := dock.Exec(ctx, string(runtime.RuntimeID), []string{"cat", controlProtocolFile})
 	if err != nil || code != 0 {
 		t.Fatalf("read %s: exit %d, %v: %s", controlProtocolFile, code, err, out)
 	}
@@ -95,7 +95,7 @@ func TestPrepareWaitsForAProvenDaemon(t *testing.T) {
 	// Asked once, with no retry on purpose. A poll here would prove only
 	// that the daemon comes up eventually, which was never in doubt; the
 	// claim is that it is already up at the instant prepare returned.
-	code, out, err := dock.Exec(ctx, runtime.RuntimeID, []string{"docker", "--host=" + innerDockerSocket, "info"})
+	code, out, err := dock.Exec(ctx, string(runtime.RuntimeID), []string{"docker", "--host=" + innerDockerSocket, "info"})
 	if err != nil {
 		t.Fatalf("probe the inner daemon: %v", err)
 	}
@@ -124,11 +124,11 @@ func TestAbortBeforeStartExitsWithTheReservedCode(t *testing.T) {
 		t.Fatalf("pre-stop observation = %s, %v; want created", obs, err)
 	}
 
-	if code, out, err := dock.ExecWithInput(ctx, runtime.RuntimeID, []string{"kill", "-TERM", "1"}, nil); err != nil || code != 0 {
+	if code, out, err := dock.ExecWithInput(ctx, string(runtime.RuntimeID), []string{"kill", "-TERM", "1"}, nil); err != nil || code != 0 {
 		t.Fatalf("signal the supervisor: exit %d, %v: %s", code, err, out)
 	}
 
-	exit, err := dock.WaitExit(ctx, runtime.RuntimeID)
+	exit, err := dock.WaitExit(ctx, string(runtime.RuntimeID))
 	if err != nil {
 		t.Fatalf("wait: %v", err)
 	}

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/rhobuild/runpool/internal/platform"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
+
+	"github.com/rhobuild/runpool/internal/assignment"
 )
 
 // busybox is the smallest image that can run a command. It is pinned by
@@ -287,7 +289,7 @@ func TestOwnershipQueries(t *testing.T) {
 		}
 	})
 
-	containers, err := c.ListOwnedContainers(ctx, instance)
+	containers, err := c.ListOwnedContainers(ctx, assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatalf("list containers: %v", err)
 	}
@@ -303,7 +305,7 @@ func TestOwnershipQueries(t *testing.T) {
 		t.Error("a started container reported as not running; recovery would clean up live work")
 	}
 
-	volumes, err := c.ListOwnedVolumes(ctx, instance)
+	volumes, err := c.ListOwnedVolumes(ctx, assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatalf("list volumes: %v", err)
 	}
@@ -311,7 +313,7 @@ func TestOwnershipQueries(t *testing.T) {
 		t.Errorf("owned volumes = %+v; want the one just created", volumes)
 	}
 
-	networks, err := c.ListOwnedNetworks(ctx, instance)
+	networks, err := c.ListOwnedNetworks(ctx, assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatalf("list networks: %v", err)
 	}
@@ -322,7 +324,7 @@ func TestOwnershipQueries(t *testing.T) {
 	// Another instance's query must not see any of it: the instance
 	// label is what keeps two controllers on one host from sweeping
 	// each other's capsules.
-	foreign, err := c.ListOwnedContainers(ctx, instance+"-other")
+	foreign, err := c.ListOwnedContainers(ctx, assignment.InstanceID(instance+"-other"))
 	if err != nil {
 		t.Fatalf("list for a foreign instance: %v", err)
 	}
@@ -411,25 +413,25 @@ func TestOwnedIDByName(t *testing.T) {
 	}
 	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
 
-	got, err := c.OwnedIDByName(ctx, "container", name, instance, "lease-own")
+	got, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "lease-own")
 	if err != nil || got != id {
 		t.Errorf("owned resolution = %q, %v; want the created id", got, err)
 	}
 
 	// Same name, different lease: name equality is not ownership.
-	if _, err := c.OwnedIDByName(ctx, "container", name, instance, "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
+	if _, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
 		t.Errorf("foreign resolution = %v; want ErrForeignResource — adopting by name "+
 			"would run work through someone else's object and later delete it", err)
 	}
-	if err := c.RemoveOwnedContainer(ctx, name, instance, "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
+	if err := c.RemoveOwnedContainer(ctx, name, assignment.InstanceID(instance), "someone-else"); !errors.Is(err, docker.ErrForeignResource) {
 		t.Fatalf("foreign removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "container", name, instance, "lease-own"); err != nil || got != id {
+	if got, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "lease-own"); err != nil || got != id {
 		t.Fatalf("foreign removal changed the owned object: id=%q err=%v", got, err)
 	}
 
 	// Absence is an answer: the create never took effect.
-	if got, err := c.OwnedIDByName(ctx, "container", instance+"-never-existed", instance, "lease-own"); err != nil || got != "" {
+	if got, err := c.OwnedIDByName(ctx, "container", instance+"-never-existed", assignment.InstanceID(instance), "lease-own"); err != nil || got != "" {
 		t.Errorf("absent resolution = %q, %v; want empty and no error", got, err)
 	}
 }
@@ -455,10 +457,10 @@ func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
 			t.Errorf("cleanup network %s: %v", networkID, err)
 		}
 	})
-	if err := c.RemoveOwnedNetwork(ctx, networkID, instance, "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
+	if err := c.RemoveOwnedNetwork(ctx, networkID, assignment.InstanceID(instance), "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
 		t.Fatalf("foreign network removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "network", networkName, instance, "lease-owner"); err != nil || got != networkID {
+	if got, err := c.OwnedIDByName(ctx, "network", networkName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != networkID {
 		t.Fatalf("network changed after refused removal: id=%q err=%v", got, err)
 	}
 
@@ -471,10 +473,10 @@ func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
 			t.Errorf("cleanup volume %s: %v", volumeName, err)
 		}
 	})
-	if err := c.RemoveOwnedVolume(ctx, volumeName, instance, "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
+	if err := c.RemoveOwnedVolume(ctx, volumeName, assignment.InstanceID(instance), "different-lease"); !errors.Is(err, docker.ErrForeignResource) {
 		t.Fatalf("foreign volume removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "volume", volumeName, instance, "lease-owner"); err != nil || got != volumeName {
+	if got, err := c.OwnedIDByName(ctx, "volume", volumeName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != volumeName {
 		t.Fatalf("volume changed after refused removal: id=%q err=%v", got, err)
 	}
 }
@@ -584,17 +586,17 @@ func TestCacheLaneVolumes(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { st.Close() })
-	mgr := cache.New(st, c, instance)
+	mgr := cache.New(st, c, assignment.InstanceID(instance))
 
 	release := func(lease string) {
 		t.Helper()
-		if err := st.Tx(ctx, func(tx *store.Tx) error { return tx.ReleaseCacheLane(lease) }); err != nil {
+		if err := st.Tx(ctx, func(tx *store.Tx) error { return tx.ReleaseCacheLane(assignment.LeaseID(lease)) }); err != nil {
 			t.Fatal(err)
 		}
 	}
 	acquire := func(gen, lease string) cache.LaneMount {
 		t.Helper()
-		loc, ok, err := mgr.Acquire(ctx, "https://github.com/acme/app", gen, lease, 2)
+		loc, ok, err := mgr.Acquire(ctx, "https://github.com/acme/app", gen, assignment.LeaseID(lease), 2)
 		if err != nil || !ok {
 			t.Fatalf("acquire %s/%s: ok=%v, %v", gen, lease, ok, err)
 		}
@@ -650,11 +652,11 @@ func TestCacheLaneVolumes(t *testing.T) {
 	if err := mgr.DeleteLane(ctx, first.LaneID); err != nil {
 		t.Fatal(err)
 	}
-	gone, err := c.OwnedIDByName(ctx, "volume", first.Volume, instance, "")
+	gone, err := c.OwnedIDByName(ctx, "volume", first.Volume, assignment.InstanceID(instance), "")
 	if err != nil || gone != "" {
 		t.Errorf("evicted volume still resolves: %q, %v", gone, err)
 	}
-	left, err := c.OwnedIDByName(ctx, "volume", other.Volume, instance, "")
+	left, err := c.OwnedIDByName(ctx, "volume", other.Volume, assignment.InstanceID(instance), "")
 	if err != nil || left == "" {
 		t.Errorf("the surviving lane's volume is gone: %q, %v", left, err)
 	}
@@ -666,7 +668,7 @@ func TestCacheLaneVolumes(t *testing.T) {
 func TestFilesystemProbe(t *testing.T) {
 	c, instance := client(t)
 
-	free, err := c.ProbeFilesystemFree(t.Context(), busybox, instance)
+	free, err := c.ProbeFilesystemFree(t.Context(), busybox, assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +703,7 @@ func TestOwnedVolumeUsage(t *testing.T) {
 		t.Fatalf("writer: exit %d, %v, %s", code, err, out)
 	}
 
-	usage, err := c.OwnedVolumeUsage(ctx, instance)
+	usage, err := c.OwnedVolumeUsage(ctx, assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +790,7 @@ func TestCleanupSurvivesCancellation(t *testing.T) {
 	}
 
 	// The helper is gone despite the cancellation.
-	left, err := c.ListOwnedContainers(context.Background(), instance)
+	left, err := c.ListOwnedContainers(context.Background(), assignment.InstanceID(instance))
 	if err != nil {
 		t.Fatalf("list after cancellation: %v", err)
 	}


### PR DESCRIPTION
## What changes

Thirteen named identifier types are declared in `internal/assignment` and
threaded through the store, the lease machine, the capsule launcher, the
cache, the allocator, the Docker adapter, the app and the command layer.
`Controller.inFlight` becomes a typed map under a mutex. No behaviour
changes: the SQL, the migrations and the generated persistence layer are
untouched, and every existing test passes unmodified in what it asserts.

## What was found

**Every identifier this control plane keys on was a bare string or
int64.** Three signatures made the cost concrete:

```go
Acquire(ctx, sourceProjectKey, generation, leaseID string, maxLanes int)
LeaseCacheLane(projectID, generation, leaseID string, maxLanes int)
Register(tierID, key string, parallelism int)
```

Two or three adjacent strings, any pair swappable. A swap compiles,
produces a query that matches no row, and returns an empty result rather
than an error — so a cache lane is leased under the wrong key, or a
binding is registered against the wrong tier, and nothing says so.

**Two names for two different things.** `SourceBindingKey` is a
binding's durable identity, the value its row is keyed by and which
outlives the process; `BindingKey` is the in-memory name derived from
configuration on every start, used for allocator accounting. They had
shared one English name, which is half the reason the previous pull
request's binding-key defect was possible to write.

**`Controller.inFlight` is a `sync.Map`, which keys on `any`.** A caller
passing a plain string where the lease id is meant compiles, misses every
entry, and hands two owners the same lease — which is exactly the defect
the ownership claim exists to prevent, and the one thing in this pass the
type checker could not have caught while the map stayed untyped.

## What the pass does and does not catch

Named types catch a swapped **variable**. They do not catch a swapped
**literal**: an untyped constant converts to either side, so
`Register("app/standard", "standard", 1)` still compiles. The three
signatures above take variables at every real call site, which is where
the risk was.

Verified both ways, by writing the swap and compiling:

```text
with typed variables:
  vet: cannot use key (variable of string type assignment.BindingKey)
       as assignment.TierID value in argument to a.Register

with untyped literals:
  compiles — an untyped constant converts to either named type
```

## Where the conversions ended up

The design for this pass said conversions would grow only inside the
store's row translators. That is where most of them are, and it is not
where all of them are — the claim was too strong and the counts say so:

```text
string(...) conversions in non-test files, after the pass:
  internal/app              33
  internal/store            28
  internal/command          21
  internal/capsule          13
  internal/platform/docker   6
  internal/lease             2
  internal/gateway           1
  internal/cache             1
```

Reading them, they are boundaries rather than leaks: a Docker label, a
deterministic resource name, a provider field and a log line all take a
plain string, so an id reaching one converts at that point. What matters
is that none of them is a signature where two identifiers sit side by
side — those are the shape this pass exists to close, and they are typed.

Three conversions that appeared in `internal/app` were the pass being
unfinished rather than a boundary, and are gone: `advanceAttempt`,
`attemptForObservation` and `AttemptOfRuntimeName` now speak the ids they
name.

## Evidence

The compiler enumerated the call sites; the suites are the proof that
nothing moved. `go vet ./...` is clean and every test passes without any
assertion being changed — only the types of helper parameters and
locals, which is what a rename of this kind is.

```text
go vet ./...                     clean
go test ./...                    all packages ok
go test -race -shuffle=on        ok (full gate suite)
git diff --stat main -- '*.sql' internal/store/sqlitedb/
                                 nothing changed
55 files changed, 722 insertions(+), 543 deletions(-)
```

The mechanically checkable rules this pass promised:

- **SQL and migrations untouched** — holds, verified by the diff above,
  including the generated `sqlitedb` package.
- **Conversions confined to the row translators** — does not hold as
  stated; see above for where they are and why.

## What would notice this regressing

Nothing hermetic notices a *type* being removed — reverting one to
`string` compiles and passes. That is an honest answer rather than a
failing one: the guard here is the compiler at each future call site, not
a test.

Two tests do cover what the compiler cannot:

- `TestTheDurableBindingKeyDoesNotMoveWithTheURLParser` (internal/app),
  from the previous change, is the reason `SourceBindingKey` and
  `BindingKey` are separate types rather than a comment.
- The full app suite covers `inFlight`: `TestPeriodicReconcileSkipsOwnedLeases`
  and `TestAFreshLeaseIsNotStranded` both fail if the claim stops
  matching, which is what a mistyped key would cause.

## Risk, compatibility and operations

**This is the widest diff of the remediation and the one with the least
behaviour in it, which is its own risk.** A mechanical change across 55
files can hide a real edit in the noise. Two things bound that: the SQL
and generated layer are provably untouched, so nothing about what is
stored or queried can have changed; and no test assertion was modified,
only parameter and local types, so the suites are testing the same
properties they were.

**Trust boundary, credentials, networking, resource limits: untouched.**
No policy decision, capability, mount or credential path is in this
change.

**Status API, schema, migrations, CLI, configuration, deployment:
unchanged.** `runpool status` emits the same document — the ids were
already strings on the wire and still are.

**Rollback** is the previous image; there is no state to migrate.

**`internal/config` deliberately keeps plain strings.** Typing
`Tier.ID` and `Target.ID` would require `internal/config` to import
`internal/assignment`, and `narrowDeps` in `test/architecture` pins that
package's direct imports to `{internal/egress}` alone. Configuration is
parsed input, so the conversion happens where the app reads it, which is
the right boundary regardless.

**Two new architecture edges**, neither of which the suite pins:
`internal/store → internal/assignment` and `internal/cache →
internal/assignment`. Both are in `corePackages`, which forbids depending
on the adapter or the provider SDK; `internal/assignment` is a
stdlib-only leaf, so `TestTheLeaseMachineLinksNoContainerRuntime` and the
rest still hold. `test/architecture/architecture_test.go` is unchanged.

## Changelog

```text
NONE
```

## Notes for your reviewer

Read the type declarations first — `internal/assignment/ids.go` is where
the argument for the change lives, and the two binding-key types carry
the paragraph that matters.

Then, if you check one mechanical claim, check that the SQL and
`internal/store/sqlitedb` are untouched. Everything else in this diff is
recoverable by re-running a compiler; a change to what is stored would
not be.

The conversion-count table is the part I would push back on if I were
reviewing: the design promised a tidier boundary than the code delivers.
I left the numbers in rather than the promise, and removed the three
conversions that were genuinely the pass being unfinished.
