### PR TITLE
fix(app, store): unwinding a lease outlives the deadline that caused it, and a lost observability write costs nothing

### DIFF
--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -33,6 +33,9 @@ type fakeCapsule struct {
 	// redelivery lands in: preparing a capsule takes minutes and the
 	// attempt is out of the launching goroutine's sight for all of it.
 	onPrepare func()
+	// onInspect sees the context an observation is made under, which is
+	// the only place its bound is observable.
+	onInspect func(context.Context)
 	// starts counts the one effect that can begin execution.
 	starts int
 }
@@ -66,7 +69,10 @@ func (f *fakeCapsule) Start(context.Context, capsule.PreparedRuntime) error {
 	return f.startErr
 }
 
-func (f *fakeCapsule) InspectExecution(context.Context, capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
+func (f *fakeCapsule) InspectExecution(ctx context.Context, _ capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
+	if f.onInspect != nil {
+		f.onInspect(ctx)
+	}
 	return f.obs, f.obsErr
 }
 
@@ -744,5 +750,126 @@ func TestTheReconcilerStopsRecoveringWhenTheShutdownBegins(t *testing.T) {
 		t.Errorf("the pass held the shutdown for %s against a %s budget; a recovery detached "+
 			"from the loop outlives the grace period the deployment is sized for",
 			elapsed.Round(time.Second), LoopStopBudget)
+	}
+}
+
+// TestALostWalkEdgeDoesNotAbortTheLaunch: an observability write that
+// did not land must not cost a prepared capsule and a serving.
+//
+// The walk into `preparing` and into `prepared` is best-effort by
+// design: it is written outside the transaction that matters, and a
+// failure is logged rather than retried, because its only reader is a
+// person. The edge into `starting` is the opposite — it is the last
+// point before an effect that can begin execution. Making that edge
+// require the exact predecessor tied an authoritative decision to a
+// best-effort one, so a transient store error during preparation tore
+// down a capsule that was ready to run and burnt one of the attempt's
+// servings.
+//
+// What the edge must still refuse is an attempt somebody else resolved;
+// TestASupersededAttemptIsNeverStarted is that half.
+func TestALostWalkEdgeDoesNotAbortTheLaunch(t *testing.T) {
+	h := newHarness(t, 1)
+	caps := &fakeCapsule{}
+	h.srv.caps = caps
+	h.srv.wait = &fakeWaiter{}
+	h.bind.gh = &fakeRegistry{}
+	if err := h.deliver(demand("job-lost-edge", "app", 42)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, "job-lost-edge")
+
+	// `preparing -> prepared` is written after Prepare returns, so
+	// putting the attempt back to where it was before `preparing` is
+	// exactly what that write failing leaves behind.
+	caps.onPrepare = func() {
+		h.inStore(func(tx *store.Tx) error {
+			return tx.Advance(attemptID, "preparing", "leased")
+		})
+	}
+
+	h.srv.wg.Add(1)
+	h.srv.runCapsule(h.bind, lease)
+
+	if caps.starts != 1 {
+		t.Errorf("the capsule was started %d time(s); want 1 — the attempt was still this serving's, "+
+			"only one state further back than the walk managed to record", caps.starts)
+	}
+	if got := reloadLease(t, h, lease.ID).State; got != store.LeaseReleased {
+		t.Errorf("lease = %s; want released", got)
+	}
+	if !h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the lease's admission credit was never returned")
+	}
+}
+
+// TestAnObservationIsAlwaysBounded: observing a runtime carries a
+// deadline of its own.
+//
+// The observation is a `docker exec` into the capsule, and an exec ends
+// when its context ends and not before — nothing in the Docker API
+// cancels one. Both callers hold something open while they wait: this
+// one is the launch goroutine the drain counts, and the other is the
+// reconciliation pass every later pass queues behind. Handed a context
+// with no deadline, a daemon that stopped answering turns a slow
+// shutdown into one that does not finish.
+func TestAnObservationIsAlwaysBounded(t *testing.T) {
+	h := newHarness(t, 1)
+	var (
+		deadline    time.Time
+		hasDeadline bool
+		observed    bool
+	)
+	caps := &fakeCapsule{
+		startErr: errors.New("the daemon refused the start"),
+		obs:      assignment.ObservedCreated,
+		onInspect: func(ctx context.Context) {
+			observed = true
+			deadline, hasDeadline = ctx.Deadline()
+		},
+	}
+	h.srv.caps = caps
+	h.srv.wait = &fakeWaiter{}
+	h.bind.gh = &fakeRegistry{}
+	if err := h.deliver(demand("job-observed", "app", 42)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-observed")
+
+	h.srv.wg.Add(1)
+	h.srv.runCapsule(h.bind, lease)
+
+	if !observed {
+		t.Fatal("the start failed and nothing observed the runtime; this test asserted nothing")
+	}
+	if !hasDeadline {
+		t.Fatal("the observation ran on a context with no deadline; a daemon that stops answering never returns it")
+	}
+	if left := time.Until(deadline); left <= 0 || left > inspectTimeout {
+		t.Errorf("the observation had %v left; want a positive bound no larger than %v", left, inspectTimeout)
+	}
+}
+
+// TestRecoveryOutlivesTheContextThatBoundedTheWait: unwinding a lease
+// does not inherit the deadline whose expiry is the reason to unwind.
+//
+// The tier's ceiling bounds the wait for a capsule that has stopped
+// reporting. That is the failure it exists to produce, so it is the
+// likeliest reason to be recovering at all — and a recovery handed the
+// context that just expired removes nothing. The capsule, its network
+// and its volume stay, and the lease keeps the admission credit they
+// were admitted on, which is capacity no later pass recovers.
+func TestRecoveryOutlivesTheContextThatBoundedTheWait(t *testing.T) {
+	ceiling, expire := context.WithCancel(context.Background())
+	unwind, done := recoveryContext(ceiling)
+	defer done()
+
+	expire()
+
+	if err := unwind.Err(); err != nil {
+		t.Fatalf("the recovery context ended with the wait's: %v; nothing it unwinds would be released", err)
+	}
+	if _, ok := unwind.Deadline(); !ok {
+		t.Error("the recovery context has no deadline; an unwind against a wedged daemon would hold the pass forever")
 	}
 }

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -779,9 +779,11 @@ func TestALostWalkEdgeDoesNotAbortTheLaunch(t *testing.T) {
 	}
 	lease, attemptID := leaseFor(t, h, "job-lost-edge")
 
-	// `preparing -> prepared` is written after Prepare returns, so
-	// putting the attempt back to where it was before `preparing` is
-	// exactly what that write failing leaves behind.
+	// `leased -> preparing` is written just before Prepare is called, so
+	// putting the attempt back to `leased` from inside it is what that
+	// write failing leaves behind. The other lost edge, `preparing ->
+	// prepared`, leaves the attempt at `preparing`; the store's own table
+	// test decides both, and this one takes the further of the two.
 	caps.onPrepare = func() {
 		h.inStore(func(tx *store.Tx) error {
 			return tx.Advance(attemptID, "preparing", "leased")
@@ -871,5 +873,85 @@ func TestRecoveryOutlivesTheContextThatBoundedTheWait(t *testing.T) {
 	}
 	if _, ok := unwind.Deadline(); !ok {
 		t.Error("the recovery context has no deadline; an unwind against a wedged daemon would hold the pass forever")
+	}
+}
+
+// ctxRemover records the context its removals run under. That context is
+// the only place the bound on unwinding is observable from outside.
+type ctxRemover struct {
+	seen        bool
+	hasDeadline bool
+	deadline    time.Time
+}
+
+func (r *ctxRemover) note(ctx context.Context) error {
+	r.seen = true
+	r.deadline, r.hasDeadline = ctx.Deadline()
+	return nil
+}
+func (r *ctxRemover) RemoveOwnedContainer(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
+	return r.note(ctx)
+}
+func (r *ctxRemover) RemoveOwnedNetwork(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
+	return r.note(ctx)
+}
+func (r *ctxRemover) RemoveOwnedVolume(ctx context.Context, _ string, _ assignment.InstanceID, _ assignment.LeaseID) error {
+	return r.note(ctx)
+}
+
+// TestAnAdoptedLeaseUnwindsOnItsOwnBudget: a wait that fails on an
+// adopted capsule unwinds it, and does so under a bound.
+//
+// What this does not prove, said plainly because the obvious reading is
+// wrong: it does not show that the unwind is detached from the context
+// that bounded the wait. recoverCapsuleFailure derives its own
+// recoveryBudget from whatever it is given, so the deadline seen here is
+// two minutes either way. The detachment only shows once the ceiling has
+// actually expired, and remainingCeiling floors at a minute of grace, so
+// no unit test can produce that without changing a production timing.
+// recoveryContext carries its own test for that half.
+//
+// What it does hold: the adopted path still unwinds, it removes the
+// objects the capsule owned, and it runs under a deadline rather than
+// none.
+func TestAnAdoptedLeaseUnwindsOnItsOwnBudget(t *testing.T) {
+	h := newHarness(t, 1)
+	rec := &ctxRemover{}
+	h.useRemover(rec)
+	h.srv.caps = &fakeCapsule{}
+	h.srv.wait = &fakeWaiter{waitErr: errors.New("the capsule stopped reporting")}
+	h.bind.gh = &fakeRegistry{}
+	if err := h.deliver(demand("job-adopted", "app", 42)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-adopted")
+
+	// A capsule left behind by a previous process owns objects, which is
+	// what makes the unwind have anything to do.
+	recorder := h.srv.leases.Recorder(t.Context(), lease.ID)
+	intent, err := recorder.Plan("container", "runner", "adopted-runner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := recorder.Creating(intent); err != nil {
+		t.Fatal(err)
+	}
+	if err := recorder.Confirm(intent, "adopted-runner"); err != nil {
+		t.Fatal(err)
+	}
+
+	h.srv.adopt(h.bind, lease, "adopted-runner")
+	h.srv.wg.Wait()
+
+	if !rec.seen {
+		t.Fatal("the adopted lease was unwound without removing anything; this test asserted nothing")
+	}
+	if !rec.hasDeadline {
+		t.Fatal("the unwind ran on a context with no deadline")
+	}
+	if left := time.Until(rec.deadline); left <= 0 || left > recoveryBudget {
+		t.Errorf("the unwind had %v left; want its own budget of at most %v. "+
+			"Anything longer is the tier's ceiling, which is the deadline that just failed",
+			left, recoveryBudget)
 	}
 }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -152,7 +152,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	// exists — invisible to every query, retried by nothing. The release
 	// already survived cancellation; the requeue must too, or the pair
 	// is not a recovery at all.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), interruptedLeaseBudget)
 	defer cancel()
 
 	evidence, err := s.leases.EvidenceOf(ctx, lease)
@@ -232,8 +232,8 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 // the admission credit they were admitted on, which is capacity the host
 // never gets back short of a restart.
 //
-// It keeps a bound of its own: an unwind that hangs holds the
-// reconciliation pass, and every later pass queues behind it.
+// It keeps a bound of its own, because an unwind that hangs is a
+// goroutine the drain waits out at shutdown.
 func recoveryContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.WithoutCancel(ctx), recoveryBudget)
 }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -170,7 +170,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	obs := assignment.ObservedAbsent
 	if evidence == store.EvidenceStartAuthorized && hasRunner {
 		var err error
-		obs, err = s.caps.InspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: assignment.RuntimeID(runner.ID)})
+		obs, err = s.inspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: assignment.RuntimeID(runner.ID)})
 		if err != nil {
 			log.Error("cannot observe the runtime of an ambiguous start", "error", err)
 		}
