### PR TITLE
fix(store, lease): a decision made twice is recorded twice, and the requeue partition is chosen where it is written

### DIFF
--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -369,10 +369,7 @@ func (m *Manager) HoldAttempt(ctx context.Context, leaseID assignment.LeaseID, r
 // matching no row, and a requeue that matches nothing rolls the whole
 // finalizing transaction back and pins the lease in cleaning.
 func (m *Manager) requeueProven(tx *store.Tx, attempt store.Attempt, leaseID assignment.LeaseID) error {
-	if attempt.State == "starting" || attempt.State == "running" {
-		return m.requeueOrReview(tx, attempt.ID, tx.RequeueProvenInert(attempt.ID), leaseID)
-	}
-	return m.requeueOrReview(tx, attempt.ID, tx.Requeue(attempt.ID), leaseID)
+	return m.requeueOrReview(tx, attempt.ID, tx.RequeueServing(attempt), leaseID)
 }
 
 // requeueOrReview turns a refused retry into a review rather than an

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
@@ -252,13 +251,13 @@ func (t *Tx) LeasesInStates(states ...LeaseState) ([]Lease, error) {
 	if len(states) == 0 {
 		return nil, nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?, ", len(states)), ", ")
+	held := placeholders(len(states))
 	args := make([]any, len(states))
 	for i, s := range states {
 		args[i] = s
 	}
 	rows, err := t.tx.Query(
-		selectLease+`WHERE state IN (`+placeholders+`) ORDER BY created_at, id`, args...)
+		selectLease+`WHERE state IN (`+held+`) ORDER BY created_at, id`, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/query/attempt_events.sql
+++ b/internal/store/query/attempt_events.sql
@@ -1,12 +1,37 @@
 -- Attempt lifecycle events: append-only, idempotent per
 -- (attempt, idempotency key), so a redelivered message cannot double
--- history. Zero rows from the insert means the event already exists,
--- which the repository reports as idempotent success after verifying
--- the existing event matches.
+-- history. Zero rows from an insert means the event already exists under
+-- that key, which the repository reports as success: the key is what
+-- makes two writes the same event, so nothing is read back to confirm
+-- it.
 
 -- name: InsertAttemptEvent :execrows
+-- For a decision that happens at most once per attempt, or one whose key
+-- already carries what makes it distinct -- a lease id, a delivery id.
 INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
 VALUES (@attempt_id, @idempotency_key, @kind, @detail_json)
+ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
+
+-- name: InsertSequencedAttemptEvent :execrows
+-- For a decision that can be made about one attempt more than once: held
+-- for review, resolved by an operator, served again, held again.
+--
+-- A fixed key makes every occurrence after the first a replay of it, and
+-- the conflict clause then drops the actor, the reason and the decision
+-- without a word. The attempt row keeps only the latest of each, so what
+-- is lost is precisely the history -- who decided what, and why, the
+-- time before.
+--
+-- The key carries how many of this kind the attempt already has. That is
+-- stable across a retry of the same transaction, because a transaction
+-- that failed rolled its insert back and the count is unchanged, and it
+-- differs for a decision genuinely made again.
+INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
+SELECT @attempt_id,
+       @kind || ':' || (SELECT count(*) FROM attempt_events prior
+                        WHERE prior.attempt_id = @attempt_id AND prior.kind = @kind),
+       @kind, @detail_json
+WHERE true
 ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
 
 -- name: ListAttemptEvents :many

--- a/internal/store/query/attempt_events.sql
+++ b/internal/store/query/attempt_events.sql
@@ -24,24 +24,29 @@ ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
 --
 -- The key carries how many of this kind the attempt already has.
 --
--- What the conflict clause protects in this table is a redelivered
--- message: those events key by delivery id, which is the identity the
--- outside world repeats. A hold or a resolve has no such identity. The
--- command runs once, and a second run finds the compare-and-swap
--- refusing, so a fixed key was protecting against nothing and dropping
--- every later decision to do it.
+-- What the conflict clause on the insert above protects against is a
+-- redelivered message: those events key by delivery id, which is the
+-- identity the outside world repeats. A hold or a resolve has no such
+-- identity. The command runs once, and a second run finds the
+-- compare-and-swap refusing, so a fixed key protected against nothing
+-- while dropping every later decision to do it.
 --
--- The clause still means something here. Two writes of this kind inside
--- one transaction would compute the same count and the second would be
--- dropped, so the invariant a caller owes is one such decision per
--- transaction, which is what each disposition does.
+-- This one carries no such clause, because it has no reachable conflict.
+-- The count only grows: the sole delete of these rows drops the attempts
+-- with them, and a row written under the old fixed key shifts the
+-- numbering without ever occupying a suffixed one. Two writes inside one
+-- transaction do not collide either, because SQLite shows an uncommitted
+-- insert to the statements after it, so the second counts the first and
+-- takes the next number.
+--
+-- Leaving the clause on would mean that a duplicate nobody can construct
+-- would be dropped in silence, with no error, from an append-only audit
+-- log. If one is ever constructed, saying so is the only useful answer.
 INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
 SELECT @attempt_id,
        @kind || ':' || (SELECT count(*) FROM attempt_events prior
                         WHERE prior.attempt_id = @attempt_id AND prior.kind = @kind),
-       @kind, @detail_json
-WHERE true
-ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
+       @kind, @detail_json;
 
 -- name: ListAttemptEvents :many
 SELECT id, attempt_id, idempotency_key, kind, detail_json, created_at

--- a/internal/store/query/attempt_events.sql
+++ b/internal/store/query/attempt_events.sql
@@ -22,10 +22,19 @@ ON CONFLICT (attempt_id, idempotency_key) DO NOTHING;
 -- is lost is precisely the history -- who decided what, and why, the
 -- time before.
 --
--- The key carries how many of this kind the attempt already has. That is
--- stable across a retry of the same transaction, because a transaction
--- that failed rolled its insert back and the count is unchanged, and it
--- differs for a decision genuinely made again.
+-- The key carries how many of this kind the attempt already has.
+--
+-- What the conflict clause protects in this table is a redelivered
+-- message: those events key by delivery id, which is the identity the
+-- outside world repeats. A hold or a resolve has no such identity. The
+-- command runs once, and a second run finds the compare-and-swap
+-- refusing, so a fixed key was protecting against nothing and dropping
+-- every later decision to do it.
+--
+-- The clause still means something here. Two writes of this kind inside
+-- one transaction would compute the same count and the second would be
+-- dropped, so the invariant a caller owes is one such decision per
+-- transaction, which is what each disposition does.
 INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
 SELECT @attempt_id,
        @kind || ':' || (SELECT count(*) FROM attempt_events prior

--- a/internal/store/query/attempts.sql
+++ b/internal/store/query/attempts.sql
@@ -124,11 +124,16 @@ WHERE id = @attempt_id AND execution_evidence = @current;
 -- leased, preparing and prepared all precede the start authorization.
 -- From starting onward at-most-once rules, and requeue must refuse.
 --
--- The evidence resets like the proof-carrying requeues' does, and for
--- the same reason: the serving is over and the next one starts from
--- nothing. The authorization can be present here - recording it commits
--- before the best-effort walk to starting - and left behind it makes the
--- next serving's first honest observation a write that moves backwards.
+-- The evidence resets like the proof-carrying requeue's does, and for the
+-- same reason: the serving is over and the next one starts from nothing,
+-- so an authorization left behind would make the next serving's first
+-- honest observation a write that moves backwards.
+--
+-- Reaching here with that authorization already recorded is not possible
+-- as the code stands: the walk to starting is the authoritative edge and
+-- it commits before the evidence, so an attempt this guard accepts has
+-- not been authorized. The reset is what keeps that a property of the
+-- ordering rather than something this query depends on.
 UPDATE assignment_attempts
 SET state = 'ready', execution_evidence = 'not_started'
 WHERE id = @attempt_id AND state IN ('leased', 'preparing', 'prepared');

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -270,6 +270,10 @@ func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, err
 // placeholders builds the `?,?,?` list a set read needs. sqlc's sqlite
 // engine has no slice parameter, and the values are always ids the
 // caller already holds, never input.
+//
+// One copy, because three grew: two of them spelled it inline and one of
+// those named its local after this function, shadowing it in the file
+// that also calls it.
 func placeholders(n int) string {
 	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
 }

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -271,9 +271,9 @@ func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, err
 // engine has no slice parameter, and the values are always ids the
 // caller already holds, never input.
 //
-// One copy, because three grew: two of them spelled it inline and one of
-// those named its local after this function, shadowing it in the file
-// that also calls it.
+// One copy, because three grew: two spelled it inline, and both named
+// their local after this function — in files that never called it, so
+// nothing broke and nothing said anything.
 func placeholders(n int) string {
 	return strings.TrimSuffix(strings.Repeat("?,", n), ",")
 }

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/store/sqlitedb"
@@ -352,7 +351,7 @@ func (t *Tx) ResolveReviewToReady(attemptID assignment.AttemptID, reason, actor 
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is not in manual review", ErrConflict, attemptID)
 	}
-	return t.RecordEventDetail(attemptID, "operator_resolved", "operator_resolved",
+	return t.RecordRepeatableEvent(attemptID, "operator_resolved",
 		map[string]string{"decision": "retry", "actor": actor, "reason": reason})
 }
 
@@ -370,7 +369,7 @@ func (t *Tx) ResolveReviewToSettled(attemptID assignment.AttemptID, resolution, 
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is not in manual review", ErrConflict, attemptID)
 	}
-	return t.RecordEventDetail(attemptID, "operator_resolved", "operator_resolved",
+	return t.RecordRepeatableEvent(attemptID, "operator_resolved",
 		map[string]string{"decision": "settle", "actor": actor, "reason": reason})
 }
 
@@ -388,6 +387,30 @@ func (t *Tx) Settle(attemptID assignment.AttemptID, currentState, resolution str
 	return t.RecordEvent(attemptID, "attempt_settled", "attempt_settled")
 }
 
+// RequeueServing returns a serving's attempt to the queue, choosing
+// between the two requeues by the state the caller read.
+//
+// The choice belongs here because the partition does. The two queries
+// have identical bodies and differ only in which states they accept, and
+// they are two rather than one on purpose: RequeueProvenInertAttempt
+// admits `starting` and `running`, which are past the start
+// authorization, and a caller may only reach it holding the daemon's
+// proof that the start never took effect. Merging them into one guard
+// would hand that permission to every caller, which is the at-most-once
+// rule given away for a shorter file.
+//
+// What nothing here states is that their union covers the states a
+// serving passes through. TestEveryServingStateCanBeDisposedOf does,
+// by walking that set and requiring each of them to dispose.
+func (t *Tx) RequeueServing(attempt Attempt) error {
+	switch attempt.State {
+	case "starting", "running":
+		return t.RequeueProvenInert(attempt.ID)
+	default:
+		return t.Requeue(attempt.ID)
+	}
+}
+
 // HoldForReview parks an attempt for an operator with the reason the
 // queue will show.
 func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason string) error {
@@ -400,7 +423,27 @@ func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason string) error 
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s cannot enter review from its state", ErrConflict, attemptID)
 	}
-	return t.RecordEvent(attemptID, "manual_review_requested", "manual_review_requested")
+	return t.RecordRepeatableEvent(attemptID, "manual_review_requested",
+		map[string]string{"reason": reason})
+}
+
+// RecordRepeatableEvent appends one lifecycle event whose kind can
+// happen to an attempt more than once, sequencing the key so a second
+// occurrence is a second event rather than a replay of the first.
+//
+// Use it for a decision a person makes: held for review, resolved,
+// served again, held again. RecordEvent is for the rest, where the key
+// already carries what makes the write distinct — a lease id, a delivery
+// id — or where the thing can only happen once.
+func (t *Tx) RecordRepeatableEvent(attemptID assignment.AttemptID, kind string, detail map[string]string) error {
+	encoded, err := json.Marshal(detail)
+	if err != nil {
+		return err
+	}
+	_, err = t.q.InsertSequencedAttemptEvent(t.ctx, sqlitedb.InsertSequencedAttemptEventParams{
+		AttemptID: string(attemptID), Kind: kind, DetailJson: string(encoded),
+	})
+	return err
 }
 
 // RecordEvent appends one lifecycle event, idempotently per key.
@@ -518,20 +561,20 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 // layer: sqlc's sqlite engine has no slice parameter, and the ids come
 // from the caller's own loop, never from input.
 func (t *Tx) ForgetUnclaimedBindings(claimed []assignment.BindingID) (int, error) {
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(claimed)), ",")
-	if placeholders == "" {
+	if len(claimed) == 0 {
 		// No claim at all is a caller with no bindings, which serve
 		// refuses before reaching here. Deleting everything on an empty
 		// list would turn that mistake into data loss.
 		return 0, nil
 	}
+	held := placeholders(len(claimed))
 	args := make([]any, len(claimed))
 	for i, id := range claimed {
 		args[i] = id
 	}
 	unclaimed := `
 		SELECT id FROM provider_bindings
-		WHERE id NOT IN (` + placeholders + `)
+		WHERE id NOT IN (` + held + `)
 		  AND NOT EXISTS (SELECT 1 FROM broker_deliveries d WHERE d.binding_id = provider_bindings.id)`
 
 	// The dependents first: both reference the binding row, so the

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -435,6 +435,11 @@ func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason string) error 
 // served again, held again. RecordEvent is for the rest, where the key
 // already carries what makes the write distinct — a lease id, a delivery
 // id — or where the thing can only happen once.
