### PR TITLE
fix(capsule): every file the supervisor writes goes through one door

### DIFF
--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -253,14 +253,15 @@ func writeDockerProxyConfig(environ func(string) string, home string, uid, gid i
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return false, fmt.Errorf("create %s: %w", dir, err)
 	}
+	// The file goes through the same door as the rest, so it is never
+	// visible half written and never visible to its owner empty. The
+	// directory keeps its own chown: a rename cannot create one.
 	path := filepath.Join(dir, "config.json")
-	if err := os.WriteFile(path, body, 0o644); err != nil {
+	if err := atomicfile.Replace(path, body, 0o644, uid, gid); err != nil {
 		return false, fmt.Errorf("write %s: %w", path, err)
 	}
-	for _, target := range []string{dir, path} {
-		if err := os.Chown(target, uid, gid); err != nil {
-			return false, fmt.Errorf("chown %s: %w", target, err)
-		}
+	if err := os.Chown(dir, uid, gid); err != nil {
+		return false, fmt.Errorf("chown %s: %w", dir, err)
 	}
 	return true, nil
 }
@@ -577,11 +578,14 @@ func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int)
 			cleanup()
 			return nil, fmt.Errorf("decode JIT bundle file %q: %w", clean, err)
 		}
-		if err := os.WriteFile(target, decoded, 0o600); err != nil {
-			cleanup()
-			return nil, err
-		}
-		if err := os.Chown(target, uid, gid); err != nil {
+		// Through the same door as the control surface, and for the
+		// reason the comment above already gives: the runner aborts on
+		// a file that exists empty, and a write that truncates first is
+		// a window in which this file exists empty. Nothing reads it
+		// before the runner is started today, so this is the window
+		// closed rather than a race fixed — and the owner lands with the
+		// contents rather than after them.
+		if err := atomicfile.Replace(target, decoded, 0o600, uid, gid); err != nil {
 			cleanup()
 			return nil, err
 		}
@@ -623,7 +627,7 @@ func setState(s string) { replaceState(stateFile, s, atomicfile.Replace) }
 
 // terminalFailure names a failure by whether the runner ever started, which
 // is the one thing the controller cannot infer from the outside. `running` is
-// written immediately before the runner is executed, so its presence is the
+// written once fork/exec has returned, so its presence is the
 // proof that the job was handed over: after it, a failure is an execution
 // outcome. Before it — no credential delivered, configuration unprepared,
 // dockerd never ready — the job never ran, and reporting an exit would settle

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -625,9 +625,9 @@ func replaceState(path, state string, replace func(string, []byte, os.FileMode, 
 
 func setState(s string) { replaceState(stateFile, s, atomicfile.Replace) }
 
-// terminalFailure names a failure by whether the runner ever started, which
-// is the one thing the controller cannot infer from the outside. `running` is
-// written once fork/exec has returned, so its presence is the
+// terminalFailure names a failure by whether the runner ever started,
+// which is the one thing the controller cannot infer from the outside.
+// `running` is written once fork/exec has returned, so its presence is the
 // proof that the job was handed over: after it, a failure is an execution
 // outcome. Before it — no credential delivered, configuration unprepared,
 // dockerd never ready — the job never ran, and reporting an exit would settle

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,8 +88,8 @@ func TestPrepareRunnerConfigRejectsPathsAndCollisions(t *testing.T) {
 }
 
 // TestTerminalFailureDistinguishesUnstartedRunners: `running` is written
-// immediately before the runner is executed, so it is the only proof the
-// supervisor has that the job was handed over. A failure before it must not
+// once fork/exec has returned, so it is the only proof the supervisor has
+// that the job was handed over. A failure before it must not
 // be reported as an execution, or the controller settles a job that never ran.
 func TestTerminalFailureDistinguishesUnstartedRunners(t *testing.T) {
 	err := errors.New("no credential was delivered")
@@ -271,33 +274,74 @@ func TestAStateThatCannotBeReplacedIsStillWritten(t *testing.T) {
 	}
 }
 
-// TestEveryControlFileIsWrittenThroughTheAtomicHelper: the helper only
-// helps the writes that use it.
+// TestEveryFileIsWrittenThroughTheAtomicHelper: the supervisor creates
+// no file except through atomicfile, save one deliberate exception.
 //
-// A test of the helper passes with none of the call sites converted, so
-// it cannot say whether one was missed — and a control file left on
-// os.WriteFile is exactly the defect, still present, in a change whose
-// evidence says it is gone. The only exception is replaceState's
-// fallback, which writes in place on purpose and by way of a parameter,
-// never by naming the file.
-func TestEveryControlFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
-	src, err := os.ReadFile("main.go")
+// A helper only helps the writes that use it, and a test of the helper
+// passes with none of them converted — so this checks the call sites.
+//
+// It parses rather than greps, because grepping was tried and did both
+// things wrong. It named the four control-file constants, so the two
+// writes whose target is a local variable were invisible to it. Counting
+// the string instead saw those, and then could not tell a call from a
+// comment naming one, so the file could not describe its own rule.
+//
+// The exception is replaceState's in-place fallback, which exists
+// because a state that cannot be written is worse than one written
+// half-way; it is named here so adding a second exception is a decision
+// somebody makes rather than a count that still passes.
+func TestEveryFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
+	const allowedIn = "replaceState"
+	creators := map[string]bool{"WriteFile": true, "Create": true, "OpenFile": true}
+
+	sources, err := filepath.Glob("*.go")
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, name := range []string{"protocolFile", "stateFile", "startFile", "jitFile"} {
-		if strings.Contains(string(src), "os.WriteFile("+name) {
-			t.Errorf("%s is written with os.WriteFile, which truncates before it writes; "+
-				"a reader landing in that window gets an empty file from a call that succeeded", name)
+	fset := token.NewFileSet()
+
+	var found int
+	for _, src := range sources {
+		if strings.HasSuffix(src, "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, src, nil, 0)
+		if err != nil {
+			t.Fatalf("%s: %v", src, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkgName, ok := sel.X.(*ast.Ident)
+				if !ok || pkgName.Name != "os" || !creators[sel.Sel.Name] {
+					return true
+				}
+				found++
+				if fn.Name.Name != allowedIn {
+					t.Errorf("%s: os.%s in %s. Every file this binary writes is read by "+
+						"something that did not wait for it, so it goes through "+
+						"atomicfile.Replace; %s is the one exception and says why",
+						fset.Position(call.Pos()), sel.Sel.Name, fn.Name.Name, allowedIn)
+				}
+				return true
+			})
 		}
 	}
-	// And no write-then-chown left anywhere: naming the four control
-	// files could not see the two that materialize the credential and
-	// the proxy config, whose targets are locals. The pairing is the
-	// shape — a file that exists before its owner does, and before its
-	// contents do.
-	if n := strings.Count(string(src), "os.WriteFile("); n != 1 {
-		t.Errorf("%d os.WriteFile calls; want 1, the in-place fallback replaceState takes when "+
-			"the atomic replacement cannot be made. Every other write goes through atomicfile", n)
+	if len(sources) == 0 {
+		t.Fatal("no sources found; this test asserted nothing")
+	}
+	if found == 0 {
+		t.Error("no file-creating call found at all; this test asserted nothing")
 	}
 }

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -291,4 +291,13 @@ func TestEveryControlFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
 				"a reader landing in that window gets an empty file from a call that succeeded", name)
 		}
 	}
+	// And no write-then-chown left anywhere: naming the four control
+	// files could not see the two that materialize the credential and
+	// the proxy config, whose targets are locals. The pairing is the
+	// shape — a file that exists before its owner does, and before its
+	// contents do.
+	if n := strings.Count(string(src), "os.WriteFile("); n != 1 {
+		t.Errorf("%d os.WriteFile calls; want 1, the in-place fallback replaceState takes when "+
+			"the atomic replacement cannot be made. Every other write goes through atomicfile", n)
+	}
 }

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -57,9 +57,9 @@ func ClassifyExit(code int) assignment.ExecutionObservation {
 
 // classifySupervisorState reads the supervisor's own account of itself. The
 // distinction that matters is whether the runner ever started: the supervisor
-// writes `running` immediately before executing it, so `aborted` means the job
-// was never handed over and `failed` means it was. Collapsing the two settles
-// an attempt that never ran as complete, and nothing requeues it.
+// writes `running` once fork/exec has returned, so `aborted` means the job was
+// never handed over and `failed` means it was. Collapsing the two settles an
+// attempt that never ran as complete, and nothing requeues it.
 func classifySupervisorState(state string) (assignment.ExecutionObservation, error) {
 	switch {
 	case state == protocol.StateBooting, state == protocol.StateWaiting:

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -43,8 +43,11 @@ const (
 	// not started: the state in which a credential is delivered and a
 	// start is authorized.
 	StateWaiting = "waiting"
-	// StateRunning is written immediately before the runner is executed,
-	// so its presence is the proof that the job was handed over.
+	// StateRunning is written once fork/exec has returned, so its
+	// presence is the proof that the job was handed over — not that the
+	// supervisor was about to try. Writing it before the exec would make
+	// a fork that failed indistinguishable from a runner that took the
+	// job and died, and the two settle an attempt differently.
 	StateRunning = "running"
 	// StateReady is the gateway's: ruleset installed and relay listening.
 	StateReady = "ready"

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -45,9 +45,14 @@ const (
 	StateWaiting = "waiting"
 	// StateRunning is written once fork/exec has returned, so its
 	// presence is the proof that the job was handed over — not that the
-	// supervisor was about to try. Writing it before the exec would make
-	// a fork that failed indistinguishable from a runner that took the
-	// job and died, and the two settle an attempt differently.
+	// supervisor was about to try.
+	//
+	// Writing it before the exec would lose a job. A fork that failed
+	// would leave this state behind, so the supervisor would report a
+	// terminal failure rather than an abort; the controller reads that
+	// as a runtime that ran, settles the attempt, and nothing requeues
+	// it. The distinction this state carries is the difference between
+	// a job retried and a job silently gone.
 	StateRunning = "running"
 	// StateReady is the gateway's: ruleset installed and relay listening.
 	StateReady = "ready"

--- a/internal/platform/atomicfile/atomicfile.go
+++ b/internal/platform/atomicfile/atomicfile.go
@@ -16,6 +16,7 @@
 package atomicfile
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -33,6 +34,17 @@ import (
 // so it never appears to that owner empty either. -1 leaves the owner
 // alone, as os.Chown does.
 func Replace(path string, data []byte, perm os.FileMode, uid, gid int) error {
+	if err := replace(path, data, perm, uid, gid); err != nil {
+		// The temporary name is an implementation detail, and it is gone
+		// by the time anyone reads the error. Naming the target is what
+		// a caller can act on — and in the capsule this text lands in
+		// the state file an operator reads.
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}
+
+func replace(path string, data []byte, perm os.FileMode, uid, gid int) error {
 	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
 	if err != nil {
 		return err


### PR DESCRIPTION
## What changes

The two writes the atomic-replace change did not reach, the guard that
could not see them, and two comments that described `running` as written
one step earlier than it is.

## What was found

**`atomicfile` reached four of six sites.** The two it missed materialize
the runner's credential and the Docker proxy config, and both are
`os.WriteFile` followed by `os.Chown`.

The credential one carries its own argument, eight lines above the write:

> the runner reads `.runner` while constructing its host context, before
> it looks at `--jitconfig`, and **aborts on a file that exists empty**

Which is verbatim the failure the atomic replace exists to prevent. A
write that truncates first is a window in which that file exists empty.

Neither is a live race — both run before `reap.start`, so no reader
exists yet — so this is a window closed rather than a defect fixed. What
does change today is the ordering of the owner: `Replace` chowns the
temporary file before the rename, so the file is never visible to the
runner uid without its contents. The old pairing made it visible owned
and empty, in that order.

**The guard could not see them, and the first fix could not see much
either.** `TestEveryControlFileIsWrittenThroughTheAtomicHelper` looked
for `os.WriteFile(<name>)` against the four control-file constants. These
two write to locals — `target`, `path` — so it returned clean over both.

Counting the string instead saw those and introduced two new holes,
both demonstrated: an `os.Create` slipped through, and a comment merely
*naming* the call made the test fail — so the file could not document the
rule it enforces.

It parses now. Every function in the package, every call to
`os.WriteFile`, `os.Create` or `os.OpenFile`, and one allowed location:
`replaceState`'s deliberate in-place fallback, named rather than counted,
so a second exception is a decision somebody makes.

**Two comments put `running` one step early.****Two comments put `running` one step early.** Both said it is written
"immediately before the runner is executed". It is written after
`reap.start(cmd)` returns — after fork/exec — which the comment eight
lines above the write states explicitly:

> `running` is written below, after this check, precisely so this case
> stays an abort.

The invariant is intact and the written version was the weaker one. Its
presence proves the job was handed over, not that the supervisor was
about to try.

There were four copies, not two. The sweep missed
`classifySupervisorState`'s — the controller-side one, which is the
comment that justifies reading `aborted` as a job never handed over, and
the most load-bearing of the four — and one in the test file this change
already edits.

The consequence that comment gave was also right in effect and wrong in
its example. A runner that took the job and died reports `exited:`, never
`failed:`. What writing `running` before the exec would actually cost is
a job: a failed fork would leave the state behind, the supervisor would
report a terminal failure rather than an abort, and the controller would
settle the attempt instead of requeuing it.

## Symmetry check

| Site | Result |
|---|---|
| `protocol`, `state`, `start`, `jitconfig` | through `atomicfile` since the change that introduced it |
| `runner-config/*` (`.runner`, `.credentials`) | the miss this closes; its own comment named the failure |
| `~/.docker/config.json` | the other miss; the directory keeps a separate chown, since a rename cannot create one |
| `replaceState`'s fallback | deliberately still `os.WriteFile`, and the guard's count is what says so out loud |
| every other write in the binary | the count is the enumeration now, so there is no list to fall behind |
| `StateRunning`'s two descriptions | the supervisor's and the protocol package's; both corrected, since the controller reads the second to classify |

## Evidence

```text
the write-then-chown put back        -> FAIL: os.WriteFile in prepareRunnerConfig
an os.Create in its place            -> FAIL: os.Create in writeDockerProxyConfig
a write moved to gateway.go          -> FAIL: os.WriteFile in stashPolicy
a comment merely naming the call     -> ok
```

The string version caught only the first: `os.Create` was invisible to
it, the second file was never read, and the comment made it fail.

The ordering was read off the code rather than the comment: `setState(protocol.StateRunning)`
follows `exit, err := reap.start(cmd)` and its error check.

## What would notice this regressing

- `TestEveryFileIsWrittenThroughTheAtomicHelper` fails on any file-creating
  call outside `replaceState`, anywhere in the package, whatever its
  target is called.
- `TestAReplacedFileIsNeverReadHalfWritten` covers the helper itself.
- `TestNoDocCommentBelongsToAnotherDeclaration` is what now catches the
  class of comment defect this PR contains two more examples of.

Nothing asserts the credential file is never observed empty, because
nothing observes it before the runner starts — the fix is the window
closed, and the window is not reachable to assert against.

## Risk, compatibility and operations

**Behaviour changes only in the window.** Same contents, same owner
outside it. The mode is now forced rather than umask-filtered and applies
to a pre-existing file, which is what the declared mode already said.

**Failures name the target rather than the temporary file.** That text
reaches an operator through the capsule's state file, and the temporary
name is gone by the time it is read.

**Two more inodes, briefly.** Both directories are on the capsule's own
filesystem and the temporary file is removed on every path.

**The capsule image changes**, so rollback is the previous image; a
capsule already running is unaffected, since both writes happen during
preparation.

**Trust boundary, schema, migrations, CLI, configuration, status API:
untouched.**

## Changelog

```text
NONE - closes a window no reader can currently enter, and corrects two
comments. The behaviour a deployment sees is unchanged.
```

## Notes for your reviewer

The judgement is whether closing an unreachable window is worth the
change. The case for: the reader that would enter it is the GitHub runner
itself, the failure it produces is an abort with no useful message, and
the file is the credential — the one file where "it happens to be safe
today because of call ordering" is the weakest kind of safety. The case
against: no test can demonstrate it, and the diff is larger than the
behaviour it changes.
