### PR TITLE
fix(gateway): a tunnel ends when it has ended, and stops when its destination is revoked

### DIFF
--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -195,14 +195,20 @@ func installPolicyWith(controlDir string,
 
 	// The two callers reach this from separate `docker exec` processes
 	// into the same container, so the lock has to be one the kernel
-	// holds. Without it both read the same policy in force, build two
-	// successors from it and race the write: the stricter one is lost —
-	// a deny-all overwritten by a reload that was already in flight —
-	// or the file the relay reads is two documents spliced together,
-	// which ParsePolicy refuses and which then fails every dial.
+	// holds. What it buys is order: each installer reads the policy
+	// actually in force and builds its successor from that, instead of
+	// from a document another installer is midway through replacing.
 	//
-	// It blocks rather than trying: an emergency close must wait its
-	// turn and then win, not give up because a reload held the lock.
+	// It orders them; it does not rank them. Every installer builds from
+	// what it reads and the last to run is what stays, so a reload that
+	// starts after an emergency close is what the relay ends up with.
+	// Nothing here prevents that, and nothing needs to: the emergency
+	// close is only reached from closeGateway, which removes the
+	// container whatever the install returned, so the policy left behind
+	// outlives nothing.
+	//
+	// It blocks rather than trying, so an installer waits its turn
+	// instead of failing because another held the lock.
 	lock, err := os.OpenFile(filepath.Join(controlDir, policyLockFile), os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("policy lock: %w", err)

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -1,14 +1,16 @@
 package gateway
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rhobuild/runpool/internal/egress"
-	"time"
 )
 
 // TestPolicyGenerationAdvancesOnlyOnChange: the relay drops pooled
@@ -140,15 +142,18 @@ func TestAWideningAllowIsRefusedOnTheReloadChannel(t *testing.T) {
 	}
 }
 
-// TestConcurrentInstallsDoNotLoseTheStricterPolicy: the two installers
-// are separate exec processes into the same container, so what
-// serializes them has to be a lock the kernel holds.
+// TestAConcurrentInstallLeavesAPolicyInForce: installers racing each
+// other leave the relay a policy it can read, at every moment and at the
+// end.
 //
