### PR TITLE
fix(capsule): the supervisor replaces a control file whole or not at all

### DIFF
--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -107,17 +107,13 @@ func runSubcommand(args []string) int {
 			fmt.Fprintln(os.Stderr, "deliver: no credential on stdin")
 			return 1
 		}
-		if err := os.WriteFile(jitFile, payload, 0o600); err != nil {
-			fmt.Fprintln(os.Stderr, "deliver:", err)
-			return 1
-		}
-		if err := os.Chown(jitFile, runnerUID, runnerGID); err != nil {
+		if err := writeControlFile(jitFile, payload, 0o600, runnerUID, runnerGID); err != nil {
 			fmt.Fprintln(os.Stderr, "deliver:", err)
 			return 1
 		}
 		return 0
 	case "start":
-		if err := os.WriteFile(startFile, []byte(protocolVersion), 0o600); err != nil {
+		if err := writeControlFile(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
 			fmt.Fprintln(os.Stderr, "start:", err)
 			return 1
 		}
@@ -196,7 +192,7 @@ func boot(log *slog.Logger) error {
 			return err
 		}
 	}
-	if err := os.WriteFile(protocolFile, []byte(protocolVersion), 0o644); err != nil {
+	if err := writeControlFile(protocolFile, []byte(protocolVersion), 0o644, -1, -1); err != nil {
 		return err
 	}
 	// Booting, not waiting: the control surface answers from here, but
@@ -597,8 +593,56 @@ func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int)
 	return cleanup, nil
 }
 
