### PR TITLE
fix(lease): one rule decides what becomes of an attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,12 @@ by its public and operational effects.
   carries its own bound. Inside a capsule the readiness probe is bounded
   the same way, so a daemon that never answers cannot spend the whole
   readiness budget in one call.
+- **One rule decides what becomes of an attempt.** The two paths that end
+  a serving — the finalizing transaction and the sweep that finds a lease
+  nobody is driving — reach the same decision through the same function,
+  so a workload cannot return to the queue on one and settle as a job
+  that ran on the other. An attempt somebody else already resolved is
+  left alone: the lease still releases and its capacity comes back.
 - **A capsule that never handed the job over returns it to the queue.**
   The supervisor exits with a status it reserves for stopping before the
   start was authorized — the ordinary end of an idle capsule when a

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -205,7 +205,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 		// should be unreachable; reaching it means something violated
 		// that, and the disposition is the only thing left to run.
 		log.Warn("disposing of an attempt left open by a released lease")
-		s.leases.DisposeStranded(ctx, lease, evidence, obs)
+		s.leases.DisposeStranded(ctx, lease, obs)
 
 	case store.LeaseReserved, store.LeaseProvisioning,
 		store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning,

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -214,50 +214,104 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), "cleanup_completed"); err != nil {
 		return err
 	}
-	// A redelivery of the same workload supersedes the attempt this
-	// lease was serving. The serving still ends — the capsule is
-	// destroyed and the lease released — but the attempt is already
-	// resolved, and forcing a disposition onto it would match no row,
-	// fail, and roll the release back with it: the lease would pin in
-	// cleaning holding its credit, for a workload that is being served
-	// by its successor.
-	//
-	// Only superseded. A settled attempt arriving here would be a second
-	// finalize, which the lease transition already refuses, and papering
-	// over that would hide it.
-	if attempt.State == "superseded" {
-		return nil
+	return m.applyDisposition(tx, attempt, lease.ID, dispositionFor(attempt, startObs))
+}
+
+// disposition is what the books must record about an attempt whose
+// serving has ended.
+//
+// It is a value rather than a branch because two paths end a serving —
+// the finalizing transaction and the sweep that finds a lease nobody is
+// driving — and they must not be able to disagree. Expressed as two
+// switches, the precedence between the rules lived in the order of the
+// cases, which nothing checks: the same attempt could settle as a job
+// that ran on one path and return to the queue on the other.
+type disposition int
+
+const (
+	// dispositionNone is an attempt that is already resolved. The
+	// serving still ends — the capsule is destroyed and the lease
+	// released — but nothing is written against the attempt. Forcing a
+	// disposition onto a resolved row matches no row, fails, and rolls
+	// the release back with it, which pins the lease in cleaning holding
+	// its admission credit for work somebody else already owns.
+	dispositionNone disposition = iota
+	// dispositionRequeue returns the workload to the queue: it provably
+	// consumed nothing.
+	dispositionRequeue
+	// dispositionSettleCompleted and dispositionSettleStarted close the
+	// attempt with what was observed of its execution.
+	dispositionSettleCompleted
+	dispositionSettleStarted
+	// dispositionReview holds the attempt for a person: settling it
+	// could drop a job that never ran, requeueing it could run one
+	// twice.
+	dispositionReview
+)
+
+// attemptIsOpen reports whether an attempt is still this lease's to
+// resolve. Anything else — superseded by a redelivery, settled, canceled
+// by the provider, or held for a person — belongs to whoever put it
+// there, and a serving that ends afterwards leaves it alone.
+func attemptIsOpen(state string) bool {
+	switch state {
+	case "ready", "leased", "preparing", "prepared", "starting", "running":
+		return true
 	}
+	return false
+}
+
+// dispositionFor decides what one ended serving means for its attempt.
+// The precedence is stated here, once, in the order these cases are
+// written — but the cases are exhaustive over a value, so adding one
+// cannot silently reorder the others the way inserting a switch case
+// above its siblings did.
+//
+// The proof outranks the evidence. `running` and `running_observed` are
+// written when the start authorization is accepted and the capsule
+// reports itself up, never when a runner is seen owning a job, while
+// ObservedCreated only ever comes from a proof: a runtime still in its
+// created state, a supervisor reporting it never started, or the exit
+// code the capsule reserves for exactly that.
+func dispositionFor(attempt store.Attempt, obs assignment.ExecutionObservation) disposition {
 	switch {
-	case startObs == assignment.ObservedCreated:
-		// Authorized, and the runtime proved the start never took
-		// effect: the work was not consumed, and this is the one path
-		// allowed back to ready past the authorization.
-		//
-		// It is decided before the evidence cases, not after them,
-		// because the evidence is the weaker statement. `running` and
-		// `running_observed` are written when the authorization is
-		// accepted and the capsule reports itself up — not when a runner
-		// is seen owning a job — while this observation only ever comes
-		// from a proof: a runtime still in its created state, a
-		// supervisor reporting it never started, or the exit code the
-		// capsule reserves for exactly that. Judged in evidence order,
-		// an aborted capsule settles as a job that started and the
-		// workload is never served again.
-		m.log.Warn("the authorized start never took effect; the attempt stays servable",
-			"attempt", attempt.ID, "lease", lease.ID)
-		return m.requeueProven(tx, attempt, lease.ID)
+	case !attemptIsOpen(attempt.State):
+		return dispositionNone
+	case obs == assignment.ObservedCreated:
+		return dispositionRequeue
 	case attempt.Evidence == store.EvidenceExitObserved:
-		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionCompletedObserved)
+		return dispositionSettleCompleted
 	case attempt.Evidence == store.EvidenceRunningObserved:
-		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionStartedObserved)
+		return dispositionSettleStarted
 	case attempt.Evidence.Retriable():
