### PR TITLE
fix(gateway, docker): the policy store stats under its own lock, and a version this client cannot use is not an unreachable daemon

### DIFF
--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -63,15 +63,24 @@ type PolicyStore struct {
 
 // Current returns the compiled policy in force, reloading it if the
 // file changed since the last read.
+//
+// The stat is inside the lock, with the read it decides. Outside it, two
+// readers crossing an install can stat different files and finish in the
+// other order, so the one that stat'd first stores what the other read
+// under the stamp of what it did not: the decider is never stale, since
+// the read is under the lock, but the stamp no longer describes it. The
+// next call then reloads a file that has not changed and advances the
+// generation for it, which retires the pooled transport and every idle
+// connection in it for nothing.
 func (s *PolicyStore) Current() (*egress.Decider, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	info, err := os.Stat(s.Path)
 	if err != nil {
 		return nil, err
 	}
 	stamp := fmt.Sprintf("%d/%d", info.ModTime().UnixNano(), info.Size())
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.decider != nil && s.stamp == stamp {
 		return s.decider, nil
 	}

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/egress"
+	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 // TestPolicyGenerationAdvancesOnlyOnChange: the relay drops pooled
@@ -339,5 +340,75 @@ func TestConcurrentInstallsAreSerialized(t *testing.T) {
 		t.Errorf("%d installers held the critical section at once; want 1 — "+
 			"each one past the read is building its successor from a policy "+
 			"another is about to replace", got)
+	}
+}
+
+// TestAReaderCrossingAnInstallDoesNotOverCountGenerations: the policy's
+// generation counts installs, not readers that raced one.
+//
+// The generation is what makes the relay retire its pooled transport and
+// every idle connection in it — a pooled request never reaches the
+// dialer, so a policy that moved has no other way to reach it. Advancing
+// it for a file that did not change is that pool thrown away for
+// nothing, on a relay that may be carrying a job's whole traffic.
+//
+// The interleaving that causes it needs the file to change between one
+// reader's stat and its turn at the lock, which no test can schedule.
+// What this does instead is race enough readers against enough installs
+// that the window is entered, and assert the invariant that survives any
+// interleaving: the generation never exceeds the number of distinct
+// policies actually installed.
+func TestAReaderCrossingAnInstallDoesNotOverCountGenerations(t *testing.T) {
+	dir := t.TempDir()
+	path := PolicyPath(dir)
+	policy := func(deny string) []byte {
+		return []byte(`{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`)
+	}
+	if err := atomicfile.Replace(path, policy("10.0.0.0/8"), 0o600, -1, -1); err != nil {
+		t.Fatal(err)
+	}
+	store := &PolicyStore{Path: path}
+	if _, err := store.Current(); err != nil {
+		t.Fatal(err)
+	}
+
+	const installs = 40
+	denies := []string{"10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"}
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := store.Current(); err != nil {
+					return
+				}
+			}
+		}()
+	}
+	for i := range installs {
+		if err := atomicfile.Replace(path, policy(denies[i%len(denies)]), 0o600, -1, -1); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	close(stop)
+	readers.Wait()
+
+	// One for the first read, and at most one per install. Two installs
+	// inside the same nanosecond-and-size stamp are indistinguishable to
+	// the store, so this is an upper bound rather than an equality.
+	if got, max := store.Generation(), uint64(installs+1); got > max {
+		t.Errorf("generation = %d after %d installs; want at most %d. "+
+			"The extra reloads are pooled transports retired for a policy that did not move",
+			got, installs, max)
 	}
 }

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -389,19 +389,29 @@ func TestAReaderCrossingAnInstallDoesNotOverCountGenerations(t *testing.T) {
 				default:
 				}
 				if _, err := store.Current(); err != nil {
+					// A reader that returned quietly would leave the
+					// ceiling below satisfied by eight dead goroutines.
+					t.Errorf("reader: %v", err)
 					return
 				}
 			}
 		}()
 	}
