### PR TITLE
test(app): the retry test waits for the retry instead of sleeping through it

### DIFF
--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -163,14 +163,26 @@ func TestAnUnreachableProviderDoesNotSpendTheQueue(t *testing.T) {
 		h.srv.loop(ctx, h.bind)
 	}()
 	<-tried
-	// Long enough for many passes: the defect spent a serving per pass.
-	time.Sleep(50 * time.Millisecond)
+	// Wait for the second pass rather than sleeping a window and hoping
+	// one fits. The backoff is a millisecond, but a loop under the race
+	// detector and coverage instrumentation on a loaded machine can take
+	// far longer than that, and this asked for two passes inside fifty —
+	// so the failure it reported was the machine's, not the loop's. A
+	// window wide enough for the slowest machine would be dead time on
+	// every other run; waiting for the thing itself is neither.
+	retried := time.After(10 * time.Second)
+	for attempts.Load() < 2 {
+		select {
+		case <-retried:
+			cancel()
+			<-stopped
+			t.Fatalf("the loop tried the provider %d time(s) in ten seconds; "+
+				"the outage has to keep it retrying", attempts.Load())
+		case <-time.After(time.Millisecond):
+		}
+	}
 	cancel()
 	<-stopped
-
-	if attempts.Load() < 2 {
-		t.Fatalf("the loop tried the provider %d times; the test needs it to keep retrying", attempts.Load())
-	}
 	if got := len(h.ready()); got != 2 {
 		t.Errorf("%d attempts still queued, want 2: the outage spent them", got)
 	}


### PR DESCRIPTION
## What changes

One test stops asserting that a fixed window was long enough, and waits
for the thing it is about instead.

## What was found

**A test failed in CI for a fact about the machine.**

```text
--- FAIL: TestAnUnreachableProviderDoesNotSpendTheQueue (0.47s)
    bindings_test.go:172: the loop tried the provider 1 times; the test needs it to keep retrying
```

`TestAnUnreachableProviderDoesNotSpendTheQueue` waits for the provider's
first refusal, sleeps 50ms, cancels, and then requires `attempts >= 2`.
The loop's backoff is set to a millisecond, so the window holds about
fifty passes on an idle machine — and guarantees none. Under `-race` with
coverage instrumentation on a loaded runner, one pass fit.

The property the test exists for is real and unchanged: an outage must
keep the loop retrying without spending the queued attempts. What was
wrong is asserting it by sleeping.

## Symmetry check

| Shape | Result |
|---|---|
| `bindings_test.go:245,253` | sleeps to separate two timestamps, then asserts a recorded moment moved or did not. A slower machine widens the gap, which is the direction that keeps it passing |
| `gateway/policy_test.go` mtime sleeps | same shape, same reason |
| `platform/docker/exec_test.go:79-86` | already polls against a two-second deadline and returns as soon as the condition holds — this shape done right |
| `fault_test.go:741` | sleeps 100ms then cancels, and asserts elapsed is under a 45s budget. An upper bound with a 450x margin, not a race for a count |
| `test/contract/capsule` | polling loops with deadlines throughout |

One instance, no siblings.

## Evidence

The CI log above is the reproduction, on the machine where it matters. It
does not reproduce locally — this laptop is not loaded enough — so the
mechanism is isolated instead, by shortening the window the old shape
leaned on:

```text
the shape that was there, with the window shortened to nothing
  -> --- FAIL: the loop tried the provider 1 times; the test needs it to keep retrying

the shape now, with no window at all to lean on
  -> ok (4 runs)
```

That is the whole of the defect: the assertion's outcome was a function
of how much progress fit in a sleep.

## What would notice this regressing

- The test itself now fails only if the loop genuinely stops retrying,
  and says so — ten seconds is long enough that reaching it means the
  loop, not the machine.
- Nothing guards against a new test being written in the old shape. Said
  plainly rather than implied.

## Risk, compatibility and operations

**No production code is touched.** One test file.

**The test gets slower only when it is about to fail.** On a passing run
it returns as soon as the second attempt lands, which is sooner than the
50ms it used to sleep unconditionally.

## Changelog

```text
NONE - a test-only change with no product effect.
```

## Notes for your reviewer

Worth knowing why this is its own change rather than folded into the
documentation branch it blocked: it is a different area with a different
failure, and the branch it blocked touches no Go outside two comments.
Landing it separately keeps the reason each change exists legible.