### PR TITLE
fix(lease): only a state one serving passes through is that serving's to resolve

### DIFF
--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -178,14 +178,14 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 
 	// An exited runtime observed here refines the evidence before any
 	// path destroys the container that proves it: the finalizing
-	// transaction then settles from evidence alone.
+	// transaction then settles from evidence alone. The write is the
+	// whole point — nothing below reads the local copy, because every
+	// disposition re-reads the row inside its own transaction.
 	if obs == assignment.ObservedExited && evidence == store.EvidenceStartAuthorized {
 		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 			return tx.RecordEvidence(lease.AttemptID, store.EvidenceExitObserved)
 		}); err != nil {
 			log.Error("cannot record the observed exit", "error", err)
-		} else {
-			evidence = store.EvidenceExitObserved
 		}
 	}
 

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -249,13 +249,31 @@ const (
 	dispositionReview
 )
 
-// attemptIsOpen reports whether an attempt is still this lease's to
-// resolve. Anything else — superseded by a redelivery, settled, canceled
-// by the provider, or held for a person — belongs to whoever put it
-// there, and a serving that ends afterwards leaves it alone.
-func attemptIsOpen(state string) bool {
+// servedByThisLease reports whether an attempt is still this lease's to
+// resolve: the five states one serving passes through, from the claim
+// that created the lease to the runner owning the job.
+//
+// Every other state belongs to whoever put the attempt there — a
+// redelivery that superseded it, a provider that canceled it, a person
+// holding it for review, or an operator who resolved one back to
+// `ready` — and a serving that ends afterwards leaves it alone.
+//
+// `ready` is deliberately absent, and its absence is what makes the
+// requeue total: `leased`, `preparing` and `prepared` are exactly what
+// RequeueAttempt accepts, and `starting` and `running` are exactly what
+// RequeueProvenInertAttempt accepts, so every disposition this set
+// admits matches a row. An attempt found in `ready` was put there by
+// something else, and requeueing it again matches nothing — which fails
+// the finalizing transaction and pins the lease in cleaning with its
+// admission credit, for a workload that is already servable.
+//
+// It is not called "open": GetOpenAttemptByWorkload means a different,
+// wider set — the seven states that block a redelivery, `manual_review`
+// among them — and one word for two sets one grep apart is how the
+// wrong one gets copied.
+func servedByThisLease(state string) bool {
 	switch state {
-	case "ready", "leased", "preparing", "prepared", "starting", "running":
+	case "leased", "preparing", "prepared", "starting", "running":
 		return true
 	}
 	return false
@@ -275,7 +293,7 @@ func attemptIsOpen(state string) bool {
 // code the capsule reserves for exactly that.
 func dispositionFor(attempt store.Attempt, obs assignment.ExecutionObservation) disposition {
 	switch {
-	case !attemptIsOpen(attempt.State):
+	case !servedByThisLease(attempt.State):
 		return dispositionNone
 	case obs == assignment.ObservedCreated:
 		return dispositionRequeue

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -314,10 +314,12 @@ func dispositionFor(attempt store.Attempt, obs assignment.ExecutionObservation) 
 
 // applyDisposition writes one decision, inside the caller's transaction.
 //
-// It takes the observation only to report it: a review is the one
-// disposition a person has to act on, and what the runtime was seen
-// doing is the input their choice turns on — absent is not the same
-// answer as unobservable.
+// It takes the observation only to report it. Both warnings carry the
+// same four fields, because both answer the same question after the
+// fact: which attempt, under which lease, how far it had got, and what
+// the runtime was seen doing. On the review — the one disposition a
+// person has to act on — the observation is the input their choice turns
+// on, since absent is not the same answer as unobservable.
 func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
 	leaseID assignment.LeaseID, obs assignment.ExecutionObservation, d disposition) error {
 
@@ -326,7 +328,8 @@ func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
 		return nil
 	case dispositionRequeue:
 		m.log.Warn("the workload was not consumed; the attempt stays servable",
-			"attempt", attempt.ID, "lease", leaseID, "state", attempt.State)
+			"attempt", attempt.ID, "lease", leaseID, "state", attempt.State,
+			"observation", string(obs))
 		return m.requeueProven(tx, attempt, leaseID)
 	case dispositionSettleCompleted:
 		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionCompletedObserved)
@@ -334,7 +337,8 @@ func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
 		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionStartedObserved)
 	default:
 		m.log.Warn("start outcome is unproven; the attempt is held for review",
-			"attempt", attempt.ID, "lease", leaseID, "observation", string(obs))
+			"attempt", attempt.ID, "lease", leaseID, "state", attempt.State,
+			"observation", string(obs))
 		return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
 	}
 }

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -214,7 +214,7 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), "cleanup_completed"); err != nil {
 		return err
 	}
