### PR TITLE
refactor(app, store, docker): a map keyed by an identifier says which one

### DIFF
--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -93,7 +93,7 @@ func newHarnessOnStore(t *testing.T, st *store.Store, parallelism int) *harness 
 		cache:     cacheMgr,
 		alloc:     allocator.New(),
 		bindings:  []*binding{b},
-		byBinding: map[int64]*binding{int64(bindingID): b},
+		byBinding: map[assignment.BindingID]*binding{bindingID: b},
 		// A lease this harness calls stranded was written moments ago,
 		// because no test here simulates the passage of time. The grace
 		// exists for a real gap between a lease committing and its owner

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -114,7 +114,7 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 				return err
 			}
 			s.bindings = append(s.bindings, b)
-			s.byBinding[int64(bindingID)] = b
+			s.byBinding[bindingID] = b
 			claimed = append(claimed, bindingID)
 		}
 	}

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -380,7 +380,7 @@ func TestStartupSaysWhereEachCredentialTravels(t *testing.T) {
 			log:       slog.New(slog.NewTextHandler(&buf, nil)),
 			store:     st,
 			alloc:     allocator.New(),
-			byBinding: map[int64]*binding{},
+			byBinding: map[assignment.BindingID]*binding{},
 		}
 		cfg := &config.Config{
 			Instance:    config.Instance{Name: "test"},

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -428,11 +428,14 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 	for _, ev := range msg.Completed {
 		s.log.Info("workload completed (hint)",
 			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName, "result", ev.Result)
-		kind, idempotency := "exit_observed", "remote_exit_observed:"+ev.RuntimeName
+		// An idempotency key, not a runtime name: the same concatenation
+		// one line up converts, and this one did not, so the key carried
+		// the type of the thing it names.
+		kind, idempotency := "exit_observed", "remote_exit_observed:"+string(ev.RuntimeName)
 		if ev.Result == "canceled" {
 			kind, idempotency = "remote_canceled", "remote_canceled"
 		}
-		record(ev, kind, string(idempotency), ev.Result == "canceled")
+		record(ev, kind, idempotency, ev.Result == "canceled")
 	}
 }
 

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -77,7 +77,7 @@ func (s *Controller) reconcile(ctx context.Context) error {
 
 	adopted := make(map[assignment.LeaseID]bool)
 	for _, lease := range live {
-		b := s.byBinding[int64(lease.BindingID)] // may be nil if the target was removed
+		b := s.byBinding[lease.BindingID] // may be nil if the target was removed
 		// Adoption means "this lease is still executing; wait it out".
 		// A lease already past draining is not executing — it is being
 		// unwound, and adopting it would run WalkToRunning and then a
@@ -562,7 +562,7 @@ func (s *Controller) resolveStranded(ctx context.Context, lease store.Lease, ret
 		return // its backoff has not elapsed; let it breathe
 	}
 	*retried++
-	b := s.byBinding[int64(lease.BindingID)] // may be nil if the target was removed
+	b := s.byBinding[lease.BindingID] // may be nil if the target was removed
 	if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
 		s.log.Warn("stranded lease still unresolved",
 			"lease", lease.ID, "state", string(lease.State), "error", err)

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -68,14 +68,14 @@ func (s *Controller) reconcile(ctx context.Context) error {
 		s.log.Info("reconciling interrupted leases", "count", n)
 	}
 
-	runnerByLease := make(map[string]docker.OwnedContainer, len(containers))
+	runnerByLease := make(map[assignment.LeaseID]docker.OwnedContainer, len(containers))
 	for _, c := range containers {
 		if c.Role == capsule.RoleCapsule {
 			runnerByLease[c.LeaseID] = c
 		}
 	}
 
-	adopted := make(map[string]bool)
+	adopted := make(map[assignment.LeaseID]bool)
 	for _, lease := range live {
 		b := s.byBinding[int64(lease.BindingID)] // may be nil if the target was removed
 		// Adoption means "this lease is still executing; wait it out".
@@ -85,11 +85,11 @@ func (s *Controller) reconcile(ctx context.Context) error {
 		// returns before any cleanup. The lease would then hold its credit
 		// and its privileged container forever, because being marked
 		// adopted also exempts it from the orphan sweep.
-		if runner, ok := runnerByLease[string(lease.ID)]; ok && runner.Running && b != nil && adoptable(lease.State) {
+		if runner, ok := runnerByLease[lease.ID]; ok && runner.Running && b != nil && adoptable(lease.State) {
 			s.log.Info("adopting running capsule", "binding", b.key, "lease", lease.ID)
 			s.reportAdoption(b, s.alloc.Adopt(b.key))
 			s.adopt(b, lease, runner.ID)
-			adopted[string(lease.ID)] = true
+			adopted[lease.ID] = true
 			continue
 		}
 		// Every nonterminal lease holds a credit until it is resolved, even
@@ -100,7 +100,7 @@ func (s *Controller) reconcile(ctx context.Context) error {
 			s.reportAdoption(b, s.alloc.Adopt(b.key))
 			defer s.releaseCreditIfDone(b, lease.ID)
 		}
-		runner, hasRunner := runnerByLease[string(lease.ID)]
+		runner, hasRunner := runnerByLease[lease.ID]
 		s.resolveInterrupted(ctx, b, lease, runner, hasRunner)
 	}
 
@@ -332,7 +332,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 // released, and retention refuses a lease that still owns an intent —
 // deliberately, so the leak stays visible in `status` rather than being
 // quietly forgotten.
-func (s *Controller) sweepOrphans(ctx context.Context, keep map[string]bool) error {
+func (s *Controller) sweepOrphans(ctx context.Context, keep map[assignment.LeaseID]bool) error {
 	wedged := 0
 	fail := func(kind, name string, err error) {
 		wedged++
@@ -491,9 +491,9 @@ func (s *Controller) sweepPeriodically(ctx context.Context) {
 		s.log.Error("periodic sweep cannot list live leases", "error", err)
 		return
 	}
-	keep := make(map[string]bool, len(live))
+	keep := make(map[assignment.LeaseID]bool, len(live))
 	for _, lease := range live {
-		keep[string(lease.ID)] = true
+		keep[lease.ID] = true
 	}
 	if err := s.sweepOrphans(ctx, keep); err != nil {
 		s.log.Error("periodic sweep failed", "error", err)

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -341,10 +341,14 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 		return fmt.Errorf("startup reconciliation: %w", err)
 	}
 
-	owner := "runpool-" + st.InstanceID()[:8]
+	// A session owner name, not an instance id. Concatenating an
+	// untyped constant onto a typed string keeps the type, so this local
+	// was an assignment.InstanceID that had to be converted back at the
+	// call — a name derived from an id is not that id.
+	owner := "runpool-" + string(st.InstanceID())[:8]
 	for _, b := range s.bindings {
 		b.newSession = func(ctx context.Context) (providerSession, error) {
-			return b.gh.OpenSession(ctx, b.scaleSetID, string(owner))
+			return b.gh.OpenSession(ctx, b.scaleSetID, owner)
 		}
 	}
 	// A session the broker still holds is one the next start has to wait

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -324,7 +324,7 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 		leaseHistory:        cfg.Retention.Window(),
 		netSandbox:          netSandbox,
 		cgroupDriver:        hostInfo.CgroupDriver,
-		byBinding:           map[int64]*binding{},
+		byBinding:           map[assignment.BindingID]*binding{},
 	}
 	s.disk = newDiskMonitor(cfg, log, st, dock, cacheMgr, s.alloc, capsuleImg)
 	// Before any binding serves: resuming an emergency is what holds the
@@ -526,7 +526,7 @@ type Controller struct {
 	cgroupDriver string
 
 	bindings  []*binding
-	byBinding map[int64]*binding // store binding id -> binding
+	byBinding map[assignment.BindingID]*binding
 
 	// launch runs one served attempt. Production points it at
 	// runCapsule; tests replace it to drive the assignment machine

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -32,7 +32,7 @@ func TestReconcileAdoptsWhatIsStillRunning(t *testing.T) {
 	}
 
 	h.objects.containers = []docker.OwnedContainer{
-		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: string(alive.ID), Running: true},
+		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: alive.ID, Running: true},
 	}
 	h.srv.caps = &fakeCapsule{obs: assignment.ObservedAbsent}
 	h.srv.wait = &fakeWaiter{}
@@ -83,7 +83,7 @@ func TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn(t *testing.T) {
 	}
 	live, _ := leaseFor(t, h, "job-1")
 	h.objects.containers = []docker.OwnedContainer{
-		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: string(live.ID), Running: true},
+		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: live.ID, Running: true},
 		{ID: "runner-orphan", Role: capsule.RoleCapsule, LeaseID: "lse-vanished"},
 	}
 

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+	"github.com/rhobuild/runpool/internal/assignment"
 	"slices"
 	"testing"
 
@@ -31,7 +32,7 @@ func TestSweepOrphansSparesWhatIsNotGarbage(t *testing.T) {
 		{ID: "vol-gone", Role: "dind-data", LeaseID: "lse-gone"},
 	}
 
-	if err := h.srv.sweepOrphans(t.Context(), map[string]bool{"lse-adopted": true}); err != nil {
+	if err := h.srv.sweepOrphans(t.Context(), map[assignment.LeaseID]bool{"lse-adopted": true}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -2,10 +2,10 @@ package app
 
 import (
 	"errors"
-	"github.com/rhobuild/runpool/internal/assignment"
 	"slices"
 	"testing"
 
+	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 )
 

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -41,14 +41,14 @@ func runCleanup(streams IO, apply bool) error {
 	// Cleanup removes what no live lease needs: resources belonging to
 	// released leases, and objects the books never recorded. A running
 	// capsule is left alone — stopping work is what drain is for.
-	keep := map[string]bool{}
+	keep := map[assignment.LeaseID]bool{}
 	snap, err := st.Snapshot()
 	if err != nil {
 		return err
 	}
 	for _, l := range snap.Leases {
 		if !l.State.Terminal() {
-			keep[string(l.ID)] = true
+			keep[l.ID] = true
 		}
 	}
 	removable := plan.exclude(keep)
@@ -232,7 +232,7 @@ func planOwnedResources(ctx context.Context, st *store.Store, dock *docker.Clien
 	return p, err
 }
 
-func (p ownedPlan) exclude(keep map[string]bool) ownedPlan {
+func (p ownedPlan) exclude(keep map[assignment.LeaseID]bool) ownedPlan {
 	out := ownedPlan{instanceID: p.instanceID}
 	for _, c := range p.containers {
 		// A helper the instance is still running is not garbage. Apply

--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -297,17 +297,17 @@ func (p ownedPlan) describe(verb string, applying bool) string {
 // held open.
 func (p ownedPlan) remove(ctx context.Context, dock *docker.Client) error {
 	for _, c := range p.containers {
-		if err := dock.RemoveOwnedContainer(ctx, c.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(c.LeaseID)); err != nil {
+		if err := dock.RemoveOwnedContainer(ctx, c.ID, assignment.InstanceID(p.instanceID), c.LeaseID); err != nil {
 			return fmt.Errorf("remove container %s: %w", c.Name, err)
 		}
 	}
 	for _, n := range p.networks {
-		if err := dock.RemoveOwnedNetwork(ctx, n.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(n.LeaseID)); err != nil {
+		if err := dock.RemoveOwnedNetwork(ctx, n.ID, assignment.InstanceID(p.instanceID), n.LeaseID); err != nil {
 			return fmt.Errorf("remove network %.12s: %w", n.ID, err)
 		}
 	}
 	for _, v := range p.volumes {
-		if err := dock.RemoveOwnedVolume(ctx, v.ID, assignment.InstanceID(p.instanceID), assignment.LeaseID(v.LeaseID)); err != nil {
+		if err := dock.RemoveOwnedVolume(ctx, v.ID, assignment.InstanceID(p.instanceID), v.LeaseID); err != nil {
 			return fmt.Errorf("remove volume %s: %w", v.ID, err)
 		}
 	}

--- a/internal/command/cleanup_test.go
+++ b/internal/command/cleanup_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"github.com/rhobuild/runpool/internal/assignment"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestExcludeSparesTheInstancesOwnObjects(t *testing.T) {
 		},
 	}
 
-	got := plan.exclude(map[string]bool{"lse-live": true})
+	got := plan.exclude(map[assignment.LeaseID]bool{"lse-live": true})
 
 	want := map[string]bool{"c2": true, "c4": true, "n2": true, "v2": true}
 	for _, id := range collectIDs(got) {

--- a/internal/command/cleanup_test.go
+++ b/internal/command/cleanup_test.go
@@ -1,10 +1,10 @@
 package command
 
 import (
-	"github.com/rhobuild/runpool/internal/assignment"
 	"strings"
 	"testing"
 
+	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
 )

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -182,7 +182,7 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	for _, c := range snap.CacheLanes {
 		holder := "free"
 		if c.LeasedBy != "" {
-			holder = "leased by " + c.LeasedBy
+			holder = "leased by " + string(c.LeasedBy)
 		}
 		fmt.Fprintf(streams.Out, "  %-16s %-12s %-40s %s\n", c.ID, c.Generation, c.SourceProjectKey, holder)
 	}

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -161,9 +161,9 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	}
 	fmt.Fprintln(streams.Out)
 	for _, l := range live {
-		resources := snap.Resources[string(l.ID)]
+		resources := snap.Resources[l.ID]
 		project := ""
-		if a, ok := snap.Attempts[string(l.ID)]; ok {
+		if a, ok := snap.Attempts[l.ID]; ok {
 			project = a.TenantKey + "/" + a.ProjectKey
 		}
 		fmt.Fprintf(streams.Out, "  %-16s %-18s %-28s %d resources\n", l.ID, l.State, project, len(resources))

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -3,6 +3,7 @@ package command
 import (
 	"time"
 
+	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/cache"
 	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
@@ -209,7 +210,7 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 		})
 	}
 	for _, l := range snap.Leases {
-		attempt := snap.Attempts[string(l.ID)]
+		attempt := snap.Attempts[l.ID]
 		project := ""
 		if attempt.TenantKey != "" || attempt.ProjectKey != "" {
 			project = attempt.TenantKey + "/" + attempt.ProjectKey
@@ -225,7 +226,7 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 			CreatedAt:   rfc3339(l.CreatedAt),
 			Resources:   []resourceDTO{},
 		}
-		for _, in := range snap.Resources[string(l.ID)] {
+		for _, in := range snap.Resources[l.ID] {
 			lease.Resources = append(lease.Resources, resourceDTO{
 				Kind: string(in.Kind), Role: in.Role, Name: in.Name, LeaseID: string(in.LeaseID), State: in.State,
 			})
@@ -241,14 +242,14 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	doc.ManualReview = append(doc.ManualReview, review...)
 	for _, c := range obs.containers {
 		doc.Containers = append(doc.Containers, containerDTO{
-			Name: c.Name, Role: c.Role, LeaseID: c.LeaseID, Running: c.Running,
+			Name: c.Name, Role: c.Role, LeaseID: string(c.LeaseID), Running: c.Running,
 		})
 	}
 	for _, n := range obs.networks {
-		doc.Networks = append(doc.Networks, resourceDTO{Kind: "network", Role: n.Role, Name: n.ID, LeaseID: n.LeaseID})
+		doc.Networks = append(doc.Networks, resourceDTO{Kind: "network", Role: n.Role, Name: n.ID, LeaseID: string(n.LeaseID)})
 	}
 	for _, v := range obs.volumes {
-		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: v.Role, Name: v.ID, LeaseID: v.LeaseID})
+		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: v.Role, Name: v.ID, LeaseID: string(v.LeaseID)})
 	}
 	if obs.err != nil {
 		doc.DockerError = obs.err.Error()
@@ -320,15 +321,15 @@ type daemonObservation struct {
 // container and used to be invisible here. An empty (non-nil) result
 // means the comparison ran and found agreement.
 func discrepancies(leases []store.Lease, obs daemonObservation) []string {
-	live := map[string]bool{}
+	live := map[assignment.LeaseID]bool{}
 	for _, l := range leases {
 		if !l.State.Terminal() {
-			live[string(l.ID)] = true
+			live[l.ID] = true
 		}
 	}
 	out := []string{}
 
-	withContainer := map[string]bool{}
+	withContainer := map[assignment.LeaseID]bool{}
 	for _, c := range obs.containers {
 		// A helper the instance is measuring with belongs to no lease by
 		// design, so judging it against the lease set reports a
@@ -343,7 +344,7 @@ func discrepancies(leases []store.Lease, obs daemonObservation) []string {
 		}
 	}
 	for _, l := range leases {
-		if live[string(l.ID)] && l.State == store.LeaseWorkloadRunning && !withContainer[string(l.ID)] {
+		if live[l.ID] && l.State == store.LeaseWorkloadRunning && !withContainer[l.ID] {
 			out = append(out, "lease "+string(l.ID)+" claims to be running with no container")
 		}
 	}

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -236,7 +236,7 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	for _, c := range snap.CacheLanes {
 		doc.CacheLanes = append(doc.CacheLanes, laneDTO{
 			ID: c.ID, SourceProjectKey: c.SourceProjectKey, Generation: c.Generation,
-			LeasedBy: c.LeasedBy, LastUsed: rfc3339(time.Unix(c.LastUsed, 0)),
+			LeasedBy: string(c.LeasedBy), LastUsed: rfc3339(time.Unix(c.LastUsed, 0)),
 		})
 	}
 	doc.ManualReview = append(doc.ManualReview, review...)
@@ -260,14 +260,14 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 }
 
 func schedulingStatus(cfg *config.Config, leases []store.Lease, queued map[int64]int, shippedCapsule string) *schedulingDTO {
-	activeByTier := make(map[string]int, len(cfg.Tiers))
+	activeByTier := make(map[assignment.TierID]int, len(cfg.Tiers))
 	active := 0
 	for _, lease := range leases {
 		if lease.State.Terminal() {
 			continue
 		}
 		active++
-		activeByTier[string(lease.TierID)]++
+		activeByTier[lease.TierID]++
 	}
 
 	mode := "independent-tiers"
@@ -290,7 +290,7 @@ func schedulingStatus(cfg *config.Config, leases []store.Lease, queued map[int64
 		dto.Available = 0
 	}
 	for _, tier := range cfg.Tiers {
-		tierActive := activeByTier[tier.ID]
+		tierActive := activeByTier[assignment.TierID(tier.ID)]
 		available := tier.Parallelism - tierActive
 		if available < 0 {
 			available = 0

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -528,12 +528,12 @@ func (m *Manager) removeObject(ctx context.Context, kind store.ResourceKind,
 // confirmed id or the deterministic name, since an unconfirmed intent's
 // object is only reachable by name. A lease with no matching intent is
 // unaffected; the point is that a row never outlives its object.
-func (m *Manager) ForgetResource(ctx context.Context, leaseID, dockerID string) error {
+func (m *Manager) ForgetResource(ctx context.Context, leaseID assignment.LeaseID, dockerID string) error {
 	if leaseID == "" {
 		return nil // never recorded, so nothing to reconcile
 	}
 	return m.store.Tx(ctx, func(tx *store.Tx) error {
-		intents, err := tx.Resources(assignment.LeaseID(leaseID))
+		intents, err := tx.Resources(leaseID)
 		if err != nil {
 			return err
 		}

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -435,7 +435,7 @@ type OwnedContainer struct {
 	Name    string
 	Kind    string
 	Role    string
-	LeaseID string
+	LeaseID assignment.LeaseID
 	Running bool
 }
 
@@ -472,11 +472,13 @@ func (c *Client) ListOwnedContainers(ctx context.Context, instanceID assignment.
 			name = strings.TrimPrefix(s.Names[0], "/")
 		}
 		out = append(out, OwnedContainer{
-			ID:      s.ID,
-			Name:    name,
-			Kind:    s.Labels[LabelKind],
-			Role:    s.Labels[LabelRole],
-			LeaseID: s.Labels[LabelLease],
+			ID:   s.ID,
+			Name: name,
+			Kind: s.Labels[LabelKind],
+			Role: s.Labels[LabelRole],
+			// The one conversion: a label is a string until it is read,
+			// and this is where it is read.
+			LeaseID: assignment.LeaseID(s.Labels[LabelLease]),
 			Running: s.State == container.StateRunning,
 		})
 	}

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -148,7 +148,7 @@ func (c *Client) AllNetworkSubnets(ctx context.Context) ([]string, error) {
 // delete every warm cache it finds.
 type OwnedResource struct {
 	ID      string
-	LeaseID string
+	LeaseID assignment.LeaseID
 	Role    string
 }
 
@@ -159,7 +159,7 @@ func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID assignment.In
 	}
 	out := make([]OwnedResource, 0, len(nets.Items))
 	for _, n := range nets.Items {
-		out = append(out, OwnedResource{ID: n.ID, LeaseID: n.Labels[LabelLease], Role: n.Labels[LabelRole]})
+		out = append(out, OwnedResource{ID: n.ID, LeaseID: assignment.LeaseID(n.Labels[LabelLease]), Role: n.Labels[LabelRole]})
 	}
 	return out, nil
 }

--- a/internal/platform/docker/volume.go
+++ b/internal/platform/docker/volume.go
@@ -58,7 +58,7 @@ func (c *Client) ListOwnedVolumes(ctx context.Context, instanceID assignment.Ins
 	}
 	out := make([]OwnedResource, 0, len(resp.Items))
 	for _, v := range resp.Items {
-		out = append(out, OwnedResource{ID: v.Name, LeaseID: v.Labels[LabelLease], Role: v.Labels[LabelRole]})
+		out = append(out, OwnedResource{ID: v.Name, LeaseID: assignment.LeaseID(v.Labels[LabelLease]), Role: v.Labels[LabelRole]})
 	}
 	return out, nil
 }

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -26,8 +26,8 @@ type Snapshot struct {
 	// and the line uninstall prints before destroying the books — need it
 	// to stay true once the rows behind it are bounded.
 	ReleasedTotal int
-	Attempts      map[string]Attempt          // by lease id
-	Resources     map[string][]ResourceIntent // by lease id
+	Attempts      map[assignment.LeaseID]Attempt
+	Resources     map[assignment.LeaseID][]ResourceIntent
 	// Queued is how many attempts wait for admission, per binding id. It
 	// is counted rather than listed because the rest of this snapshot is
 	// keyed by lease, and an attempt waiting for admission has none — so
@@ -93,8 +93,8 @@ type CacheLaneInfo struct {
 func (s *Store) Snapshot() (Snapshot, error) {
 	snap := Snapshot{
 		InstanceID: s.instanceID,
-		Attempts:   map[string]Attempt{},
-		Resources:  map[string][]ResourceIntent{},
+		Attempts:   map[assignment.LeaseID]Attempt{},
+		Resources:  map[assignment.LeaseID][]ResourceIntent{},
 		Queued:     map[int64]int{},
 	}
 	version, err := s.SchemaVersion()
@@ -188,8 +188,8 @@ const selectAttempt = `SELECT id, delivery_id, binding_id, source_workload_key, 
 // One read per lease made `runpool status` cost two round trips per row
 // on the single connection every lease transition also waits for, and a
 // snapshot carries up to a hundred leases.
-func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
-	out := make(map[string]Attempt, len(leases))
+func (t *Tx) attemptsOfLeases(leases []Lease) (map[assignment.LeaseID]Attempt, error) {
+	out := make(map[assignment.LeaseID]Attempt, len(leases))
 	if len(leases) == 0 {
 		return out, nil
 	}
@@ -212,7 +212,7 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 		return nil, err
 	}
 	defer rows.Close()
-	byAttempt := make(map[string]Attempt, len(args))
+	byAttempt := make(map[assignment.AttemptID]Attempt, len(args))
 	for rows.Next() {
 		var r sqlitedb.AssignmentAttempt
 		if err := rows.Scan(&r.ID, &r.DeliveryID, &r.BindingID, &r.SourceWorkloadKey,
@@ -220,7 +220,7 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 			&r.ReviewReason, &r.ReviewedAt, &r.ReviewedBy, &r.ReceivedAt, &r.SettledAt); err != nil {
 			return nil, err
 		}
-		byAttempt[r.ID] = fromRow(r)
+		byAttempt[assignment.AttemptID(r.ID)] = fromRow(r)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -231,19 +231,19 @@ func (t *Tx) attemptsOfLeases(leases []Lease) (map[string]Attempt, error) {
 	// appended after live ones, so the row that lost its attempt was
 	// always the lease still running.
 	for _, l := range leases {
-		attempt, ok := byAttempt[string(l.AttemptID)]
+		attempt, ok := byAttempt[l.AttemptID]
 		if !ok {
 			return nil, fmt.Errorf("lease %s names attempt %s, which does not exist", l.ID, l.AttemptID)
 		}
-		out[string(l.ID)] = attempt
+		out[l.ID] = attempt
 	}
 	return out, nil
 }
 
 // resourcesOfLeases reads every lease's resource intents in one query,
 // for the same reason attemptsOfLeases exists.
-func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, error) {
-	out := make(map[string][]ResourceIntent, len(leases))
+func (t *Tx) resourcesOfLeases(leases []Lease) (map[assignment.LeaseID][]ResourceIntent, error) {
+	out := make(map[assignment.LeaseID][]ResourceIntent, len(leases))
 	if len(leases) == 0 {
 		return out, nil
 	}
@@ -262,7 +262,7 @@ func (t *Tx) resourcesOfLeases(leases []Lease) (map[string][]ResourceIntent, err
 		if err != nil {
 			return nil, err
 		}
-		out[string(in.LeaseID)] = append(out[string(in.LeaseID)], in)
+		out[in.LeaseID] = append(out[in.LeaseID], in)
 	}
 	return out, rows.Err()
 }

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -84,7 +84,7 @@ type CacheLaneInfo struct {
 	ID               string
 	SourceProjectKey string
 	Generation       string
-	LeasedBy         string
+	LeasedBy         assignment.LeaseID
 	LastUsed         int64
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -605,7 +605,7 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	}
 
 	// Three live leases, each in a different state.
-	live := map[string]bool{}
+	live := map[assignment.LeaseID]bool{}
 	for i, state := range []LeaseState{LeaseReserved, LeaseProvisioning, LeaseRuntimeRegistered} {
 		key := assignment.SourceWorkloadKey(fmt.Sprintf("live-%d", i))
 		attempt := seedAttempt(t, s, binding, "msg-"+string(key), "job-"+key)
@@ -614,7 +614,7 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			live[string(lease.ID)] = true
+			live[lease.ID] = true
 			if state == LeaseReserved {
 				return nil
 			}
@@ -634,9 +634,9 @@ func TestSnapshotBoundsHistoryButNeverLiveWork(t *testing.T) {
 	}
 
 	var gotLive, gotReleased int
-	seen := map[string]bool{}
+	seen := map[assignment.LeaseID]bool{}
 	for _, l := range snap.Leases {
-		seen[string(l.ID)] = true
+		seen[l.ID] = true
 		if l.State.Terminal() {
 			gotReleased++
 		} else {
@@ -1659,7 +1659,7 @@ func TestEveryLeaseKeepsItsAttempt(t *testing.T) {
 	})
 
 	// Live first, released after: the order Snapshot builds.
-	var got map[string]Attempt
+	var got map[assignment.LeaseID]Attempt
 	inTx(t, s, func(tx *Tx) error {
 		var err error
 		got, err = tx.attemptsOfLeases([]Lease{second, first})
@@ -1667,7 +1667,7 @@ func TestEveryLeaseKeepsItsAttempt(t *testing.T) {
 	})
 
 	for _, l := range []Lease{second, first} {
-		a, ok := got[string(l.ID)]
+		a, ok := got[l.ID]
 		if !ok {
 			t.Errorf("lease %s has no attempt in the report; it serves %s", l.ID, l.AttemptID)
 			continue
@@ -1741,7 +1741,7 @@ func TestTheSetReadAgreesWithTheGeneratedQuery(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		set = byLease[string(lease.ID)]
+		set = byLease[lease.ID]
 		return nil
 	})
 


### PR DESCRIPTION
## What changes

Thirteen maps keyed by an identifier now say which identifier. The type
reaches the Docker label it is read from, one function stops taking two
adjacent strings, and two locals stop inheriting a type from a string
they were concatenated onto.

No behaviour change: every value stored and every value sent is the same
byte for byte.

## What was found

**The identifier types stopped at the map.** `internal/assignment/ids.go`
exists for one reason, in its own words:

> They are distinct types because every one of them is a string or an
> integer, and a function taking four of those accepts them in any order.

Every map keyed by one of them was `map[string]`, so inside those the
swap compiled again — and each one forced a `string(...)` at its call
sites, which is where a reader has to stop and check rather than read.

Thirteen maps carry their key's type now: the snapshot's `Attempts`,
`Resources` and `Queued`; the reconciler's runner index, adoption set and
keep set; the status document's `live`, `withContainer` and
`activeByTier`; `runpool cleanup`'s keep set; the report's attempt
lookup; and the controller's binding index. Twenty-seven conversions went
with them, twenty of them outside tests.

The first version of this stopped at nine and drew the line in the wrong
place — it said configuration ids and wire-shape DTOs stay strings, which
covered none of the four it had missed. Two of those are keyed by a
binding id, an `int64`, so an unstated rule had crept in: string-keyed
maps only. That is not a rule. A binding id passed where a delivery id
belongs is the same mistake and the same silently empty result.

**The type stopped one step short of the label.** `docker.OwnedContainer`
and `docker.OwnedResource` carried the lease id as a bare `string`, while
five functions in the same file already took `assignment.LeaseID`:

```go
func (c *Client) RemoveOwnedContainer(ctx context.Context, reference string,
    instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
```

So the conversion sat at every consumer instead of at the one place a
label becomes a value. It is at the label now — one conversion, where it
is read.

**One function took the two strings this vocabulary exists to separate.**

```go
func (m *Manager) ForgetResource(ctx context.Context, leaseID, dockerID string) error
```

A lease id and a Docker object id, adjacent, both `string`. Swapping them
produced a query that matched nothing and reported success, which is the
failure `ids.go` names in its own doc comment.

**Two locals inherited a type by concatenation.** Go keeps the named type
when an untyped constant is concatenated onto it, so:

```go
owner := "runpool-" + st.InstanceID()[:8]        // an assignment.InstanceID
...b.gh.OpenSession(ctx, b.scaleSetID, string(owner))
```

A session owner name derived from an instance id is not that id, and the
conversion back at the call is the tell. The same in `delivery.go`, where
an idempotency key built from a runtime name carried that type — and the
line directly above it converts at the right place, so the file
disagreed with itself.

## Symmetry check

| Path | Result |
|---|---|
| every `map[string]` in the touched packages | audited; the ones keyed by a CIDR, a label, an env name or a JSON field stay strings, because that is what they are |
| `config`'s validation sets | left as strings: configuration ids are strings until the app makes them identifiers, and typing them would reach into a package whose job is to read a file |
| the DTOs in `statusdto.go` | left as strings, deliberately — they are the wire shape, and the conversion is at the boundary that builds them |
| `byKey` in `delivery.go` | keyed by a workload key and left a string, because `assignment.WorkloadAssignment` holds that key as a bare string itself. Typing the map would put a conversion at the map rather than at the field, and the field is where it belongs — a different change |
| integer-keyed maps | converted too. The first version of this branch typed only string-keyed ones without saying so, which is a rule about Go rather than about identifiers |
| `docker.OwnedContainer` / `OwnedResource` | both carried the same untyped field from the same label; both typed |
| the five sibling functions in `docker.go` | already took `assignment.LeaseID`, which is what made the field the odd one out |
| `HelperInFlight` / `InstanceInfrastructure` | compare against `""`, which a named string type still allows |
| the two derived locals | both found by grepping for a conversion back to `string`, which is the shape that gives them away |

## Evidence

The compiler is the evidence for a change whose whole purpose is that a
mistake stops compiling. Every conversion removed was one it pointed at:

```text
internal/command/status.go:164: cannot use string(l.ID) as assignment.LeaseID
internal/app/reconcile.go:74:   cannot use c.LeaseID as string value in map index
internal/lease/lease.go:531:    ForgetResource(ctx, leaseID, dockerID string)
```

What remains is the boundaries — a Docker label, the status document's
wire shape, an idempotency key, a rendered id — which is where a
conversion belongs.

The verification worth naming is not the compiler's. A type-only
refactor that changes a value is invisible to it, so the status document
was built from one fixture before and after and compared byte for byte:
2519 bytes, identical, over a fixture carrying empty lease ids, a lease
whose attempt is missing, a released lease, orphans of all three kinds,
and every branch of `discrepancies`. And a defined string type with no
`String` method — which `ids.go` forbids on purpose — was confirmed to
render identically through `slog`'s text and JSON handlers and through
`%s`, `%v`, `%+v` and `%q`, which covers the two log lines whose argument
changed type without the line changing.

The full suite passes unchanged: no test was rewritten to accommodate a
type, only to name one.

## What would notice this regressing

- The compiler, which is the point. A lease id where an attempt id
  belongs, or either where a Docker id belongs, is now a build failure
  rather than a query that matches nothing.
- Nothing new is asserted at runtime, because nothing changes at runtime.

Said plainly: this PR adds no test. It removes the possibility of a class
of mistake rather than detecting one, and a test that a swap fails to
compile is a test that cannot be written in the language.

## Risk, compatibility and operations

**No behaviour change.** Every value written, read, labelled and rendered
is identical. `assignment.LeaseID` is a `string`, so nothing about the
representation moves.

**The risk is a mechanical diff over fifteen files.** It is bounded by
being type-only: the compiler accepted no version of this that changed a
value, and every edit was made by following an error it produced rather
than by search and replace across a package.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** The status document's JSON is byte-identical.

## Changelog

```text
NONE - types only, with no effect a deployment can observe.
```

## Notes for your reviewer

The judgement is where to stop. Configuration ids stay strings: `config`
reads a file, and a file has strings in it; they become identifiers when
the app builds a binding from them. The status DTOs stay strings for the
same reason in the other direction — they are the wire shape, and the
document is the boundary.

Worth checking hardest that no conversion changed a value rather than a
type. The ones to look at are the label reads in `docker`, where a
missing label is `""` and stays `""`, and `statusdto.go`, where the
conversions moved from the map lookups to the struct literals.