-		m.log.Warn("delivery failed before any start was authorized; the attempt stays servable",
-			"attempt", attempt.ID, "lease", lease.ID)
-		return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), lease.ID)
+		return dispositionRequeue
+	case obs == assignment.ObservedRunning:
+		// The runtime demonstrably began. This reaches the sweep when a
+		// binding is gone and adoption was impossible.
+		return dispositionSettleStarted
+	default:
+		return dispositionReview
+	}
+}
+
+// applyDisposition writes one decision, inside the caller's transaction.
+func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
+	leaseID assignment.LeaseID, d disposition) error {
+
+	switch d {
+	case dispositionNone:
+		return nil
+	case dispositionRequeue:
+		m.log.Warn("the workload was not consumed; the attempt stays servable",
+			"attempt", attempt.ID, "lease", leaseID, "state", attempt.State)
+		return m.requeueProven(tx, attempt, leaseID)
+	case dispositionSettleCompleted:
+		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionCompletedObserved)
+	case dispositionSettleStarted:
+		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionStartedObserved)
 	default:
 		m.log.Warn("start outcome is unproven; the attempt is held for review",
-			"attempt", attempt.ID, "lease", lease.ID, "observation", string(startObs))
+			"attempt", attempt.ID, "lease", leaseID)
 		return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
 	}
 }
@@ -307,30 +361,17 @@ func (m *Manager) requeueOrReview(tx *store.Tx, attemptID assignment.AttemptID, 
 	return tx.HoldForReview(attemptID, store.ReviewReasonRetryBudgetExhausted)
 }
 
