### PR TITLE
fix(app, store): closing a gateway bounds its removal, and one list says what states an attempt can hold

### DIFF
--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -450,17 +450,19 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 	return failed, nil
 }
 
-// gatewayExecTimeout bounds one gateway control exec, so a refresh pass
-// costs at most one of these per gateway rather than an unknown amount.
-// The pass holds the refresh lock and every launch waits on that lock
-// with a plain mutex, which takes no context of its own.
-const gatewayExecTimeout = 30 * time.Second
+// gatewayControlTimeout bounds one gateway control operation — an exec
+// into it, or its removal — so a refresh pass costs a known number of
+// these rather than an unknown amount. The pass holds the refresh lock
+// and every launch waits on that lock with a plain mutex, which takes no
+// context of its own, so anything unbounded under it is unbounded for
+// every launch on the host.
+const gatewayControlTimeout = 30 * time.Second
 
 // execGateway runs one gateway control command under its own bound.
 func (n *networkSandbox) execGateway(ctx context.Context,
 	call func(context.Context) (int, string, error)) (int, string, error) {
 
-	ctx, cancel := context.WithTimeout(ctx, gatewayExecTimeout)
+	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
 	defer cancel()
 	return call(ctx)
 }
@@ -483,6 +485,18 @@ func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) e
 		n.log.Error("gateway deny-all failed; removing the gateway",
 			"container", containerID, "exit", code, "error", err, "output", out)
 	}
+	// Bounded like the exec above it, and for the same reason. This runs
+	// under the refresh lock, and every launch waits on that lock with a
+	// plain mutex that takes no context: a daemon that accepts the
+	// removal and then answers nothing would hold it for the life of the
+	// process, and no launch could time out of it. That is the failure
+	// the fan-out above exists to bound, and leaving it here left it in
+	// the same function.
+	//
+	// A removal that cannot be confirmed is reported. The gateway is
+	// still there, so the next pass finds it and closes it again.
+	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
+	defer cancel()
 	return n.daemon.RemoveContainer(ctx, containerID)
 }
 

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -112,8 +112,12 @@ type fakeSandboxDaemon struct {
 	mu       sync.Mutex
 	inFlight int
 	peak     int
-	reloaded []string
-	removed  []string
+	// removeDeadline is the bound a container removal ran under, which
+	// is where an unbounded one would otherwise be invisible.
+	removeDeadline time.Time
+	removeBounded  bool
+	reloaded       []string
+	removed        []string
 }
 
 // serve models one gateway control command occupying the daemon for as
@@ -200,7 +204,10 @@ func (f *fakeSandboxDaemon) ExecWithInput(_ context.Context, id string, _ []stri
 	f.note(&f.reloaded, id)
 	return 0, "", nil
 }
-func (f *fakeSandboxDaemon) RemoveContainer(_ context.Context, id string) error {
+func (f *fakeSandboxDaemon) RemoveContainer(ctx context.Context, id string) error {
+	f.mu.Lock()
+	f.removeDeadline, f.removeBounded = ctx.Deadline()
+	f.mu.Unlock()
 	f.serve()
 	f.note(&f.removed, id)
 	return nil
@@ -531,5 +538,43 @@ func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 			"Fewer means launches wait out more waves than they should; more means the "+
 			"bound is not holding, and a pass that opens one exec per capsule trades a "+
 			"slow refresh for a slow daemon", peak, count, want)
+	}
+}
+
+// TestClosingAGatewayIsBoundedInBothSteps: closing a gateway bounds its
+// removal, not only the exec that precedes it.
+//
+// Both steps run under the refresh lock, and every launch waits on that
+// lock with a plain mutex — no context, nothing to give up, no way to
+// time out. A daemon that accepts a container removal and then answers
+// nothing is an ordinary failure, and an unbounded one there holds that
+// lock for the life of the process while every launch on the host blocks
+// behind it. Bounding the exec and not the removal left that in the same
+// function as the bound.
+func TestClosingAGatewayIsBoundedInBothSteps(t *testing.T) {
+	d := &fakeSandboxDaemon{containers: []docker.OwnedContainer{
+		{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
+	}}
+	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
+
+	// A context with no deadline of its own, which is what the watch
+	// loop hands this path.
+	if err := n.closeGateway(context.Background(), "gw-1"); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if !slices.Equal(d.removes(), []string{"gw-1"}) {
+		t.Fatalf("removed %v; want gw-1", d.removes())
+	}
+
+	d.mu.Lock()
+	bounded, deadline := d.removeBounded, d.removeDeadline
+	d.mu.Unlock()
+	if !bounded {
+		t.Fatal("the removal ran on a context with no deadline; a daemon that stops " +
+			"answering holds the refresh lock, and every launch waits on it uninterruptibly")
+	}
+	if left := time.Until(deadline); left <= 0 || left > gatewayControlTimeout {
+		t.Errorf("the removal had %v left; want a positive bound no larger than %v",
+			left, gatewayControlTimeout)
 	}
 }

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -576,14 +576,6 @@ func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
 	}
 }
 
