### PR TITLE
docs(reference, adrs): the record describes the binding key and the shutdown budget the code uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,11 @@ by its public and operational effects.
   serve loops are waited out, the drain is spent, then every message
   session closes concurrently under one shared budget, so the bound does
   not grow with the binding count and the sessions are closed rather than
-  left for the next start to wait out. The periodic reconciler's recovery
+  left for the next start to wait out. An operator running their own
+  compose file rather than the one shipped here sizes the stop grace
+  period against that whole budget and not against the drain window: a
+  value between the two ends mid-shutdown, and the platform kills the
+  process with its message sessions still open. The periodic reconciler's recovery
   ends with that shutdown instead of running a budget of its own, because
   its work is resumable — the next start finds each lease where the
   shutdown left it. A

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -59,10 +59,13 @@ services:
       timeout: 5s
       retries: 3
       start_period: 30s
-    # Must exceed the controller's drain window, so the drain ends and the
-    # message sessions close before the platform kills the container. A
-    # session left open is one the next start waits out as a conflict.
-    # Anything still running is adopted on the next start.
+    # Must exceed the controller's ShutdownBudget, which is the whole of
+    # what a stop needs: stopping the loops, draining the capsules, and
+    # closing the message sessions. Sizing against the drain alone leaves
+    # a period that ends mid-shutdown, and the platform kills the
+    # container with sessions still open — which the next start waits out
+    # as a conflict, one per binding. Anything still running when the
+    # process goes is adopted on the next start.
     stop_grace_period: 150s
 
 volumes:

--- a/docs/adrs/2026-08-17-target-hosts-and-scopes.md
+++ b/docs/adrs/2026-08-17-target-hosts-and-scopes.md
@@ -76,3 +76,25 @@ at organization and repository scope.
 - A typo in a host no longer fails at configuration validation. It fails
   at `runpool doctor`, one step later, against the real service — which
   is where a wrong-but-well-formed host was always going to fail.
+
+## Amendment
+
+**Date:** 2026-08-19
+
+One sentence above is no longer true. "The lifecycle core keys on opaque
+provider identity and is unaffected" described the binding key as it was
+when this was written. It is now built from the configured target id, the
+runner group and the scale set name — the scope and the URL are not in
+it, and the target id is.
+
+What that changes for an operator: **renaming a `targets[].id` produces a
+different binding.** The new key matches no row, so a row is written for
+it, and the old row stays behind holding the scale set id that was
+registered under the old name. Nothing reconciles the two. A target id is
+therefore part of the binding's identity rather than a label on it, and
+renaming one is a migration.
+
+The decision this ADR records is unchanged: enterprise is a scope, the
+host is not the unit of refusal, and the rules that branch on scope are
+still runner groups and cache lanes. Only the claim about what the
+lifecycle keys on was wrong.

--- a/docs/adrs/2026-08-17-target-hosts-and-scopes.md
+++ b/docs/adrs/2026-08-17-target-hosts-and-scopes.md
@@ -88,11 +88,30 @@ runner group and the scale set name — the scope and the URL are not in
 it, and the target id is.
 
 What that changes for an operator: **renaming a `targets[].id` produces a
