### PR TITLE
perf(app): a policy change pays its gateway exec bounds in parallel

### DIFF
--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -199,7 +199,9 @@ func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
 
 	n.rediscover(t.Context())
 
-	if !slices.Equal(d.removed, []string{"gw-1", "gw-2"}) {
-		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removed)
+	// Sorted: closing fans out, so the order is the order the daemon
+	// answered in and nothing should depend on it.
+	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
+		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removes())
 	}
 }

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -415,6 +414,12 @@ func eachGateway[T any](items []T, fn func(T)) {
 // worked around. It returns the ids of the gateways that did not take
 // the new policy, so the caller can decide what that costs from what
 // the change was.
+//
+// Those ids come back in whatever order the daemon answered, because the
+// gateways are reached concurrently. No caller may depend on it. Sorting
+// here would be a second mechanism for a property nothing reads — the
+// one caller takes a length and iterates order-blind, and a test that
+// compares the set sorts what it compares.
 func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []string) (failed []string, err error) {
 	containers, err := n.daemon.ListOwnedContainers(ctx, n.instanceID)
 	if err != nil {
@@ -442,9 +447,6 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 		}
 		n.log.Info("gateway policy reloaded", "container", c.Name)
 	})
-	// Concurrent appends make the order the daemon answered in, which
-	// nothing should depend on. Sorted so a caller cannot start.
-	slices.Sort(failed)
 	return failed, nil
 }
 

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/netip"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -365,13 +366,48 @@ func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox)
 	// something the policy now denies. Close those gateways.
 	n.log.Error("a restriction could not be installed; closing the affected gateways",
 		"gateways", len(failed))
-	for _, id := range failed {
+	eachGateway(failed, func(id string) {
 		if err := n.closeGateway(ctx, id); err != nil {
 			n.log.Error("a gateway could not be closed and may still relay a denied address",
 				"container", id, "error", err)
 		}
-	}
+	})
 	return nil
+}
+
+// gatewayFanout is how many gateway control commands run at once.
+//
+// A refresh pass holds the refresh lock, and every launch waits on that
+// lock with a plain mutex that takes no context and cannot be given up.
+// So the pass's duration is a launch's worst-case wait — and walking the
+// gateways one at a time made that duration the number of gateways times
+// the exec bound. There is one gateway per running capsule, so it grew
+// with exactly the parallelism the host was configured for: at
+// thirty-two in flight, sixteen minutes with every launch stopped, for
+// one policy change.
+//
+// Bounded rather than unbounded. These are execs into containers on a
+// single daemon, and a pass that opens one per capsule trades a slow
+// refresh for a slow daemon, which every other caller then waits on too.
+const gatewayFanout = 8
+
+// eachGateway runs fn over every item concurrently, at most
+// gatewayFanout at a time, and returns once all of them have finished.
+// fn is called from several goroutines, so what it touches must be safe
+// for that.
+func eachGateway[T any](items []T, fn func(T)) {
+	var wg sync.WaitGroup
+	slots := make(chan struct{}, gatewayFanout)
+	for _, item := range items {
+		wg.Add(1)
+		slots <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-slots }()
+			fn(item)
+		}()
+	}
+	wg.Wait()
 }
 
 // reloadGateways hands the new sets to every running gateway this
@@ -388,21 +424,27 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 	if err != nil {
 		return nil, err
 	}
-	for _, c := range containers {
+	var mu sync.Mutex
+	eachGateway(containers, func(c docker.OwnedContainer) {
 		if c.Role != capsule.RoleGateway || !c.Running {
-			continue
+			return
 		}
 		code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
 			return n.daemon.ExecWithInput(ctx, c.ID,
 				[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
 		})
 		if err != nil || code != 0 {
+			mu.Lock()
 			failed = append(failed, c.ID)
+			mu.Unlock()
 			n.log.Error("gateway policy reload failed", "container", c.Name, "exit", code, "error", err, "output", out)
-			continue
+			return
 		}
 		n.log.Info("gateway policy reloaded", "container", c.Name)
-	}
+	})
+	// Concurrent appends make the order the daemon answered in, which
+	// nothing should depend on. Sorted so a caller cannot start.
+	slices.Sort(failed)
 	return failed, nil
 }
 