-	return m.applyDisposition(tx, attempt, lease.ID, dispositionFor(attempt, startObs))
+	return m.applyDisposition(tx, attempt, lease.ID, startObs, dispositionFor(attempt, startObs))
 }
 
 // disposition is what the books must record about an attempt whose
@@ -313,8 +313,13 @@ func dispositionFor(attempt store.Attempt, obs assignment.ExecutionObservation) 
 }
 
 // applyDisposition writes one decision, inside the caller's transaction.
+//
+// It takes the observation only to report it: a review is the one
+// disposition a person has to act on, and what the runtime was seen
+// doing is the input their choice turns on — absent is not the same
+// answer as unobservable.
 func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
-	leaseID assignment.LeaseID, d disposition) error {
+	leaseID assignment.LeaseID, obs assignment.ExecutionObservation, d disposition) error {
 
 	switch d {
 	case dispositionNone:
@@ -329,7 +334,7 @@ func (m *Manager) applyDisposition(tx *store.Tx, attempt store.Attempt,
 		return tx.Settle(attempt.ID, attempt.State, assignment.ResolutionStartedObserved)
 	default:
 		m.log.Warn("start outcome is unproven; the attempt is held for review",
-			"attempt", attempt.ID, "lease", leaseID)
+			"attempt", attempt.ID, "lease", leaseID, "observation", string(obs))
 		return tx.HoldForReview(attempt.ID, store.ReviewReasonStartOutcomeUnknown)
 	}
 }
@@ -388,7 +393,7 @@ func (m *Manager) requeueOrReview(tx *store.Tx, attemptID assignment.AttemptID, 
 // disposeAttempt once carried their own switches and drifted apart.
 func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) {
 	m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
-		return m.applyDisposition(tx, attempt, lease.ID, dispositionFor(attempt, obs))
+		return m.applyDisposition(tx, attempt, lease.ID, obs, dispositionFor(attempt, obs))
 	})
 }
 

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -576,6 +576,14 @@ func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
 	}
 }
 
+// attemptStates is every state an attempt can hold, terminal ones
+// included. It is the domain the test below filters, so the test states
+// the question and the predicate states the answer.
+var attemptStates = []string{
+	"ready", "leased", "preparing", "prepared", "starting", "running",
+	"superseded", "settled", "canceled", "manual_review",
+}
+
 // TestEveryServingStateCanBeDisposedOf: no disposition this decision can
 // reach fails to match a row.
 //
@@ -585,10 +593,19 @@ func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
 // that matches nothing, and the finalizing transaction rolls back with
 // it — the lease pins in cleaning holding its admission credit, and a
 // lease already in cleaning cannot move there again, so no later pass
-// recovers it. This walks the whole set and requires the lease released
-// from each.
+// recovers it.
+//
+// The states walked come from the predicate itself, not from a list
+// beside it: a state added to the serving set is disposed of here
+// whether or not anyone remembers this test. One the fixture cannot
+// drive to fails in advanceAttemptTo, which names it.
 func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
-	for _, state := range []string{"leased", "preparing", "prepared", "starting", "running"} {
+	var walked int
+	for _, state := range attemptStates {
+		if !servedByThisLease(state) {
+			continue
+		}
+		walked++
 		t.Run(state, func(t *testing.T) {
 			f := newFixture(t, nopRemover{})
 			f.driveTo(store.LeaseCleaning)
@@ -605,6 +622,9 @@ func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
 				t.Errorf("lease = %s after disposing an attempt in %s; want released", got, state)
 			}
 		})
+	}
+	if walked == 0 {
+		t.Fatal("the serving set admits no state; this test asserted nothing")
 	}
 }
 

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -528,6 +528,8 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 			"starting", store.EvidenceStartAuthorized, assignment.ObservedRunning, dispositionSettleStarted},
 		"an unprovable start is held": {
 			"starting", store.EvidenceStartAuthorized, assignment.ObservedAbsent, dispositionReview},
+		"an attempt an operator returned to the queue is left alone": {
+			"ready", store.EvidenceNotStarted, "", dispositionNone},
 		"a superseded attempt is left alone": {
 			"superseded", store.EvidenceNotStarted, "", dispositionNone},
 		"a held attempt is left alone": {
@@ -571,5 +573,62 @@ func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
 					got.State, got.Resolution)
 			}
 		})