-different binding.** The new key matches no row, so a row is written for
-it, and the old row stays behind holding the scale set id that was
-registered under the old name. Nothing reconciles the two. A target id is
-therefore part of the binding's identity rather than a label on it, and
-renaming one is a migration.
+different binding, and the old one is forgotten on the same startup.**
+
+The new key matches no row, so a row is written for it. The old row is
+then unclaimed, and `ForgetUnclaimedBindings` deletes it along with the
+adapter metadata holding the scale set id registered under the old name.
+The one exception is a binding that still holds deliveries: forgetting it
+would orphan the attempts hanging off them, so it is kept.
+
+The visible consequence is a refusal, not a silent duplicate. The new
+binding has no record of the scale set, which still exists at the
+provider under the unchanged name, so the first pass refuses to adopt it:
+
+> scale set %q already exists in runner group %q (id %d) and this
+> instance has no record of creating it
+
+That pass writes its intention, so the next one adopts and the binding
+serves. What does not come back is that binding's contact history, and a
+`scaleSetName` rename is worse than a `targets[].id` one: `runpool
+uninstall --delete-scale-sets` names the sets to remove from the binding
+rows, so the set under the old name is orphaned at the provider and the
+only local record of it is gone.
+
+A target id is therefore part of the binding's identity rather than a
+label on it, and renaming one is a migration.
 
 The decision this ADR records is unchanged: enterprise is a scope, the
 host is not the unit of refusal, and the rules that branch on scope are

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -55,14 +55,15 @@ absent state, because the attempt it was asked about cannot exist.
 | `disk_pressure` | object or null | `level`, `free_bytes`, `free_inodes`, `managed_bytes`, `measured_at` |
 | `bindings` | array | `target_id`, `provider_kind`, `source_binding_key`, and the provider reach fields below |
 | `leases` | array | `id`, `state`, `terminal`, `attempt_id`, `project`, `runtime_name`, `evidence`, `created_at`, `resources[]`. Every live lease, plus recent finished ones — see below |
+| `leases[].resources` | array | What the lease owns on the daemon: `kind`, `role`, `name`, `lease_id`, and `state` — one of `planned`, `creating`, `present`, `cleanup_pending`, `deleting`, which is the books' account of the object rather than the daemon's |
 | `released_total` | number | How many finished leases the store holds, which is more than the `leases` array carries |
 | `cache_lanes` | array | `id`, `source_project_key`, `generation`, `leased_by`, `last_used` |
 | `manual_review` | array | Attempts held for a person: `id`, `workload`, `project`, `state`, `review_reason`, `age_seconds`, and once resolved `resolution` and `reviewed_by` |
 | `containers` | array | Owned containers: `name`, `role`, `lease_id`, `running` |
-| `networks`, `volumes` | array | Owned objects: `kind`, `role`, `name`, `lease_id` |
+| `networks`, `volumes` | array | Owned objects: `kind`, `role`, `name`, `lease_id`. No `state` — it is recorded per lease, and these are reported from the daemon |
 | `discrepancies` | array or null | Where the books and the daemon disagree; `null` if the daemon could not be asked |
 | `docker_error` | string, optional | Why the daemon could not be asked |
-| `capsule_image_error` | string, optional | Why the capsule image could not be resolved. Present means the `capsule_image` on every tier is what this build ships, not what a launch would run |
+| `capsule_image_error` | string, optional | Why the shipped capsule image could not be resolved. It concerns only the tiers that name no `capsule_image` of their own: those report what the build ships rather than what a launch would run, while a tier naming its own image reports that one |
 
 Each binding reports what its own loop last managed with its provider:
 `last_contact_at` when a provider call last succeeded, and `last_error`
@@ -119,9 +120,12 @@ knowing what any of it means.
 
 One consequence an operator needs, because it is not visible from the
 key: renaming a `targets[].id` in configuration produces a different
-binding. The new key has no row, so a new one is written and the old row
-is left behind holding the scale set id that was registered under it. It
-is a rename of the binding, not of a label on it.
+binding, and the old one is forgotten on the same startup — with the
+scale set id recorded against it. The renamed binding then meets a
+refusal on its first pass, adopts on the next, and does not get its
+contact history back. It is a rename of the binding, not of a label on
+it; `docs/adrs/2026-08-17-target-hosts-and-scopes.md` has the whole of
+it.
 
 Lease states are `reserved`, `provisioning`, `runtime_registered`,
 `workload_running`, `draining`, `cleaning`, `released`, `failed`,

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -62,6 +62,7 @@ absent state, because the attempt it was asked about cannot exist.
 | `networks`, `volumes` | array | Owned objects: `kind`, `role`, `name`, `lease_id` |
 | `discrepancies` | array or null | Where the books and the daemon disagree; `null` if the daemon could not be asked |
 | `docker_error` | string, optional | Why the daemon could not be asked |