+	// Deferred as well as called, so a failure out of the loop below
+	// cannot leave eight goroutines spinning for the rest of the run.
+	settle := sync.OnceFunc(func() {
+		close(stop)
+		readers.Wait()
+	})
+	defer settle()
+
 	for i := range installs {
 		if err := atomicfile.Replace(path, policy(denies[i%len(denies)]), 0o600, -1, -1); err != nil {
 			t.Fatal(err)
 		}
 		time.Sleep(time.Millisecond)
 	}
-	close(stop)
-	readers.Wait()
+	settle()
 
 	// One for the first read, and at most one per install. Two installs
 	// inside the same nanosecond-and-size stamp are indistinguishable to

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -50,13 +50,22 @@ func (c *Client) OnCleanupError(fn func(name string, err error)) { c.onCleanupEr
 
 // New connects to the local daemon and proves liveness immediately: a
 // controller that cannot reach its daemon must fail at startup, not at
-// first lease. API version negotiation is the client's default.
+// first lease.
+//
+// The ping negotiates the API version rather than leaving it to the
+// first real request. The client negotiates lazily otherwise, once,
+// behind its own lock — correct, but it makes whichever caller happens
+// to be first pay for it, and since the gateway refresh fans out that
+// caller can be one of eight goroutines racing into the same lock while
+// holding the one every launch waits on. Settling it here costs nothing:
+// the ping is already being made, and a daemon that answers it is a
+// daemon whose version is known.
 func New(ctx context.Context) (*Client, error) {
 	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cli.Ping(ctx, client.PingOptions{}); err != nil {
+	if _, err := cli.Ping(ctx, client.PingOptions{NegotiateAPIVersion: true}); err != nil {
 		cli.Close()
 		return nil, fmt.Errorf("docker daemon unreachable: %w", err)
 	}

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -53,21 +53,29 @@ func (c *Client) OnCleanupError(fn func(name string, err error)) { c.onCleanupEr
 // first lease.
 //
 // The ping negotiates the API version rather than leaving it to the
-// first real request. The client negotiates lazily otherwise, once,
-// behind its own lock — correct, but it makes whichever caller happens
-// to be first pay for it, and since the gateway refresh fans out that
-// caller can be one of eight goroutines racing into the same lock while
-// holding the one every launch waits on. Settling it here costs nothing:
-// the ping is already being made, and a daemon that answers it is a
-// daemon whose version is known.
+// first real request. Not for speed — serve reads the daemon's facts on
+// the next line, so the lazy negotiation was already settled on the
+// startup goroutine long before anything ran concurrently. What it buys
+// is a failure with somewhere to appear: the lazy path runs inside
+// getAPIPath, which discards the error, so a version this client cannot
+// use surfaces as whatever the first request happens to fail with. Here
+// it surfaces as a refusal to start, next to the reason.
+//
+// A daemon whose version this client cannot use is one it should not
+// start against, and saying so is not the same as saying the daemon is
+// unreachable — the daemon answered.
 func New(ctx context.Context) (*Client, error) {
 	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, err
 	}
-	if _, err := cli.Ping(ctx, client.PingOptions{NegotiateAPIVersion: true}); err != nil {
+	if _, err := cli.Ping(ctx, client.PingOptions{}); err != nil {
 		cli.Close()
 		return nil, fmt.Errorf("docker daemon unreachable: %w", err)
+	}
+	if _, err := cli.Ping(ctx, client.PingOptions{NegotiateAPIVersion: true}); err != nil {
+		cli.Close()
+		return nil, fmt.Errorf("docker daemon answered but its API version is unusable: %w", err)
 	}
 	return &Client{cli: cli, onCleanupError: func(string, error) {}}, nil
 }

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -172,9 +172,10 @@ func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID assignment.In
 // its lease in the same label map as the rest of its identity, so there
 // is no window in which one exists without it; the instance's own
 // objects are created without that label on purpose. Naming the
-// persistent roles instead only looked equivalent: a fourth persistent
-// role added later would be swept away as garbage by everything that
-// spelled the rule that way.
+// persistent roles instead only looked equivalent: there are two of them
+// — the uplink network and a cache lane volume — and a third added later
+// would be swept away as garbage by everything that spelled the rule
+// that way.
 func (r OwnedResource) InstanceInfrastructure() bool { return r.LeaseID == "" }
 
 // ShortID trims an object id to the width daemon tooling displays,


### PR DESCRIPTION
## What changes

`PolicyStore.Current` takes its lock before deciding whether to reload,
the Docker client negotiates its API version at connect, and a comment
counts the persistent roles correctly.

## What was found

**A reader crossing an install cached the new policy under the old
stamp.** `Current` stat'd the file, computed a stamp from it, and only
then took the lock:

```go
info, err := os.Stat(s.Path)
stamp := fmt.Sprintf("%d/%d", info.ModTime().UnixNano(), info.Size())

s.mu.Lock()
```

Two readers crossing an install stat different files and can reach the
lock in the other order. The second one in stores what it read — under
the stamp it computed before the install. The decider is never stale,
because the `ReadFile` is inside the lock, so this is conservative in the
direction that matters. What it costs is that the *next* call sees a
stamp that does not describe what is cached, reloads a file that has not
changed, and advances the generation for it.

That generation is not bookkeeping. It is what makes the relay retire its
pooled transport and every idle connection in it — a pooled request never
reaches the dialer, so a policy that moved has no other way to reach one.

Measured, eight readers against forty installs:

```text
generation = 201 after 40 installs; want at most 41
```

Five times the pool retirements, not one spurious reload. The estimate in
the note that recorded this said "one reload and one generation bump"; it
was wrong by a factor of five, and only running it said so.

**The Docker client negotiated its API version on whichever request
arrived first.** `New` pings with `client.PingOptions{}`, which leaves
`NegotiateAPIVersion` false, so the client defers negotiation to
`checkVersion` on the first real call.

The first version of this change justified settling it at connect by the
gateway fan-out — that the caller paying for the lazy negotiation could
be one of eight goroutines holding the lock every launch waits on. That
cannot happen: `serve` reads the daemon's facts on the line after
`docker.New`, on the startup goroutine, before a binding exists. The
negotiation was always settled long before anything ran concurrently.

What it actually buys is a failure with somewhere to appear. The lazy
path runs inside `getAPIPath`, which does `_ = cli.checkVersion(ctx)` —
the error is discarded, so a version this client cannot use surfaces as
whatever the first request happens to fail with. At connect it surfaces
as a refusal to start, next to the reason.

Which is why the ping is now two. A daemon that does not answer is
unreachable and says so. A daemon that answers with a version this client
cannot use is a different fact and gets a different sentence — reporting
it as unreachable sends an operator to look at a socket that is working.

Measured against a fake daemon, old behaviour versus new:

| daemon `Api-Version` | before | after |
|---|---|---|
| `1.51` | connects, requests work | unchanged |
| header absent | connects at 1.55 | unchanged |
| `1.40` | connects at 1.40 | unchanged |
| `DOCKER_API_VERSION` set | uses the override | unchanged — `FromEnv` marks it negotiated, so the ping short-circuits |
| `1.24` / `1.39` | connects, **first request fails** | fails at startup |
| `v1.47` or `unknown` | connects at 1.55, requests work | fails at startup |

The last row is the one to weigh: a daemon reporting a `v`-prefixed or
non-numeric version connected and worked before, and now refuses to
start. Real dockerd emits a bare `1.xx`, so the trigger is a socket proxy
or an alternate daemon that rewrites the header. Kept deliberately — a
version this client cannot parse is a host it should not start against,
which is the same rule `doctor` applies to everything else — and the
error now says which of the two things went wrong.

The row above it is an improvement: a daemon below API 1.40 was already
broken, and the failure moves from the first request to startup.

**A comment reasoned about a fourth**A comment reasoned about a fourth persistent role.** There are two: the
uplink network and a cache lane volume. The one worth reasoning about is
a third.

## Symmetry check

| Path | Result |
|---|---|
| `Current`'s other reader | `expireStaleConnections` calls it once per forwarded request; same fix, same lock |
| `Generation` and `policyGen.Swap` | unchanged — they read a counter that now moves once per install |
| `installPolicyWith` | the writer, serialized by its own `flock`; untouched |
| every other `os.Stat` in the gateway | none decides a cached value, so none has this shape |
| `docker.New`'s other callers | one, in `serve`; the negotiation is per-client and settles for every later call |
| the persistent roles | `RoleUplink` and `cache.RoleCacheLane`, which is what `discrepancies` checks; `RoleCapsule`, `RoleGateway` and `RoleNetwork` all carry a lease |

## Evidence

```text
the stat goes back outside the lock
  -> --- FAIL: TestAReaderCrossingAnInstallDoesNotOverCountGenerations
     generation = 201 after 40 installs; want at most 41
  -> --- FAIL (second run): generation = 185 after 40 installs
```

Five runs under `-race`, failing every time with the mutation and passing
every time without it.

The API version was read off a live daemon rather than argued from the
client's source, and the role count off `discrepancies`, which is the
code that enumerates them.

## What would notice this regressing

- `TestAReaderCrossingAnInstallDoesNotOverCountGenerations` races eight
  readers against forty installs and holds the generation to one per
  install plus the first read.

  It is more deterministic than the first version of this claimed. The
  interleaving is not schedulable, but the assertion is an invariant of
  every interleaving rather than a likely count, and against the mutation
  it fails 5 of 5 runs at GOMAXPROCS 1, 2 and 8. It also cannot pass with
  its readers dead — each reports its error instead of returning quietly —
  and its stop is deferred, so a failing install cannot leave eight
  goroutines spinning for the rest of the run.

- Nothing guards the API version negotiation. A test would have to assert
  a field of the vendored client's internal state, or measure which
  goroutine paid for a lock; neither is worth its weight. The value was
  verified once, by hand, against a daemon.

## Risk, compatibility and operations

**`Current` now holds its lock across a stat.** It was already holding it
across a read and a parse on any change; the stat is microseconds and the
callers poll at 30 seconds.

**Connect does one more thing before returning.** It is the same ping,
with the option set, so a daemon that was reachable before is reachable
now. A daemon whose version cannot be negotiated fails at startup rather
than at first request — which is what the surrounding comment already
says this function is for.

**Fewer pool retirements under load.** A relay carrying traffic through a
policy change keeps connections it used to throw away.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** Rollback is the previous image.

## Changelog

```text
### Fixed
- A gateway that reads its policy while an install is in flight no longer
  discards its pooled connections repeatedly for a policy that has not
  changed.
```

## Notes for your reviewer

The measurement is the part worth checking. The note that recorded this
called it conservative and cheap — one extra reload — and running it gave
five times the pool retirements. If the ceiling in the test is wrong, the
number it reports is wrong too: it allows one generation per install plus
the initial read, and treats two installs sharing a nanosecond-and-size
stamp as indistinguishable, which is why it is an upper bound rather than
an equality.

And the impact is worse than the commit says rather than better:
`expireStaleConnections` runs on every forwarded request, not on a timer.
So a generation that keeps moving retired the transport per request,
which is the transport-per-request shape `roundTripper`'s own comment
says was removed for leaking a connection pool on every call.

Second, the last row of the version table. Refusing to start over an
unparseable API version is a judgement, not a fact — the client could
carry on at its default as it did before. The case for refusing is that
this is the one place the failure has a name; the case against is that a
deployment behind a header-rewriting proxy stops starting on an upgrade.