@@ -222,6 +222,22 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	}
 }
 
+// recoveryContext detaches unwinding from whatever bounded the step that
+// failed.
+//
+// A step's context expiring is the failure the step's bound exists to
+// produce, so it is the likeliest reason to be unwinding at all — and a
+// recovery handed the context that just expired releases nothing. The
+// capsule, its network and its volume stay behind, and the lease keeps
+// the admission credit they were admitted on, which is capacity the host
+// never gets back short of a restart.
+//
+// It keeps a bound of its own: an unwind that hangs holds the
+// reconciliation pass, and every later pass queues behind it.
+func recoveryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), recoveryBudget)
+}
+
 func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string) {
 	// Claimed here rather than inside the goroutine, so no pass can see the
 	// lease as ownerless in the gap before it is scheduled.
@@ -242,9 +258,11 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		// an adopted capsule is a capsule, and one of the two paths
 		// reaching around it is how they come to behave differently.
 		exit, err := s.wait.WaitExit(ctx, runnerContainer)
+		done, endRecovery := recoveryContext(ctx)
+		defer endRecovery()
 		if err != nil {
 			s.log.Error("adopted capsule wait failed", "lease", lease.ID, "error", err)
-			if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
+			if err := s.recoverCapsuleFailure(done, b, lease.ID, ""); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}
@@ -257,7 +275,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		if obs := capsule.ClassifyExit(int(exit)); obs != assignment.ObservedExited {
 			s.log.Warn("the adopted capsule reports the runner never started; the attempt is returned to the queue",
 				"lease", lease.ID, "exit", exit)
-			if err := s.recoverCapsuleFailure(ctx, b, lease.ID, obs); err != nil {
+			if err := s.recoverCapsuleFailure(done, b, lease.ID, obs); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}
@@ -266,13 +284,13 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		// The adopted capsule was awaited to its exit. Recording the
 		// observation is what lets the finalizing transaction settle the
 		// attempt from evidence, like any other completed run.
-		if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceExitObserved); err != nil {
+		if err := s.leases.RecordEvidence(done, lease.ID, store.EvidenceExitObserved); err != nil {
 			s.log.Error("cannot record the adopted capsule's exit", "lease", lease.ID, "error", err)
 		}
-		if err := s.leases.WalkToRunning(ctx, lease); err != nil {
+		if err := s.leases.WalkToRunning(done, lease); err != nil {
 			s.log.Error("adopted capsule state repair failed", "lease", lease.ID, "error", err)
 		}
-		if err := s.leases.Release(ctx, lease.ID, store.LeaseWorkloadRunning); err != nil {
+		if err := s.leases.Release(done, lease.ID, store.LeaseWorkloadRunning); err != nil {
 			s.log.Error("adopted capsule cleanup failed", "lease", lease.ID, "error", err)
 			return
 		}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -49,22 +49,6 @@ func (s *Controller) advanceAttempt(ctx context.Context, attemptID assignment.At
 // runCapsule drives one lease through the machine on its own context:
 // cancelling serve stops admission, not a running job — drain waits, and
 // whatever outlives the drain window is adopted on the next start.
-// inspectExecution bounds one observation of a runtime.
-//
-// The observation itself is a `docker exec` into the capsule, and an exec
-// runs until its context ends. Both callers hold something open while
-// they wait: the launch goroutine that the drain counts, and the
-// reconciliation pass that every later pass queues behind. Handing either
-// of them a context with no deadline makes a wedged daemon an unbounded
-// shutdown rather than a slow one.
-func (s *Controller) inspectExecution(ctx context.Context,
-	prepared capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
-
-	ctx, cancel := context.WithTimeout(ctx, inspectTimeout)
-	defer cancel()
-	return s.caps.InspectExecution(ctx, prepared)
-}
-
 func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	defer s.wg.Done()
 	attemptID := lease.AttemptID
@@ -213,7 +197,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// on. Requiring `prepared` made a transient store error tear down a
 	// capsule that was ready to run.
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		return tx.AuthorizeStart(attemptID)
+		return tx.AuthorizeStart(lease.ID, attemptID)
 	}); err != nil {
 		log.Warn("the attempt moved before the start was authorized; nothing is started",
 			"attempt", attemptID, "error", err)
@@ -466,4 +450,21 @@ func remainingCeiling(tier config.Tier, createdAt time.Time) time.Duration {
 		return left
 	}
 	return grace
+}
+
+// inspectExecution bounds one observation of a runtime.
+//
+// The observation is a `docker exec` into the capsule, and an exec runs
+// until its context ends: nothing in the Docker API cancels one. Both
+// callers hold something open while they wait — this one is a launch
+// goroutine the drain counts, and the other is startup, before any loop
+// has begun. Handed a context with no deadline, a daemon that accepted
+// the call and stopped answering makes a wedged shutdown out of a slow
+// one.
+func (s *Controller) inspectExecution(ctx context.Context,
+	prepared capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
+
+	ctx, cancel := context.WithTimeout(ctx, inspectTimeout)
+	defer cancel()
+	return s.caps.InspectExecution(ctx, prepared)
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -49,6 +49,22 @@ func (s *Controller) advanceAttempt(ctx context.Context, attemptID assignment.At
 // runCapsule drives one lease through the machine on its own context:
 // cancelling serve stops admission, not a running job — drain waits, and
 // whatever outlives the drain window is adopted on the next start.
+// inspectExecution bounds one observation of a runtime.
+//
+// The observation itself is a `docker exec` into the capsule, and an exec
+// runs until its context ends. Both callers hold something open while
+// they wait: the launch goroutine that the drain counts, and the
+// reconciliation pass that every later pass queues behind. Handing either
+// of them a context with no deadline makes a wedged daemon an unbounded
+// shutdown rather than a slow one.
+func (s *Controller) inspectExecution(ctx context.Context,
+	prepared capsule.PreparedRuntime) (assignment.ExecutionObservation, error) {
+
+	ctx, cancel := context.WithTimeout(ctx, inspectTimeout)
+	defer cancel()
+	return s.caps.InspectExecution(ctx, prepared)
+}
+
 func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	defer s.wg.Done()
 	attemptID := lease.AttemptID
@@ -190,8 +206,14 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// compare-and-swap is not an effect, and an authorization recorded
 	// for a start that will not be attempted is a claim that never
 	// became true.
+	//
+	// It matches a set rather than the exact predecessor because the two
+	// edges before it are best-effort: advanceAttempt logs a failure and
+	// carries on, which is right for observability and wrong to depend
+	// on. Requiring `prepared` made a transient store error tear down a
+	// capsule that was ready to run.
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		return tx.Advance(attemptID, "prepared", "starting")
+		return tx.AuthorizeStart(attemptID)
 	}); err != nil {
 		log.Warn("the attempt moved before the start was authorized; nothing is started",
 			"attempt", attemptID, "error", err)
@@ -211,7 +233,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		// A failed Start call does not prove no start: the request may
 		// have taken effect before the error. Classify from the daemon
 		// now, before any cleanup can destroy the answer.
-		obs, ierr := s.caps.InspectExecution(ctx, prepared)
+		obs, ierr := s.inspectExecution(ctx, prepared)
 		if ierr != nil {
 			log.Error("start outcome cannot be observed", "start_error", startErr, "inspect_error", ierr)
 		}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -80,6 +80,15 @@ const (
 	// question about a different party.
 	capsulePrepTimeout = 15 * time.Minute
 
+	// inspectTimeout bounds one observation of a runtime. It reaches the
+	// capsule through a `docker exec`, and an exec ends when its context
+	// does and not before: a daemon that has stopped answering parks the
+	// caller for as long as it is given. Both callers are places nothing
+	// else can proceed past - the launch goroutine the drain waits on,
+	// and the reconciliation pass every later pass queues behind - so an
+	// unbounded one there is an unbounded shutdown.
+	inspectTimeout = 30 * time.Second
+
 	// receiveFailuresBeforeReopen is how many consecutive polls may fail
 	// before the binding stops trusting its session. The upstream client
 	// refreshes an expired session itself and leaves the handle dead when

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -80,14 +80,25 @@ const (
 	// question about a different party.
 	capsulePrepTimeout = 15 * time.Minute
 
+	// interruptedLeaseBudget bounds resolving one lease left behind by a
+	// previous process: reading its evidence, observing its runtime if
+	// the start was authorized, and unwinding it.
+	interruptedLeaseBudget = 30 * time.Second
+
 	// inspectTimeout bounds one observation of a runtime. It reaches the
 	// capsule through a `docker exec`, and an exec ends when its context
 	// does and not before: a daemon that has stopped answering parks the
-	// caller for as long as it is given. Both callers are places nothing
-	// else can proceed past - the launch goroutine the drain waits on,
-	// and the reconciliation pass every later pass queues behind - so an
-	// unbounded one there is an unbounded shutdown.
-	inspectTimeout = 30 * time.Second
+	// caller for as long as it is given, and neither caller can proceed
+	// past it — one is a launch goroutine the drain counts, the other is
+	// startup.
+	//
+	// It is deliberately a fraction of interruptedLeaseBudget rather than
+	// equal to it. A bound equal to the budget it sits inside can never
+	// take effect, and worse, an observation that spends the whole budget
+	// leaves the unwinding that follows it a context with nothing left. A
+	// container inspect and one supervisor exec do not need ten seconds;
+	// a daemon that does is one the observation should give up on.
+	inspectTimeout = 10 * time.Second
 
 	// receiveFailuresBeforeReopen is how many consecutive polls may fail
 	// before the binding stops trusting its session. The upstream client

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -94,9 +94,21 @@ WHERE id = @attempt_id AND state = @current;
 -- canceled, settled and manual_review are all outside this set, so a
 -- redelivery that replaced this attempt during preparation still stops
 -- the start, which is the property the edge exists for.
+--
+-- The set alone does not say the attempt is still this serving's, only
+-- that nobody has resolved it. `prepared` used to carry that by
+-- accident, being a marker the starting goroutine had just written
+-- itself; `leased` is written by whoever claimed the attempt. So the
+-- lease is named here too, and at-most-once is proved by the row rather
+-- than by an in-memory claim and two partial indexes agreeing.
 UPDATE assignment_attempts
 SET state = 'starting'
-WHERE id = @attempt_id AND state IN ('leased', 'preparing', 'prepared');
+WHERE assignment_attempts.id = @attempt_id
+  AND assignment_attempts.state IN ('leased', 'preparing', 'prepared')
+  AND EXISTS (SELECT 1 FROM capsule_leases
+              WHERE capsule_leases.id = @lease_id
+                AND capsule_leases.attempt_id = @attempt_id
+                AND capsule_leases.state <> 'released');
 
 -- name: RecordAttemptEvidence :execrows
 -- Evidence is monotonic and compare-and-swap on the value the caller

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -79,6 +79,25 @@ UPDATE assignment_attempts
 SET state = @next
 WHERE id = @attempt_id AND state = @current;
 
+-- name: AuthorizeAttemptStart :execrows
+-- The one authoritative edge in the walk, and the reason it names a set
+-- rather than a single state.
+--
+-- Every other edge is best-effort observability, written outside the
+-- transaction that matters and logged rather than retried when it fails.
+-- So a serving that reached a prepared capsule may still have its attempt
+-- sitting at any state it passed through, and requiring the last of them
+-- turns one lost observability write into a torn-down capsule and a
+-- burnt serving.
+--
+-- What must not match is an attempt somebody else resolved. superseded,
+-- canceled, settled and manual_review are all outside this set, so a
+-- redelivery that replaced this attempt during preparation still stops
+-- the start, which is the property the edge exists for.
+UPDATE assignment_attempts
+SET state = 'starting'
+WHERE id = @attempt_id AND state IN ('leased', 'preparing', 'prepared');
+
 -- name: RecordAttemptEvidence :execrows
 -- Evidence is monotonic and compare-and-swap on the value the caller
 -- read. If another writer moved it in between, nothing is written and

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -164,22 +164,29 @@ func (t *Tx) Advance(attemptID assignment.AttemptID, from, to string) error {
 }
 
 // AuthorizeStart is the compare-and-swap that decides whether a start may
-// be attempted at all. It accepts any state this serving passed through
-// on the way to a prepared capsule, and no state anybody else could have
-// put the attempt in.
+// be attempted at all. It matches an attempt in a state this serving
+// passed through, still held by this lease.
 //
 // Advance is the wrong shape here. Its edges are observability, written
 // outside the transaction that matters, so an attempt can legitimately be
 // behind by one when the start is authorized. Requiring the exact
 // predecessor spends a prepared capsule and a serving on a write that
 // only ever existed to be read by an operator.
-func (t *Tx) AuthorizeStart(attemptID assignment.AttemptID) error {
-	affected, err := t.q.AuthorizeAttemptStart(t.ctx, string(attemptID))
+//
+// It takes the lease because the state set alone does not prove
+// ownership. `prepared` proved it by accident — the starting goroutine
+// wrote it itself moments earlier — while `leased` is written by whoever
+// claimed the attempt. Naming the lease keeps at-most-once a property of
+// the row rather than of three separate invariants agreeing.
+func (t *Tx) AuthorizeStart(leaseID assignment.LeaseID, attemptID assignment.AttemptID) error {
+	affected, err := t.q.AuthorizeAttemptStart(t.ctx, sqlitedb.AuthorizeAttemptStartParams{
+		AttemptID: string(attemptID), LeaseID: string(leaseID),
+	})
 	if err != nil {
 		return err
 	}
 	if affected == 0 {
-		return fmt.Errorf("%w: attempt %s is not this serving's to start", ErrConflict, attemptID)
+		return fmt.Errorf("%w: attempt %s is not lease %s's to start", ErrConflict, attemptID, leaseID)
 	}
 	return nil
 }

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -163,6 +163,27 @@ func (t *Tx) Advance(attemptID assignment.AttemptID, from, to string) error {
 	return nil
 }
 
+// AuthorizeStart is the compare-and-swap that decides whether a start may
+// be attempted at all. It accepts any state this serving passed through
+// on the way to a prepared capsule, and no state anybody else could have
+// put the attempt in.
+//
+// Advance is the wrong shape here. Its edges are observability, written
+// outside the transaction that matters, so an attempt can legitimately be
+// behind by one when the start is authorized. Requiring the exact
+// predecessor spends a prepared capsule and a serving on a write that
+// only ever existed to be read by an operator.
+func (t *Tx) AuthorizeStart(attemptID assignment.AttemptID) error {
+	affected, err := t.q.AuthorizeAttemptStart(t.ctx, string(attemptID))
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return fmt.Errorf("%w: attempt %s is not this serving's to start", ErrConflict, attemptID)
+	}
+	return nil
+}
+
 // ErrRetryBudgetExhausted reports a requeue refused because the attempt
 // has already had every serving it is allowed. It is not a safety
 // refusal — the work provably never began — so the caller holds the

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -9,6 +9,34 @@ import (
 	"context"
 )
 
+const authorizeAttemptStart = `-- name: AuthorizeAttemptStart :execrows
+UPDATE assignment_attempts
+SET state = 'starting'
+WHERE id = ?1 AND state IN ('leased', 'preparing', 'prepared')
+`
+
+// The one authoritative edge in the walk, and the reason it names a set
+// rather than a single state.
+//
+// Every other edge is best-effort observability, written outside the
+// transaction that matters and logged rather than retried when it fails.
+// So a serving that reached a prepared capsule may still have its attempt
+// sitting at any state it passed through, and requiring the last of them
+// turns one lost observability write into a torn-down capsule and a
+// burnt serving.
+//
+// What must not match is an attempt somebody else resolved. superseded,
+// canceled, settled and manual_review are all outside this set, so a
+// redelivery that replaced this attempt during preparation still stops
+// the start, which is the property the edge exists for.
+func (q *Queries) AuthorizeAttemptStart(ctx context.Context, attemptID string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, authorizeAttemptStart, attemptID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const cancelReadyAttempt = `-- name: CancelReadyAttempt :execrows
 UPDATE assignment_attempts
 SET state = 'canceled', resolution = ?1, settled_at = unixepoch()

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -12,8 +12,18 @@ import (
 const authorizeAttemptStart = `-- name: AuthorizeAttemptStart :execrows
 UPDATE assignment_attempts
 SET state = 'starting'
-WHERE id = ?1 AND state IN ('leased', 'preparing', 'prepared')
+WHERE assignment_attempts.id = ?1
+  AND assignment_attempts.state IN ('leased', 'preparing', 'prepared')
+  AND EXISTS (SELECT 1 FROM capsule_leases
+              WHERE capsule_leases.id = ?2
+                AND capsule_leases.attempt_id = ?1
+                AND capsule_leases.state <> 'released')
 `
+
+type AuthorizeAttemptStartParams struct {
+	AttemptID string
+	LeaseID   string
+}
 
 // The one authoritative edge in the walk, and the reason it names a set
 // rather than a single state.
@@ -29,8 +39,15 @@ WHERE id = ?1 AND state IN ('leased', 'preparing', 'prepared')
 // canceled, settled and manual_review are all outside this set, so a
 // redelivery that replaced this attempt during preparation still stops
 // the start, which is the property the edge exists for.
-func (q *Queries) AuthorizeAttemptStart(ctx context.Context, attemptID string) (int64, error) {
-	result, err := q.db.ExecContext(ctx, authorizeAttemptStart, attemptID)
+//
+// The set alone does not say the attempt is still this serving's, only
+// that nobody has resolved it. `prepared` used to carry that by
+// accident, being a marker the starting goroutine had just written
+// itself; `leased` is written by whoever claimed the attempt. So the
+// lease is named here too, and at-most-once is proved by the row rather
+// than by an in-memory claim and two partial indexes agreeing.
+func (q *Queries) AuthorizeAttemptStart(ctx context.Context, arg AuthorizeAttemptStartParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, authorizeAttemptStart, arg.AttemptID, arg.LeaseID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1487,3 +1487,88 @@ func TestTheRetryCountIsIndexed(t *testing.T) {
 		t.Errorf("the retry count plans as %q; want an index, not a scan of every lease ever recorded", joined)
 	}
 }
+
+// TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized: the one
+// authoritative edge in the walk accepts exactly the states a serving
+// passes through before its start.
+//
+// The edges before it are observability. They are written outside the
+// transaction that matters and a failure is logged rather than retried,
+// because their only reader is a person — so an attempt can legitimately
+// be a state or two behind when the start is authorized. Requiring the
+// exact predecessor made a lost observability write tear down a prepared
+// capsule and burn a serving.
+//
+// What it must still refuse is every state somebody else could have put
+// the attempt in, and every state that means a start already happened. A
+// second authorization is a second run of the same job.
+//
+// The table is the specification. It is checked against the schema's own
+// CHECK constraint, so a state added to the product without a decision
+// here fails rather than defaulting to one.
+func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
+	cases := []struct {
+		state     string
+		authorize bool
+		because   string
+	}{
+		{"ready", false, "an operator returned it to the queue; a new serving claims it"},
+		{"leased", true, "this serving's, with both walk edges lost"},
+		{"preparing", true, "this serving's, with the edge into prepared lost"},
+		{"prepared", true, "this serving's, with nothing lost"},
+		{"starting", false, "already authorized; a second start is a second run"},
+		{"running", false, "already started; a second start is a second run"},
+		{"superseded", false, "a redelivery replaced it and its successor is serving"},
+		{"canceled", false, "the source withdrew the workload"},
+		{"settled", false, "already resolved"},
+		{"manual_review", false, "held for a person who has not decided yet"},
+	}
+
+	// The universe comes from the schema, not from beside the table.
+	schema, err := migrationsFS.ReadFile("migrations/000001_initial.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decided := make(map[string]bool, len(cases))
+	for _, c := range cases {
+		decided[c.state] = true
+	}
+	body := string(schema)
+	start := strings.Index(body, "CHECK (state IN ('ready'")
+	if start < 0 {
+		t.Fatal("the attempt state CHECK constraint moved; this test can no longer prove it is total")
+	}
+	constraint := body[start : start+strings.Index(body[start:], "))")]
+	for _, state := range strings.Split(constraint, "'") {
+		if len(state) == 0 || strings.ContainsAny(state, "(), \n\t") || state == "CHECK " {
+			continue
+		}
+		if !decided[state] {
+			t.Errorf("the schema allows attempt state %q and this test decides nothing about it", state)
+		}
+	}
+
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	for _, c := range cases {
+		t.Run(c.state, func(t *testing.T) {
+			workload := assignment.SourceWorkloadKey("job-" + c.state)
+			id := seedAttempt(t, s, binding, "msg-"+c.state, workload)
+			inTx(t, s, func(tx *Tx) error { return tx.Advance(id, "ready", c.state) })
+
+			var err error
+			inTx(t, s, func(tx *Tx) error {
+				err = tx.AuthorizeStart(id)
+				return nil
+			})
+			switch {
+			case c.authorize && err != nil:
+				t.Errorf("AuthorizeStart from %s refused (%v); it must be allowed — %s", c.state, err, c.because)
+			case !c.authorize && err == nil:
+				t.Errorf("AuthorizeStart from %s was allowed; it must be refused — %s", c.state, c.because)
+			case !c.authorize && !errors.Is(err, ErrConflict):
+				t.Errorf("AuthorizeStart from %s failed with %v; want ErrConflict", c.state, err)
+			}
+		})
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1550,15 +1550,34 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 
 	s := newStore(t)
 	binding := seedBinding(t, s)
+
+	// Each case gets a real lease, because the authorization is scoped to
+	// one: an attempt in a servable state is not enough on its own.
+	leased := func(t *testing.T, name, state string) (assignment.LeaseID, assignment.AttemptID) {
+		t.Helper()
+		id := seedAttempt(t, s, binding, "msg-"+name, assignment.SourceWorkloadKey("job-"+name))
+		var leaseID assignment.LeaseID
+		inTx(t, s, func(tx *Tx) error {
+			lease, err := tx.LeaseAttempt(id, binding, "tier-a")
+			if err != nil {
+				return err
+			}
+			leaseID = lease.ID
+			if state == "leased" {
+				return nil
+			}
+			return tx.Advance(id, "leased", state)
+		})
+		return leaseID, id
+	}
+
 	for _, c := range cases {
 		t.Run(c.state, func(t *testing.T) {
-			workload := assignment.SourceWorkloadKey("job-" + c.state)
-			id := seedAttempt(t, s, binding, "msg-"+c.state, workload)
-			inTx(t, s, func(tx *Tx) error { return tx.Advance(id, "ready", c.state) })
+			leaseID, id := leased(t, c.state, c.state)
 
 			var err error
 			inTx(t, s, func(tx *Tx) error {
-				err = tx.AuthorizeStart(id)
+				err = tx.AuthorizeStart(leaseID, id)
 				return nil
 			})
 			switch {
@@ -1571,4 +1590,42 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 			}
 		})
 	}
+
+	// The state set says nobody has resolved the attempt. It does not say
+	// the attempt is still this lease's, and that is the half that keeps
+	// a job from being run twice.
+	t.Run("a lease that has been released", func(t *testing.T) {
+		leaseID, id := leased(t, "released-lease", "prepared")
+		// reserved -> failed -> cleaning -> released is the shortest real
+		// path to a released lease; the state machine refuses shortcuts.
+		inTx(t, s, func(tx *Tx) error {
+			for _, edge := range [][2]LeaseState{
+				{LeaseReserved, LeaseFailed},
+				{LeaseFailed, LeaseCleaning},
+				{LeaseCleaning, LeaseReleased},
+			} {
+				if err := tx.TransitionLease(leaseID, edge[0], edge[1]); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		inTx(t, s, func(tx *Tx) error {
+			if err := tx.AuthorizeStart(leaseID, id); !errors.Is(err, ErrConflict) {
+				t.Errorf("AuthorizeStart on a released lease = %v; want ErrConflict", err)
+			}
+			return nil
+		})
+	})
+
+	t.Run("a lease that never held this attempt", func(t *testing.T) {
+		_, id := leased(t, "wrong-lease-a", "prepared")
+		other, _ := leased(t, "wrong-lease-b", "prepared")
+		inTx(t, s, func(tx *Tx) error {
+			if err := tx.AuthorizeStart(other, id); !errors.Is(err, ErrConflict) {
+				t.Errorf("AuthorizeStart with another lease's id = %v; want ErrConflict", err)
+			}
+			return nil
+		})
+	})
 }

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -197,6 +197,50 @@ func TestExec(t *testing.T) {
 	}
 }
 
+// TestExecHonoursItsContext: an exec ends when its context ends.
+//
+// Nothing in the Docker API cancels a running exec. The command keeps
+// running inside the container, and the client's only lever is the
+// hijacked connection it is reading from — so the deadline is honoured
+// by closing that connection, not by the daemon. Compilation cannot say
+// whether that wiring survived, and the callers that depend on it are
+// the ones nothing else proceeds past: the launch goroutine the drain
+// counts, and the reconciliation pass every later pass queues behind. An
+// exec that outlives its context there is an unbounded shutdown.
+func TestExecHonoursItsContext(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	id, err := c.CreateContainer(ctx, docker.ContainerSpec{
+		Name:   instance + "-exec-ctx",
+		Image:  busybox,
+		Cmd:    []string{"sleep", "300"},
+		Labels: labels(instance, "lease-exec-ctx", "task", "helper"),
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
+	if err := c.StartContainer(ctx, id); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// The command outlasts the context thirtyfold, so a return inside
+	// the bound cannot be the command finishing.
+	bounded, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	start := time.Now()
+	_, _, err = c.Exec(bounded, id, []string{"sleep", "60"})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Error("exec returned no error after its context expired; the caller cannot tell it was cut short")
+	}
+	if elapsed > 30*time.Second {
+		t.Fatalf("exec returned after %v with a 2s context; it is bounded by the command, not the caller", elapsed)
+	}
+}
+
 // TestExecWithInput covers the credential channel: stdin into an exec
 // is the one path into a running container that Docker persists nowhere
 // — not in the container config, not in an image layer, not in the log

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -236,7 +236,10 @@ func TestExecHonoursItsContext(t *testing.T) {
 	if err == nil {
 		t.Error("exec returned no error after its context expired; the caller cannot tell it was cut short")
 	}
-	if elapsed > 30*time.Second {
+	// Ten seconds is five times the bound and a sixth of the command. A
+	// looser window would let a return that owes nothing to the context
+	// pass for one that does.
+	if elapsed > 10*time.Second {
 		t.Fatalf("exec returned after %v with a 2s context; it is bounded by the command, not the caller", elapsed)
 	}
 }


### PR DESCRIPTION
## What changes

Three places where a context or a compare-and-swap reached further than
it should, and the Docker contract that was named in an earlier change
and never written.

- Unwinding an adopted lease no longer inherits the deadline whose expiry
  is the reason to be unwinding.
- Observing a runtime carries a bound; it is a `docker exec`, and an exec
  ends when its context ends.
- The one authoritative edge in the attempt walk accepts any state this
  serving passed through, instead of requiring the last one a
  best-effort write happened to record — and names the lease, so that
  at-most-once is proved by the row.
- `TestExecHonoursItsContext` exists.

## What was found

**A recovery handed an expired context releases nothing.** `adopt` bounds
its wait by what is left of the tier's ceiling, which is right: a capsule
that stopped reporting is exactly what the ceiling is for, and restarting
that clock on every controller restart would let it hold its credit
indefinitely. But everything after the wait ran on the same context. The
ceiling expiring is the single likeliest reason to reach the recovery at
all, and a recovery on a context that has already ended removes no
container, no network and no volume, and returns no admission credit. The
next pass finds the same lease and repeats the same nothing.

The rule now has a name — `recoveryContext` — and everything past the
wait uses it: the two recovery calls, the evidence write, the state
repair and the release.

**A bound equal to the budget it sits inside is not a bound.**
`resolveInterrupted` already wraps its whole pass in 30 seconds, and the
first version of this change set the observation's bound to 30 seconds
too, so at that caller it could never take effect — and worse, an
observation free to spend the entire budget leaves the unwinding after it
a context with nothing left. It is 10 seconds now, and the pass budget it
sits inside has a name (`interruptedLeaseBudget`) instead of being the
same literal written twice.

**An observation could not be interrupted.** `InspectExecution` reaches
the capsule through a `docker exec`. Nothing in the Docker API cancels a
running exec; the client's only lever is the connection it is reading
from, and it uses it when the context ends. Both callers were handing it
a context with no deadline: the launch goroutine, which the drain counts
and waits for, and the reconciliation pass, which every later pass queues
behind. A daemon that accepted the call and then stopped answering turned
a slow shutdown into one that does not finish. Both callers go through
one bounded helper now, at 30 seconds — the same order as the gateway's
own exec bound.

**The authoritative edge depended on two best-effort ones.** The walk
into `preparing` and into `prepared` is observability: written outside
the transaction that matters, logged rather than retried when it fails,
because its only reader is a person. The edge into `starting` is the
opposite — the last point before the one effect that can begin execution.
It required the attempt to be exactly `prepared`, so a transient store
error on either observability write tore down a capsule that was ready to
run and spent one of the attempt's servings on it.

It matches `('leased','preparing','prepared')` now. The property that
matters is unchanged and is what the set is chosen for: `superseded`,
`canceled`, `settled`, `manual_review` and `ready` are all outside it, so
a redelivery that replaced this attempt during preparation still stops
the start, and so does an operator who resolved it. `starting` and
`running` are outside it too — a second authorization is a second run.

**But the set alone stopped proving whose attempt it is.** `prepared`
carried that by accident: it was a marker the starting goroutine had
written itself moments earlier, so matching it was an ownership proof in
the row. `leased` is written by whoever claimed the attempt. Widening the
set therefore moved at-most-once out of the query and onto three separate
invariants agreeing — an in-memory claim map and two partial indexes —
none of which is visible from the statement that decides it. The
authorization names the lease now:

```sql
AND EXISTS (SELECT 1 FROM capsule_leases
            WHERE capsule_leases.id = @lease_id
              AND capsule_leases.attempt_id = @attempt_id
              AND capsule_leases.state <> 'released')
```

Nothing about the reachable behaviour changes; what changes is that the
safety is legible where the decision is made.

**A doc comment was swallowed.** The observation helper was inserted
between `runCapsule`'s doc comment and `runCapsule`, so the comment
attached to the helper. `go doc` showed `inspectExecution` documented as
"runCapsule drives one lease through the machine". The helper sits at the
end of the file with a comment of its own.

**A contract was named and never written.** An earlier change cited
`TestExecHonoursItsContext` as covering the exec bound. It did not exist.
It does now, in the gated Docker suite, and it runs against a real
daemon.

## Symmetry check

| Path | Result |
|---|---|
| the two `InspectExecution` callers | both go through `inspectExecution`; the bound is written once |
| `recoverCapsuleFailure`'s callers | the launch path already unwinds on a context that is not the step's; `adopt` was the one that did not, and is the only place `recoveryContext` was needed |
| everything after `WaitExit` in `adopt` | audited line by line — the ceiling context now appears exactly twice, at its creation and at the wait |
| `Advance`'s other edges | unchanged and still exact; they are observability, and a set there would hide a real disagreement |
| `RequeueAttempt`'s guard | the same three states, by coincidence of meaning rather than by sharing — noticed while mutating, and the mutation was narrowed to the one query so the two are proven independent |
| `ClaimReadyAttempt` | still `ready` only; claiming is the other compare-and-swap that decides who serves, and it must stay exact |
| the schema's CHECK constraint | read by the new store test, so a state added to the product without a decision about starting fails |

## Evidence

Four mutations, one per mechanism:

```text
the start authorization requires the exact predecessor
  -> --- FAIL: TestALostWalkEdgeDoesNotAbortTheLaunch
     the capsule was started 0 time(s); want 1
  -> --- FAIL: TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized/leased
     AuthorizeStart from leased refused; it must be allowed
  -> --- FAIL: .../preparing

the observation carries no bound
  -> --- FAIL: TestAnObservationIsAlwaysBounded
     the observation ran on a context with no deadline

the recovery inherits the wait's cancellation
  -> --- FAIL: TestRecoveryOutlivesTheContextThatBoundedTheWait
     the recovery context ended with the wait's: context canceled

the authorization does not name the lease
  -> --- FAIL: .../a_lease_that_has_been_released
  -> --- FAIL: .../a_lease_that_never_held_this_attempt

the exec has no context watchdog
  -> --- FAIL: TestExecHonoursItsContext (60.30s)
     exec returned after 1m0.05s with a 2s context
```

And one against the totality guard itself, because a guard that cannot
fail is not one:

```text
a state the schema allows is left out of the table
  -> --- FAIL: TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized
     the schema allows attempt state "canceled" and this test decides nothing about it
```

`TestExecHonoursItsContext` was run against a real daemon (Docker
29.6.1), passing in 5.30s and failing in 60.30s with the watchdog
removed. No containers were left behind.

## What would notice this regressing

- `TestALostWalkEdgeDoesNotAbortTheLaunch` puts the attempt back where a
  lost walk edge leaves it and requires the capsule to start anyway.
- `TestASupersededAttemptIsNeverStarted` is the other half, unchanged: an
  attempt somebody else resolved is still never started.
- `TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized` decides every
  state the schema allows, and fails if the schema grows one it has no
  answer for.
- `TestAnObservationIsAlwaysBounded` asserts the deadline rather than
  waiting one out, so it is deterministic and costs nothing.
- `TestRecoveryOutlivesTheContextThatBoundedTheWait` cancels the wait's
  context and requires the recovery's to survive it.
- `TestAnAdoptedLeaseUnwindsOnItsOwnBudget` drives `adopt` with a failing
  wait and requires the objects to be removed under a deadline.

**One thing here has no test, and saying so is better than implying
otherwise.** That `adopt` passes the detached context rather than the
wait's is not covered. `recoverCapsuleFailure` derives its own
`recoveryBudget` from whatever it is handed, so the deadline an unwind
sees is two minutes either way; the difference only appears once the
ceiling has actually expired, and `remainingCeiling` floors at a minute
of grace, so no unit test can produce that without changing a production
timing. The helper carries its own test for the half that is testable,
and the test above says in its own comment what it does not prove.
- `TestExecHonoursItsContext`, gated, against a real daemon.

## Risk, compatibility and operations

**The start authorization is strictly wider, in one direction only.** It
admits two states it previously refused, both of which mean "this
serving's attempt, one observability write behind". Every state that
means somebody else owns the attempt is still refused, and that is the
property the edge exists for.

**Recovery gains its own two-minute budget.** An unwind that would
previously have been cut short by an expired ceiling now runs, and one
against a wedged daemon is bounded rather than instant.

**Observation gains a 30-second bound.** A daemon slower than that now
reports the runtime as unobservable rather than blocking, which routes
the attempt to review instead of hanging the pass. That is the intended
trade: an attempt a person looks at beats a controller that will not
shut down.

**The start authorization now reads `capsule_leases`.** One indexed
lookup by primary key, inside a transaction that was already open.

**Schema: one new query, no migration.** No column, table or index
changes. **Trust boundary, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous image.

## Changelog

```text
### Fixed
- A controller restart that adopts a running capsule now releases the
  capsule, its network and its volume even when the tier's ceiling
  expires during the wait, instead of leaving them behind with the
  lease's admission credit.
- Observing a runtime is bounded, so a Docker daemon that stops answering
  no longer prevents the controller from shutting down.
- A transient database error while preparing a capsule no longer tears
  that capsule down and spends one of the job's attempts.
```

## Notes for your reviewer

The part to check hardest is the widened set on the start authorization,
because it is the one change that makes an authoritative decision accept
more than it did. The argument is that the edges before it are
deliberately best-effort — `advanceAttempt` logs and continues — so
requiring the last of them coupled a decision that must be right to a
write that is allowed to be lost. The states left out are the whole
point, and the store test decides every one of them against the schema's
own constraint rather than against a list kept beside it.

The second thing to weigh is the 10-second observation bound. It is now
a third of the pass it sits inside, deliberately, so that an unresponsive
daemon costs an observation rather than the whole budget for unwinding
the lease. A container inspect plus one supervisor exec does not need
longer, and a daemon that does is one the observation should give up on —
the attempt goes to review, which is a person's problem rather than a
hung controller.

Also worth knowing: `RequeueAttempt` happens to carry the same three
states. They are not shared and should not be — one answers "can this be
returned to the queue", the other "may this be started". The mutation
above was narrowed to the single query for that reason, so the evidence
is about this edge and not both.