+| `capsule_image_error` | string, optional | Why the capsule image could not be resolved. Present means the `capsule_image` on every tier is what this build ships, not what a launch would run |
 
 Each binding reports what its own loop last managed with its provider:
 `last_contact_at` when a provider call last succeeded, and `last_error`
@@ -111,10 +112,16 @@ whose length is what the document reports and not what exists.
 
 The document is provider neutral, and deliberately so: a consumer that
 parses `source_binding_key` is reading the wrong document. It is the
-provider's own identity, versioned and opaque here; for a GitHub Actions
-binding it reads as scope, URL, runner group and scale set name, which
-is enough to tell two bindings apart without knowing what any of it
-means.
+binding's own identity, versioned and opaque here; for a GitHub Actions
+binding it is built from the configured target id, the runner group and
+the scale set name, which is enough to tell two bindings apart without
+knowing what any of it means.
+
+One consequence an operator needs, because it is not visible from the
+key: renaming a `targets[].id` in configuration produces a different
+binding. The new key has no row, so a new one is written and the old row
+is left behind holding the scale set id that was registered under it. It
+is a rename of the binding, not of a label on it.
 
 Lease states are `reserved`, `provisioning`, `runtime_registered`,
 `workload_running`, `draining`, `cleaning`, `released`, `failed`,

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -124,6 +124,12 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 	// What configuration no longer claims is forgotten. A renamed scale
 	// set or a removed tier leaves a row nothing serves, and the report
 	// carries it forever with no command that removes it.