+// writeControlFile replaces one file of the control surface so that no
+// reader can observe it partly written.
+//
+// Every file here is read by a separate process on its own schedule,
+// with nothing between them: the launcher `cat`s the protocol
+// declaration while boot is writing it, and execs `supervisor state`
+// while the run loop is moving the state along. os.WriteFile creates and
+// truncates before it writes, so a read landing in that window succeeds
+// and returns nothing — and nothing is not "not yet", it is a different
+// answer. An empty protocol declaration reads as a version this
+// controller does not speak, which parks a healthy capsule for an
+// operator to look at; an empty state reads as a state nothing
+// recognizes, which makes a running capsule unobservable and sends its
+// attempt to review.
+//
+// A rename is atomic: a reader sees the file before or the file after,
+// never a file mid-write. The temporary name is unique because two
+// writers sharing one would put the same window back a level down.
+//
+// uid and gid are passed to Chown before the rename, so a file that
+// needs an owner never appears with the wrong one. -1 leaves it alone,
+// as os.Chown does.
+func writeControlFile(path string, data []byte, perm os.FileMode, uid, gid int) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name())
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if uid >= 0 || gid >= 0 {
+		if err := tmp.Chown(uid, gid); err != nil {
+			tmp.Close()
+			return err
+		}
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
 func setState(s string) {
-	_ = os.WriteFile(stateFile, []byte(s), 0o644)
+	_ = writeControlFile(stateFile, []byte(s), 0o644, -1, -1)
 }
 
 // terminalFailure names a failure by whether the runner ever started, which

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -49,6 +49,7 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/capsule/protocol"
+	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 const (
@@ -107,13 +108,13 @@ func runSubcommand(args []string) int {
 			fmt.Fprintln(os.Stderr, "deliver: no credential on stdin")
 			return 1
 		}
-		if err := writeControlFile(jitFile, payload, 0o600, runnerUID, runnerGID); err != nil {
+		if err := atomicfile.Replace(jitFile, payload, 0o600, runnerUID, runnerGID); err != nil {
 			fmt.Fprintln(os.Stderr, "deliver:", err)
 			return 1
 		}
 		return 0
 	case "start":
-		if err := writeControlFile(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
+		if err := atomicfile.Replace(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
 			fmt.Fprintln(os.Stderr, "start:", err)
 			return 1
 		}
@@ -192,7 +193,7 @@ func boot(log *slog.Logger) error {
 			return err
 		}
 	}
-	if err := writeControlFile(protocolFile, []byte(protocolVersion), 0o644, -1, -1); err != nil {
+	if err := atomicfile.Replace(protocolFile, []byte(protocolVersion), 0o644, -1, -1); err != nil {
 		return err
 	}
 	// Booting, not waiting: the control surface answers from here, but
@@ -593,57 +594,32 @@ func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int)
 	return cleanup, nil
 }
 
-// writeControlFile replaces one file of the control surface so that no
-// reader can observe it partly written.
+// replaceState records the supervisor's own account of itself, and
+// prefers a state that is written to one that is written atomically.
 //
-// Every file here is read by a separate process on its own schedule,
-// with nothing between them: the launcher `cat`s the protocol
-// declaration while boot is writing it, and execs `supervisor state`
-// while the run loop is moving the state along. os.WriteFile creates and
-// truncates before it writes, so a read landing in that window succeeds
-// and returns nothing — and nothing is not "not yet", it is a different
-// answer. An empty protocol declaration reads as a version this
-// controller does not speak, which parks a healthy capsule for an
-// operator to look at; an empty state reads as a state nothing
-// recognizes, which makes a running capsule unobservable and sends its
-// attempt to review.
+// The two failures are not equal. A reader that catches the file
+// mid-write reports the capsule as unobservable, and its attempt is held
+// for a person: recoverable, and visible. A state left stale reports a
+// running job as one that never started — terminalFailure reads anything
+// but `running` as aborted — and the controller requeues it, so the same
+// job runs twice. That is the outcome this whole machine is built to
+// prevent.
 //
-// A rename is atomic: a reader sees the file before or the file after,
-// never a file mid-write. The temporary name is unique because two
-// writers sharing one would put the same window back a level down.
+// The atomic replacement needs a new inode where an in-place write
+// reuses the block already there, and the control directory is a
+// one-megabyte tmpfs it shares with a credential that may be a megabyte
+// itself. So the in-place write is what happens when the replacement
+// cannot be made, rather than nothing happening at all.
 //
-// uid and gid are passed to Chown before the rename, so a file that
-// needs an owner never appears with the wrong one. -1 leaves it alone,
-// as os.Chown does.
-func writeControlFile(path string, data []byte, perm os.FileMode, uid, gid int) error {
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
-	if err != nil {
-		return err
+// replace is a parameter so the fallback can be exercised without
+// filling a filesystem.
+func replaceState(path, state string, replace func(string, []byte, os.FileMode, int, int) error) {
+	if err := replace(path, []byte(state), 0o644, -1, -1); err != nil {
+		_ = os.WriteFile(path, []byte(state), 0o644)
 	}
-	defer os.Remove(tmp.Name())
-	if err := tmp.Chmod(perm); err != nil {
-		tmp.Close()
-		return err
-	}
-	if uid >= 0 || gid >= 0 {
-		if err := tmp.Chown(uid, gid); err != nil {
-			tmp.Close()
-			return err
-		}
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmp.Name(), path)
 }
 
-func setState(s string) {
-	_ = writeControlFile(stateFile, []byte(s), 0o644, -1, -1)
-}
+func setState(s string) { replaceState(stateFile, s, atomicfile.Replace) }
 
 // terminalFailure names a failure by whether the runner ever started, which
 // is the one thing the controller cannot infer from the outside. `running` is

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -237,88 +236,59 @@ func TestTheReadinessProbeIsBounded(t *testing.T) {
 	}
 }
 
-// TestAControlFileIsNeverReadHalfWritten: a reader racing a writer of the
-// control surface sees the previous contents or the next, never nothing.
+// TestAStateThatCannotBeReplacedIsStillWritten: when the atomic
+// replacement fails, the state is written in place rather than not at
+// all.
 //
-// The launcher reads these files from outside the container while the
-// supervisor writes them from inside, with no lock and no handshake
-// between them — it `cat`s the protocol declaration during boot and
-// execs `supervisor state` on every poll of a running capsule. A write
-// that truncates first gives that reader an empty file that reads as a
-// successful answer, and an empty answer is not "not yet": an empty
-// protocol declaration is a version this controller does not speak, and
-// an empty state is a state nothing recognizes. Both park a healthy
-// capsule.
+// The two failures are not equal, and this is which one to take. A
+// reader catching the file mid-write reports the capsule as
+// unobservable, and the attempt is held for a person to look at. A state
+// left stale reports a running job as one that never started —
+// terminalFailure reads anything but `running` as aborted — and the
+// controller requeues it, so the customer's job runs twice.
 //
-// It is fixed in the writer rather than by retrying in the reader. The
-// reader cannot tell a file caught mid-write from one with the wrong
-// contents, and a retry would leave the same window for every other
-// reader of the control surface.
-func TestAControlFileIsNeverReadHalfWritten(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "protocol")
-	// Two payloads of very different lengths: a torn read between two
-	// equal ones can look intact, and it is the tail of the longer that
-	// makes a partial write visible.
-	payloads := [][]byte{[]byte("2"), []byte(strings.Repeat("9", 4096))}
-	if err := writeControlFile(path, payloads[0], 0o644, -1, -1); err != nil {
+// The failure is reachable: the atomic replacement needs a new inode
+// where an in-place write reuses the block already there, and the
+// control directory is a one-megabyte tmpfs shared with a credential
+// that may be a megabyte itself.
+func TestAStateThatCannotBeReplacedIsStillWritten(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state")
+	if err := os.WriteFile(path, []byte("waiting"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	stop := make(chan struct{})
-	bad := make(chan string, 1)
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			raw, err := os.ReadFile(path)
-			if err != nil {
-				// A rename never leaves the target absent, so a missing
-				// file is a finding rather than something to poll past.
-				select {
-				case bad <- "unreadable: " + err.Error():
-				default:
-				}
-				return
-			}
-			whole := false
-			for _, want := range payloads {
-				if string(raw) == string(want) {
-					whole = true
-				}
-			}
-			if !whole {
-				select {
-				case bad <- fmt.Sprintf("%d bytes: %.32q", len(raw), raw):
-				default:
-				}
-				return
-			}
-		}
-	}()
+	replaceState(path, "running", func(string, []byte, os.FileMode, int, int) error {
+		return errors.New("no space left on device")
+	})
 
-	var wg sync.WaitGroup
-	for i := range 8 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for range 40 {
-				if err := writeControlFile(path, payloads[i%len(payloads)], 0o644, -1, -1); err != nil {
-					t.Errorf("write: %v", err)
-					return
-				}
-			}
-		}()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
 	}
-	wg.Wait()
-	close(stop)
+	if string(raw) != "running" {
+		t.Errorf("state = %q after a replacement that could not be made; want running. "+
+			"A stale state is read as a job that never ran, and the controller runs it again", raw)
+	}
+}
 
-	select {
-	case raw := <-bad:
-		t.Fatalf("a reader observed a control file that is neither payload — %s", raw)
-	default:
+// TestEveryControlFileIsWrittenThroughTheAtomicHelper: the helper only
+// helps the writes that use it.
+//
+// A test of the helper passes with none of the call sites converted, so
+// it cannot say whether one was missed — and a control file left on
+// os.WriteFile is exactly the defect, still present, in a change whose
+// evidence says it is gone. The only exception is replaceState's
+// fallback, which writes in place on purpose and by way of a parameter,
+// never by naming the file.
+func TestEveryControlFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"protocolFile", "stateFile", "startFile", "jitFile"} {
+		if strings.Contains(string(src), "os.WriteFile("+name) {
+			t.Errorf("%s is written with os.WriteFile, which truncates before it writes; "+
+				"a reader landing in that window gets an empty file from a call that succeeded", name)
+		}
 	}
 }

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -233,5 +234,91 @@ func TestTheReadinessProbeIsBounded(t *testing.T) {
 	if elapsed > dockerdProbeTimeout+5*time.Second {
 		t.Errorf("one probe took %s against a %s bound; the readiness budget is spent inside a single call",
 			elapsed.Round(time.Second), dockerdProbeTimeout)
+	}
+}
+
+// TestAControlFileIsNeverReadHalfWritten: a reader racing a writer of the
+// control surface sees the previous contents or the next, never nothing.
+//
+// The launcher reads these files from outside the container while the
+// supervisor writes them from inside, with no lock and no handshake
+// between them — it `cat`s the protocol declaration during boot and
+// execs `supervisor state` on every poll of a running capsule. A write
+// that truncates first gives that reader an empty file that reads as a
+// successful answer, and an empty answer is not "not yet": an empty
+// protocol declaration is a version this controller does not speak, and
+// an empty state is a state nothing recognizes. Both park a healthy
+// capsule.
+//
+// It is fixed in the writer rather than by retrying in the reader. The
+// reader cannot tell a file caught mid-write from one with the wrong
+// contents, and a retry would leave the same window for every other
+// reader of the control surface.
+func TestAControlFileIsNeverReadHalfWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "protocol")
+	// Two payloads of very different lengths: a torn read between two
+	// equal ones can look intact, and it is the tail of the longer that
+	// makes a partial write visible.
+	payloads := [][]byte{[]byte("2"), []byte(strings.Repeat("9", 4096))}
+	if err := writeControlFile(path, payloads[0], 0o644, -1, -1); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	bad := make(chan string, 1)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				// A rename never leaves the target absent, so a missing
+				// file is a finding rather than something to poll past.
+				select {
+				case bad <- "unreadable: " + err.Error():
+				default:
+				}
+				return
+			}
+			whole := false
+			for _, want := range payloads {
+				if string(raw) == string(want) {
+					whole = true
+				}
+			}
+			if !whole {
+				select {
+				case bad <- fmt.Sprintf("%d bytes: %.32q", len(raw), raw):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 40 {
+				if err := writeControlFile(path, payloads[i%len(payloads)], 0o644, -1, -1); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+
+	select {
+	case raw := <-bad:
+		t.Fatalf("a reader observed a control file that is neither payload — %s", raw)
+	default:
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 // Config is what the gateway needs to start. The caller supplies the
@@ -74,7 +75,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// The policy in force lives in a file from here on, so a reload
 	// exec and this process agree on one source.
 	path := PolicyPath(cfg.ControlDir)
-	if err := writeFileAtomic(path, []byte(cfg.Policy)); err != nil {
+	if err := atomicfile.Replace(path, []byte(cfg.Policy), 0o600, -1, -1); err != nil {
 		return fmt.Errorf("policy file: %w", err)
 	}
 	store := &PolicyStore{Path: path}
@@ -160,30 +161,4 @@ func ClassifyLegs(p egress.Policy) (Legs, error) {
 		return l, fmt.Errorf("not attached to both networks (internal %q, uplink %q)", l.InternalIf, l.UplinkIf)
 	}
 	return l, nil
-}
-
-// writeFileAtomic replaces a control file by rename, so a reader never
-// observes a half-written policy.
-func writeFileAtomic(path string, data []byte) error {
-	// A unique temp name, not a fixed one. The rename is atomic, but the
-	// write into a shared name is not: two writers truncate and fill the
-	// same file, and the rename then publishes whatever interleaving
-	// won — a document the reader refuses, after which every dial fails.
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(tmp.Name())
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmp.Name(), path)
 }

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 // MaxPolicyBytes bounds a policy document. The real one is a few
@@ -239,5 +240,5 @@ func installPolicyWith(controlDir string,
 	if err != nil {
 		return err
 	}
-	return writeFileAtomic(path, encoded)
+	return atomicfile.Replace(path, encoded, 0o600, -1, -1)
 }

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,9 +149,10 @@ func TestAWideningAllowIsRefusedOnTheReloadChannel(t *testing.T) {
 // the kernel lock that orders the installers and the unique temporary
 // name that makes each write atomic — and this test passes as long as
 // one of them does, which is exactly why it cannot stand for either.
-// TestConcurrentInstallsAreSerialized covers the lock and
-// TestAConcurrentWriteIsNeverReadHalfWritten covers the write; each
-// fails on its own mechanism alone.
+// TestConcurrentInstallsAreSerialized covers the lock, and the write is
+// covered where it lives, by atomicfile's own
+// TestAReplacedFileIsNeverReadHalfWritten; each fails on its own
+// mechanism alone.
 func TestAConcurrentInstallLeavesAPolicyInForce(t *testing.T) {
 	dir := t.TempDir()
 	path := PolicyPath(dir)
@@ -339,82 +339,5 @@ func TestConcurrentInstallsAreSerialized(t *testing.T) {
 		t.Errorf("%d installers held the critical section at once; want 1 — "+
 			"each one past the read is building its successor from a policy "+
 			"another is about to replace", got)
-	}
-}
-
-// TestAConcurrentWriteIsNeverReadHalfWritten: a reader of a file
-// replaced by writeFileAtomic never sees a partial document.
-//
-// The rename is atomic; the write into the temporary file behind it is
-// not. Writers sharing one temporary name truncate and fill it in turn,
-// and the rename publishes whatever interleaving won. Every caller gets
-// this, including the ones with no lock around them, so it is tested
-// where it lives rather than through an installer that is serialized
-// anyway.
-func TestAConcurrentWriteIsNeverReadHalfWritten(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "doc.json")
-	// Documents of very different lengths: a splice between two equal
-	// ones can go unnoticed, and the tail of the longer is what makes a
-	// half-written file visibly unparseable.
-	docs := [][]byte{
-		[]byte(`{"a":1}`),
-		[]byte(`{"a":1,"b":"` + strings.Repeat("x", 4096) + `"}`),
-	}
-	if err := writeFileAtomic(path, docs[0]); err != nil {
-		t.Fatal(err)
-	}
-
-	stop := make(chan struct{})
-	bad := make(chan string, 1)
-	go func() {
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			raw, err := os.ReadFile(path)
-			if err != nil {
-				// A rename never leaves the target absent, so this is a
-				// finding rather than something to poll past: a writer
-				// that removed and recreated the file would show up here
-				// and nowhere else.
-				select {
-				case bad <- "unreadable: " + err.Error():
-				default:
-				}
-				return
-			}
-			if !json.Valid(raw) {
-				select {
-				case bad <- string(raw):
-				default:
-				}
-				return
-			}
-		}
-	}()
-
-	var wg sync.WaitGroup
-	for i := range 16 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for range 20 {
-				if err := writeFileAtomic(path, docs[i%len(docs)]); err != nil {
-					t.Errorf("write: %v", err)
-					return
-				}
-			}
-		}()
-	}
-	wg.Wait()
-	close(stop)
-
-	select {
-	case raw := <-bad:
-		t.Fatalf("a reader observed a document that is not whole (%d bytes):\n%.200s", len(raw), raw)
-	default:
 	}
 }