@@ -448,16 +490,21 @@ func (n *networkSandbox) closeGateways(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	var failures int
-	for _, c := range containers {
+	var (
+		mu       sync.Mutex
+		failures int
+	)
+	eachGateway(containers, func(c docker.OwnedContainer) {
 		if c.Role != capsule.RoleGateway || !c.Running {
-			continue
+			return
 		}
 		if err := n.closeGateway(ctx, c.ID); err != nil {
+			mu.Lock()
 			failures++
+			mu.Unlock()
 			n.log.Error("a gateway could not be closed", "container", c.Name, "error", err)
 		}
-	}
+	})
 	if failures > 0 {
 		return fmt.Errorf("%d gateway(s) could not be closed", failures)
 	}

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -3,11 +3,14 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"reflect"
 	"slices"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
@@ -97,11 +100,72 @@ type fakeSandboxDaemon struct {
 	listErr error
 	// refuse names the containers whose exec fails, which is how a
 	// gateway that will not take a new policy is expressed.
-	refuse   map[string]bool
+	refuse map[string]bool
+	// delay is how long each gateway control command takes, which is
+	// what makes a serial pass distinguishable from a concurrent one.
+	delay time.Duration
+
+	// The pass fans out over gateways now, so what it records is written
+	// from several goroutines and in no fixed order. The mutex is the
+	// fake's own; the accessors below sort, so a test asserts what was
+	// touched rather than the order the daemon answered in.
+	mu       sync.Mutex
+	inFlight int
+	peak     int
 	reloaded []string
-	denied   []string
 	removed  []string
 }
+
+// serve models one gateway control command occupying the daemon for as
+// long as it takes, which is what the concurrency counters below see.
+func (f *fakeSandboxDaemon) serve() {
+	f.enter()
+	defer f.leave()
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+}
+
+func (f *fakeSandboxDaemon) note(into *[]string, id string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	*into = append(*into, id)
+}
+
+// enter and leave track how many control commands the daemon is serving
+// at once. That is what a refresh's cost turns on, and unlike wall-clock
+// time it does not change with how loaded the machine is.
+func (f *fakeSandboxDaemon) enter() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inFlight++
+	if f.inFlight > f.peak {
+		f.peak = f.inFlight
+	}
+}
+
+func (f *fakeSandboxDaemon) leave() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inFlight--
+}
+
+func (f *fakeSandboxDaemon) peakInFlight() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.peak
+}
+
+func (f *fakeSandboxDaemon) sorted(from *[]string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := slices.Clone(*from)
+	slices.Sort(out)
+	return out
+}
+
+func (f *fakeSandboxDaemon) reloads() []string { return f.sorted(&f.reloaded) }
+func (f *fakeSandboxDaemon) removes() []string { return f.sorted(&f.removed) }
 
 func (f *fakeSandboxDaemon) EnsureOwnedNetwork(context.Context, docker.NetworkSpec) (string, error) {
 	return f.uplinkID, nil
@@ -122,21 +186,23 @@ func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, assignment.Inst
 	return f.containers, nil
 }
 func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, _ []string) (int, string, error) {
-	f.denied = append(f.denied, id)
+	f.serve()
 	if f.refuse[id] {
 		return 1, "refused", nil
 	}
 	return 0, "", nil
 }
 func (f *fakeSandboxDaemon) ExecWithInput(_ context.Context, id string, _ []string, _ []byte) (int, string, error) {
+	f.serve()
 	if f.refuse[id] {
 		return 1, "refused", nil
 	}
-	f.reloaded = append(f.reloaded, id)
+	f.note(&f.reloaded, id)
 	return 0, "", nil
 }
 func (f *fakeSandboxDaemon) RemoveContainer(_ context.Context, id string) error {
-	f.removed = append(f.removed, id)
+	f.serve()
+	f.note(&f.removed, id)
 	return nil
 }
 
@@ -242,11 +308,11 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 		n.applyPolicy(t.Context(), &capsule.Sandbox{
 			UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8", "192.168.0.0/16"},
 		})