+	//
+	// A binding that still holds deliveries is kept: forgetting it would
+	// orphan the attempts hanging off those rows. Everything else goes,
+	// including the recorded scale set id — which is why a rename is a
+	// migration rather than an edit, and why sourceBindingKey's own
+	// documentation says what a moved key costs.
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 		forgotten, err := tx.ForgetUnclaimedBindings(claimed)
 		if err != nil {
@@ -145,10 +151,13 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 // It is built from what an operator configured and never from a parsed
 // form of the target's URL. A key carrying the parsed scope and the
 // canonical URL moves whenever the parser changes how it reads an
-// address a deployment did not touch — and a moved key is a second row
-// beside the first, with the original left in `status` for good and
-// nothing that removes it. Scope and canonical URL still travel, in the
-// adapter's own metadata, which is where provider identity belongs.
+// address a deployment did not touch, and a key that moves is a rename:
+// the new one matches no row, so a row is written for it, and the old
+// one is forgotten by ForgetUnclaimedBindings on the same startup —
+// taking the scale set id recorded against it. The next pass then has to
+// adopt a set it has no record of creating, which is a refusal before it
+// is an adoption. Scope and canonical URL still travel, in the adapter's
+// own metadata, which is where provider identity belongs.
 func sourceBindingKey(target config.Target, scaleSetName string) string {
 	return fmt.Sprintf("v2|%s|%s|%s", target.ID, target.RunnerGroup, scaleSetName)
 }

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -66,8 +66,10 @@ type statusDoc struct {
 	Discrepancies []string `json:"discrepancies"`
 	DockerError   string   `json:"docker_error,omitempty"`
 	// CapsuleImageError explains a capsule image this command could not
-	// resolve. The tier entries then carry whatever the build ships, so
-	// this is what tells a reader those are not the images a launch would
+	// resolve. It is about the shipped default only: a tier naming its
+	// own capsule_image reports that one, and a launch would run it. The
+	// tiers that name none carry the build's reference instead, so this
+	// is what tells a reader those are not the images a launch would
 	// run — the alternative, refusing to answer at all, took every other
 	// fact in this document down with one unset environment variable.
 	CapsuleImageError string `json:"capsule_image_error,omitempty"`

--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -90,6 +90,18 @@ var narrowDeps = map[string][]string{
 		module + "/internal/egress",
 		module + "/internal/platform/docker",
 	},
+	// The gateway is the one process a capsule's traffic passes through,
+	// and it runs from the capsule image rather than the controller
+	// binary. What it may know is the policy vocabulary it enforces, the
+	// control protocol it answers on, and the file replacement its
+	// installs need — never the store, the lease machine or an adapter.
+	// A relay that could reach the books is a relay that can be made to
+	// answer a question instead of forwarding a packet.
+	module + "/internal/gateway": {
+		module + "/internal/capsule/protocol",
+		module + "/internal/egress",
+		module + "/internal/platform/atomicfile",
+	},
 }
 
 func deps(t *testing.T, pkg string) map[string]bool {


### PR DESCRIPTION
## What changes

Four places where the written record described behaviour the code does
not have, and one import set that had grown two edges with nothing
holding it. No behaviour change.

## What was found

**The binding key is documented as something it is not.** The status
reference says it "reads as scope, URL, runner group and scale set name".
The code builds it from the configured target id, the runner group and
the scale set name:

```go
func sourceBindingKey(target config.Target, scaleSetName string) string {
	return fmt.Sprintf("v2|%s|%s|%s", target.ID, target.RunnerGroup, scaleSetName)
}
```

The scope and the URL are not in it. The target id is, and that carries a
consequence an operator cannot see from the key: **renaming a
`targets[].id` produces a different binding, and the old one is forgotten
on the same startup.**

The first version of this change said the opposite — that the old row
stays behind with nothing that removes it. `ForgetUnclaimedBindings`
deletes it, along with the adapter metadata holding the scale set id, and
keeps only a binding that still holds deliveries, because forgetting that
one would orphan the attempts hanging off them.

That false claim was copied from a comment on `sourceBindingKey` saying a
moved key leaves "the original left in `status` for good and nothing that
removes it" — twenty lines below the call that removes it. Correcting the
documents without correcting the comment would have left the trap in
place for whoever reads it next, so it is corrected too.

**And the visible consequence is a refusal, not a silent duplicate.** The
new binding has no record of a scale set that still exists at the
provider under the unchanged name, so `EnsureScaleSet` takes its refusal
branch:

> scale set %q already exists in runner group %q (id %d) and this
> instance has no record of creating it

That pass writes its intention, so the next one adopts and the binding
serves. What does not come back is the binding's contact history. And a
`scaleSetName` rename is worse than a `targets[].id` one: `runpool
uninstall --delete-scale-sets` names the sets to remove from the binding
rows, so the set under the old name is orphaned at the provider while the
only local record of it is deleted.

**An ADR states a property the same change removed.** `2026-08-17
target-hosts-and-scopes` says "the lifecycle core keys on opaque provider
identity and is unaffected". That was true when it was written. It
carries a dated amendment correcting the sentence, saying what an
operator has to do about it, and stating that the decision the ADR
records — enterprise is a scope, the host is not the unit of refusal — is
unchanged. Amending rather than editing, because the record of what was
decided and why is the point of keeping one.

**`capsule_image_error` is emitted and appears in no table.** Added — and
narrower than the first version of this row said. It concerns the shipped
default only: a tier naming its own `capsule_image` reports that image,
and a launch would run it. Only the tiers naming none fall back to the
build's reference. The overstatement came from the field's own Go
comment, which is corrected with it.

**`leases[].resources[].state` is emitted and documented nowhere.** It is
always present — `NOT NULL DEFAULT 'planned'` over `planned`, `creating`,
`present`, `cleanup_pending`, `deleting` — and it is the books' account
of the object rather than the daemon's. The `networks` and `volumes`
arrays carry the same shape without it, which is what made the omission
easy to miss and easy to apply to the wrong array.

**The compose file's rule produces a value that fails.** It said the stop
grace period must exceed "the controller's drain window". The drain is
one of three terms — the loops are stopped, the drain is spent, then the
message sessions close — and `ShutdownBudget` is their sum. An operator
following the rule sizes against 60s, picks something like 90s, and the
platform kills the process mid-shutdown with its message sessions still
open, which the next start waits out as a conflict, one per binding. The
shipped value (150s) was always above the real budget (120s); the rule
beside it was the wrong one. It names `ShutdownBudget` now, and the
changelog says the same for an operator running their own file.

**The gateway's imports were unpinned.** `narrowDeps` fixes the exact
direct-import set of the packages whose weight is a property rather than
an accident. The gateway was not among them, and it has since acquired
edges to `capsule/protocol` and `platform/atomicfile`. It is the one
process a capsule's traffic passes through, and it ships inside the
capsule image rather than the controller binary, so what it may know is
the policy vocabulary it enforces, the control protocol it answers on,
and the file replacement its installs need. A relay that could reach the
books is a relay that can be made to answer a question instead of
forwarding a packet.

## Symmetry check

| Path | Result |
|---|---|
| `desired_state` | the round's inventory said to remove it from the status reference; it is not there. Its only occurrence anywhere is the changelog entry recording its removal, which is correct content — checked case-insensitively across the repository |
| the other `narrowDeps` entries | `config`, `lease`, `doctor`, `capsule` — all still exact; the gateway was the gap |
| `internal/store`, `internal/cache` | still `corePackages` only, deliberately: neither has a knowledge boundary the way the gateway does |
| the two `"v2\|"` version literals | unchanged and still unnamed; that is recorded debt for a later round, not something a documentation change should touch |
| every other claim in the status reference | the pre-serve shape now matches the code exactly, which the previous change made true; the lease-state list and the evidence ladder were checked against their Go declarations |
| the compose file's other bounds | `healthcheck` intervals and `start_period` describe themselves and do not restate a controller constant |

## Evidence

```text
mutation: drop one edge from the gateway's pinned set
  -> --- FAIL: TestNarrowPackagesStayNarrow
```

That is the only executable claim here. Everything else was checked by
reading the code that produces the behaviour, and the first version of
this change proves how little that is worth on its own: the central claim
was copied from a stale comment and was the exact inverse of what
`ForgetUnclaimedBindings` does. The corrected claims were traced through
`buildBindings` to `ForgetUnclaimedBindings` to `ensureScaleSet` to
`EnsureScaleSet`'s refusal branch, and the two-pass behaviour read off
`intended = recorded`.

The shutdown arithmetic came out of `serve.go`:
`ShutdownBudget = LoopStopBudget + DrainTimeout + SessionCloseBudget`,
which is 45s + 60s + 15s = 120s against a documented rule that would have
produced anything over 60s.

## What would notice this regressing

- `TestNarrowPackagesStayNarrow` fails if the gateway gains or loses a
  direct internal import without the set being updated to say so.
- The doc-links and document-reference gates already fail on a broken
  link or a reference to a document that does not exist; both are green.
- Nothing test-shaped guards the prose itself. Said plainly rather than
  implied: a future change that alters the binding key again will not be
  caught by a test, and the ADR amendment exists partly so the next
  person reads why the key is what it is before changing it. The first
  version of this change is the evidence for that — it stated the exact
  opposite of the code and every gate passed.

## Risk, compatibility and operations

**No behaviour changes.** No Go file outside a test is touched.

**One operator-facing correction.** Anyone who sized a stop grace period
from the old compose comment has a value that can end mid-shutdown. The
changelog entry says what to size it against instead.

**Schema, migrations, trust boundary, credentials, CLI, configuration,
status API: untouched.** The status document's shape is unchanged; only
its description of two fields is.

## Changelog

```text
The compose note is added to the existing shutdown entry rather than as a
new one: it is the same behaviour, described correctly for an operator
who does not use the file shipped here.
```

## Notes for your reviewer

The judgement here is amending the ADR rather than editing the sentence.
An ADR records what was decided and why, so a sentence that was true when
written and is false now is history rather than a mistake — editing it
would erase the fact that the property was once relied on. The amendment
is dated, says which sentence it corrects, and says what did not change.

Worth checking hardest: whether the rename consequence is now right. The
first version was inverted, and it was inverted because it trusted a
comment instead of the call twenty lines above it. What it says now was
traced end to end — the delete, the exception for a binding holding
deliveries, the refusal on the first pass, the adoption on the second —
but this is prose, and prose is the part no gate checks.