-// attemptStates is every state an attempt can hold, terminal ones
-// included. It is the domain the test below filters, so the test states
-// the question and the predicate states the answer.
-var attemptStates = []string{
-	"ready", "leased", "preparing", "prepared", "starting", "running",
-	"superseded", "settled", "canceled", "manual_review",
-}
-
 // TestEveryServingStateCanBeDisposedOf: no disposition this decision can
 // reach fails to match a row.
 //
@@ -595,13 +587,16 @@ var attemptStates = []string{
 // lease already in cleaning cannot move there again, so no later pass
 // recovers it.
 //
-// The states walked come from the predicate itself, not from a list
-// beside it: a state added to the serving set is disposed of here
-// whether or not anyone remembers this test. One the fixture cannot
-// drive to fails in advanceAttemptTo, which names it.
+// The states walked are the store's own list filtered through the
+// predicate, so neither side of the question is restated here: the
+// domain comes from store.AllAttemptStates, which its own test holds
+// against the schema's constraint, and the answer comes from
+// servedByThisLease. A state added to the serving set is disposed of
+// here whether or not anyone remembers this test, and one the fixture
+// cannot drive to fails in advanceAttemptTo, which names it.
 func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
 	var walked int
-	for _, state := range attemptStates {
+	for _, state := range store.AllAttemptStates {
 		if !servedByThisLease(state) {
 			continue
 		}

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -13,6 +13,21 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 )
 
+// AllAttemptStates lists every state an attempt can hold, terminal ones
+// included, in the order the walk reaches them.
+//
+// It exists for the reason AllLeaseStates does. Anything that has to
+// decide something for every state — a disposition, a report, a table
+// test — needs the list to come from one place, or a state added later
+// is quietly left undecided by whichever copy nobody updated.
+// TestAttemptStatesCoverTheSchema holds it against the constraint the
+// database enforces, so the list cannot drift from what a row may
+// actually contain.
+var AllAttemptStates = []string{
+	"ready", "leased", "preparing", "prepared", "starting", "running",
+	"manual_review", "superseded", "settled", "canceled",
+}
+
 // Attempt is the store's domain-facing view of one attempt row. It is a
 // translation, not the generated row: consumers never see table types,
 // so a schema change stops at this boundary.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1524,27 +1524,15 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 		{"manual_review", false, "held for a person who has not decided yet"},
 	}
 
-	// The universe comes from the schema, not from beside the table.
-	schema, err := migrationsFS.ReadFile("migrations/000001_initial.up.sql")
-	if err != nil {
-		t.Fatal(err)
-	}
+	// The universe comes from the one list, which its own test holds
+	// against the schema.
 	decided := make(map[string]bool, len(cases))
 	for _, c := range cases {
 		decided[c.state] = true
 	}
-	body := string(schema)
-	start := strings.Index(body, "CHECK (state IN ('ready'")
-	if start < 0 {
-		t.Fatal("the attempt state CHECK constraint moved; this test can no longer prove it is total")
-	}
-	constraint := body[start : start+strings.Index(body[start:], "))")]
-	for _, state := range strings.Split(constraint, "'") {
-		if len(state) == 0 || strings.ContainsAny(state, "(), \n\t") || state == "CHECK " {
-			continue
-		}
+	for _, state := range AllAttemptStates {
 		if !decided[state] {
-			t.Errorf("the schema allows attempt state %q and this test decides nothing about it", state)
+			t.Errorf("an attempt can be %q and this test decides nothing about starting it", state)
 		}
 	}
 
@@ -1759,5 +1747,44 @@ func TestTheSetReadAgreesWithTheGeneratedQuery(t *testing.T) {
 
 	if generated != set {
 		t.Errorf("the two projections disagree:\n generated: %+v\n set read:  %+v", generated, set)
+	}
+}
+
+// TestAttemptStatesCoverTheSchema: the list every caller decides from is
+// the set the database actually allows.
+//
+// A list beside a constraint is a list that drifts from it, and the
+// drift is silent in the direction that matters: a state the schema
+// gains and the list does not is a state every table test skips while
+// reporting itself total.
+func TestAttemptStatesCoverTheSchema(t *testing.T) {
+	schema, err := migrationsFS.ReadFile("migrations/000001_initial.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(schema)
+	start := strings.Index(body, "CHECK (state IN ('ready'")
+	if start < 0 {
+		t.Fatal("the attempt state CHECK constraint moved; this test can no longer find it")
+	}
+	constraint := body[start : start+strings.Index(body[start:], "))")]
+
+	listed := make(map[string]bool, len(AllAttemptStates))
+	for _, s := range AllAttemptStates {
+		listed[s] = true
+	}
+	found := 0
+	for _, state := range strings.Split(constraint, "'") {
+		if len(state) == 0 || strings.ContainsAny(state, "(), \n\t") || state == "CHECK " {
+			continue
+		}
+		found++
+		if !listed[state] {
+			t.Errorf("the schema allows attempt state %q and AllAttemptStates omits it", state)
+		}
+	}
+	if found != len(AllAttemptStates) {
+		t.Errorf("the constraint names %d states and AllAttemptStates has %d; "+
+			"one of them lists something the other does not", found, len(AllAttemptStates))
 	}
 }


### PR DESCRIPTION
## What changes

Two things the last round left half-done, both in the shape that round
was written to break: a rule applied to one of two paths, and a guard
that states a property it does not have.

## What was found

**The bound was added to the exec and not to the removal beside it.**

```go
func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) error {
	code, out, err := n.execGateway(ctx, ...)   // bounded
	...
	return n.daemon.RemoveContainer(ctx, containerID)   // not
}
```

Both steps run under `refreshMu`, which `refresh` holds across
`applyPolicy`, and every launch waits on it through `forLaunch` with a
plain `Lock()` — no context, nothing to give up. The path that reaches
this from the watch loop hands it a context with no deadline of its own.

So: a rediscovery classifies a change as a restriction, a gateway
refuses the new policy, and the daemon accepts the container removal and
then answers nothing — the ordinary reason `docker rm` hangs. The refresh
lock is held for the life of the process and **every capsule launch on
the host blocks behind it, uninterruptibly.** That is precisely the
failure the bounded fan-out in this file was added to prevent, left in
the same function as the bound.

The constant is `gatewayControlTimeout` now, because it bounds two kinds
of gateway control operation rather than one.

**A totality guard walked a list beside the predicate while saying it did
not.** `TestEveryServingStateCanBeDisposedOf` said:

> The states walked come from the predicate itself, not from a list
> beside it: a state added to the serving set is disposed of here whether
> or not anyone remembers this test.

It walked `attemptStates` — a hand copy of the schema's `CHECK`, used
nowhere else — and filtered that through the predicate. A state added to
`servedByThisLease` but absent from the copy was skipped in silence, and
`walked == 0` only fires if the predicate admits nothing at all. The one
divergence the guard exists to catch is the one it could not see.

**Attempt states had no canonical list.** Lease states have
`AllLeaseStates` and a test that holds it against the machine. Attempt
states had a copy in the lease suite and a private schema parse in the
store suite — two places, neither authoritative. `AllAttemptStates` sits
beside `AllLeaseStates` now; the schema check belongs to the list rather
than to one of its callers, and both the disposition guard and the start
authorization table read from it.

## Symmetry check

| Path | Result |
|---|---|
| `closeGateway`'s two steps | exec was bounded, removal was not; both are now |
| `closeGateways` and `applyPolicy`'s failed loop | both reach `closeGateway`, so both inherit the bound |
| `execGateway`'s other callers | `reloadGateways` only, already bounded and unchanged |
| `build()` → `discoverHostCIDRs` → `RunTask` | also unbounded under the same lock, and older than this round — recorded as debt rather than folded in here |
| `AllLeaseStates` | already canonical with its own test; this is the missing half of that pair |
| the two former copies of the attempt states | the lease suite's `attemptStates` and the store suite's private parse — both gone, both now read the list |
| `Attempt.State`'s type | still `string`, so the list is `[]string`; typing it is recorded debt and not a documentation change's business |

## Evidence

```text
the removal loses its bound again
  -> --- FAIL: TestClosingAGatewayIsBoundedInBothSteps
     the removal ran on a context with no deadline; a daemon that stops answering
     holds the refresh lock, and every launch waits on it uninterruptibly

a state the schema allows is dropped from the canonical list
  -> --- FAIL: TestAttemptStatesCoverTheSchema
     the schema allows attempt state "canceled" and AllAttemptStates omits it
     the constraint names 10 states and AllAttemptStates has 9
```

And the drift itself, demonstrated rather than argued — the same mutation
against both shapes of the guard:

```text
put "ready" back in the serving set

  walking the hand-written list  -> ok        (the guard sees nothing)
  walking AllAttemptStates       -> FAIL      (the guard sees it)
```

## What would notice this regressing

- `TestClosingAGatewayIsBoundedInBothSteps` passes a context with no
  deadline, which is what the watch loop passes, and requires the removal
  to have one anyway.
- `TestAttemptStatesCoverTheSchema` fails in both directions: a state the
  schema gains, and a state the list has that the schema does not.
- `TestEveryServingStateCanBeDisposedOf` now fails when the serving set
  gains a state no requeue guard accepts, which is what it always said it
  did.

## Risk, compatibility and operations

**A gateway removal that takes longer than 30 seconds now fails instead
of blocking.** The gateway is still there, the failure is logged, and the
next pass finds it and closes it again — where before, nothing on the
host could start until the daemon answered.

**No other behaviour changes.** `AllAttemptStates` is a new exported list
with no caller outside tests; the schema, the queries and the disposition
logic are untouched.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous binary.

## Changelog

```text
### Fixed
- Closing an egress gateway now bounds the container removal as well as
  the command that precedes it. A Docker daemon that accepted the removal
  and stopped answering would otherwise hold the lock every capsule
  launch waits on, for as long as the controller ran.
```

## Notes for your reviewer

Worth checking hardest: whether 30 seconds is the right bound for a
removal, given it is also the exec bound and `closeGateway` does both, so
the function's worst case is 60 seconds under the refresh lock. The
argument for one constant is that both are the same kind of thing — one
request to the local daemon about one container — and that a bound is
about the daemon not answering rather than about how long the work takes.

One thing deliberately left: `build()` reaches `RunTask` under the same
lock with no bound, which is the same shape and older than this round. It
is recorded rather than folded in, because it needs its own reasoning
about what a probe that never answers should cost.