-		if !slices.Equal(d.reloaded, []string{"gw-ok"}) {
-			t.Errorf("reloaded %v; only running gateways take a policy", d.reloaded)
+		if !slices.Equal(d.reloads(), []string{"gw-ok"}) {
+			t.Errorf("reloaded %v; only running gateways take a policy", d.reloads())
 		}
-		if !slices.Equal(d.removed, []string{"gw-bad"}) {
-			t.Errorf("removed %v; the gateway that refused a restriction must be closed", d.removed)
+		if !slices.Equal(d.removes(), []string{"gw-bad"}) {
+			t.Errorf("removed %v; the gateway that refused a restriction must be closed", d.removes())
 		}
 	})
 
@@ -254,8 +320,8 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 		d := &fakeSandboxDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1"})
-		if len(d.removed) != 0 {
-			t.Errorf("removed %v; a gateway keeping a stricter policy is not a danger", d.removed)
+		if len(d.removes()) != 0 {
+			t.Errorf("removed %v; a gateway keeping a stricter policy is not a danger", d.removes())
 		}
 	})
 
@@ -263,8 +329,8 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 		d := &fakeSandboxDaemon{containers: gateways}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}})
-		if len(d.reloaded)+len(d.removed) != 0 {
-			t.Errorf("an unchanged policy touched %v / %v", d.reloaded, d.removed)
+		if len(d.reloads())+len(d.removes()) != 0 {
+			t.Errorf("an unchanged policy touched %v / %v", d.reloads(), d.removes())
 		}
 	})
 
@@ -272,8 +338,8 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 		d := &fakeSandboxDaemon{containers: gateways}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-2", Deny: []string{"10.0.0.0/8"}})
-		if !slices.Equal(d.reloaded, []string{"gw-ok", "gw-bad"}) {
-			t.Errorf("reloaded %v; a new uplink has to reach every gateway", d.reloaded)
+		if !slices.Equal(d.reloads(), []string{"gw-bad", "gw-ok"}) {
+			t.Errorf("reloaded %v; a new uplink has to reach every gateway", d.reloads())
 		}
 	})
 }
@@ -294,8 +360,8 @@ func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 	if err := n.closeGateways(t.Context()); err != nil {
 		t.Fatal(err)
 	}
-	if !slices.Equal(d.removed, []string{"gw-1", "gw-2"}) {
-		t.Errorf("removed %v; a gateway that refuses deny-all still has to stop relaying", d.removed)
+	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
+		t.Errorf("removed %v; a gateway that refuses deny-all still has to stop relaying", d.removes())
 	}
 }
 