+//
+// One such event per transaction. The count that forms the key is read
+// inside the transaction, so two of the same kind in one would collide
+// and the second would be dropped; every caller here writes one, as the
+// terminal act of a disposition.
 func (t *Tx) RecordRepeatableEvent(attemptID assignment.AttemptID, kind string, detail map[string]string) error {
 	encoded, err := json.Marshal(detail)
 	if err != nil {

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -436,10 +436,10 @@ func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason string) error 
 // already carries what makes the write distinct — a lease id, a delivery
 // id — or where the thing can only happen once.
 //
-// One such event per transaction. The count that forms the key is read
-// inside the transaction, so two of the same kind in one would collide
-// and the second would be dropped; every caller here writes one, as the
-// terminal act of a disposition.
+// It carries no conflict clause, unlike RecordEvent, because it has no
+// reachable conflict to absorb — the query says why. A duplicate it
+// cannot construct would be an error rather than a silent drop, which is
+// the right answer for an append-only log.
 func (t *Tx) RecordRepeatableEvent(attemptID assignment.AttemptID, kind string, detail map[string]string) error {
 	encoded, err := json.Marshal(detail)
 	if err != nil {

--- a/internal/store/sqlitedb/attempt_events.sql.go
+++ b/internal/store/sqlitedb/attempt_events.sql.go
@@ -50,8 +50,6 @@ SELECT ?1,
        ?2 || ':' || (SELECT count(*) FROM attempt_events prior
                         WHERE prior.attempt_id = ?1 AND prior.kind = ?2),
        ?2, ?3
-WHERE true
-ON CONFLICT (attempt_id, idempotency_key) DO NOTHING
 `
 
 type InsertSequencedAttemptEventParams struct {
@@ -71,17 +69,24 @@ type InsertSequencedAttemptEventParams struct {
 //
 // The key carries how many of this kind the attempt already has.
 //
-// What the conflict clause protects in this table is a redelivered
-// message: those events key by delivery id, which is the identity the
-// outside world repeats. A hold or a resolve has no such identity. The
-// command runs once, and a second run finds the compare-and-swap
-// refusing, so a fixed key was protecting against nothing and dropping
-// every later decision to do it.
+// What the conflict clause on the insert above protects against is a
+// redelivered message: those events key by delivery id, which is the
+// identity the outside world repeats. A hold or a resolve has no such
+// identity. The command runs once, and a second run finds the
+// compare-and-swap refusing, so a fixed key protected against nothing
+// while dropping every later decision to do it.
 //
-// The clause still means something here. Two writes of this kind inside
-// one transaction would compute the same count and the second would be
-// dropped, so the invariant a caller owes is one such decision per
-// transaction, which is what each disposition does.
+// This one carries no such clause, because it has no reachable conflict.
+// The count only grows: the sole delete of these rows drops the attempts
+// with them, and a row written under the old fixed key shifts the
+// numbering without ever occupying a suffixed one. Two writes inside one
+// transaction do not collide either, because SQLite shows an uncommitted
+// insert to the statements after it, so the second counts the first and
+// takes the next number.
+//
+// Leaving the clause on would mean that a duplicate nobody can construct
+// would be dropped in silence, with no error, from an append-only audit
+// log. If one is ever constructed, saying so is the only useful answer.
 func (q *Queries) InsertSequencedAttemptEvent(ctx context.Context, arg InsertSequencedAttemptEventParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, insertSequencedAttemptEvent, arg.AttemptID, arg.Kind, arg.DetailJson)
 	if err != nil {

--- a/internal/store/sqlitedb/attempt_events.sql.go
+++ b/internal/store/sqlitedb/attempt_events.sql.go
@@ -69,10 +69,19 @@ type InsertSequencedAttemptEventParams struct {
 // is lost is precisely the history -- who decided what, and why, the
 // time before.
 //
-// The key carries how many of this kind the attempt already has. That is
-// stable across a retry of the same transaction, because a transaction
-// that failed rolled its insert back and the count is unchanged, and it
-// differs for a decision genuinely made again.
+// The key carries how many of this kind the attempt already has.
+//
+// What the conflict clause protects in this table is a redelivered
+// message: those events key by delivery id, which is the identity the
+// outside world repeats. A hold or a resolve has no such identity. The
+// command runs once, and a second run finds the compare-and-swap
+// refusing, so a fixed key was protecting against nothing and dropping
+// every later decision to do it.
+//
+// The clause still means something here. Two writes of this kind inside
+// one transaction would compute the same count and the second would be
+// dropped, so the invariant a caller owes is one such decision per
+// transaction, which is what each disposition does.
 func (q *Queries) InsertSequencedAttemptEvent(ctx context.Context, arg InsertSequencedAttemptEventParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, insertSequencedAttemptEvent, arg.AttemptID, arg.Kind, arg.DetailJson)
 	if err != nil {

--- a/internal/store/sqlitedb/attempt_events.sql.go
+++ b/internal/store/sqlitedb/attempt_events.sql.go
@@ -25,9 +25,12 @@ type InsertAttemptEventParams struct {
 
 // Attempt lifecycle events: append-only, idempotent per
 // (attempt, idempotency key), so a redelivered message cannot double
-// history. Zero rows from the insert means the event already exists,
-// which the repository reports as idempotent success after verifying
-// the existing event matches.
+// history. Zero rows from an insert means the event already exists under
+// that key, which the repository reports as success: the key is what
+// makes two writes the same event, so nothing is read back to confirm
+// it.
+// For a decision that happens at most once per attempt, or one whose key
+// already carries what makes it distinct -- a lease id, a delivery id.
 func (q *Queries) InsertAttemptEvent(ctx context.Context, arg InsertAttemptEventParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, insertAttemptEvent,
 		arg.AttemptID,
@@ -35,6 +38,43 @@ func (q *Queries) InsertAttemptEvent(ctx context.Context, arg InsertAttemptEvent
 		arg.Kind,
 		arg.DetailJson,
 	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const insertSequencedAttemptEvent = `-- name: InsertSequencedAttemptEvent :execrows
+INSERT INTO attempt_events (attempt_id, idempotency_key, kind, detail_json)
+SELECT ?1,
+       ?2 || ':' || (SELECT count(*) FROM attempt_events prior
+                        WHERE prior.attempt_id = ?1 AND prior.kind = ?2),
+       ?2, ?3
+WHERE true
+ON CONFLICT (attempt_id, idempotency_key) DO NOTHING
+`
+
+type InsertSequencedAttemptEventParams struct {
+	AttemptID  string
+	Kind       string
+	DetailJson string
+}
+
+// For a decision that can be made about one attempt more than once: held
+// for review, resolved by an operator, served again, held again.
+//
+// A fixed key makes every occurrence after the first a replay of it, and
+// the conflict clause then drops the actor, the reason and the decision
+// without a word. The attempt row keeps only the latest of each, so what
+// is lost is precisely the history -- who decided what, and why, the
+// time before.
+//
+// The key carries how many of this kind the attempt already has. That is
+// stable across a retry of the same transaction, because a transaction
+// that failed rolled its insert back and the count is unchanged, and it
+// differs for a decision genuinely made again.
+func (q *Queries) InsertSequencedAttemptEvent(ctx context.Context, arg InsertSequencedAttemptEventParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertSequencedAttemptEvent, arg.AttemptID, arg.Kind, arg.DetailJson)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/sqlitedb/attempts.sql.go
+++ b/internal/store/sqlitedb/attempts.sql.go
@@ -446,11 +446,16 @@ WHERE id = ?1 AND state IN ('leased', 'preparing', 'prepared')
 // leased, preparing and prepared all precede the start authorization.
 // From starting onward at-most-once rules, and requeue must refuse.
 //
-// The evidence resets like the proof-carrying requeues' does, and for
-// the same reason: the serving is over and the next one starts from
-// nothing. The authorization can be present here - recording it commits
-// before the best-effort walk to starting - and left behind it makes the
-// next serving's first honest observation a write that moves backwards.
+// The evidence resets like the proof-carrying requeue's does, and for the
+// same reason: the serving is over and the next one starts from nothing,
+// so an authorization left behind would make the next serving's first
+// honest observation a write that moves backwards.
+//
+// Reaching here with that authorization already recorded is not possible
+// as the code stands: the walk to starting is the authoritative edge and
+// it commits before the evidence, so an attempt this guard accepts has
+// not been authorized. The reset is what keeps that a property of the
+// ordering rather than something this query depends on.
 func (q *Queries) RequeueAttempt(ctx context.Context, attemptID string) (int64, error) {
 	result, err := q.db.ExecContext(ctx, requeueAttempt, attemptID)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1788,3 +1788,65 @@ func TestAttemptStatesCoverTheSchema(t *testing.T) {
 			"one of them lists something the other does not", found, len(AllAttemptStates))
 	}
 }
+
+// TestASecondReviewCycleIsItsOwnHistory: holding an attempt twice, and
+// resolving it twice, leaves four decisions in the record rather than
+// two.
+//
+// The attempt row keeps only the latest review reason, the latest actor
+// and the latest resolution, so the event log is the whole of what says
+// who decided what and why the time before. A fixed idempotency key made
+// every occurrence after the first a replay: the insert's conflict
+// clause dropped it, silently and successfully, and the earlier decision
+// was the one that survived.
+//
+// The cycle is reachable — hold, an operator resolves back to the queue,
+// the attempt is served again and held again — and one of this round's
+// own changes is what made it complete rather than pin the lease.
+func TestASecondReviewCycleIsItsOwnHistory(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	id := seedAttempt(t, s, binding, "msg-two-reviews", "job-two-reviews")
+
+	cycle := func(reason, actor, why string) {
+		t.Helper()
+		inTx(t, s, func(tx *Tx) error {
+			if err := tx.HoldForReview(id, reason); err != nil {
+				return err
+			}
+			return tx.ResolveReviewToReady(id, why, actor)
+		})
+	}
+	cycle(ReviewReasonStartOutcomeUnknown, "alice", "the runner never picked it up")
+	cycle(ReviewReasonStartOutcomeUnknown, "bob", "the daemon was replaced mid-flight")
+
+	var events []Event
+	inTx(t, s, func(tx *Tx) error {
+		var err error
+		events, err = tx.Events(id)
+		return err
+	})
+
+	var holds, resolves []string
+	for _, e := range events {
+		switch e.Kind {
+		case "manual_review_requested":
+			holds = append(holds, e.Detail)
+		case "operator_resolved":
+			resolves = append(resolves, e.Detail)
+		}
+	}
+	if len(holds) != 2 {
+		t.Errorf("%d hold(s) recorded for two reviews: %v", len(holds), holds)
+	}
+	if len(resolves) != 2 {
+		t.Fatalf("%d resolution(s) recorded for two decisions: %v", len(resolves), resolves)
+	}
+	// Both actors, not the first one twice and not the last one only.
+	joined := strings.Join(resolves, " ")
+	for _, actor := range []string{"alice", "bob"} {
+		if !strings.Contains(joined, actor) {
+			t.Errorf("the record does not name %s: %v", actor, resolves)
+		}
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1817,8 +1817,11 @@ func TestASecondReviewCycleIsItsOwnHistory(t *testing.T) {
 			return tx.ResolveReviewToReady(id, why, actor)
 		})
 	}
+	// Distinct reasons as well as distinct actors, so the hold half of
+	// this proves the second hold was recorded rather than merely that
+	// two rows exist.
 	cycle(ReviewReasonStartOutcomeUnknown, "alice", "the runner never picked it up")
-	cycle(ReviewReasonStartOutcomeUnknown, "bob", "the daemon was replaced mid-flight")
+	cycle(ReviewReasonRetryBudgetExhausted, "bob", "the daemon was replaced mid-flight")
 
 	var events []Event
 	inTx(t, s, func(tx *Tx) error {
@@ -1838,6 +1841,12 @@ func TestASecondReviewCycleIsItsOwnHistory(t *testing.T) {
 	}
 	if len(holds) != 2 {
 		t.Errorf("%d hold(s) recorded for two reviews: %v", len(holds), holds)
+	}
+	held := strings.Join(holds, " ")
+	for _, reason := range []string{ReviewReasonStartOutcomeUnknown, ReviewReasonRetryBudgetExhausted} {
+		if !strings.Contains(held, reason) {
+			t.Errorf("the record does not carry the hold for %s: %v", reason, holds)
+		}
 	}
 	if len(resolves) != 2 {
 		t.Fatalf("%d resolution(s) recorded for two decisions: %v", len(resolves), resolves)


### PR DESCRIPTION
## What changes

Four things in `internal/store`: an audit record that dropped every
decision after the first, a partition chosen in a package that does not
own it, three copies of one helper, and a comment justified by an
ordering that has since reversed.

## What was found

**A second review cycle lost its decision.** `HoldForReview` wrote its
event under the fixed key `manual_review_requested`, and both resolves
under `operator_resolved`. `InsertAttemptEvent` is
`ON CONFLICT (attempt_id, idempotency_key) DO NOTHING`, so the second
occurrence collided with the first and was dropped — with no error, and
reported as success.

What that costs is precisely the history. The attempt row keeps the
latest `review_reason`, the latest `reviewed_by` and the latest
`resolution`; the event log is the only thing that says who decided what,
and why, the time before. Reproduced:

```text
with a fixed key
  1 hold(s) recorded for two reviews
  1 resolution(s) recorded for two decisions:
    [{"actor":"alice","decision":"retry","reason":"the runner never picked it up"}]
```

Alice survives, Bob is gone.

The cycle is reachable — held, an operator resolves back to the queue,
the attempt is served again and held again — and it was one of this work's
own earlier changes that made that cycle *complete* rather than pin the
lease in `cleaning`. So the defect is older than this round and this
round is what made it happen.

The key now carries how many events of that kind the attempt already has,
computed in the insert itself, and the write carries no conflict clause.

Both of those took three tries to justify, and the two wrong ones are
worth recording because they were wrong in the same way — a claim about
the database made without asking it.

The first said the count is stable across a transaction retry. Nothing
retries a transaction here: `Store.Tx` begins, runs, commits and rolls
back on error, `_txlock=immediate` takes the write lock at BEGIN so a
contended transaction fails before its body runs, and the retry budget
the `Tx` carries counts how many times an attempt may be *served*.

The second said two writes of one kind in one transaction would collide,
so a caller owes one per transaction. They do not collide:

```text
sqlite> INSERT ... SELECT 'att', 'hold:' || (SELECT count(*) ...);
sqlite> INSERT ... SELECT 'att', 'hold:' || (SELECT count(*) ...);
hold:0
hold:1
```

SQLite shows an uncommitted insert to the statements after it, so the
second counts the first.

What is true: the conflict clause protects a *redelivered message*, and
those events key by delivery id — the identity the outside world repeats.
A hold or a resolve has no such identity; the command runs once, and a
second run meets a compare-and-swap that refuses. So the fixed key
protected against nothing while dropping every later decision.

And the sequenced write has no conflict to absorb. The count only grows —
the sole delete of these rows drops the attempts with them — a row under
the old fixed key shifts the numbering without occupying a suffixed one,
two writes in one transaction take consecutive numbers, and the single
writer with an immediate lock serializes the rest. The clause is removed
rather than explained a third time: what it would do, if a duplicate
nobody can construct ever arrived, is drop a row from an append-only
audit log with no error.

`Settle` keeps its fixed key: its guard is a compare-and-swap on the
state it read, so a second settle matches no row.

**The requeue partition was chosen in `internal/lease` and written in
`internal/store`.** `requeueProven` tested `starting || running` in Go to
pick between two queries whose guards say the same thing in SQL.

The choice moves to the store. It stays a choice, deliberately: the two
queries have identical bodies and differ only in the states they accept,
because `RequeueProvenInertAttempt` admits the two states past the start
authorization and a caller may only reach it holding the daemon's proof
that the start never took effect. One guard over the union would hand
that permission to every caller — the at-most-once rule traded for a
shorter file.

What nothing stated is that their union covers the states a serving
passes through. `TestEveryServingStateCanBeDisposedOf` does, by walking
that set; the comment names it instead of leaving a reader to hope.

**Three copies of the placeholder list.** Two spelled
`strings.TrimSuffix(strings.Repeat(...))` inline, and one of those named
its local `placeholders` — shadowing the function of that name, in the
same package that declares it.

**`RequeueAttempt`'s comment justified its evidence reset by an ordering
that reversed.** It said the authorization "can be present here —
recording it commits before the best-effort walk to starting". Since the
walk to `starting` became the authoritative edge it commits *first*, so
an attempt this guard accepts has not been authorized. The reset stays;
the comment now says it keeps that a property of the ordering rather than
something the query depends on.

## Symmetry check

| Path | Result |
|---|---|
| every fixed event key | `manual_review_requested` and `operator_resolved` can repeat and are sequenced; `attempt_settled` cannot — the settle CAS matches no row a second time; `cleanup_completed:<lease>` and the delivery keys already carry their discriminator |
| `RecordEvent` vs `RecordEventDetail` vs the new sequenced write | the first two keep their callers, which all carry a discriminator or happen once; the comment on each says which case it is for |
| the two requeue queries | left as two on purpose, and the reason is now written where the choice is made |
| `requeueOrReview` | unchanged; it takes the error, so the dispatch had to happen before it either way |
| the three placeholder builders | one function, three callers; the shadowing local is gone |
| `attempt_events.sql`'s header | claimed the repository verifies a matching event before reporting success. The query that could do that was deleted in an earlier round; the header now says the key is what makes two writes the same event |

## Evidence

```text
the sequenced key is fixed again, with the conflict clause still present
  -> --- FAIL: TestASecondReviewCycleIsItsOwnHistory
     1 hold(s) recorded for two reviews
     1 resolution(s) recorded for two decisions: [{"actor":"alice",...}]

the same mutation, with the clause removed as it now is
  -> --- FAIL: constraint failed: UNIQUE constraint failed:
     attempt_events.attempt_id, attempt_events.idempotency_key (2067)
```

The first is the defect: alice survives, bob is gone, no error. The
second is what removing the clause buys — the same mistake is now a
failure rather than a missing row.

The other three are refactors and comment corrections with no behaviour
to mutate: `sqlc diff` is clean after regeneration, `staticcheck` is
clean where it previously had a shadowed name to complain about, and the
existing lease and store suites cover the dispatch's two branches
already — `TestEveryServingStateCanBeDisposedOf` walks all five serving
states through it.

## What would notice this regressing

- `TestASecondReviewCycleIsItsOwnHistory` runs two full cycles and
  requires four decisions in the log, naming both actors — so a fixed key
  fails it, and so does a key that keeps only the last.
- `TestEveryServingStateCanBeDisposedOf` walks the serving set through
  `RequeueServing`, so a dispatch that sends a state to the wrong query
  fails there.
- `TestNoDocCommentBelongsToAnotherDeclaration`, added alongside, is what
  now catches the class of comment defect this PR contains two examples
  of.

## Risk, compatibility and operations

**The event log gains rows it previously dropped.** A deployment that has
held and resolved the same attempt more than once will record subsequent
cycles from now on. Nothing reads the log programmatically —
`runpool attempts inspect` renders it — so a consumer counting events
sees a number that can now grow where it could not.

**No behaviour change in the requeue.** The same states reach the same
queries; only where the choice is made moved.

**Schema: no migration.** One new query, no table, column or index
change. **Trust boundary, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous binary; rows written under
sequenced keys stay readable, since the key is opaque to every reader.

## Changelog

```text
### Fixed
- An attempt held for review and resolved more than once now records each
  decision. Every cycle after the first was silently dropped, so the
  operator, the reason and the decision from the earlier one were the only
  ones kept.
```

## Notes for your reviewer

The part to check hardest is the sequenced key, and the honest framing is
that its justification was wrong twice before this. Both times the error
was the same: a claim about SQLite stated instead of asked. What is
written now was asked — the two-insert transcript above is the answer to
the second one.

What would still make it wrong: a delete of `attempt_events` rows that
leaves their attempt behind, which would let the count fall and a new key
land on an old row. There is none today; `PurgeAttemptEvents` runs only
from `PurgeEverything`, which drops the attempts in the same pass.

Second, whether the two requeue queries should have been merged. They are
byte-identical apart from the state set, which is the shape of duplication
worth removing — and this deliberately does not, because the difference
is a permission rather than a value. Worth disagreeing with if you read
it otherwise.

