### PR TITLE
fix(app, capsule): nothing under the refresh lock is unbounded, and a doc comment sits on what it names

### DIFF
--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -87,7 +87,7 @@ func main() {
 			os.Exit(runGateway(log))
 		case "gateway-reload":
 			os.Exit(runGatewayReload())
-		case "gateway-deny-all":
+		case protocol.GatewayDenyAllCommand:
 			os.Exit(runGatewayDenyAll())
 		}
 		os.Exit(runSubcommand(os.Args[1:]))

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -502,11 +502,6 @@ func (s *Controller) scheduleReadyAttempts(ctx context.Context, b *binding) {
 	}
 }
 
-// announce tells the broker this binding's current credit, and logs the
-// tier's whole accounting when the number changes. A binding announcing
-// zero is the question an operator will ask about, and the answer —
-// who holds the discovery credit, who has demand, who is running — is
-// only meaningful as the pool's state, not the binding's.
 // backoff is the pause between failed polls. Held on the controller so a
 // test can exercise the failure run without waiting out real seconds.
 func (s *Controller) backoff() time.Duration {

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -12,8 +12,9 @@ import (
 	"github.com/rhobuild/runpool/internal/store"
 )
 
-// strandedGrace is how long a live lease is left alone before the
-// periodic pass may consider it ownerless.
+// defaultStrandedGrace is how long a live lease is left alone before the
+// periodic pass may consider it ownerless. A test overrides it through
+// the controller's own strandedGrace field.
 //
 // It is keyed on the last transition rather than on creation, so it also
 // keeps the pass off a lease a goroutine is actively moving: every

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -137,7 +137,25 @@ func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
 // interface networks discovered through a short-lived host-namespace
 // probe, every Docker subnet the daemon knows, the baseline ranges, and
 // the uplink itself.
+// sandboxBuildBudget bounds discovering the environment: the uplink
+// network, its subnet, the host's own addresses and the daemon's other
+// subnets.
+//
+// It is one budget over the whole of build rather than one per step,
+// because what it protects is the refresh lock and not any particular
+// call. Every launch waits on that lock with a plain mutex that takes no
+// context, so a step that never returns is a host on which nothing new
+// can start, and which step it was does not change that.
+//
+// Generous enough for the probe image to be pulled, which is the slow
+// step on a cold host, and shorter than rediscoverInterval so a build
+// that hangs cannot leave two passes overlapping.
+const sandboxBuildBudget = 2 * time.Minute
+
 func (n *networkSandbox) build(ctx context.Context) (*capsule.Sandbox, error) {
+	ctx, cancel := context.WithTimeout(ctx, sandboxBuildBudget)
+	defer cancel()
+
 	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, docker.NetworkSpec{
 		Name: "runpool-uplink-" + string(n.instanceID)[:8],
 		Labels: map[string]string{

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/egress"
 	"github.com/rhobuild/runpool/internal/platform/docker"
@@ -122,7 +123,7 @@ func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
 	for _, c := range cfg.Network.DenyCIDRs {
 		n.denies = append(n.denies, c.String())
 	}
-	initial, err := n.build(ctx)
+	initial, err := n.build(ctx, sandboxFirstBuildBudget)
 	if err != nil {
 		return nil, err
 	}
@@ -137,23 +138,8 @@ func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
 // interface networks discovered through a short-lived host-namespace
 // probe, every Docker subnet the daemon knows, the baseline ranges, and
 // the uplink itself.
-// sandboxBuildBudget bounds discovering the environment: the uplink
-// network, its subnet, the host's own addresses and the daemon's other
-// subnets.
-//
-// It is one budget over the whole of build rather than one per step,
-// because what it protects is the refresh lock and not any particular
-// call. Every launch waits on that lock with a plain mutex that takes no
-// context, so a step that never returns is a host on which nothing new
-// can start, and which step it was does not change that.
-//
-// Generous enough for the probe image to be pulled, which is the slow
-// step on a cold host, and shorter than rediscoverInterval so a build
-// that hangs cannot leave two passes overlapping.
-const sandboxBuildBudget = 2 * time.Minute
-
-func (n *networkSandbox) build(ctx context.Context) (*capsule.Sandbox, error) {
-	ctx, cancel := context.WithTimeout(ctx, sandboxBuildBudget)
+func (n *networkSandbox) build(ctx context.Context, budget time.Duration) (*capsule.Sandbox, error) {
+	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 
 	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, docker.NetworkSpec{
@@ -192,6 +178,36 @@ func (n *networkSandbox) build(ctx context.Context) (*capsule.Sandbox, error) {
 // the cost of noticing late is a hole that stays open until then, and
 // the cost of noticing often is one probe container.
 const rediscoverInterval = 5 * time.Minute
+
+// The two budgets on discovering the environment. It is one budget over
+// the whole of build rather than one per step, because what it protects
+// is a caller that cannot give up rather than any particular call, and
+// which step hung does not change that.
+//
+// They differ because their callers do. The first build runs from
+// newNetworkSandbox, before the state exists and before any binding does:
+// nothing holds the refresh lock, nothing waits on it, and the probe
+// image may still have to be pulled — it is the capsule image, which is
+// hundreds of megabytes. Failing that for being slow is a controller
+// that will not start on a cold host with an ordinary link.
+//
+// Every later build runs from refresh, under the lock that every launch
+// takes with a plain mutex — no context, no way out — so an unbounded
+// step there is a host on which nothing new can start. By then the image
+// is present, so what remains is creating a network, inspecting it,
+// running a small container to completion and listing subnets. The bound
+// stays under rediscoverInterval so a build that hangs cannot leave two
+// passes overlapping, which TestDiscoveringTheEnvironmentIsBounded
+// requires.
+//
+// What this does not cover: an image removed from under a running
+// controller makes a later build pull again, on the tighter budget, and
+// a refresh that fails closes every gateway. That host has lost the
+// image its capsules run from and is going to fail launches regardless.
+const (
+	sandboxFirstBuildBudget = 10 * time.Minute
+	sandboxRefreshBudget    = 2 * time.Minute
+)
 
 // PolicyChange classifies what a rediscovered deny set does to the one
 // in force. The distinction decides what a failure to install it costs.
@@ -314,7 +330,7 @@ func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error
 func (n *networkSandbox) refresh(ctx context.Context) error {
 	n.state.refreshMu.Lock()
 	defer n.state.refreshMu.Unlock()
-	next, err := n.build(ctx)
+	next, err := n.build(ctx, sandboxRefreshBudget)
 	if err != nil {
 		return err
 	}
@@ -439,7 +455,7 @@ func eachGateway[T any](items []T, fn func(T)) {
 // one caller takes a length and iterates order-blind, and a test that
 // compares the set sorts what it compares.
 func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []string) (failed []string, err error) {
-	containers, err := n.daemon.ListOwnedContainers(ctx, n.instanceID)
+	containers, err := n.ownedContainers(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -476,6 +492,20 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 // every launch on the host.
 const gatewayControlTimeout = 30 * time.Second
 
+// ownedContainers asks the daemon what this instance owns, under a bound.
+//
+// Both callers run inside the refresh lock, and enumerating is the first
+// thing each does — so a daemon that accepts the request and answers
+// nothing would hold that lock before any gateway had been reached, with
+// every launch on the host waiting on it and none able to time out. It
+// is the same reason the exec and the removal below are bounded, and
+// leaving it out left the pass unbounded at its very first step.
+func (n *networkSandbox) ownedContainers(ctx context.Context) ([]docker.OwnedContainer, error) {
+	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
+	defer cancel()
+	return n.daemon.ListOwnedContainers(ctx, n.instanceID)
+}
+
 // execGateway runs one gateway control command under its own bound.
 func (n *networkSandbox) execGateway(ctx context.Context,
 	call func(context.Context) (int, string, error)) (int, string, error) {
@@ -495,7 +525,7 @@ func (n *networkSandbox) execGateway(ctx context.Context,
 func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) error {
 	code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
 		return n.daemon.Exec(ctx, containerID,
-			[]string{capsule.SupervisorPath, "gateway-deny-all"})
+			[]string{capsule.SupervisorPath, protocol.GatewayDenyAllCommand})
 	})
 	if err != nil || code != 0 {
 		// The policy could not be closed from inside; removing the
@@ -520,7 +550,7 @@ func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) e
 
 // closeGateways closes every live gateway this instance owns.
 func (n *networkSandbox) closeGateways(ctx context.Context) error {
-	containers, err := n.daemon.ListOwnedContainers(ctx, n.instanceID)
+	containers, err := n.ownedContainers(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -116,8 +116,18 @@ type fakeSandboxDaemon struct {
 	// is where an unbounded one would otherwise be invisible.
 	removeDeadline time.Time
 	removeBounded  bool
-	reloaded       []string
-	removed        []string
+	// buildDeadline is the bound the environment discovery ran under.
+	// The probe waits on a process rather than on a request, so an
+	// unbounded one there is unbounded for every launch on the host.
+	buildDeadline time.Time
+	buildBounded  bool
+	reloaded      []string
+	removed       []string
+	// denied names the gateways asked to revoke their own policy.
+	// Removing one is not the same as trying to revoke it first: the
+	// removal is the fallback, and a close that skipped straight to it
+	// would leave the gateway relaying until the daemon answered.
+	denied []string
 }
 
 // serve models one gateway control command occupying the daemon for as
@@ -168,6 +178,7 @@ func (f *fakeSandboxDaemon) sorted(from *[]string) []string {
 	return out
 }
 
+func (f *fakeSandboxDaemon) denies() []string  { return f.sorted(&f.denied) }
 func (f *fakeSandboxDaemon) reloads() []string { return f.sorted(&f.reloaded) }
 func (f *fakeSandboxDaemon) removes() []string { return f.sorted(&f.removed) }
 
@@ -180,7 +191,10 @@ func (f *fakeSandboxDaemon) NetworkSubnet(context.Context, string) (string, erro
 func (f *fakeSandboxDaemon) AllNetworkSubnets(context.Context) ([]string, error) {
 	return f.subnets, nil
 }
-func (f *fakeSandboxDaemon) RunTask(context.Context, docker.ContainerSpec) (int64, string, error) {
+func (f *fakeSandboxDaemon) RunTask(ctx context.Context, _ docker.ContainerSpec) (int64, string, error) {
+	f.mu.Lock()
+	f.buildDeadline, f.buildBounded = ctx.Deadline()
+	f.mu.Unlock()
 	return 0, f.probeOut, f.probeErr
 }
 func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error) {
@@ -191,6 +205,7 @@ func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, assignment.Inst
 }
 func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, _ []string) (int, string, error) {
 	f.serve()
+	f.note(&f.denied, id)
 	if f.refuse[id] {
 		return 1, "refused", nil
 	}
@@ -351,9 +366,16 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	})
 }
 
-// TestCloseGatewaysRemovesEvenWhatWillNotDeny: an established tunnel is
-// already past the relay's check, so closing the policy from inside is
-// not enough on its own. The container goes either way.
+// TestCloseGatewaysRemovesEvenWhatWillNotDeny: closing a gateway asks it
+// to revoke its own policy first, and removes the container either way.
+//
+// Both halves matter and only one was held. An established tunnel is
+// already past the relay's check, so revoking from inside is not enough
+// on its own and the container goes regardless — that is the half this
+// test had. The other is that the revocation is attempted at all: going
+// straight to the removal leaves the gateway relaying for as long as the
+// daemon takes to answer, which is exactly the window the deny-all is
+// there to close.
 func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 	d := &fakeSandboxDaemon{
 		containers: []docker.OwnedContainer{
@@ -369,6 +391,10 @@ func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 	}
 	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
 		t.Errorf("removed %v; a gateway that refuses deny-all still has to stop relaying", d.removes())
+	}
+	if !slices.Equal(d.denies(), []string{"gw-1", "gw-2"}) {
+		t.Errorf("asked %v to revoke their own policy; want both, before either was removed. "+
+			"A close that skips it relays until the daemon answers the removal", d.denies())
 	}
 }
 
@@ -576,5 +602,50 @@ func TestClosingAGatewayIsBoundedInBothSteps(t *testing.T) {
 	if left := time.Until(deadline); left <= 0 || left > gatewayControlTimeout {
 		t.Errorf("the removal had %v left; want a positive bound no larger than %v",
 			left, gatewayControlTimeout)
+	}
+}
+
+// TestDiscoveringTheEnvironmentIsBounded: building the sandbox runs
+// under a deadline, because the refresh lock is held across it.
+//
+// The host probe is a container: created, started, waited on, and read.
+// Waiting on a process that never exits is not a request that times out
+// on its own, and the three daemon calls around it are no better against
+// a daemon that has stopped answering. Every launch takes the refresh
+// lock through forLaunch with a plain mutex — no context, no way out —
+// so anything unbounded here is a host on which nothing new can start
+// for as long as the controller runs.
+//
+// The bound is asserted rather than waited out: a test that waits two
+// minutes to prove a two-minute budget is a test nobody runs.
+func TestDiscoveringTheEnvironmentIsBounded(t *testing.T) {
+	d := &fakeSandboxDaemon{
+		uplinkID:     "up-1",
+		uplinkSubnet: "172.30.0.0/24",
+		subnets:      []string{"172.18.0.0/16"},
+		probeOut:     "2: eth0    inet 192.0.2.10/24 scope global eth0",
+	}
+	n := newTestSandbox(t, d, nil)
+
+	// A context with no deadline of its own, which is what the watch
+	// loop and a launch both hand this path.
+	if _, err := n.build(context.Background()); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	d.mu.Lock()
+	bounded, deadline := d.buildBounded, d.buildDeadline
+	d.mu.Unlock()
+	if !bounded {
+		t.Fatal("the host probe ran on a context with no deadline; a probe that never exits " +
+			"holds the refresh lock, and every launch waits on it uninterruptibly")
+	}
+	if left := time.Until(deadline); left <= 0 || left > sandboxBuildBudget {
+		t.Errorf("the probe had %v left; want a positive bound no larger than %v",
+			left, sandboxBuildBudget)
+	}
+	if sandboxBuildBudget >= rediscoverInterval {
+		t.Errorf("the build budget is %v against a %v rediscovery interval; a build that "+
+			"hangs would leave two passes overlapping", sandboxBuildBudget, rediscoverInterval)
 	}
 }

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -8,11 +8,13 @@ import (
 	"log/slog"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/capsule"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 
@@ -121,13 +123,19 @@ type fakeSandboxDaemon struct {
 	// unbounded one there is unbounded for every launch on the host.
 	buildDeadline time.Time
 	buildBounded  bool
-	reloaded      []string
-	removed       []string
-	// denied names the gateways asked to revoke their own policy.
-	// Removing one is not the same as trying to revoke it first: the
-	// removal is the fallback, and a close that skipped straight to it
-	// would leave the gateway relaying until the daemon answered.
-	denied []string
+	// listDeadline is the bound the gateway enumeration ran under. It is
+	// the first thing a refresh pass does, so an unbounded one there
+	// holds the lock before any gateway has been reached.
+	listDeadline time.Time
+	listBounded  bool
+	reloaded     []string
+	removed      []string
+	// events is what the daemon was asked to do, in order, as
+	// "<verb>:<container>". Two sorted sets cannot say that the
+	// revocation came before the removal, and per-gateway order is
+	// deterministic even under the fan-out, so one ordered log is both
+	// smaller and stronger.
+	events []string
 }
 
 // serve models one gateway control command occupying the daemon for as
@@ -178,8 +186,20 @@ func (f *fakeSandboxDaemon) sorted(from *[]string) []string {
 	return out
 }
 
-func (f *fakeSandboxDaemon) denies() []string  { return f.sorted(&f.denied) }
 func (f *fakeSandboxDaemon) reloads() []string { return f.sorted(&f.reloaded) }
+
+// eventsFor is the ordered record for one container.
+func (f *fakeSandboxDaemon) eventsFor(id string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for _, e := range f.events {
+		if strings.HasSuffix(e, ":"+id) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
 func (f *fakeSandboxDaemon) removes() []string { return f.sorted(&f.removed) }
 
 func (f *fakeSandboxDaemon) EnsureOwnedNetwork(context.Context, docker.NetworkSpec) (string, error) {
@@ -197,15 +217,20 @@ func (f *fakeSandboxDaemon) RunTask(ctx context.Context, _ docker.ContainerSpec)
 	f.mu.Unlock()
 	return 0, f.probeOut, f.probeErr
 }
-func (f *fakeSandboxDaemon) ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error) {
+func (f *fakeSandboxDaemon) ListOwnedContainers(ctx context.Context, _ assignment.InstanceID) ([]docker.OwnedContainer, error) {
+	f.mu.Lock()
+	f.listDeadline, f.listBounded = ctx.Deadline()
+	f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
 	return f.containers, nil
 }
-func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, _ []string) (int, string, error) {
+func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
 	f.serve()
-	f.note(&f.denied, id)
+	// The command, not merely that some exec happened: closing a gateway
+	// and reloading one are both execs, and only one of them revokes.
+	f.note(&f.events, cmd[len(cmd)-1]+":"+id)
 	if f.refuse[id] {
 		return 1, "refused", nil
 	}
@@ -224,6 +249,7 @@ func (f *fakeSandboxDaemon) RemoveContainer(ctx context.Context, id string) erro
 	f.removeDeadline, f.removeBounded = ctx.Deadline()
 	f.mu.Unlock()
 	f.serve()
+	f.note(&f.events, "remove:"+id)
 	f.note(&f.removed, id)
 	return nil
 }
@@ -274,7 +300,7 @@ func TestBuildRefusesABlindDenySet(t *testing.T) {
 	n := newTestSandbox(t, &fakeSandboxDaemon{
 		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: "",
 	}, nil)
-	if _, err := n.build(t.Context()); err == nil {
+	if _, err := n.build(t.Context(), sandboxRefreshBudget); err == nil {
 		t.Fatal("a sandbox was built from a probe that saw no global network")
 	}
 }
@@ -293,7 +319,7 @@ func TestBuildDeniesEverythingItDiscovered(t *testing.T) {
 	n.denies = []string{"203.0.113.0/24"}
 	n.allow = []string{"10.9.0.0/16"}
 
-	sb, err := n.build(t.Context())
+	sb, err := n.build(t.Context(), sandboxRefreshBudget)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -392,9 +418,16 @@ func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
 		t.Errorf("removed %v; a gateway that refuses deny-all still has to stop relaying", d.removes())
 	}
-	if !slices.Equal(d.denies(), []string{"gw-1", "gw-2"}) {
-		t.Errorf("asked %v to revoke their own policy; want both, before either was removed. "+
-			"A close that skips it relays until the daemon answers the removal", d.denies())
+	// Ordered, and naming the command. A close that removed first and
+	// revoked afterwards, or that ran some other exec, leaves the
+	// gateway relaying until the daemon answers — which is the window
+	// the revocation exists to close, and neither shape is visible in a
+	// sorted set of container ids.
+	for _, id := range []string{"gw-1", "gw-2"} {
+		want := []string{protocol.GatewayDenyAllCommand + ":" + id, "remove:" + id}
+		if got := d.eventsFor(id); !slices.Equal(got, want) {
+			t.Errorf("%s saw %v; want %v", id, got, want)
+		}
 	}
 }
 
@@ -629,7 +662,7 @@ func TestDiscoveringTheEnvironmentIsBounded(t *testing.T) {
 
 	// A context with no deadline of its own, which is what the watch
 	// loop and a launch both hand this path.
-	if _, err := n.build(context.Background()); err != nil {
+	if _, err := n.build(context.Background(), sandboxRefreshBudget); err != nil {
 		t.Fatalf("build: %v", err)
 	}
 
@@ -640,12 +673,60 @@ func TestDiscoveringTheEnvironmentIsBounded(t *testing.T) {
 		t.Fatal("the host probe ran on a context with no deadline; a probe that never exits " +
 			"holds the refresh lock, and every launch waits on it uninterruptibly")
 	}
-	if left := time.Until(deadline); left <= 0 || left > sandboxBuildBudget {
+	if left := time.Until(deadline); left <= 0 || left > sandboxRefreshBudget {
 		t.Errorf("the probe had %v left; want a positive bound no larger than %v",
-			left, sandboxBuildBudget)
+			left, sandboxRefreshBudget)
 	}
-	if sandboxBuildBudget >= rediscoverInterval {
+	if sandboxRefreshBudget >= rediscoverInterval {
 		t.Errorf("the build budget is %v against a %v rediscovery interval; a build that "+
-			"hangs would leave two passes overlapping", sandboxBuildBudget, rediscoverInterval)
+			"hangs would leave two passes overlapping", sandboxRefreshBudget, rediscoverInterval)
+	}
+}
+
+// TestEnumeratingGatewaysIsBounded: asking the daemon what this instance
+// owns runs under a deadline.
+//
+// It is the first thing both passes over the gateways do, and both run
+// inside the refresh lock. A daemon that accepts the request and answers
+// nothing would hold that lock before a single gateway had been reached,
+// with every launch on the host waiting on a plain mutex it cannot time
+// out of. Bounding the exec and the removal further in, and not this,
+// left the pass unbounded at its very first step.
+func TestEnumeratingGatewaysIsBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*networkSandbox) error
+	}{
+		{"reloading", func(n *networkSandbox) error {
+			_, err := n.reloadGateways(context.Background(), nil, []string{"10.0.0.0/8"})
+			return err
+		}},
+		{"closing", func(n *networkSandbox) error {
+			return n.closeGateways(context.Background())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &fakeSandboxDaemon{containers: []docker.OwnedContainer{
+				{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
+			}}
+			n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
+
+			// A context with no deadline of its own, which is what the
+			// watch loop hands this path.
+			if err := tc.run(n); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			d.mu.Lock()
+			bounded, deadline := d.listBounded, d.listDeadline
+			d.mu.Unlock()
+			if !bounded {
+				t.Fatal("the enumeration ran on a context with no deadline; a daemon that " +
+					"stops answering holds the refresh lock before any gateway is reached")
+			}
+			if left := time.Until(deadline); left <= 0 || left > gatewayControlTimeout {
+				t.Errorf("the enumeration had %v left; want a positive bound no larger than %v",
+					left, gatewayControlTimeout)
+			}
+		})
 	}
 }

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -84,3 +84,14 @@ func Terminal(state string) bool {
 // be read. Without it, every abort read as an ordinary exit — and an
 // attempt that never ran was settled as complete and never requeued.
 const AbortedExitCode = 79
+
+// GatewayDenyAllCommand is the supervisor subcommand that revokes a
+// gateway's own egress policy from inside it.
+//
+// It lives here for the reason the rest of this package does: the
+// controller spells it to ask and the supervisor spells it to answer,
+// and they are two binaries. A typo on either side is a gateway that
+// keeps relaying while the exec reports a failure the caller logs and
+// moves past — which is the shape of every other value this package
+// exists to keep from being written twice.
+const GatewayDenyAllCommand = "gateway-deny-all"

--- a/internal/command/doctor.go
+++ b/internal/command/doctor.go
@@ -64,16 +64,16 @@ func runDoctor(streams IO, asJSON bool) error {
 	return nil
 }
 
-// runHealthcheck is the container health command. Liveness answers
-// whether this process can still reach its own state; readiness adds
-// the host contract. It is deliberately cheap and local: no GitHub call,
-// so a broker outage never marks the controller unhealthy.
 // livenessVerdictTolerance is how stale the disk monitor's last verdict
 // may be before liveness reads the serve loop as stopped. The monitor
 // writes one per minute; ten of them is far past any transient stall a
 // restart would not fix, while a single slow cycle never trips it.
 const livenessVerdictTolerance = 10 * time.Minute
 
+// runHealthcheck is the container health command. Liveness answers
+// whether this process can still reach its own state; readiness adds
+// the host contract. It is deliberately cheap and local: no GitHub call,
+// so a broker outage never marks the controller unhealthy.
 func runHealthcheck(streams IO, mode string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -394,9 +394,6 @@ func (v *validator) appCredential(path string, cr Credential) {
 	}
 }
 
-// secretPath refuses a reference that names a different file depending on
-// how the process was started. The controller's working directory is not
-// part of the contract.
 // secretRef holds every env-xor-file secret reference to one rule:
 // exactly one side set, a well-formed variable name, a reviewable file
 // path. The field names arrive as parameters so the third credential
@@ -415,6 +412,9 @@ func (v *validator) secretRef(path, envField, fileField, envName, filePath strin
 	}
 }
 
+// secretPath refuses a reference that names a different file depending on
+// how the process was started. The controller's working directory is not
+// part of the contract.
 func (v *validator) secretPath(path, ref string) {
 	switch {
 	case ref == "":

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -201,6 +201,13 @@ func checkDaemon(ctx context.Context, d daemonInfo) Result {
 	return Result{"docker daemon", Pass, detail, ""}
 }
 
+// networkProbeClient is the two calls the bridge probe needs, named so
+// the probe cannot reach the rest of a daemon client.
+type networkProbeClient interface {
+	CreateNetwork(context.Context, docker.NetworkSpec) (string, error)
+	RemoveNetwork(context.Context, string) error
+}
+
 // checkIsolatedBridge proves the daemon actually provides the capability
 // the restricted profile depends on, rather than inferring it from a
 // version number. Engine 28 introduced the isolated bridge gateway mode,
@@ -215,11 +222,6 @@ func checkDaemon(ctx context.Context, d daemonInfo) Result {
 // moment it exists. Failing here is the point: a host that cannot build
 // this network must be refused before it accepts work, not after a job
 // has already been assigned to it.
-type networkProbeClient interface {
-	CreateNetwork(context.Context, docker.NetworkSpec) (string, error)
-	RemoveNetwork(context.Context, string) error
-}
-
 func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
 	const name = "isolated bridge"
 	if d == nil {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -25,6 +25,10 @@ type migration struct {
 	up      string
 }
 
+// loadMigrations reads the embedded set once. Every open consults it and
+// the bytes cannot change while the process runs.
+var loadMigrations = sync.OnceValues(embeddedMigrations)
+
 // embeddedMigrations reads migrations/NNNNNN_name.up.sql in order.
 //
 // There are no down scripts. A down script claims every schema change is
@@ -32,10 +36,6 @@ type migration struct {
 // the rollback path is restoring the backup taken before the migration
 // ran, which is a copy of what actually existed rather than a guess at
 // how to rebuild it.
-// loadMigrations reads the embedded set once. Every open consults it and
-// the bytes cannot change while the process runs.
-var loadMigrations = sync.OnceValues(embeddedMigrations)
-
 func embeddedMigrations() ([]migration, error) {
 	entries, err := migrationsFS.ReadDir("migrations")
 	if err != nil {

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -10,6 +10,10 @@ package consistency
 import (
 	"encoding/json"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -211,5 +215,108 @@ func TestTheTwoRetryBudgetDefaultsAgree(t *testing.T) {
 		t.Fatalf("config.DefaultRetryBudget = %d, store.DefaultRetryBudget = %d; "+
 			"a deployment and a maintenance command would enforce different budgets",
 			config.DefaultRetryBudget, store.DefaultRetryBudget)
+	}
+}
+
+// TestNoDocCommentBelongsToAnotherDeclaration: a doc comment sits on the
+// thing it names.
+//
+// Inserting a declaration between a comment and the declaration it
+// documents silently reassigns the comment. The result compiles, gofmt
+// says nothing, and `go vet` says nothing — staticcheck's ST1020 checks
+// only exported names, and this codebase is mostly unexported. What a
+// reader gets is `go doc` reporting one function's purpose under another
+// function's name, and the next person to change either reasons from a
+// sentence that was never about it.
+//
+// The rule is narrow on purpose. A doc comment that simply does not open
+// with its own name is a style question and there are legitimate ones
+// here. A doc comment that opens with the name of a *different*
+// declaration in the same file is not a style question: it is a comment
+// that was detached from what it describes.
+func TestNoDocCommentBelongsToAnotherDeclaration(t *testing.T) {
+	fset := token.NewFileSet()
+	var found []string
+
+	err := filepath.WalkDir(repoPath(), func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case d.IsDir():
+			// Generated code carries whatever its generator emits, and
+			// vendored trees are not ours to describe.
+			if name := d.Name(); name == ".git" || name == "sqlitedb" || name == "vendor" {
+				return filepath.SkipDir
+			}
+			return nil
+		case !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go"):
+			return nil
+		}
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+
+		// Every name this file declares, so the check can tell "a
+		// different declaration" from an ordinary first word.
+		declared := map[string]bool{}
+		ast.Inspect(file, func(n ast.Node) bool {
+			switch decl := n.(type) {
+			case *ast.FuncDecl:
+				declared[decl.Name.Name] = true
+			case *ast.TypeSpec:
+				declared[decl.Name.Name] = true
+			case *ast.ValueSpec:
+				for _, id := range decl.Names {
+					declared[id.Name] = true
+				}
+			}
+			return true
+		})
+
+		check := func(doc *ast.CommentGroup, name string, pos token.Pos) {
+			if doc == nil || len(doc.List) == 0 {
+				return
+			}
+			words := strings.Fields(strings.TrimPrefix(doc.List[0].Text, "//"))
+			if len(words) == 0 {
+				return
+			}
+			first := strings.Trim(words[0], "`*.,:")
+			if first == name || !declared[first] {
+				return
+			}
+			found = append(found, fmt.Sprintf(
+				"%s: the doc comment on %s begins with %q, which is another declaration in this file. "+
+					"Something was inserted between %q's comment and %q",
+				fset.Position(pos), name, first, first, first))
+		}
+		for _, decl := range file.Decls {
+			switch decl := decl.(type) {
+			case *ast.FuncDecl:
+				check(decl.Doc, decl.Name.Name, decl.Pos())
+			case *ast.GenDecl:
+				// Only single-spec blocks: a grouped const or var block
+				// documents the group, not its first member.
+				if len(decl.Specs) != 1 {
+					continue
+				}
+				switch spec := decl.Specs[0].(type) {
+				case *ast.TypeSpec:
+					check(decl.Doc, spec.Name.Name, decl.Pos())
+				case *ast.ValueSpec:
+					if len(spec.Names) > 0 {
+						check(decl.Doc, spec.Names[0].Name, decl.Pos())
+					}
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range found {
+		t.Error(f)
 	}
 }


### PR DESCRIPTION
## What changes

The last unbounded work under the refresh lock gets a bound, and the test
that covers closing a gateway covers both halves of what it does.

## What was found

**`build()` is the last unbounded thing under `refreshMu`.** The previous
round bounded the gateway exec and then the gateway removal beside it.
`refresh` holds the lock across `build` as well, and `build` makes four
daemon calls on whatever context it was handed:

```go
n.daemon.EnsureOwnedNetwork(ctx, ...)   // create or adopt
n.daemon.NetworkSubnet(ctx, uplinkID)   // inspect
n.discoverHostCIDRs(ctx)                // RunTask: create, start, WaitExit, logs
n.daemon.AllNetworkSubnets(ctx)         // list
```

The probe is the worst of the four. `RunTask` waits on a container to
exit, and a process that never exits is not a request that times out on
its own — the other three are ordinary daemon calls, which hang just as
long against a daemon that stopped answering. Every launch takes this
lock through `forLaunch` with a plain `Lock()`: no context, nothing to
give up. Unbounded here is a host on which nothing new can start for as
long as the controller runs.

One budget over the whole of `build` rather than one per step, because
what it protects is the lock rather than any particular call, and which
step hung does not change the consequence. Two minutes: long enough for
the probe image to be pulled on a cold host — `CreateContainer` pulls a
missing image, which is the slow step — and shorter than
`rediscoverInterval` so a hung build cannot leave two passes overlapping.
The test asserts that relation rather than trusting the two constants to
stay ordered.

**`closeGateway` does two things and one was held.** It asks the gateway
to revoke its own policy, then removes the container whatever that
returned. `TestCloseGatewaysRemovesEvenWhatWillNotDeny` asserted the
removal — the half where an established tunnel is already past the
relay's check, so revoking from inside is not enough on its own.

Nothing asserted the revocation was attempted. A close that skipped
straight to the removal would have passed, and would leave the gateway
relaying for as long as the daemon took to answer — which is the exact
window the deny-all exists to close.

The record that assertion needed existed and was deleted in the previous
round for having no reader. The missing reader was this assertion.

## Symmetry check

| Path | Result |
|---|---|
| everything under `refreshMu` | `build` was the last unbounded one; `applyPolicy` → `reloadGateways` and `closeGateway`'s two steps were bounded in the previous round |
| `build`'s four calls | one budget covers all four and anything added later, which is the property the lock needs |
| `RunTask`'s own cleanup | already derives its own deadline from `context.WithoutCancel`, so the removal of the probe container survives the budget expiring |
| `discoverHostCIDRs`' other caller | none; it is reached only from `build` |
| `closeGateway`'s two steps | both now bounded and both now asserted |
| `closeGateways` and `applyPolicy`'s failed loop | both reach `closeGateway`, so both inherit the assertion's subject |

## Evidence

```text
environment discovery loses its bound
  -> --- FAIL: TestDiscoveringTheEnvironmentIsBounded
     the host probe ran on a context with no deadline; a probe that never exits
     holds the refresh lock, and every launch waits on it uninterruptibly

the close skips the revocation and goes straight to the removal
  -> --- FAIL: TestCloseGatewaysRemovesEvenWhatWillNotDeny
     asked [] to revoke their own policy; want both, before either was removed
```

Both bounds are asserted rather than waited out. A test that spends two
minutes proving a two-minute budget is a test nobody runs, and one that
measures wall-clock instead of the deadline is a test of the machine.

## What would notice this regressing

- `TestDiscoveringTheEnvironmentIsBounded` passes a context with no
  deadline — what the watch loop and a launch both pass — and requires
  the probe to have one anyway. It also fails if the budget ever reaches
  the rediscovery interval.
- `TestCloseGatewaysRemovesEvenWhatWillNotDeny` now fails on either half:
  a removal that does not happen, or a revocation that is not attempted.

## Risk, compatibility and operations

**A refresh that takes longer than two minutes now fails instead of
blocking.** The pass is retried on the next rediscovery, and a launch
that was waiting on the lock gets an error rather than never returning.
On a cold host the probe image pull happens inside that budget; a link
slow enough to exceed it fails the refresh and retries, where before it
would have held every launch on the host.

**No other behaviour changes.** The four daemon calls, the probe, the
deny-all and the removal are all unchanged in what they do.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous binary.

## Changelog

```text
### Fixed
- Rediscovering the network environment is bounded. A Docker daemon that
  stopped answering, or a host probe that never exited, would otherwise
  hold the lock every capsule launch waits on for as long as the
  controller ran.
```

## Notes for your reviewer

The number to argue with is two minutes. It is chosen against two things
that are checkable — a probe image pull, and the five-minute rediscovery
interval, which the test asserts it stays under — rather than measured,
because what it bounds is a daemon not answering rather than work taking
a knowable time.

The alternative shape is a bound per call, which would say which step
hung. It is not what this does, deliberately: the lock does not care
which one, and four budgets are four things to keep in proportion instead
of one.