-// Without one they read the same policy in force, build two successors
-// and race the write: an emergency close is overwritten by a reload that
-// was already in flight, or the file is two documents spliced together —
-// which the reader refuses, after which every dial fails.
-func TestConcurrentInstallsDoNotLoseTheStricterPolicy(t *testing.T) {
+// This is the composition, not either mechanism. Two things hold it up —
+// the kernel lock that orders the installers and the unique temporary
+// name that makes each write atomic — and this test passes as long as
+// one of them does, which is exactly why it cannot stand for either.
+// TestConcurrentInstallsAreSerialized covers the lock and
+// TestAConcurrentWriteIsNeverReadHalfWritten covers the write; each
+// fails on its own mechanism alone.
+func TestAConcurrentInstallLeavesAPolicyInForce(t *testing.T) {
 	dir := t.TempDir()
 	path := PolicyPath(dir)
 	inForce := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
@@ -270,5 +275,138 @@ func TestAPolicyMoveRetiresTheTransport(t *testing.T) {
 	if got := r.roundTripper(); got == first {
 		t.Error("the transport survived a policy move; a connection pooled under the old one " +
 			"still carries the next request past the dialer, where the address is checked")
+	}
+}
+
+// TestConcurrentInstallsAreSerialized: two installers never occupy the
+// critical section at once.
+//
+// A reload and an emergency close arrive as separate `docker exec`
+// processes into the same container, so nothing in the program's own
+// memory can order them — it has to be a lock the kernel holds. Without
+// one they both read the same policy in force and each builds its
+// successor from a document the other is about to replace, so the second
+// rename silently discards the first install's decision.
+//
+// This is deliberately not the same test as the one above. A unique
+// temporary name alone keeps every observable state parseable, so a
+// splice test passes whether or not the lock is there, and for a while
+// one test stood for both mechanisms while only one of them was really
+// covered.
+func TestConcurrentInstallsAreSerialized(t *testing.T) {
+	dir := t.TempDir()
+	inForce := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+		`"allow":[],"deny":["10.0.0.0/8"]}`
+	if err := os.WriteFile(PolicyPath(dir), []byte(inForce), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	noKernel := func(egress.Policy) error { return nil }
+
+	// build runs between the read of the policy in force and the write
+	// of its successor, which is the whole of the section the lock has
+	// to hold shut.
+	var inside, peak atomic.Int32
+	install := func() error {
+		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+			n := inside.Add(1)
+			for {
+				seen := peak.Load()
+				if n <= seen || peak.CompareAndSwap(seen, n) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			inside.Add(-1)
+			next := current
+			next.Deny = []string{"10.0.0.0/8", "192.168.0.0/16"}
+			return next, next.Validate()
+		}, noKernel)
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := install(); err != nil {
+				t.Errorf("install: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got != 1 {
+		t.Errorf("%d installers held the critical section at once; want 1 — "+
+			"each one past the read is building its successor from a policy "+
+			"another is about to replace", got)
+	}
+}
+
+// TestAConcurrentWriteIsNeverReadHalfWritten: a reader of a file
+// replaced by writeFileAtomic never sees a partial document.
+//
+// The rename is atomic; the write into the temporary file behind it is
+// not. Writers sharing one temporary name truncate and fill it in turn,
+// and the rename publishes whatever interleaving won. Every caller gets
+// this, including the ones with no lock around them, so it is tested
+// where it lives rather than through an installer that is serialized
+// anyway.
+func TestAConcurrentWriteIsNeverReadHalfWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc.json")
+	// Documents of very different lengths: a splice between two equal
+	// ones can go unnoticed, and the tail of the longer is what makes a
+	// half-written file visibly unparseable.
+	docs := [][]byte{
+		[]byte(`{"a":1}`),
+		[]byte(`{"a":1,"b":"` + strings.Repeat("x", 4096) + `"}`),
+	}
+	if err := writeFileAtomic(path, docs[0]); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				continue // the rename is atomic; a missing file is not
+			}
+			if !json.Valid(raw) {
+				select {
+				case bad <- string(raw):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 20 {
+				if err := writeFileAtomic(path, docs[i%len(docs)]); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+
+	select {
+	case raw := <-bad:
+		t.Fatalf("a reader observed a document that is not whole (%d bytes):\n%.200s", len(raw), raw)
+	default:
 	}
 }

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -376,7 +376,15 @@ func TestAConcurrentWriteIsNeverReadHalfWritten(t *testing.T) {
 			}
 			raw, err := os.ReadFile(path)
 			if err != nil {
-				continue // the rename is atomic; a missing file is not
+				// A rename never leaves the target absent, so this is a
+				// finding rather than something to poll past: a writer
+				// that removed and recreated the file would show up here
+				// and nowhere else.
+				select {
+				case bad <- "unreadable: " + err.Error():
+				default:
+				}
+				return
 			}
 			if !json.Valid(raw) {
 				select {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -242,9 +242,12 @@ func (r *Relay) tunnelDestinationAllowed(upstream net.Conn) func() bool {
 // through to a full close.
 type closeWriter interface{ CloseWrite() error }
 
-// tunnelPollInterval is how often a quiet direction re-checks the
-// tunnel's shared activity clock. It also bounds how far past the idle
-// timeout a genuinely silent tunnel can live.
+// tunnelPollInterval is how often a direction re-checks the tunnel's
+// shared activity clock and the policy its destination was authorised
+// under. It bounds two things: how far past the idle timeout a genuinely
+// silent tunnel can live, and — the one that matters for egress — how
+// long a destination the policy has stopped allowing keeps flowing
+// through a tunnel that is already open.
 const tunnelPollInterval = 30 * time.Second
 
 // tunnel copies both directions and returns when both of them have
@@ -264,6 +267,10 @@ const tunnelPollInterval = 30 * time.Second
 // a per-direction deadline severed a large upload or a slow download
 // while it was actively streaming. Each direction now reads in short
 // intervals and consults a clock both of them write.
+// stillAllowed is consulted once per poll interval by each direction:
+// a tunnel is authorised at CONNECT and then runs for as long as both
+// ends keep talking, so without it a policy tightened underneath one
+// applies only to destinations nobody had reached yet.
 func tunnel(client, upstream net.Conn, stillAllowed func() bool) {
 	tunnelWith(client, upstream, TunnelIdleTimeout, tunnelPollInterval, stillAllowed)
 }
@@ -341,13 +348,23 @@ func tunnelWith(client, upstream net.Conn, idle, poll time.Duration, stillAllowe
 			}
 			break
 		}
-		// The tunnel is over rather than half-closed, so close it.
+		// This is an abnormal end — a write that failed, a read error,
+		// an idle bound reached, a destination revoked — not the clean
+		// half-close above, which returns before here. Close both.
+		//
 		// Waking the peer with a deadline does not end it: the peer
 		// re-arms its own on the next turn of its loop and parks again,
-		// and repeats that until the idle bound — ten minutes of a
-		// connection slot held by a tunnel that has already finished.
-		// A close returns its reads immediately and permanently. The
-		// deferred closes further up are idempotent.
+		// and repeats that until the idle bound. That is ten minutes of
+		// a connection slot held by a tunnel whose other end has already
+		// gone. A close returns the peer's reads immediately and
+		// permanently, and the deferred closes further up are the same
+		// two calls, only later — this brings them forward to the moment
+		// the tunnel actually ended.
+		//
+		// Closing a socket with unread inbound data sends a reset rather
+		// than a clean shutdown, so a revoked destination reaches its
+		// client as a reset connection. That is the intent: the transfer
+		// is being stopped, not allowed to drain.
 		_ = src.Close()
 		_ = dst.Close()
 	}

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -201,7 +201,39 @@ func (r *Relay) establishTunnel(w http.ResponseWriter, upstream net.Conn) {
 		}
 		_ = upstream.SetWriteDeadline(time.Time{})
 	}
-	tunnel(client, upstream)
+	tunnel(client, upstream, r.tunnelDestinationAllowed(upstream))
+}
+
+// tunnelDestinationAllowed builds the check a running tunnel repeats
+// against the policy in force. It closes over the peer address the
+// tunnel is actually joined to rather than the name that was resolved:
+// a name can be made to resolve somewhere else between the dial and the
+// re-check, and the address is what the policy decides about anyway.
+//
+// Anything it cannot answer is a denial. A policy that cannot be read is
+// not in force — the same rule dial applies — and an address that cannot
+// be parsed cannot be checked at all.
+func (r *Relay) tunnelDestinationAllowed(upstream net.Conn) func() bool {
+	peer, parseErr := netip.ParseAddrPort(upstream.RemoteAddr().String())
+	addr := peer.Addr().Unmap()
+	return func() bool {
+		if parseErr != nil {
+			r.Log.Warn("egress tunnel closed: peer address unreadable",
+				"peer", upstream.RemoteAddr().String(), "error", parseErr)
+			return false
+		}
+		policy, err := r.Policy.Current()
+		if err != nil {
+			r.Log.Warn("egress tunnel closed: policy unavailable",
+				"address", addr.String(), "error", err)
+			return false
+		}
+		if policy.Allowed(addr) {
+			return true
+		}
+		r.Log.Warn("egress tunnel closed: destination no longer allowed", "address", addr.String())
+		return false
+	}
 }
 
 // closeWriter is the half-close a tunnel propagates. Every connection a
@@ -232,30 +264,62 @@ const tunnelPollInterval = 30 * time.Second
 // a per-direction deadline severed a large upload or a slow download
 // while it was actively streaming. Each direction now reads in short
 // intervals and consults a clock both of them write.
-func tunnel(client, upstream net.Conn) {
-	tunnelWith(client, upstream, TunnelIdleTimeout, tunnelPollInterval)
+func tunnel(client, upstream net.Conn, stillAllowed func() bool) {
+	tunnelWith(client, upstream, TunnelIdleTimeout, tunnelPollInterval, stillAllowed)
 }
 
-func tunnelWith(client, upstream net.Conn, idle, poll time.Duration) {
-	// One clock for the tunnel: activity in either direction is what
-	// keeps the other alive.
-	var lastActivity atomic.Int64
-	lastActivity.Store(time.Now().UnixNano())
+// tunnelClock is the activity clock two directions of one tunnel share:
+// traffic either way is what keeps the other alive.
+//
+// Every value it holds is a duration since the tunnel began, never a
+// wall-clock instant. The deadlines it is compared against are monotonic
+// — that is what net.Conn deadlines and time.Since are — and mixing the
+// two means an NTP correction or a VM resume either severs a tunnel that
+// is actively streaming or leaves a dead one holding its slot past the
+// idle bound.
+type tunnelClock struct {
+	start time.Time
+	last  atomic.Int64
+}
+
+func newTunnelClock() *tunnelClock { return &tunnelClock{start: time.Now()} }
+
+// mark records traffic. idleFor reports how long ago the last traffic
+// was, in the same monotonic frame.
+func (c *tunnelClock) mark()                     { c.last.Store(int64(time.Since(c.start))) }
+func (c *tunnelClock) sinceStart() time.Duration { return time.Since(c.start) }
+func (c *tunnelClock) idleFor() time.Duration    { return c.sinceStart() - time.Duration(c.last.Load()) }
+
+func tunnelWith(client, upstream net.Conn, idle, poll time.Duration, stillAllowed func() bool) {
+	clock := newTunnelClock()
 
 	var wg sync.WaitGroup
 	copyIdle := func(dst, src net.Conn) {
 		defer wg.Done()
 		buf := make([]byte, 32<<10)
+		nextCheck := poll
 		for {
+			// A tunnel outlives the decision that authorised it, so the
+			// destination is re-checked while it runs. The bound is
+			// elapsed time, not the read deadline below: a direction
+			// carrying traffic returns from every read before that
+			// deadline fires, and a bulk transfer to a destination just
+			// revoked is exactly the case this exists to stop.
+			if elapsed := clock.sinceStart(); elapsed >= nextCheck {
+				nextCheck = elapsed + poll
+				if !stillAllowed() {
+					break
+				}
+			}
 			_ = src.SetReadDeadline(time.Now().Add(poll))
 			n, err := src.Read(buf)
 			if n > 0 {
-				lastActivity.Store(time.Now().UnixNano())
+				clock.mark()
 				_ = dst.SetWriteDeadline(time.Now().Add(idle))
 				if _, werr := dst.Write(buf[:n]); werr != nil {
 					break
 				}
-				lastActivity.Store(time.Now().UnixNano())
+				clock.mark()
 			}
 			switch {
 			case err == nil:
@@ -263,7 +327,7 @@ func tunnelWith(client, upstream net.Conn, idle, poll time.Duration) {
 			case errors.Is(err, os.ErrDeadlineExceeded):
 				// Quiet here. The tunnel is idle only if it is quiet
 				// both ways, which is what the shared clock answers.
-				if time.Since(time.Unix(0, lastActivity.Load())) < idle {
+				if clock.idleFor() < idle {
 					continue
 				}
 			case errors.Is(err, io.EOF):
@@ -277,10 +341,15 @@ func tunnelWith(client, upstream net.Conn, idle, poll time.Duration) {
 			}
 			break
 		}
-		// The tunnel is over rather than half-closed: unblock the peer
-		// instead of leaving its goroutine parked on a read.
-		_ = src.SetReadDeadline(time.Now())
-		_ = dst.SetReadDeadline(time.Now())
+		// The tunnel is over rather than half-closed, so close it.
+		// Waking the peer with a deadline does not end it: the peer
+		// re-arms its own on the next turn of its loop and parks again,
+		// and repeats that until the idle bound — ten minutes of a
+		// connection slot held by a tunnel that has already finished.
+		// A close returns its reads immediately and permanently. The
+		// deferred closes further up are idempotent.
+		_ = src.Close()
+		_ = dst.Close()
 	}
 	wg.Add(2)
 	go copyIdle(upstream, client)

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -294,6 +295,10 @@ func TestTunnelCarriesTheBytesTheServerAlreadyRead(t *testing.T) {
 	<-done
 }
 
+// alwaysAllowed is the destination check for tunnels whose policy is not
+// what the test is about.
+func alwaysAllowed() bool { return true }
+
 // tcpPair dials a loopback listener and hands back both ends of one real
 // TCP connection. Real sockets, not net.Pipe: a half-close is a property
 // of the transport, and a pipe has no such thing.
@@ -338,7 +343,7 @@ func TestAHalfClosingClientStillReceivesItsWholeResponse(t *testing.T) {
 	clientEnd, clientSide := tcpPair(t)
 	upstreamSide, upstreamEnd := tcpPair(t)
 
-	go tunnelWith(clientSide, upstreamSide, 5*time.Second, 500*time.Millisecond)
+	go tunnelWith(clientSide, upstreamSide, 5*time.Second, 500*time.Millisecond, alwaysAllowed)
 
 	// The request goes out, then the client is done sending.
 	if _, err := clientEnd.Write([]byte("request")); err != nil {
@@ -426,7 +431,7 @@ func TestAOneWayTransferOutlivesTheIdleBound(t *testing.T) {
 	clientEnd, clientSide := tcpPair(t)
 	upstreamSide, upstreamEnd := tcpPair(t)
 
-	go tunnelWith(clientSide, upstreamSide, idle, poll)
+	go tunnelWith(clientSide, upstreamSide, idle, poll, alwaysAllowed)
 
 	// One direction streams steadily for well past the idle bound; the
 	// other says nothing at all.
@@ -451,5 +456,124 @@ func TestAOneWayTransferOutlivesTheIdleBound(t *testing.T) {
 		t.Errorf("the client received %d of %d bytes over %s with a %s idle bound; "+
 			"the quiet direction expired while the other was streaming",
 			len(got), beats, time.Duration(beats)*30*time.Millisecond, idle)
+	}
+}
+
+// TestADeadTunnelReleasesItsSlotAtOnce: a tunnel that has ended gives up
+// its connection slot when it ends, not when the idle bound expires.
+//
+// Ending it by nudging the peer's read deadline does not end it. The
+// peer wakes, finds the shared clock recent, and re-arms its own
+// deadline on the next turn of its loop, and it repeats that until the
+// idle bound — ten minutes during which the relay's connection quota is
+// one smaller for a tunnel with nothing on either end.
+func TestADeadTunnelReleasesItsSlotAtOnce(t *testing.T) {
+	const (
+		idle = 3 * time.Second
+		poll = 100 * time.Millisecond
+	)
+	clientEnd, clientSide := tcpPair(t)
+	upstreamSide, upstreamEnd := tcpPair(t)
+	_ = clientEnd
+
+	done := make(chan struct{})
+	go func() {
+		tunnelWith(clientSide, upstreamSide, idle, poll, alwaysAllowed)
+		close(done)
+	}()
+
+	// A reset, not a clean shutdown: the upstream is gone and says so
+	// with an error, which is the abnormal end this is about.
+	if err := upstreamEnd.(*net.TCPConn).SetLinger(0); err != nil {
+		t.Fatal(err)
+	}
+	if err := upstreamEnd.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(idle - time.Second):
+		t.Fatalf("the tunnel outlived its upstream by more than %v; it is waiting out the idle bound", idle-time.Second)
+	}
+}
+
+// TestARevokedDestinationEndsALiveTunnel: a destination the policy stops
+// allowing stops flowing, within one poll interval, while it is still
+// carrying traffic.
+//
+// A tunnel is authorised once, at CONNECT, and then runs for as long as
+// both ends keep talking. A policy tightened underneath it — a lease
+// narrowing its allowances, a redelivery installing a smaller set — has
+// to reach the connections already open, or the tightening only applies
+// to destinations nobody had reached yet.
+//
+// The traffic is the point: this stays busy throughout, and a direction
+// carrying bytes returns from every read before its deadline fires, so a
+// check hung off that deadline would never run here.
+func TestARevokedDestinationEndsALiveTunnel(t *testing.T) {
+	const (
+		idle = 30 * time.Second
+		poll = 50 * time.Millisecond
+	)
+	clientEnd, clientSide := tcpPair(t)
+	upstreamSide, upstreamEnd := tcpPair(t)
+
+	var allowed atomic.Bool
+	allowed.Store(true)
+
+	done := make(chan struct{})
+	go func() {
+		tunnelWith(clientSide, upstreamSide, idle, poll, allowed.Load)
+		close(done)
+	}()
+	go func() {
+		for {
+			if _, err := upstreamEnd.Write([]byte("x")); err != nil {
+				return
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	// Do not revoke anything until the tunnel is demonstrably carrying
+	// traffic, or the test could pass against a tunnel that never ran.
+	if err := clientEnd.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadFull(clientEnd, make([]byte, 8)); err != nil {
+		t.Fatalf("the tunnel never carried anything: %v", err)
+	}
+
+	allowed.Store(false)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the tunnel kept flowing to a destination the policy no longer allows")
+	}
+}
+
+// TestTheTunnelClockIsMonotonic: the clock two directions share measures
+// in a frame no clock correction can move.
+//
+// Every deadline around it is monotonic, because that is what net.Conn
+// deadlines and time.Since are. A wall-clock instant mixed in means an
+// NTP step or a VM resume either severs a tunnel mid-transfer or leaves
+// a finished one holding its slot long past the idle bound, and neither
+// shows up as anything but an unexplained connection.
+func TestTheTunnelClockIsMonotonic(t *testing.T) {
+	c := newTunnelClock()
+
+	// Round(0) is what strips a monotonic reading, so a time that still
+	// carries one is not equal to itself rounded.
+	if c.start == c.start.Round(0) {
+		t.Fatal("the tunnel clock's origin carries no monotonic reading; every bound derived from it moves with the wall clock")
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	before := c.idleFor()
+	c.mark()
+	if after := c.idleFor(); after >= before {
+		t.Errorf("idleFor = %v after marking traffic and %v before; a mark must reset it", after, before)
 	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -269,7 +270,17 @@ func TestTunnelCarriesTheBytesTheServerAlreadyRead(t *testing.T) {
 		buffered: bufio.NewReadWriter(reader, bufio.NewWriter(serverSide)),
 	}
 
-	r := &Relay{Log: discardLogger()}
+	// A real policy store, not a nil one: establishTunnel now starts a
+	// tunnel that consults the policy on its own schedule, and a fixture
+	// that passes only because the poll interval outlasts the test is a
+	// fixture that stops passing the day someone shortens it.
+	policyDir := t.TempDir()
+	if err := os.WriteFile(PolicyPath(policyDir),
+		[]byte(`{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",`+
+			`"allow":["0.0.0.0/0"],"deny":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := &Relay{Policy: &PolicyStore{Path: PolicyPath(policyDir)}, Log: discardLogger()}
 	done := make(chan struct{})
 	go func() { defer close(done); r.establishTunnel(w, upstream) }()
 
@@ -527,23 +538,53 @@ func TestARevokedDestinationEndsALiveTunnel(t *testing.T) {
 		tunnelWith(clientSide, upstreamSide, idle, poll, allowed.Load)
 		close(done)
 	}()
-	go func() {
+
+	// Both ends write, and both ends are drained. One-way traffic would
+	// not do: the silent direction's read deadline fires every poll, so a
+	// check hung off that deadline runs there and the test would pass
+	// against exactly the shape it exists to rule out.
+	stop := make(chan struct{})
+	t.Cleanup(func() { close(stop) })
+	stream := func(w net.Conn) {
 		for {
-			if _, err := upstreamEnd.Write([]byte("x")); err != nil {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := w.Write([]byte("x")); err != nil {
 				return
 			}
 			time.Sleep(2 * time.Millisecond)
 		}
-	}()
+	}
+	drain := func(rd net.Conn) {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := rd.Read(buf); err != nil {
+				return
+			}
+		}
+	}
+	go stream(upstreamEnd)
+	go stream(clientEnd)
 
-	// Do not revoke anything until the tunnel is demonstrably carrying
-	// traffic, or the test could pass against a tunnel that never ran.
-	if err := clientEnd.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		t.Fatal(err)
+	// Do not revoke anything until both directions are demonstrably
+	// carrying traffic, or the test could pass against a tunnel that
+	// never ran, or one running one-way.
+	for _, end := range []net.Conn{clientEnd, upstreamEnd} {
+		if err := end.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.ReadFull(end, make([]byte, 8)); err != nil {
+			t.Fatalf("the tunnel never carried anything towards %s: %v", end.LocalAddr(), err)
+		}
+		if err := end.SetReadDeadline(time.Time{}); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if _, err := io.ReadFull(clientEnd, make([]byte, 8)); err != nil {
-		t.Fatalf("the tunnel never carried anything: %v", err)
-	}
+	go drain(clientEnd)
+	go drain(upstreamEnd)
 
 	allowed.Store(false)
 	select {


### PR DESCRIPTION
## What changes

A CONNECT tunnel gets three corrections, all in what happens after it is
established: it closes when it ends instead of nudging a deadline, its
idle clock stops being a wall-clock instant, and it re-checks its
destination against the policy in force while it runs.

Separately, the test that covered the policy file's integrity is split so
each mechanism has a case that fails without it, and the lock's comment
is corrected to describe what the lock does.

## What was found

**A finished tunnel held a connection slot for ten minutes.** The
abnormal ends — a write failure, a reset, the idle bound — set a read
deadline on both connections to unblock the peer. It does not unblock
it. The peer wakes with `os.ErrDeadlineExceeded`, finds the shared clock
recent, `continue`s to the top of its loop and re-arms its own deadline,
and repeats that until the idle bound expires. `MaxProxyConnections` is
one smaller for the whole of it. Measured: with a reset upstream and a
3s idle bound, the tunnel returned in 2.01s under the old code and
immediately under the new one.

**The idle clock was wall-clock while everything it is compared against
is monotonic.** `time.Now().UnixNano()` drops the monotonic reading, and
`time.Since(time.Unix(0, n))` is therefore wall-clock subtraction, sat
next to `SetReadDeadline` and `time.Since` which are not. An NTP
correction or a VM resume either severs a tunnel mid-transfer or leaves
a finished one past its bound. Neither leaves anything behind but a
connection nobody can explain.

**A tunnel was authorised once and never re-checked.** The HTTP path
retires its pool when the policy generation moves, so a tightened policy
reaches pooled connections. Tunnels had no equivalent: a lease narrowing
its allowances, or a redelivery installing a smaller set, applied only to
destinations nobody had reached yet, while a transfer already running to
a now-denied address continued to completion. Each direction re-checks
once per poll interval — 30s in production, the declared maximum delay.

The check is against the peer address the tunnel is joined to, not the
name that was resolved: a name can be made to resolve elsewhere between
the dial and the re-check, and the address is what the policy decides
about anyway. Anything unanswerable is a denial, the same rule `dial`
applies to an unreadable policy.

The bound is elapsed time rather than the read deadline. A direction
carrying traffic returns from every read before that deadline fires, so a
check hung off it would never run during a bulk transfer — which is the
case that matters most.

**One test stood for two mechanisms, and passed on either.** The policy
file is protected by the kernel lock that orders installers and by the
unique temporary name that makes each write atomic.
`TestConcurrentInstallsDoNotLoseTheStricterPolicy` asserted only that a
racing reader never saw an unparseable document, which either mechanism
alone delivers.

Measured rather than assumed, and the measurement went the other way from
what the name suggested: with the lock present, replacing the unique
temporary name with a shared one left the test **passing**. The lock was
carrying it, and the atomic write was uncovered — not the reverse.

**And the lock's comment promised a rank it does not provide.** It said
an emergency close "must wait its turn and then win". It waits its turn;
it does not win. Every installer builds its successor from what it reads,
so the last to run is what stays, and a reload that starts after an
emergency close is what the relay ends up with. The consequence is
bounded rather than fixed here: `closeGateway` calls `RemoveContainer`
whatever the deny-all install returned, so the policy left behind
outlives nothing. The comment now describes the ordering the lock gives.

## Symmetry check

| Path | Result |
|---|---|
| the two directions of a tunnel | both run the same `copyIdle`; the change is inside it, so neither can drift from the other |
| `copyIdle`'s three exits — EOF, error, idle | EOF returns early as a half-close and is untouched; error and idle both reach the close |
| the half-close path | returns before the close, verified by `TestAHalfClosingClientStillReceivesItsWholeResponse` still passing |
| `forward` (pooled HTTP) vs `connect` (tunnel) | `forward` already revalidates through `expireStaleConnections`; the tunnel is the leg that had no equivalent, which is this change |
| `dial`'s denial rules | an unreadable policy refuses; the tunnel re-check now applies the same rule rather than failing open |
| `expireStaleConnections` | unchanged; it retires the pool, which is a different mechanism for a different connection kind |
| `writeFileAtomic`'s other callers | they have no lock around them, which is why the atomic-write test now targets the function rather than an installer |
| the reload path vs the emergency-close path | both reach `installPolicyWith`; neither outranks the other, which is now what the comment says |

## Evidence

Four mutations against the five tunnel tests. Each fails exactly one, and
moves nothing else:

```text
mutation                          half-close  one-way  dead  revoked  clock
deadline nudge instead of close   pass        pass     FAIL  pass     pass
wall-clock origin (Round(0))      pass        pass     pass  pass     FAIL
no destination re-check           pass        pass     pass  FAIL     pass
check hung off the read deadline  pass        pass     pass  FAIL     pass
```

The last one is the shape the re-check is deliberately not: it fires only
when a direction goes quiet. It is here because the first version of
`TestARevokedDestinationEndsALiveTunnel` drove traffic one way only, so
the client-to-upstream direction was silent for the whole test, its read
deadline fired every poll, and a deadline-hung check ran there. The test
passed against the very shape its comment ruled out. It now writes from
both ends, drains both, and waits until both directions have carried
bytes before revoking anything.

And the policy file, both mutations crossed against all three tests:

```text
mutation                    composition   serialized   atomic write
a shared temporary name     pass          pass         FAIL
LOCK_SH instead of LOCK_EX  pass          FAIL         pass
```

The composition test passes under both. That is the demonstration that it
could not have stood for either mechanism, and the reason it now says so
in its own comment.

## What would notice this regressing

- `TestADeadTunnelReleasesItsSlotAtOnce` resets an upstream and requires
  the tunnel to return well inside its idle bound. It covers the abnormal
  end only: an upstream that closes cleanly is a half-close, the peer is
  left to finish, and a tunnel quiet on both sides after that still lives
  out its idle bound — which is what the idle bound is for.
- `TestARevokedDestinationEndsALiveTunnel` keeps the tunnel streaming
  throughout, so it fails a check that only runs on a quiet direction.
- `TestTheTunnelClockIsMonotonic` asserts the clock's origin still
  carries a monotonic reading. It pins the origin, not the arithmetic —
  a rewrite back to storing wall-clock nanoseconds would leave `start`
  unused, which staticcheck refuses.
- `TestConcurrentInstallsAreSerialized` counts installers inside the
  critical section.
- `TestAConcurrentWriteIsNeverReadHalfWritten` races writers of very
  different lengths against a reader.
- `TestAHalfClosingClientStillReceivesItsWholeResponse` and
  `TestAOneWayTransferOutlivesTheIdleBound` are what keep the new close
  from ending a tunnel that is only half-closed or one-way busy.

## Risk, compatibility and operations

**A revoked destination now ends a running transfer.** That is the point,
and it is a behaviour change an operator can see: a job downloading from
an address removed from its policy gets a truncated transfer instead of a
completed one, within 30 seconds. The alternative — closing the whole
gateway on any tightening — cuts destinations that are still allowed and
loses the job outright.

**The re-check costs one policy read per tunnel per 30s.** `Current()` is
a stat on a cached hit, which is the same call `expireStaleConnections`
already makes per forwarded request.

**Capacity is recovered, not spent.** A relay that was losing connection
slots to finished tunnels for ten minutes at a time gets them back when
the tunnel ends.

**A revoked transfer ends as a reset, not a clean shutdown.** Closing a
socket that still has unread inbound data sends RST. That is the intent
here — the transfer is being stopped, not drained — but a client sees
`connection reset by peer` rather than a truncated-but-clean stream, and
on Linux the reset can discard bytes already delivered to its receive
queue.

**Trust boundary: tightened.** A tunnel can no longer outlive the policy
that authorised it. Nothing loosens.

**Credentials, schema, migrations, CLI, configuration, status API:
untouched.** Rollback is the previous image.

## Changelog

```text
### Fixed
- A CONNECT tunnel now ends when it ends, rather than holding one of the
  relay's connection slots until the idle timeout expires.
- A destination removed from a capsule's egress policy now stops flowing
  within 30 seconds, including through a tunnel that is already open and
  carrying traffic.
- A tunnel's idle bound is measured on a monotonic clock, so a host clock
  correction no longer severs a live transfer or extends a finished one.
```

## Notes for your reviewer

The part worth checking hardest is the re-check bound. It is deliberately
not tied to the read deadline, because a direction carrying traffic never
reaches that deadline — a tunnel doing a bulk transfer would have been
exactly the case a deadline-driven check missed, and it is the case the
policy change is most likely to be about.

Also worth knowing: `establishTunnel`'s fixture used to build a `Relay`
with a nil `PolicyStore`, and it now starts a tunnel that consults the
policy on its own schedule. It passed only because the poll interval
outlasts the test. It has a real store now, because a fixture that
depends on that is one that breaks the day somebody shortens the
interval.

Second, the measurement in the split. The expectation going in was that
the unique temporary name was carrying the old test on its own; it is the
lock that carries it, and the atomic write had no coverage at all. The
crossed table above is the whole of that claim — each mutation run
against all three tests, not just its own.