-// DisposeStranded applies the evidence's ruling to an attempt whose
-// lease already finished its own lifecycle. Release and disposition
-// commit together, so this should be unreachable; it exists because an
-// invariant nothing checks is an assumption.
-func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, evidence store.Evidence, obs assignment.ExecutionObservation) {
-	switch {
-	case evidence == store.EvidenceExitObserved:
-		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionCompletedObserved)
-	case evidence == store.EvidenceRunningObserved:
-		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionStartedObserved)
-	case evidence.Retriable(), obs == assignment.ObservedCreated:
-		m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
-			return m.requeueProven(tx, attempt, lease.ID)
-		})
-	case obs == assignment.ObservedRunning:
-		// Running reaches here only when the binding is gone and
-		// adoption was impossible; the runtime demonstrably began.
-		m.settleAttemptOfLease(ctx, lease.ID, assignment.ResolutionStartedObserved)
-	default:
-		m.log.Warn("start outcome cannot be proven; holding the attempt for review", "lease", lease.ID)
-		m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
-			return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
-		})
-	}
+// DisposeStranded applies the same ruling as the finalizing transaction
+// to an attempt whose lease already finished its own lifecycle. Release
+// and disposition commit together, so this should be unreachable; it
+// exists because an invariant nothing checks is an assumption.
+//
+// It decides through dispositionFor, which is the point: this path and
+// disposeAttempt once carried their own switches and drifted apart.
+func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) {
+	m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
+		return m.applyDisposition(tx, attempt, lease.ID, dispositionFor(attempt, obs))
+	})
 }
 
 // withAttemptOfLease resolves the attempt a lease serves and runs one
@@ -350,12 +391,6 @@ func (m *Manager) withAttemptOfLease(ctx context.Context, leaseID assignment.Lea
 		m.log.Error("cannot dispose of the attempt of a released lease",
 			"lease", leaseID, "error", err)
 	}
-}
-
-func (m *Manager) settleAttemptOfLease(ctx context.Context, leaseID assignment.LeaseID, resolution string) {
-	m.withAttemptOfLease(ctx, leaseID, func(tx *store.Tx, attempt store.Attempt) error {
-		return tx.Settle(attempt.ID, attempt.State, resolution)
-	})
 }
 
 // Quarantine parks a lease whose cleanup failed. It keeps consuming

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -473,3 +473,103 @@ func TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning(t *testing.T)
 		t.Errorf("lease = %s; want released in the same commit", got)
 	}
 }