@@ -388,5 +454,60 @@ func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
 	}
 	if len(daemon.reloaded) != 1 || daemon.reloaded[0] != "gw-1" {
 		t.Errorf("gateways reloaded on the retry = %v; want the restriction to reach gw-1", daemon.reloaded)
+	}
+}
+
+// TestARefreshCostsOneTimeoutNotN: installing a policy reaches every
+// gateway in about what one gateway costs, not that times their number.
+//
+// The pass holds the refresh lock, and every launch waits on that lock
+// with a plain mutex — no context, nothing to give up, no way to time
+// out. So the pass's duration is a launch's worst-case wait. There is
+// one gateway per running capsule, so walking them one at a time made
+// that wait grow with exactly the parallelism the host was configured
+// for: at thirty-two capsules and a thirty-second exec bound, sixteen
+// minutes during which nothing new could start, for one policy change.
+func TestARefreshCostsOneTimeoutNotN(t *testing.T) {
+	const (
+		count   = 24
+		perCall = 40 * time.Millisecond
+	)
+	containers := make([]docker.OwnedContainer, 0, count)
+	for i := range count {
+		id := fmt.Sprintf("gw-%02d", i)
+		containers = append(containers, docker.OwnedContainer{
+			ID: id, Name: id, Role: capsule.RoleGateway, Running: true,
+		})
+	}
+	d := &fakeSandboxDaemon{containers: containers, delay: perCall}
+	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
+
+	failed, err := n.reloadGateways(t.Context(), nil, []string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(failed) != 0 {
+		t.Fatalf("gateways refused the policy: %v", failed)
+	}
+	// Every one of them, so a pass that is cheap because it skipped work
+	// cannot pass for a pass that is cheap because it fanned out.
+	if got := len(d.reloads()); got != count {
+		t.Fatalf("reloaded %d of %d gateways", got, count)
+	}
+
+	// What is asserted is how many commands the daemon served at once,
+	// not how long the pass took. Wall-clock is a machine-speed test: it
+	// passes on an idle laptop and fails under coverage instrumentation,
+	// and neither says anything about the code. Overlap is the mechanism
+	// that makes the cost one exec bound rather than as many as there
+	// are capsules.
+	peak := d.peakInFlight()
+	if peak < 2 {
+		t.Errorf("peak %d gateway command(s) in flight for %d gateways; the pass is serial, "+
+			"and every launch waits out all of it", peak, count)
+	}
+	if peak > gatewayFanout {
+		t.Errorf("peak %d in flight against a bound of %d; a pass that opens one exec per "+
+			"capsule trades a slow refresh for a slow daemon", peak, gatewayFanout)
 	}
 }

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -452,13 +452,14 @@ func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
 	if err := n.applyPolicy(t.Context(), tightened); err != nil {
 		t.Fatalf("the retry failed: %v", err)
 	}
-	if len(daemon.reloaded) != 1 || daemon.reloaded[0] != "gw-1" {
-		t.Errorf("gateways reloaded on the retry = %v; want the restriction to reach gw-1", daemon.reloaded)
+	if got := daemon.reloads(); len(got) != 1 || got[0] != "gw-1" {
+		t.Errorf("gateways reloaded on the retry = %v; want the restriction to reach gw-1", got)
 	}
 }
 
-// TestARefreshCostsOneTimeoutNotN: installing a policy reaches every
-// gateway in about what one gateway costs, not that times their number.
+// TestARefreshPaysItsExecBoundsInParallel: installing a policy overlaps
+// the gateways it reaches, so the wait is the number of waves and not the
+// number of gateways.
 //
 // The pass holds the refresh lock, and every launch waits on that lock
 // with a plain mutex — no context, nothing to give up, no way to time
@@ -467,11 +468,33 @@ func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
 // that wait grow with exactly the parallelism the host was configured
 // for: at thirty-two capsules and a thirty-second exec bound, sixteen
 // minutes during which nothing new could start, for one policy change.
-func TestARefreshCostsOneTimeoutNotN(t *testing.T) {
+//
+// The exec count is unchanged — still one per gateway. What changed is
+// how many are outstanding at once, which is what the wait is made of:
+// ceil(N/8) bounds rather than N.
+func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 	const (
 		count   = 24
 		perCall = 40 * time.Millisecond
 	)
+	// Two checks on the knob before the one on the code, because the
+	// assertion below compares against the knob and so moves with it.
+	//
+	// A fan-out of one is not a narrower tuning, it is the serial pass
+	// this replaces. Whether eight is the right width is a judgement
+	// about how much a single daemon should be asked at once, and no test
+	// can settle that; that it is more than one is not a judgement.
+	if gatewayFanout < 2 {
+		t.Fatalf("the fan-out bound is %d, which is the serial pass with extra steps", gatewayFanout)
+	}
+	// And the bound is only observable with more gateways than slots:
+	// with fewer, a bounded pass and an unbounded one both run everything
+	// at once and look identical.
+	if gatewayFanout >= count {
+		t.Fatalf("this test needs more gateways (%d) than the fan-out bound (%d), "+
+			"or it cannot tell a bounded pass from an unbounded one", count, gatewayFanout)
+	}
+
 	containers := make([]docker.OwnedContainer, 0, count)
 	for i := range count {
 		id := fmt.Sprintf("gw-%02d", i)
@@ -498,16 +521,15 @@ func TestARefreshCostsOneTimeoutNotN(t *testing.T) {
 	// What is asserted is how many commands the daemon served at once,
 	// not how long the pass took. Wall-clock is a machine-speed test: it
 	// passes on an idle laptop and fails under coverage instrumentation,
-	// and neither says anything about the code. Overlap is the mechanism
-	// that makes the cost one exec bound rather than as many as there
-	// are capsules.
-	peak := d.peakInFlight()
-	if peak < 2 {
-		t.Errorf("peak %d gateway command(s) in flight for %d gateways; the pass is serial, "+
-			"and every launch waits out all of it", peak, count)
-	}
-	if peak > gatewayFanout {
-		t.Errorf("peak %d in flight against a bound of %d; a pass that opens one exec per "+
-			"capsule trades a slow refresh for a slow daemon", peak, gatewayFanout)
+	// and neither says anything about the code.
+	//
+	// Exactly the bound, in both directions: fewer means the slots are
+	// not being filled and launches wait out more waves than they should,
+	// more means the bound is not holding at all.
+	if peak, want := d.peakInFlight(), gatewayFanout; peak != want {
+		t.Errorf("peak %d gateway command(s) in flight for %d gateways; want %d. "+
+			"Fewer means launches wait out more waves than they should; more means the "+
+			"bound is not holding, and a pass that opens one exec per capsule trades a "+
+			"slow refresh for a slow daemon", peak, count, want)
 	}
 }


### PR DESCRIPTION
## What changes

The three loops that walk gateways one at a time now fan out, bounded, so
a policy change's cost is the number of waves rather than the number of
gateways.

Said precisely, because the first version of this said it wrong: the exec
count is unchanged at one per gateway. What changed is how many are
outstanding at once, so a launch waits `ceil(N/8)` exec bounds instead of
`N`. At the parallelism where it mattered — thirty-two capsules, a
thirty-second bound — sixteen minutes becomes two.

## What was found

**The refresh pass's duration is a launch's worst-case wait, and it grew
with the parallelism the host was configured for.**

`reloadGateways` walked the gateways serially with a thirty-second bound
on each, holding `refreshMu` throughout. Every launch takes that same
lock, and it is a plain `sync.Mutex` — no context, nothing to give up, no
way to time out. The existing comment already said as much:

> The pass holds the refresh lock and every launch waits on that lock
> with a plain mutex, which takes no context of its own.

What it did not say is that there is one gateway per running capsule, so
the pass cost *N* × 30s where *N* is the live parallelism. At thirty-two
capsules that is sixteen minutes with nothing new able to start, for one
policy change — and the change most likely to trigger it, a redelivery
narrowing a capsule's allowances, is the one that happens under load.

**Two other loops have the same shape**, and both were left as they were
in the first version of this change until the symmetry list caught them:
`closeGateways` on the fail-closed path, and `applyPolicy`'s close of
every gateway that refused a restriction. The second is the worse of the
two — it runs when a restriction did not land, which means capsules can
still reach a denied address while it works through them one at a time.

**The order of what refused became nondeterministic.** The first version
sorted before returning; nothing reads that order — the one caller takes
a length and iterates order-blind — so the sort was a second mechanism
for a property already covered, and it is gone. The function documents
that the order is the daemon's and no caller may depend on it, and the
tests that compare the set sort what they compare.

## Symmetry check

| Path | Result |
|---|---|
| `reloadGateways` | the reported loop; fans out |
| `closeGateways` | same shape, same lock, fans out |
| `applyPolicy`'s close of the failed set | same shape; fans out, and it is the one that runs while a denial is not in force |
| `execGateway` | unchanged — it is the per-call bound, and the point is to pay it once rather than *N* times |
| `n.log` | `*slog.Logger` is safe for concurrent use; the calls inside the loops needed nothing |
| `failed` and the failure count | written from several goroutines now, so both are behind a mutex; the order is documented as the daemon's rather than normalised |
| `fakeSandboxDaemon` | appended to slices with no lock, which the race detector reported the moment the loops fanned out; it has a mutex and sorted accessors now |
| `monitor_test.go`'s close assertion | compared the close order; it reads the sorted accessor |
| `fakeObjects` (the sweep's fake) | untouched — the sweep is not fanned out, so its records stay ordered |

## Evidence

Three mutations:

```text
the fan-out is one (the serial pass)
  -> FAIL: the fan-out bound is 1, which is the serial pass with extra steps

the fan-out is unbounded (the slot channel removed)
  -> FAIL: peak 24 gateway command(s) in flight for 24 gateways; want 8

the bound is widened past the gateway count
  -> FAIL: this test needs more gateways (24) than the fan-out bound (64),
     or it cannot tell a bounded pass from an unbounded one
```

The middle one is the mechanism. The other two are checks on the knob the
assertion compares against, and they exist because without them the
assertion moved with the mutation: `peak == gatewayFanout` passes for a
fan-out of one, which is not a narrower tuning but the serial pass this
replaces. Two earlier tests in this codebase failed the same way — an
expected value that the thing under test also sets — and this is the
third, caught before merge rather than after.

What no mutation here settles is whether eight is the right width. That
is a judgement about how much a single daemon should be asked at once,
and a test cannot make it. For the record, the measurement: at a fan-out
of two the same work takes four times the waves — 0.50s against 0.12s in
the test, and at thirty-two capsules eight minutes against two. Eight is
chosen so the divisor is large enough to matter at any parallelism this
supports and small enough that a refresh cannot become the reason the
daemon is slow.

An earlier version of this test measured wall-clock time — 24 gateways at
40ms each, asserting the pass finished in under half the serial cost. It
passed on an idle machine, and the coverage gate, which runs the suite
instrumented, failed it. That is a machine-speed test: neither result
said anything about the code. It asserts overlap now, which is the
mechanism that produces the cost, and which is the same on any machine.

The race detector also earned its keep here: the fake daemon had been
appending to three slices with no lock since it was written, harmless
while every caller was serial.

## What would notice this regressing

- `TestARefreshPaysItsExecBoundsInParallel` fails on a serial pass, on an
  unbounded one, and on a bound too wide for its own fixture to observe.
  It also requires all 24 gateways to have been reloaded, so a pass that
  is cheap because it skipped work cannot pass for one that is cheap
  because it fanned out.
- `TestApplyPolicyCostsWhatTheChangeWas` and
  `TestRediscoverClosesEveryGatewayWhenDiscoveryFails` still hold what
  each change does and does not touch; both read sorted records now.
- `go test -race` over the package, which is what reported the fake's
  unsynchronized appends.

## Risk, compatibility and operations

**Up to eight gateway execs run at once where one did.** That is eight
`docker exec` calls into eight containers on one daemon. The daemon
serves them concurrently already — every launch does the same — and the
bound is what keeps a large host from turning a refresh into a
daemon-wide slowdown.

**A launch's worst-case wait for a policy change drops from N × 30s to
about ⌈N/8⌉ × 30s.** At the parallelism where it mattered, sixteen
minutes becomes about two.

**Failure handling is unchanged in kind.** The same gateways are
reloaded, the same ones reported as refusing, the same ones closed. What
changed is when, not which.

**Trust boundary: unchanged, and the fail-closed path is faster.** A
restriction that did not land is what triggers closing the affected
gateways, and that now happens in parallel rather than one at a time
while the denial is not in force.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous binary.

## Changelog

```text
### Changed
- An egress policy change now reaches every gateway concurrently. It
  previously reached them one at a time, holding the lock every launch
  waits on, so the pause before new jobs could start grew with the number
  of capsules running — at 32 in flight, about sixteen minutes.
```

## Notes for your reviewer

Two things this leaves for a later round, both pre-existing and neither
in scope: `docker.New` pings with `NegotiateAPIVersion` unset, so API
version negotiation is deferred to the first real request — single-
flighted, so not a bug, but with the fan-out that first request can now
be one of eight; and nothing asserts that `closeGateway` attempts
`gateway-deny-all` before removing the container, only that the removal
happens.

The number to argue with is the bound of eight. It is a guess about a
daemon, not a measurement: what is measured is that unbounded and serial
both fail the test, so the bound is somewhere between. Eight is enough
that the wait stops scaling with parallelism in any configuration this
supports, and small enough that a refresh cannot itself become the reason
the daemon is slow.

Worth knowing that the generic helper takes items rather than gateways,
so all three call sites share it. It is deliberately not an errgroup:
none of the three wants the first error to cancel the rest — a gateway
that refuses is data the caller acts on, not a reason to stop asking the
others — and each collects a different result, which errgroup does not
help with.