--- a/internal/platform/atomicfile/atomicfile.go
+++ b/internal/platform/atomicfile/atomicfile.go
@@ -1,0 +1,73 @@
+// Package atomicfile replaces a file so that no reader can observe it
+// partly written.
+//
+// It exists because two very different parts of the product need the
+// same guarantee against the same mistake. The egress gateway's policy
+// is installed by one process and read by another with no lock between
+// them; the capsule supervisor's control surface is written inside a
+// container and read from outside it by `docker exec`. In both, the
+// writer's obvious call — os.WriteFile — creates and truncates before it
+// writes, so a read landing in that window succeeds and returns nothing.
+// Nothing is not "not yet": it is a different answer, and both readers
+// act on it.
+//
+// Keeping one copy is the point. There were two, and they had already
+// drifted apart on the details that matter.
+package atomicfile
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Replace writes data to a temporary file beside path and renames it
+// over the top. A reader sees the file before or the file after, never
+// one mid-write.
+//
+// The temporary name is unique. Two writers sharing one would truncate
+// and fill the same file in turn, which puts the window back one level
+// down and publishes whichever interleaving won.
+//
+// uid and gid are applied before the rename, so a file that needs an
+// owner never appears without it. They are applied after the contents,
+// so it never appears to that owner empty either. -1 leaves the owner
+// alone, as os.Chown does.
+func Replace(path string, data []byte, perm os.FileMode, uid, gid int) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	// Only until the rename succeeds. Removing afterwards would delete a
+	// name that is free again and may already belong to another writer's
+	// temporary file, whose own rename would then fail for no reason it
+	// could report.
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmp.Name())
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if uid >= 0 || gid >= 0 {
+		if err := tmp.Chown(uid, gid); err != nil {
+			tmp.Close()
+			return err
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
+}

--- a/internal/platform/atomicfile/atomicfile_test.go
+++ b/internal/platform/atomicfile/atomicfile_test.go
@@ -1,0 +1,131 @@
+package atomicfile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestAReplacedFileIsNeverReadHalfWritten: a reader racing writers sees
+// one whole payload or the other, never a partial one and never nothing.
+//
+// Both callers have a reader in another process on its own schedule,
+// with no lock and no handshake: the relay reads the egress policy while
+// an install replaces it, and the controller `cat`s the capsule's
+// protocol declaration and execs it for its state while the supervisor
+// writes both. A write that truncates first hands those readers an empty
+// file from a call that succeeded, and an empty answer is not "not yet"
+// to any of them — it is a policy that does not parse, a protocol
+// version nobody speaks, or a state nothing recognizes.
+func TestAReplacedFileIsNeverReadHalfWritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc")
+	// Payloads of very different lengths: a tear between two equal ones
+	// can look intact, and it is the tail of the longer that makes a
+	// partial write visible.
+	payloads := [][]byte{[]byte("2"), []byte(strings.Repeat("9", 4096))}
+	if err := Replace(path, payloads[0], 0o600, -1, -1); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	// The reader is joined rather than abandoned: a tear found on the
+	// last write must still be reported, and a finding sent after the
+	// check would simply be lost.
+	watched := make(chan struct{})
+	bad := make(chan string, 1)
+	go func() {
+		defer close(watched)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				// A rename never leaves the target absent, so this is a
+				// finding rather than something to poll past: a writer
+				// that removed and recreated the file would show up here
+				// and nowhere else.
+				select {
+				case bad <- "unreadable: " + err.Error():
+				default:
+				}
+				return
+			}
+			whole := false
+			for _, want := range payloads {
+				if string(raw) == string(want) {
+					whole = true
+				}
+			}
+			if !whole {
+				select {
+				case bad <- fmt.Sprintf("%d bytes: %.32q", len(raw), raw):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 40 {
+				if err := Replace(path, payloads[i%len(payloads)], 0o600, -1, -1); err != nil {
+					t.Errorf("replace: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	<-watched
+
+	select {
+	case raw := <-bad:
+		t.Fatalf("a reader observed a file that is neither payload — %s", raw)
+	default:
+	}
+}
+
+// TestAFailedReplaceLeavesNothingBehind: the temporary file does not
+// outlive a failure, and a successful one does not remove a name it no
+// longer owns.
+func TestAFailedReplaceLeavesNothingBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "doc")
+	if err := Replace(path, []byte("in force"), 0o600, -1, -1); err != nil {
+		t.Fatal(err)
+	}
+	// An owner this process cannot grant: the chown fails after the
+	// temporary file exists and has been written.
+	if err := Replace(path, []byte("next"), 0o600, 0, 0); err == nil && os.Geteuid() != 0 {
+		t.Fatal("chowning to root succeeded as an unprivileged user; this test asserted nothing")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "doc" {
+			t.Errorf("a failed replace left %q behind", e.Name())
+		}
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.Geteuid() != 0 && string(raw) != "in force" {
+		t.Errorf("the file reads %q; a replace that failed must not have changed it", raw)
+	}
+}


### PR DESCRIPTION
## What changes

The capsule supervisor replaces every file of its control surface
atomically, so a reader outside the container cannot observe one partly
written. The helper that does it is shared with the egress gateway, which
had its own copy, and a state that cannot be replaced atomically is
written in place rather than not at all.

## What was found

**A truncated read is not "not yet" — it is a different answer, and it
parks a healthy capsule.**

`os.WriteFile` creates and truncates before it writes. The launcher reads
these files from outside the container on its own schedule, with no lock
and no handshake between them: it `cat`s the protocol declaration while
boot is writing it, and execs `supervisor state` on every poll of a
running capsule. A read landing in that window succeeds and returns
nothing.

Nothing then flows through both readers as a real answer:

```go
// protocolVerdict, on an empty but successful read
case got != ProtocolVersion:
	return fmt.Errorf("%w: it speaks control protocol %q and this controller speaks %q",
		ErrIncompatibleImage, got, ProtocolVersion)
```

`ErrIncompatibleImage` is the one preparation failure the controller does
not retry — deliberately, since a capsule that does not speak this
protocol will not start speaking it on the next attempt. So it holds the
attempt with `ReviewReasonIncompatibleCapsule` and waits for a person.
A capsule that was booting correctly gets an operator ticket saying its
image is wrong.

The state file has the same window and a worse frequency: `setState` is
called on every transition, the launcher polls `state` throughout, and
`classifySupervisorState("")` falls to its default —
`capsule reports unrecognized state ""` — which becomes
`ObservedUnavailable`. That is the observation that can justify neither a
retry nor a settlement, so the attempt goes to review as well.

**Fixed in the writer, not the reader.** A reader cannot tell a file
caught mid-write from one with the wrong contents; a writer can decline
to expose it half-written. Adding a retry in `awaitProtocol` would treat
the symptom and leave the same window for every other reader of the
control surface — and there are four files with readers in two
processes.

**Making the write atomic put a worse failure in its place.** A rename
needs a new inode where writing in place reuses the block already there.
The control directory is a one-megabyte tmpfs shared with a credential
that may be a megabyte itself, and `setState` discarded its error, so on
a full one the state simply stopped moving. `terminalFailure` reads
anything but `running` as aborted, the controller classifies that as a
job that never started, and returns it to the queue: **the customer's job
runs twice.** Reachable only because of this change, and worse than
anything it fixes.

The two failures are not equal, which is why the fallback is a decision
rather than a hedge. A reader that catches the file mid-write reports the
capsule as unobservable and the attempt is held for a person —
recoverable, and visible. A state left stale is neither. So the in-place
write is what happens when the replacement cannot be made.

**And there were two copies of this helper.** The gateway had one already,
installed for the same reason against the same mistake, and they had
drifted on the details that matter: one hardcoded its mode, neither set
an owner, and both removed the temporary file after a successful rename —
a name that is free by then and may already belong to another writer,
whose own rename would fail for no reason it could report. There is one
copy now, in a leaf that needs only the standard library.

The owner is also applied after the contents rather than before. The
first version of this change chowned the empty temporary file, which
handed uid 1001 something it could open for writing; the version before
this branch had exposed only a complete file owned by root. Later is the
ordering that needs no argument.

## Symmetry check

All four control-surface files, and what reads each:

| File | Reader | Window mattered? |
|---|---|---|
| `protocol` | the launcher, `cat` from outside, during boot while it is being written | yes — this is the reported defect |
| `state` | the launcher, `supervisor state` on every poll, while the run loop writes it | yes, and more often than the protocol one |
| `jitconfig` | the supervisor itself, after the start signal | no — the write and the read are ordered by the launcher, but it carries the credential, so it goes through the same door and gets its owner set before it exists rather than after |
| `start` | the supervisor, `os.Stat` only | no — nothing reads its contents; it goes through the same door so the next reader of them does not have to rediscover why |

Also checked and deliberately left alone: the Docker proxy config written
during boot (`~/.docker/config.json`). It is not control surface, and it
is written before anything exists that could read it.

## Evidence

Three mutations, one per mechanism:

```text
the replace truncates in place instead of renaming
  -> --- FAIL: TestAReplacedFileIsNeverReadHalfWritten
     a reader observed a file that is neither payload — 512 bytes: "999999..."

a state that cannot be replaced is not written at all
  -> --- FAIL: TestAStateThatCannotBeReplacedIsStillWritten
     state = "waiting" after a replacement that could not be made; want running

one call site is left on os.WriteFile
  -> --- FAIL: TestEveryControlFileIsWrittenThroughTheAtomicHelper
     protocolFile is written with os.WriteFile, which truncates before it writes
```

The first is the defect exactly — a partial read from a call that
succeeded. The third exists because the first cannot fail for a call site
that was missed: a test of the helper passes with none of them
converted.

The two consequences were read out of the code rather than assumed —
`protocolVerdict`'s `got != ProtocolVersion` branch on an empty `got`,
and `classifySupervisorState`'s default on `""`.

## What would notice this regressing

- `TestAControlFileIsNeverReadHalfWritten` races eight writers of two
  very different lengths against a reader, and requires every observed
  state to be one whole payload or the other. It also fails on a read
  error, because a rename never leaves the target absent — that is what
  would catch a writer that removed and recreated the file instead.
- `TestAStateThatCannotBeReplacedIsStillWritten` drives the fallback
  through an injected failure, so it needs no full filesystem.
- `TestEveryControlFileIsWrittenThroughTheAtomicHelper` names any control
  file left writing in place.
- `TestAFailedReplaceLeavesNothingBehind` requires a failed replace to
  leave no temporary file and the previous contents intact.
- `TestProtocolVerdict` continues to hold the judgement itself, including
  that a version this controller does not speak is refused.

## Risk, compatibility and operations

**Behaviour changes only in the window.** Outside it, every file has the
same contents, mode and owner as before.

**The credential's owner is set before the file exists,** rather than in
a second call after it. Nothing observed the gap — the only reader is the
supervisor itself, as root — but the ordering is now the one that needs
no argument.

**One more inode per write, briefly.** The control surface is tmpfs and
the temporary file is removed on every path, including failure.

**The gateway now writes its policy through the shared helper**, at the
same mode it used before. Its own concurrency test moved to the package
that owns the mechanism.

**Trust boundary, schema, migrations, CLI, configuration, status API:
untouched.** The capsule image changes, so the rollback is the previous
image, and a capsule already running is unaffected — this is a boot-time
and poll-time write path.

## Changelog

```text
### Fixed
- A capsule whose control files were read while being written could be
  reported as speaking the wrong protocol, or as being in a state the
  controller does not recognize, and its job held for an operator. The
  supervisor now replaces those files atomically.
```

## Notes for your reviewer

The judgement worth checking is that this belongs in the writer. The case
for it: the reader has no way to distinguish an empty file from a wrong
one, both readers are separate processes on independent schedules, and
there are four files rather than one — a retry would have to be added to
each reader, and every future one.

The case against, for completeness: `awaitProtocol` already polls, so a
single extra guard there would have covered the reported symptom in one
line. It would not have covered the state file, which is read far more
often and by a different path, and it would have left the window in
place.

The other thing to weigh is the fallback in `replaceState`. It does put
a torn read back on the table for the state file, in the one case where
the atomic path cannot run. That is deliberate and the reasoning is
above: unobservable is a state a person resolves, and a job run twice is
not.

No reader-side retry was added, deliberately. With the writes atomic an
empty read is not reachable, so a guard against it would be code that
cannot execute.