+
+// TestAHeldAttemptDoesNotPinItsLease: a serving that ends against an
+// attempt somebody else already resolved still releases its lease.
+//
+// An attempt held for review is not this lease's to dispose of — a
+// person owns it now. Writing a disposition onto it anyway matches no
+// row, fails, and rolls the release back with it: the lease stays in
+// cleaning holding its admission credit, and because a lease already in
+// cleaning cannot move there again, every later reconciliation pass
+// repeats the identical rollback and the capacity is gone for good.
+func TestAHeldAttemptDoesNotPinItsLease(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	f.driveTo(store.LeaseCleaning)
+	id := assignment.AttemptID(f.attempt)
+	f.tx(func(tx *store.Tx) error {
+		return tx.HoldForReview(id, store.ReviewReasonIncompatibleCapsule)
+	})
+
+	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if got := f.reload().State; got != store.LeaseReleased {
+		t.Errorf("lease = %s; want released — a held attempt must not pin the lease serving it", got)
+	}
+	if got := f.attemptState(); got.State != "manual_review" {
+		t.Errorf("attempt = %s; want it left in manual_review for the person who holds it", got.State)
+	}
+}
+
+// TestBothDispositionPathsAgree: the finalizing transaction and the
+// stranded-lease sweep decide the same thing about the same attempt.
+//
+// They once carried a switch each and the cases drifted into different
+// orders, so an attempt with a proven-inert start returned to the queue
+// through one and settled as a job that ran through the other. The
+// decision is one function now; this is what says so.
+func TestBothDispositionPathsAgree(t *testing.T) {
+	for name, tc := range map[string]struct {
+		state    string
+		evidence store.Evidence
+		obs      assignment.ExecutionObservation
+		want     disposition
+	}{
+		"proven inert outranks a running observation": {
+			"running", store.EvidenceRunningObserved, assignment.ObservedCreated, dispositionRequeue},
+		"an observed exit settles as completed": {
+			"running", store.EvidenceExitObserved, "", dispositionSettleCompleted},
+		"a running observation settles as started": {
+			"running", store.EvidenceRunningObserved, "", dispositionSettleStarted},
+		"nothing prepared returns to the queue": {
+			"leased", store.EvidenceNotStarted, "", dispositionRequeue},
+		"a running runtime settles as started": {
+			"starting", store.EvidenceStartAuthorized, assignment.ObservedRunning, dispositionSettleStarted},
+		"an unprovable start is held": {
+			"starting", store.EvidenceStartAuthorized, assignment.ObservedAbsent, dispositionReview},
+		"a superseded attempt is left alone": {
+			"superseded", store.EvidenceNotStarted, "", dispositionNone},
+		"a held attempt is left alone": {
+			"manual_review", store.EvidenceNotStarted, "", dispositionNone},
+		"a settled attempt is left alone": {
+			"settled", store.EvidenceExitObserved, "", dispositionNone},
+	} {
+		t.Run(name, func(t *testing.T) {
+			attempt := store.Attempt{State: tc.state, Evidence: tc.evidence}
+			if got := dispositionFor(attempt, tc.obs); got != tc.want {
+				t.Errorf("dispositionFor(%s, %s, %s) = %d; want %d",
+					tc.state, tc.evidence, tc.obs, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAProvenInertStartIsRequeuedFromEitherPath drives the same lease
+// state through both endings and requires the same outcome.
+func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
+	for name, end := range map[string]func(*fixture){
+		"the finalizing transaction": func(f *fixture) {
+			if err := f.m.Finalize(f.t.Context(), f.lease.ID, assignment.ObservedCreated); err != nil {
+				f.t.Fatalf("Finalize: %v", err)
+			}
+		},
+		"the stranded sweep": func(f *fixture) {
+			f.m.DisposeStranded(f.t.Context(), f.reload(), assignment.ObservedCreated)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t, nopRemover{})
+			f.driveTo(store.LeaseCleaning)
+			f.advanceAttemptTo("running")
+			f.recordEvidence(store.EvidenceRunningObserved)
+
+			end(f)
+
+			if got := f.attemptState(); got.State != "ready" {
+				t.Errorf("attempt = %s (resolution %q); want it back in the queue",
+					got.State, got.Resolution)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

`dispositionFor` decides what an ended serving means for its attempt, and
`applyDisposition` writes it; the finalizing transaction and the
stranded-lease sweep both go through them. An attempt that is not in an
open state is left alone. The requeue is chosen by the attempt's actual
state on both requeue paths, and an observed running runtime settles as
started from either ending.

## What was found

**A held attempt pinned its lease and its capacity, permanently.** An
attempt in `manual_review` fell to the evidence-retriable branch and
called `tx.Requeue`, whose guard is `state IN ('leased','preparing',
'prepared')`. Zero rows gives ErrConflict, which rolls back the whole
finalizing transaction, so the lease never leaves `cleaning` — and
`ToCleaning` from `cleaning` is a no-op, so every later reconciliation
pass repeats the identical rollback. The binding loses one admission
credit per occurrence, for the life of the process.

Reproduced:

```text
Finalize -> attempt att-b6c9fa094b47513e is past the point of safe requeue
lease    -> cleaning
```

The path that produces it is ordinary: a capsule image that does not
speak this controller's protocol fails `Prepare`, `HoldAttempt` moves the
attempt to `manual_review`, and `recoverCapsuleFailure` finalizes the
lease immediately afterwards.

**The two endings disagreed.** `disposeAttempt` judged `ObservedCreated`
ahead of the evidence; `DisposeStranded` judged `EvidenceRunningObserved`
first. The controller records `running_observed` as soon as `Start`
returns — before any proof a runner took the job — so a supervisor that
then exits with the reserved abort code produced a requeue through one
path and `started_observed` through the other. A job that provably never
ran, closed as one that did.

They also differed on `ObservedRunning`: a settle on one path, a review
on the other. The runtime demonstrably began, so settling is right in
both.

**A third instance of the same shape, found by tracing the siblings.** The
evidence-retriable branch used the plain requeue, and an attempt can
reach it in `starting`: the walk advances the state before the
authorization is recorded, so a failure to record leaves `starting` with
`runtime_prepared`. The plain requeue's guard stops at `prepared`, so
that would have failed and pinned the lease exactly as the held attempt
did. Both requeue paths now choose by state.

## Symmetry check

Written before the code, and each one read:

| Path | Result |
|---|---|
| `disposeAttempt` | rewritten to use the shared decision |
| `DisposeStranded` | rewritten to use the shared decision; its now-unused `evidence` parameter is dropped |
| `settleAttemptOfLease` | existed only for `DisposeStranded`; removed with it |
| `requeueProven` | now the only requeue, reached from both dispositions |
| `requeueOrReview` | unchanged; still converts an exhausted budget into a review |
| `HoldAttempt` | left alone — it puts an attempt *into* review deliberately rather than ending a serving |
| `withAttemptOfLease` | unchanged; the open-state rule now lives in the decision its callers share |
| `CancelReady` (internal/app) | left alone — the provider closing unstarted work, guarded on `ready` and outside this decision |

## Evidence

Hermetic. Each mechanism is checked by reverting **only that mechanism** —
the three mutations below were run one at a time, not together.

```text
M1: put manual_review back in the open set
  -> TestAHeldAttemptDoesNotPinItsLease
     Finalize: attempt att-3de64682070005ab is past the point of safe requeue

M2: judge the evidence ahead of the proof again
  -> TestBothDispositionPathsAgree/proven_inert_outranks_a_running_observation
     dispositionFor(running, running_observed, created) = 3; want 1
  -> TestAProvenInertStartIsRequeuedFromEitherPath also fails

M3: return the requeue to the plain form
  -> TestAProvenInertStartIsRequeuedFromEitherPath/the_finalizing_transaction
     Finalize: attempt att-ab187944b71537ac is past the point of safe requeue
```

## What would notice this regressing

- `TestAHeldAttemptDoesNotPinItsLease` fails if any resolved state
  re-enters the open set.
- `TestBothDispositionPathsAgree` is a table over nine (state, evidence,
  observation) triples and fails on any precedence change.
- `TestAProvenInertStartIsRequeuedFromEitherPath` drives one lease state
  through both endings and requires the same outcome, so a future path
  that grows its own switch fails here.
- `staticcheck` catches a disposition helper that loses its last caller,
  which is how the orphaned `settleAttemptOfLease` surfaced.

## Risk, compatibility and operations

**Behaviour changes in three places, all toward doing less.** An attempt
already resolved is no longer written to; the requeue is chosen by state
rather than by which branch reached it; and an observed running runtime
settles rather than going to review on the launch path. Nothing settles
where it previously requeued.

**At-most-once is unaffected.** The proof still outranks the evidence, and
the requeue past the start authorization still goes through
`RequeueProvenInert`, whose guard is unchanged.

**An operator-visible improvement:** a job whose capsule image is refused
no longer costs its binding a permanent admission credit. Deployments
that hit it were losing capacity with no command to recover it short of a
restart.

**Trust boundary, credentials, networking, resource limits: untouched.**
No CLI, configuration, status API, schema or migration change. Rollback
is the previous image; there is no state to migrate.

## Changelog

```text
State and operations:
- One rule decides what becomes of an attempt. The two paths that end a
  serving — the finalizing transaction and the sweep that finds a lease
  nobody is driving — reach the same decision through the same function, so
  a workload cannot return to the queue on one and settle as a job that ran
  on the other. An attempt somebody else already resolved is left alone: the
  lease still releases and its capacity comes back.
```

## Notes for your reviewer

The third instance is the one I would look at, because nothing reported
it — it came out of writing the sibling list before touching the code.
The evidence-retriable branch and the held attempt fail the same way for
the same reason, and only one of them was visible.

`DisposeStranded` loses its `evidence` parameter: it read the attempt
again through `withAttemptOfLease` anyway, so the caller was passing a
staler copy of a value the function already had.
