### PR TITLE
fix(store, command): every lease reports the attempt it serves, and the answer before the first serve is its own document

### DIFF
--- a/internal/app/images.go
+++ b/internal/app/images.go
@@ -23,12 +23,11 @@ type imageLock struct {
 	} `json:"images"`
 }
 
-// DefaultCapsuleImage is what a development build runs when nothing
-// overrides it. It is exported because a reader of `runpool status` has
-// to be able to tell "this image could not be resolved" from "no image
-// is configured", and those are the same answer if an unresolvable one
-// reports as empty.
-const DefaultCapsuleImage = "runpool-capsule:dev"
+// defaultCapsuleImage is what a development build runs when nothing
+// overrides it, and the reason an unstamped build cannot fail to
+// resolve: it is substituted before any check, and it passes all of
+// them.
+const defaultCapsuleImage = "runpool-capsule:dev"
 
 // CapsuleImage resolves the outer capsule image the controller creates.
 // Exported because two surfaces must give the same answer: serve, which
@@ -43,7 +42,7 @@ const DefaultCapsuleImage = "runpool-capsule:dev"
 // digests — so the lock still reviews everything privileged that runs.
 func CapsuleImage(environ func(string) string, buildDefault string) (string, error) {
 	if buildDefault == "" {
-		buildDefault = DefaultCapsuleImage
+		buildDefault = defaultCapsuleImage
 	}
 	override := environ("RUNPOOL_CAPSULE_IMAGE")
 	if config.IsDigestQualifiedImage(buildDefault) {
@@ -52,7 +51,7 @@ func CapsuleImage(environ func(string) string, buildDefault string) (string, err
 		}
 		return buildDefault, nil
 	}
-	if buildDefault != DefaultCapsuleImage {
+	if buildDefault != defaultCapsuleImage {
 		return "", fmt.Errorf("release capsule image %q is not digest-qualified", buildDefault)
 	}
 	if override != "" {

--- a/internal/app/images.go
+++ b/internal/app/images.go
@@ -23,6 +23,13 @@ type imageLock struct {
 	} `json:"images"`
 }
 
+// DefaultCapsuleImage is what a development build runs when nothing
+// overrides it. It is exported because a reader of `runpool status` has
+// to be able to tell "this image could not be resolved" from "no image
+// is configured", and those are the same answer if an unresolvable one
+// reports as empty.
+const DefaultCapsuleImage = "runpool-capsule:dev"
+
 // CapsuleImage resolves the outer capsule image the controller creates.
 // Exported because two surfaces must give the same answer: serve, which
 // launches it, and status, which reports it — a report resolved by any
@@ -36,7 +43,7 @@ type imageLock struct {
 // digests — so the lock still reviews everything privileged that runs.
 func CapsuleImage(environ func(string) string, buildDefault string) (string, error) {
 	if buildDefault == "" {
-		buildDefault = "runpool-capsule:dev"
+		buildDefault = DefaultCapsuleImage
 	}
 	override := environ("RUNPOOL_CAPSULE_IMAGE")
 	if config.IsDigestQualifiedImage(buildDefault) {
@@ -45,7 +52,7 @@ func CapsuleImage(environ func(string) string, buildDefault string) (string, err
 		}
 		return buildDefault, nil
 	}
-	if buildDefault != "runpool-capsule:dev" {
+	if buildDefault != DefaultCapsuleImage {
 		return "", fmt.Errorf("release capsule image %q is not digest-qualified", buildDefault)
 	}
 	if override != "" {

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -95,6 +96,14 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	// answer is labelled with the failure rather than presented as the
 	// controller's view.
 	shippedCapsule, imageErr := app.CapsuleImage(os.Getenv, buildCapsule)
+	if imageErr != nil {
+		// CapsuleImage returns the empty string beside its error, and
+		// CapsuleImageError promises the tier entries carry what the
+		// build ships. Without this every tier reported an empty image,
+		// which reads as "none configured" rather than "this one could
+		// not be resolved" — and those call for different actions.
+		shippedCapsule = cmp.Or(buildCapsule, app.DefaultCapsuleImage)
+	}
 	doc := statusDocument(snap, cfg, review, obs, shippedCapsule)
 	if imageErr != nil {
 		doc.CapsuleImageError = imageErr.Error()
@@ -293,7 +302,11 @@ func age(d time.Duration) string {
 // controller has ever run, in whichever form the caller asked for.
 func reportNoState(streams IO, asJSON bool) error {
 	if asJSON {
-		return json.NewEncoder(streams.Out).Encode(statusDoc{
+		// The head alone. Encoding the whole document here emitted the
+		// served form's thirteen other fields as their zero values, and
+		// a reader following the published shape would have taken
+		// `discrepancies: null` to mean the daemon could not be asked.
+		return json.NewEncoder(streams.Out).Encode(statusHead{
 			APIVersion: statusAPIVersion,
 			Served:     false,
 			StateDir:   stateDir(),

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -1,7 +1,6 @@
 package command
 
 import (
-	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -102,7 +101,11 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 		// build ships. Without this every tier reported an empty image,
 		// which reads as "none configured" rather than "this one could
 		// not be resolved" — and those call for different actions.
-		shippedCapsule = cmp.Or(buildCapsule, app.DefaultCapsuleImage)
+		//
+		// buildCapsule is never empty here: an empty one is substituted
+		// for the development default, which resolves without error, so
+		// reaching this line at all means the build stamped a reference.
+		shippedCapsule = buildCapsule
 	}
 	doc := statusDocument(snap, cfg, review, obs, shippedCapsule)
 	if imageErr != nil {

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -17,18 +17,30 @@ import (
 // because consumers branch on length, not on presence.
 const statusAPIVersion = "v1"
 
-type statusDoc struct {
+// statusHead is what both forms of the document carry, and the whole of
+// the pre-serve one.
+//
+// It is a type rather than four fields repeated in two places, because a
+// map that re-spells the tags lets the two forms drift under a rename
+// with nothing to notice. It is separate from the served form's fields
+// rather than mixed in with them, because the pre-serve answer has to be
+// encodable on its own: encoding the whole document there emitted every
+// field of the served form as its zero value — thirteen of them,
+// including `discrepancies: null`, which this API defines as "the daemon
+// could not be asked".
+type statusHead struct {
 	APIVersion string `json:"api_version"`
 	// Served discriminates v1's two forms: true carries the document
 	// below, false is the pre-serve form with only state_dir and detail.
 	// A consumer branches on this, not on which fields happen to exist.
 	Served bool `json:"served"`
-	// StateDir and Detail are the pre-serve form's whole payload, and
-	// they are fields rather than a map the other branch builds by hand:
-	// a map re-spells every tag, so the two forms of one document could
-	// drift under a rename with nothing to notice.
-	StateDir      string         `json:"state_dir,omitempty"`
-	Detail        string         `json:"detail,omitempty"`
+	// StateDir and Detail are the pre-serve form's whole payload.
+	StateDir string `json:"state_dir,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type statusDoc struct {
+	statusHead
 	Instance      string         `json:"instance"`
 	HostTopology  string         `json:"host_topology"`
 	SchemaVersion int            `json:"schema_version"`
@@ -160,8 +172,7 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 		topology = cfg.Host.Topology
 	}
 	doc := statusDoc{
-		Served:        true,
-		APIVersion:    statusAPIVersion,
+		statusHead:    statusHead{APIVersion: statusAPIVersion, Served: true},
 		Instance:      snap.InstanceID,
 		HostTopology:  topology,
 		SchemaVersion: snap.SchemaVersion,

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -365,7 +365,7 @@ func TestAnUnresolvableImageStillReportsWhatTheBuildShips(t *testing.T) {
 
 	// A quick-start configuration, so the document carries a tier to
 	// report an image for.
-	t.Setenv(config.EnvHostTopology, "single")
+	t.Setenv(config.EnvHostTopology, config.HostTopologySharedDaemon)
 
 	const release = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
 		"2222222222222222222222222222222222222222222222222222222222222222"

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -311,3 +311,84 @@ func TestBothStatusAnswersShareOneEnvelope(t *testing.T) {
 		t.Error("the served form does not say so")
 	}
 }
+
+// TestThePreServeAnswerCarriesOnlyItsOwnFields: before the controller
+// has ever run, the document is four keys.
+//
+// The published shape says so — "it carries exactly api_version, served,
+// state_dir and detail" — and encoding the served form's struct there
+// emitted every one of its other fields as a zero value. Two of those
+// are actively misleading rather than merely noisy: `discrepancies:
+// null` is defined by this API as "the daemon could not be asked", and
+// `docker_error` being absent then says it could. A reader diagnosing a
+// fresh install would be told the daemon is unreachable and given no
+// reason why.
+func TestThePreServeAnswerCarriesOnlyItsOwnFields(t *testing.T) {
+	var out bytes.Buffer
+	if err := reportNoState(IO{Out: &out}, true); err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("--json produced %q, which is not a document: %v", out.String(), err)
+	}
+	want := map[string]bool{"api_version": true, "served": true, "state_dir": true, "detail": true}
+	for key := range doc {
+		if !want[key] {
+			t.Errorf("the pre-serve document carries %q, which belongs to the served form", key)
+		}
+	}
+	for key := range want {
+		if _, ok := doc[key]; !ok {
+			t.Errorf("the pre-serve document is missing %q", key)
+		}
+	}
+}
+
+// TestAnUnresolvableImageStillReportsWhatTheBuildShips: a capsule image
+// this command cannot resolve is labelled, not blanked.
+//
+// CapsuleImage returns the empty string beside its error, and
+// capsule_image_error's own documentation promises the tier entries
+// carry what the build ships. Reporting an empty image instead says "no
+// image is configured", which is a different finding with a different
+// fix, and it is the one a reader would act on because the tier entry is
+// where they look.
+func TestAnUnresolvableImageStillReportsWhatTheBuildShips(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("RUNPOOL_STATE_DIR", dir)
+	st, err := store.Open(dir, store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Close()
+
+	// A quick-start configuration, so the document carries a tier to
+	// report an image for.
+	t.Setenv(config.EnvHostTopology, "single")
+
+	const release = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+	t.Setenv("RUNPOOL_CAPSULE_IMAGE", "ghcr.io/example/other:latest")
+
+	var out bytes.Buffer
+	if err := runStatus(IO{Out: &out, Err: &bytes.Buffer{}}, true, release); err != nil {
+		t.Fatalf("status refused to answer: %v", err)
+	}
+	var doc statusDoc
+	if err := json.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("the document does not decode: %v\n%s", err, out.String())
+	}
+	if doc.CapsuleImageError == "" {
+		t.Fatal("the image resolved; this test asserted nothing")
+	}
+	if doc.Scheduling == nil || len(doc.Scheduling.Tiers) == 0 {
+		t.Fatal("no tier entries to check")
+	}
+	for _, tier := range doc.Scheduling.Tiers {
+		if tier.CapsuleImage == "" {
+			t.Errorf("tier %s reports an empty capsule image; want what the build ships, "+
+				"which is what capsule_image_error says the entries carry", tier.ID)
+		}
+	}
+}

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
@@ -169,8 +170,15 @@ func (t *Tx) CacheLanes() ([]CacheLaneInfo, error) {
 }
 
 // selectAttempt is the attempt column list this file's set read scans.
-// It matches the generated GetAttempt query's projection; the schema
-// parity test is what keeps the two in step.
+// It repeats the generated GetAttempt query's projection by hand,
+// because sqlc's sqlite engine has no slice parameter and a set read
+// cannot be generated.
+//
+// Two column lists that must agree and cannot be made to share one:
+// TestTheSetReadAgreesWithTheGeneratedQuery reads the same attempt both
+// ways and requires the results to be identical. That catches a column
+// added to one and not the other, and a reordering that swaps two
+// columns of the same type, which no compiler can.
 const selectAttempt = `SELECT id, delivery_id, binding_id, source_workload_key, tenant_key,
        project_key, state, execution_evidence, resolution, review_reason, reviewed_at,
        reviewed_by, received_at, settled_at FROM assignment_attempts `
@@ -185,10 +193,17 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 	if len(leases) == 0 {
 		return out, nil
 	}
-	byAttempt := make(map[string]string, len(leases)) // attempt id -> lease id
+	// Distinct attempt ids. Several leases can name one attempt: the
+	// index that forbids two live leases per attempt says nothing about
+	// a released one, so an attempt returned to the queue and served
+	// again is named by both.
 	args := make([]any, 0, len(leases))
+	asked := make(map[assignment.AttemptID]struct{}, len(leases))
 	for _, l := range leases {
-		byAttempt[string(l.AttemptID)] = string(l.ID)
+		if _, dup := asked[l.AttemptID]; dup {
+			continue
+		}
+		asked[l.AttemptID] = struct{}{}
 		args = append(args, l.AttemptID)
 	}
 	rows, err := t.tx.Query(selectAttempt+
@@ -197,6 +212,7 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 		return nil, err
 	}
 	defer rows.Close()
+	byAttempt := make(map[string]Attempt, len(args))
 	for rows.Next() {
 		var r sqlitedb.AssignmentAttempt
 		if err := rows.Scan(&r.ID, &r.DeliveryID, &r.BindingID, &r.SourceWorkloadKey,
@@ -204,9 +220,24 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 			&r.ReviewReason, &r.ReviewedAt, &r.ReviewedBy, &r.ReceivedAt, &r.SettledAt); err != nil {
 			return nil, err
 		}
-		out[byAttempt[r.ID]] = fromRow(r)
+		byAttempt[r.ID] = fromRow(r)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Keyed by lease, because "what is this lease serving" is the
+	// question the report asks. Keying by attempt made two leases of one
+	// attempt collapse into a single entry, and released leases are
+	// appended after live ones, so the row that lost its attempt was
+	// always the lease still running.
+	for _, l := range leases {
+		attempt, ok := byAttempt[string(l.AttemptID)]
+		if !ok {
+			return nil, fmt.Errorf("lease %s names attempt %s, which does not exist", l.ID, l.AttemptID)
+		}
+		out[string(l.ID)] = attempt
+	}
+	return out, nil
 }
 
 // resourcesOfLeases reads every lease's resource intents in one query,

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1629,3 +1629,112 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 		})
 	})
 }
+
+// TestEveryLeaseKeepsItsAttempt: two leases that served one attempt each
+// get their own row in the report.
+//
+// The index that forbids two live leases per attempt says nothing about
+// a released one, so an attempt returned to the queue and served again
+// is named by both. Indexing the lookup by attempt made them collapse
+// into one entry, and the snapshot appends released leases after live
+// ones — so the entry that survived belonged to the lease that had
+// finished, and the lease still running was the one reported as serving
+// nothing.
+func TestEveryLeaseKeepsItsAttempt(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	id := seedAttempt(t, s, binding, "msg-two-leases", "job-two-leases")
+
+	var first, second Lease
+	inTx(t, s, func(tx *Tx) error {
+		l, err := tx.LeaseAttempt(id, binding, "tier-a")
+		if err != nil {
+			return err
+		}
+		first = l
+		for _, edge := range [][2]LeaseState{
+			{LeaseReserved, LeaseFailed},
+			{LeaseFailed, LeaseCleaning},
+			{LeaseCleaning, LeaseReleased},
+		} {
+			if err := tx.TransitionLease(first.ID, edge[0], edge[1]); err != nil {
+				return err
+			}
+		}
+		// Back to the queue and served again, which is the whole of how
+		// one attempt comes to have two leases.
+		if err := tx.Advance(id, "leased", "ready"); err != nil {
+			return err
+		}
+		second, err = tx.LeaseAttempt(id, binding, "tier-a")
+		return err
+	})
+
+	// Live first, released after: the order Snapshot builds.
+	var got map[string]Attempt
+	inTx(t, s, func(tx *Tx) error {
+		var err error
+		got, err = tx.attemptsOfLeases([]Lease{second, first})
+		return err
+	})
+
+	for _, l := range []Lease{second, first} {
+		a, ok := got[string(l.ID)]
+		if !ok {
+			t.Errorf("lease %s has no attempt in the report; it serves %s", l.ID, l.AttemptID)
+			continue
+		}
+		if a.ID != id {
+			t.Errorf("lease %s reports attempt %s; want %s", l.ID, a.ID, id)
+		}
+	}
+}
+
+// TestTheSetReadAgreesWithTheGeneratedQuery: the hand-written column
+// list and the generated one return the same attempt.
+//
+// sqlc's sqlite engine has no slice parameter, so the report's set read
+// cannot be generated and repeats the projection by hand. Nothing makes
+// the two share a definition, and nothing about them fails to compile
+// when they disagree: a column added to one is a scan error at best and
+// a shifted value at worst, and two columns of the same type swapped in
+// one list is silent in both.
+func TestTheSetReadAgreesWithTheGeneratedQuery(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	id := seedAttempt(t, s, binding, "msg-parity", "job-parity")
+
+	// Every nullable column filled, so a projection that shifts two of
+	// them cannot pass by both being empty.
+	var lease Lease
+	inTx(t, s, func(tx *Tx) error {
+		l, err := tx.LeaseAttempt(id, binding, "tier-a")
+		if err != nil {
+			return err
+		}
+		lease = l
+		if err := tx.RecordEvidence(id, EvidenceStartAuthorized); err != nil {
+			return err
+		}
+		return tx.HoldForReview(id, ReviewReasonStartOutcomeUnknown)
+	})
+
+	var generated, set Attempt
+	inTx(t, s, func(tx *Tx) error {
+		row, err := tx.q.GetAttempt(tx.ctx, string(id))
+		if err != nil {
+			return err
+		}
+		generated = fromRow(row)
+		byLease, err := tx.attemptsOfLeases([]Lease{lease})
+		if err != nil {
+			return err
+		}
+		set = byLease[string(lease.ID)]
+		return nil
+	})
+
+	if generated != set {
+		t.Errorf("the two projections disagree:\n generated: %+v\n set read:  %+v", generated, set)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1699,24 +1699,47 @@ func TestEveryLeaseKeepsItsAttempt(t *testing.T) {
 // when they disagree: a column added to one is a scan error at best and
 // a shifted value at worst, and two columns of the same type swapped in
 // one list is silent in both.
+//
+// Every column below holds a value unique among the columns it could be
+// confused with, so any swap changes the result. A row driven there by
+// the state machine instead would leave several columns equal, and the
+// swaps between those are exactly the ones no compiler can catch.
 func TestTheSetReadAgreesWithTheGeneratedQuery(t *testing.T) {
 	s := newStore(t)
 	binding := seedBinding(t, s)
 	id := seedAttempt(t, s, binding, "msg-parity", "job-parity")
 
-	// Every nullable column filled, so a projection that shifts two of
-	// them cannot pass by both being empty.
 	var lease Lease
 	inTx(t, s, func(tx *Tx) error {
 		l, err := tx.LeaseAttempt(id, binding, "tier-a")
-		if err != nil {
-			return err
-		}
 		lease = l
-		if err := tx.RecordEvidence(id, EvidenceStartAuthorized); err != nil {
-			return err
-		}
-		return tx.HoldForReview(id, ReviewReasonStartOutcomeUnknown)
+		return err
+	})
+
+	// A distinct value in every column, written directly. Driving the
+	// row there through the state machine leaves columns that cannot be
+	// told apart: resolution and reviewed_by are both the empty string
+	// until an operator resolves a review, reviewed_at and settled_at
+	// are both null until one happens, and reviewed_at and received_at
+	// are both unixepoch() in the same second when one does. Any of
+	// those pairs could be swapped in one list and not the other, and
+	// nothing would notice — which is the whole of what this test is
+	// for.
+	inTx(t, s, func(tx *Tx) error {
+		_, err := tx.tx.Exec(`UPDATE assignment_attempts SET
+			source_workload_key = 'workload-value',
+			tenant_key          = 'tenant-value',
+			project_key         = 'project-value',
+			state               = 'manual_review',
+			execution_evidence  = 'running_observed',
+			resolution          = 'resolution-value',
+			review_reason       = 'review-reason-value',
+			reviewed_by         = 'reviewed-by-value',
+			reviewed_at         = 111,
+			received_at         = 222,
+			settled_at          = 333
+			WHERE id = ?`, string(id))
+		return err
 	})
 
 	var generated, set Attempt


### PR DESCRIPTION
## What changes

Four corrections to what the reporting surfaces say: the attempt a lease
is serving, the parity of two column lists that must agree, the shape of
the answer before the controller has ever run, and the image reported for
a tier when it cannot be resolved.

## What was found

**Two leases of one attempt collapsed, and the one that lost it was the
one still running.** `attemptsOfLeases` built a map from attempt to
lease, so a later lease overwrote an earlier one's entry. One attempt has
two leases whenever it is returned to the queue and served again — the
partial index forbidding two *live* leases per attempt says nothing about
a released one — and `Snapshot` appends released leases after live ones.
So the surviving entry belonged to the lease that had finished, and
`runpool status` reported the lease actually running as serving nothing.

It is keyed by lease now, which is the question the report asks. Two
things fall out: the query asked for the shared attempt id twice, so it
deduplicates before asking; and a lease naming an attempt that does not
exist is an error rather than a silently absent entry, which is what the
per-lease loop it replaced used to do.

**A comment claimed a coverage that did not exist.** `selectAttempt` said
"the schema parity test is what keeps the two in step". No test looked at
it. The two column lists cannot be made to share a definition — sqlc's
sqlite engine has no slice parameter, so a set read cannot be generated —
and nothing about them fails to compile when they disagree: a column
added to one is a scan error at best and a shifted value at worst, and
two same-typed columns swapped in one list is silent in both.

There is a test now that reads one attempt through both and requires the
results identical. Its first version claimed to fill every nullable
column and filled none of them: a row driven there through the state
machine has `resolution` and `reviewed_by` both empty until an operator
resolves a review, `reviewed_at` and `settled_at` both null until one
happens, and `reviewed_at` and `received_at` both `unixepoch()` in the
same second when one does. Three pairs, each invisible to a swap, and
they are precisely the swaps the test exists for. Every column now holds
a value unique among the ones it could be confused with, written directly
rather than walked to. The comment on `selectAttempt` names the test.

**The answer before the first serve carried thirteen fields that belong
to the other form.** `reportNoState` encoded the served form's struct, so
every field of it appeared as a zero value. The published shape is
explicit — "it carries exactly `api_version`, `served`, `state_dir` and
`detail`" — and two of the extras are worse than noise:

> Discrepancies is the books-versus-daemon comparison across every
> observed object kind. It is null only when the daemon could not be
> asked, which docker_error then explains.

So the document told a reader diagnosing a fresh install that the daemon
was unreachable, and gave no reason, because `docker_error` is
`omitempty`. The head both forms share is its own type now, and the
pre-serve answer encodes that — which keeps what the fields were for in
the first place, a single spelling of the tags that cannot drift under a
rename, while letting the smaller form be encoded on its own.

**An unresolvable image reported as no image at all.** `CapsuleImage`
returns the empty string beside its error, and `runStatus` passed it
through to every tier. But `capsule_image_error`'s own documentation
says the opposite:

> The tier entries then carry whatever the build ships, so this is what
> tells a reader those are not the images a launch would run.

An empty `capsule_image` reads as "none configured", which is a different
finding with a different fix — and the tier entry is where a reader
looks. The fallback is what the build ships.

It was written as a choice between that and the development default. The
default arm cannot run: an empty build reference is substituted for it
before any check and passes all of them, so `CapsuleImage` cannot return
an error when the caller passed nothing — reaching the fallback means the
build stamped a reference. The branch is gone and the constant is
unexported again, since the export existed only for it.

## Symmetry check

| Path | Result |
|---|---|
| `resourcesOfLeases` | already keyed by lease id straight from the row; it never had the defect, which is why the two now read the same way |
| the three tables `Snapshot` fills per lease | attempts, resources, and the lease list itself — only attempts indexed by anything other than the lease |
| `selectIntent` | the other hand-written projection; it is scanned by `scanIntent`, which is shared by both readers, so there is one list rather than two |
| `GetAttemptByLease` | generated, single-row, unaffected — it answers a different question and shares no list |
| both consumers of `snap.Attempts` | `status.go` and `statusdto.go` both index by lease id, so neither needed changing once the map was keyed that way |
| the two forms of the status document | the served form still carries the head through embedding, so `TestBothStatusAnswersShareOneEnvelope` holds unchanged |
| `CapsuleImage`'s other caller | `serve` must not launch an image it could not resolve, so it keeps the empty string and the error; the fallback is at the reporting call site only |

## Evidence

Four mutations, one per mechanism:

```text
the lookup is keyed by attempt again
  -> --- FAIL: TestEveryLeaseKeepsItsAttempt
     lease 8446235003790a50 has no attempt in the report; it serves att-ceb21658252a54a8

one column dropped from the hand-written projection
  -> --- FAIL: TestTheSetReadAgreesWithTheGeneratedQuery

each of the three same-typed pairs swapped, one at a time
  resolution <-> reviewed_by   -> FAIL
  reviewed_at <-> settled_at   -> FAIL
  reviewed_at <-> received_at  -> FAIL

the pre-serve answer encodes the whole document
  -> --- FAIL: TestThePreServeAnswerCarriesOnlyItsOwnFields
     carries "schema_version" / "bindings" / "leases", which belong to the served form

an unresolvable image reports empty
  -> --- FAIL: TestAnUnresolvableImageStillReportsWhatTheBuildShips
     tier standard reports an empty capsule image
```

The first mutation had to be written twice. The obvious form left `fmt`
unused, so the package did not build and the run proved nothing — a
mutation that fails to compile is not a mutation.

## What would notice this regressing

- `TestEveryLeaseKeepsItsAttempt` builds the real shape: one attempt,
  a released lease and a live one, passed in the order `Snapshot` builds.
- `TestTheSetReadAgreesWithTheGeneratedQuery` gives every column a value
  unique among the ones it could be confused with, so any reordering of
  two same-typed columns fails it — verified for all three such pairs.
- `TestThePreServeAnswerCarriesOnlyItsOwnFields` checks the key set both
  ways: nothing extra, nothing missing.
- `TestAnUnresolvableImageStillReportsWhatTheBuildShips` fails first if
  the image resolves, so it cannot pass by never reaching the case.
- `TestBothStatusAnswersShareOneEnvelope` is unchanged and still requires
  both forms to decode into one struct with no unknown fields.

## Risk, compatibility and operations

**The pre-serve document loses thirteen fields.** That is the published
contract being met rather than broken — the reference has said four since
it was written — but a consumer that read `bindings` or `leases` from it
was reading `null` and now reads nothing. Both mean the same to a
consumer branching on `served`, which the document tells it to do.

**`runpool status` gains an error case it did not have.** A lease naming
an attempt that does not exist now fails the snapshot instead of
reporting that lease with a zero-valued attempt. It is a foreign key, so
this is unreachable short of corruption, and reporting a fabricated
attempt for a real lease is the worse answer.

**Tier entries report a non-empty image where they reported an empty
one** when the image cannot be resolved. `capsule_image_error` already
said what that means.

**Schema, migrations, trust boundary, credentials, configuration:
untouched.** Rollback is the previous binary.

## Changelog

```text
### Fixed
- `runpool status` reported a lease as serving no attempt when that
  attempt had been served before by a lease that has since been released.
- The status document produced before the controller's first serve
  carried fields belonging to the served form, including a null
  `discrepancies`, which this API defines as "the daemon could not be
  asked".
- A capsule image that cannot be resolved is reported for each tier as
  what the build ships, rather than as an empty string.
```

## Notes for your reviewer

The judgement worth checking is making a missing attempt an error. The
alternative is what the code did before the map: report the lease with a
zero-valued attempt. The argument for the error is that `attempt_id` is a
foreign key, so the case needs corruption to reach, and a status document
that shows a real lease serving an attempt with an empty id and no state
is a worse thing to hand someone than a failure that says what is wrong.

Also worth knowing: the first version of the parity test asserted the
right thing about a row that could not distinguish three of its column
pairs, and its comment claimed otherwise. The evidence above is each of
those pairs swapped on its own, because a totality claim about a
projection is only worth what the swaps prove.

Second, the head split. It could have been done by adding `omitempty` to
every field of the served form instead, which would be a smaller diff. It
would also make the served document lose `released_total: 0` and empty
arrays, which consumers do read — so the two forms would differ in
whether a field means "empty" or "absent", which is exactly the ambiguity
`served` exists to remove.