+	}
+}
+
+// TestEveryServingStateCanBeDisposedOf: no disposition this decision can
+// reach fails to match a row.
+//
+// The requeue is split across two queries whose guards between them
+// cover exactly the five states one serving passes through. A state
+// admitted to the set but absent from both guards produces a requeue
+// that matches nothing, and the finalizing transaction rolls back with
+// it — the lease pins in cleaning holding its admission credit, and a
+// lease already in cleaning cannot move there again, so no later pass
+// recovers it. This walks the whole set and requires the lease released
+// from each.
+func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
+	for _, state := range []string{"leased", "preparing", "prepared", "starting", "running"} {
+		t.Run(state, func(t *testing.T) {
+			f := newFixture(t, nopRemover{})
+			f.driveTo(store.LeaseCleaning)
+			if state != "leased" {
+				f.advanceAttemptTo(state)
+			}
+
+			// Retriable evidence is the disposition that reaches the
+			// requeue from every one of these states.
+			if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+				t.Fatalf("Finalize from %s: %v", state, err)
+			}
+			if got := f.reload().State; got != store.LeaseReleased {
+				t.Errorf("lease = %s after disposing an attempt in %s; want released", got, state)
+			}
+		})
+	}
+}
+
+// TestAnAttemptReturnedToTheQueueDoesNotPinItsLease: an operator can
+// resolve a held attempt back to `ready` while the lease that served it
+// is still cleaning up, and that serving must still end.
+func TestAnAttemptReturnedToTheQueueDoesNotPinItsLease(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	f.driveTo(store.LeaseCleaning)
+	id := assignment.AttemptID(f.attempt)
+	f.tx(func(tx *store.Tx) error {
+		if err := tx.HoldForReview(id, store.ReviewReasonRetryBudgetExhausted); err != nil {
+			return err
+		}
+		return tx.ResolveReviewToReady(id, "resolved", "operator")
+	})
+
+	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if got := f.reload().State; got != store.LeaseReleased {
+		t.Errorf("lease = %s; want released — an attempt already servable must not pin it", got)
+	}
+	if got := f.attemptState().State; got != "ready" {
+		t.Errorf("attempt = %s; want it left where the operator put it", got)
 	}
 }


### PR DESCRIPTION
## What changes

`ready` leaves the set of states a disposition may act on, and the
predicate is renamed to say what the set is. The five that remain are the
states one serving passes through, which is what makes the requeue total.

Three smaller corrections ride along. The test that guards the totality
now derives the states it walks from the predicate instead of restating
them; both warnings a disposition emits carry the same four fields; and
`resolveInterrupted` stops keeping a local copy of evidence it has just
written.

## What was found

**A requeue from `ready` matches no row, and the lease pays for it.**
`RequeueAttempt`'s guard is `state IN ('leased','preparing','prepared')`.
An attempt found in `ready` at disposition time takes the
evidence-retriable branch, reaches the plain requeue, matches nothing,
and the ErrConflict rolls back the finalizing transaction. The lease
never leaves `cleaning`, and `ToCleaning` from `cleaning` is a no-op, so
every later reconciliation pass repeats the identical rollback. The
binding's admission credit is gone for the life of the process.

Reproduced, with an operator resolving a held attempt back to the queue
while the lease that served it was still cleaning up:

```text
Finalize -> attempt att-3c98abbf51f63100 is past the point of safe requeue
lease    -> cleaning
```

This is the same defect, at a different state, as the one the previous
change removed — and it was inside that change. The set was written as
"the states an attempt can be open in" when what the disposition needs is
"the states this serving is responsible for". Those differ by exactly
`ready`: the lease claims its attempt to `leased` when it is created, so
an attempt found in `ready` afterwards was put there by something else.

**The set is now provably total rather than carefully chosen.** The
requeue is split across two queries. `leased`, `preparing` and `prepared`
are exactly what `RequeueAttempt` accepts; `starting` and `running` are
exactly what `RequeueProvenInertAttempt` accepts. With `ready` gone,
every disposition the set admits matches a row — a property the code
holds, not a list somebody keeps right.

**The name was a trap.** `attemptIsOpen` sat one grep away from
`GetOpenAttemptByWorkload`, which means a different and wider set: the
seven states that block a redelivery, `manual_review` among them. Two
sets under one word is how the wrong one gets copied into the next
guard. It is `servedByThisLease` over the serving states now.

**The test that guards totality could not see the drift it guards
against.** `TestEveryServingStateCanBeDisposedOf` said it walked the
whole set and walked a literal list beside it, so the two could disagree
silently — with `ready` back in the predicate the test still passed. It
now filters every attempt state through `servedByThisLease` and walks
what survives, and fails outright if the predicate admits nothing, so it
cannot pass by asserting an empty loop.

**Both warnings a disposition emits now answer the same question.** The
requeue line carried the state and not the observation; the hold-for-
review line carried the observation and not the state. The hold is the
one disposition a person has to act on, and both fields are inputs to
their decision: `starting` and `running` differ on whether a runner may
already hold the job, and an absent runtime is not the same answer as one
that cannot be observed. Both lines carry attempt, lease, state and
observation.

**A local copy of the evidence outlived the write that mattered.**
`resolveInterrupted` reassigned its own `evidence` after `RecordEvidence`
succeeded, and nothing below reads it: every disposition re-reads the row
inside its own transaction, and the logger that would have shown it is
bound by `slog.With` before the block. The assignment did nothing but
imply a local value fed a decision it never fed.

## Symmetry check

| Path | Result |
|---|---|
| `RequeueAttempt`'s guard | `leased, preparing, prepared` — covered by the set, verified against the SQL |
| `RequeueProvenInertAttempt`'s guard | `starting, running` — covered, verified |
| `SettleAttempt`'s guard | compare-and-swap on the state just read, so any serving state matches |
| `MarkAttemptManualReview`'s guard | six states including `ready`; a proper superset of the set, and wider on purpose — it also serves `HoldAttempt` |
| `ListAttemptsAttachedToReleasedLeases` | already selects exactly the five serving states, so the sweep feeding `DisposeStranded` and this predicate now agree |
| `GetOpenAttemptByWorkload` | the wider seven-state set, unchanged; it answers a different question and the rename is what keeps the two apart |
| `HoldAttempt` | writes `HoldForReview` without consulting the set, correctly: it is the explicit broken-configuration hold, not a disposition, and on a terminal attempt its ErrConflict is logged inside its own transaction |
| `requeueProven`'s private split | a third copy of the same partition, alongside the two SQL guards; left as is, and the new test is what fails if the three drift |
| `dispositionFor`'s other cases | unchanged; only the first case's set moved |
| the two `Warn` lines in `applyDisposition` | were asymmetric in their fields; now identical |

## Evidence

```text
mutation 1 — the set: put "ready" back in the serving set
  -> TestBothDispositionPathsAgree/an_attempt_an_operator_returned_to_the_queue_is_left_alone
     dispositionFor(ready, not_started, ) = 1; want 0
  -> TestAnAttemptReturnedToTheQueueDoesNotPinItsLease also fails

mutation 2 — the derivation: the same mutation, against the totality test
  before: TestEveryServingStateCanBeDisposedOf passes with "ready" in the set
  after:  --- FAIL: TestEveryServingStateCanBeDisposedOf/ready
          lease_test.go:613: no path defined to attempt state "ready"
```

One mutation per mechanism: the first isolates the set, the second
isolates whether the totality test can see a change to it. The second is
what makes the first durable — before it, the guard passed either way.

## What would notice this regressing

- `TestEveryServingStateCanBeDisposedOf` derives its states from
  `servedByThisLease`, finalizes from each, and requires the lease
  released every time — so a state added to the set without a matching
  requeue guard fails here, and so does a state the fixture cannot reach.
- `TestAnAttemptReturnedToTheQueueDoesNotPinItsLease` covers the path
  that reaches it in practice.
- `TestBothDispositionPathsAgree` gains a `ready` row.

The two log lines are operator-facing fields, not behaviour, and nothing
asserts them. Said plainly rather than claimed otherwise.

## Risk, compatibility and operations

**Behaviour changes in one direction only:** a disposition that would
have failed now writes nothing and lets the lease release. No attempt
that was previously resolved is left unresolved — `ready` is already
servable, which is why leaving it alone is correct.

**Operationally this recovers capacity that was being lost.** A
deployment where an operator resolved a review while a lease was cleaning
up was losing one admission credit per occurrence with no command to get
it back short of a restart.

**Two log lines gain a field each.** Anything parsing them by field name
is unaffected; anything matching the whole line is not.

**Trust boundary, credentials, schema, migrations, CLI, configuration,
status API: untouched.** Rollback is the previous image.

## Changelog

```text
NONE — the behaviour it restores was described by the previous entry, which
already states that an attempt somebody else resolved is left alone and the
lease still releases. This makes that true for one more state.
```

## Notes for your reviewer

Worth saying plainly: this is the defect the previous change fixed,
surviving inside the fix. The set was written from the wrong question —
"which states is an attempt open in" rather than "which states is this
serving responsible for" — and the two differ by exactly the state that
breaks it.

What I would check first is the totality claim, because it is the part
that makes this durable rather than another careful list: the two requeue
guards in `attempts.sql`, read against the five states, should cover them
with nothing left over.

Two things this leaves alone, both pre-existing and neither in scope
here. `requeueProven` keeps a private copy of the same partition the two
SQL guards encode, so the rule is written in three places. And
`HoldForReview` and `ResolveReviewToReady` record their events under
fixed idempotency keys while `InsertAttemptEvent` is `ON CONFLICT DO
NOTHING`, so a second hold or resolve of the same attempt keeps its
`review_reason` but loses the actor and decision from the history —
`disposeAttempt` keys by lease id for exactly this reason. This change is
what lets that second cycle happen at all, rather than pinning the lease
on the first.
