### PR TITLE
refactor(store, assignment): an attempt's state is a type, and two versions that read alike are named apart

### DIFF
--- a/internal/app/attribution_test.go
+++ b/internal/app/attribution_test.go
@@ -239,7 +239,7 @@ func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
 		after, err = tx.Get(assignment.AttemptID(successor))
 		return err
 	})
-	if after.State != "ready" {
+	if after.State != store.AttemptReady {
 		t.Errorf("the successor is %q/%q; it was never cancelled, and closing it "+
 			"destroys work the provider is still waiting for a runner on",
 			after.State, after.Resolution)

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -76,7 +76,7 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 			var knownSetID int64
 			if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 				var err error
-				if bindingID, err = tx.EnsureBinding(assignment.TargetID(target.ID), "github_actions", assignment.SourceBindingKey(sourceBindingKey)); err != nil {
+				if bindingID, err = tx.EnsureBinding(assignment.TargetID(target.ID), "github_actions", sourceBindingKey); err != nil {
 					return err
 				}
 				// The scale set id recorded against this binding is the

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -145,6 +145,22 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 	return nil
 }
 
+// bindingKeyVersion prefixes the binding key, and is not the delivery
+// key's version even though it reads the same today.
+//
+// Bumping it renames every binding. The new key matches no row, so a row
+// is written for it and the old one is unclaimed — ForgetUnclaimedBindings
+// deletes it on the same startup, taking the scale set id recorded
+// against it, unless it still holds deliveries. Every binding then meets
+// a provider that already has its scale set under the unchanged name and
+// refuses to adopt one it has no record of creating, once each, before
+// settling. The contact history does not come back.
+//
+// That is a migration, not an encoding change. Anything that makes this
+// value move deserves the same reading as renaming a targets[].id, which
+// docs/adrs/2026-08-17-target-hosts-and-scopes.md records.
+const bindingKeyVersion = "v2"
+
 // sourceBindingKey is a binding's durable identity: the row every
 // delivery, attempt and lease hangs off.
 //
@@ -158,8 +174,9 @@ func (s *Controller) buildBindings(ctx context.Context, cfg *config.Config, envi
 // adopt a set it has no record of creating, which is a refusal before it
 // is an adoption. Scope and canonical URL still travel, in the adapter's
 // own metadata, which is where provider identity belongs.
-func sourceBindingKey(target config.Target, scaleSetName string) string {
-	return fmt.Sprintf("v2|%s|%s|%s", target.ID, target.RunnerGroup, scaleSetName)
+func sourceBindingKey(target config.Target, scaleSetName string) assignment.SourceBindingKey {
+	return assignment.SourceBindingKey(fmt.Sprintf("%s|%s|%s|%s",
+		bindingKeyVersion, target.ID, target.RunnerGroup, scaleSetName))
 }
 
 // ensureScaleSet creates or adopts this binding's scale set and records

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -429,6 +429,29 @@ func TestStartupSaysWhereEachCredentialTravels(t *testing.T) {
 // the original is left in `status` for good with no command that removes
 // it. Every delivery, attempt and lease hangs off that row, so the
 // history goes with it.
+// TestTheBindingKeyIsVersionedAndPinned: the durable binding key is a
+// literal here, not a comparison against itself.
+//
+// Its sibling in internal/assignment pins the delivery key this way, and
+// that is the cheaper of the two to move: a re-keyed delivery is
+// processed again and finds its attempts by workload key. This one is
+// the expensive one. Moving it renames every binding — the old row is
+// forgotten on the next startup with the scale set id recorded against
+// it, and each binding then meets a provider that already holds its
+// scale set and refuses to adopt one it has no record of creating.
+//
+// The test that existed compared sourceBindingKey's output to
+// sourceBindingKey's output, so any change to the encoding, version
+// included, left the suite green. The costly one was the unpinned one.
+func TestTheBindingKeyIsVersionedAndPinned(t *testing.T) {
+	got := sourceBindingKey(config.Target{ID: "app", RunnerGroup: "default"}, "runpool-standard")
+	if want := assignment.SourceBindingKey("v2|app|default|runpool-standard"); got != want {
+		t.Errorf("sourceBindingKey = %q; want %q. This value keys every delivery, attempt "+
+			"and lease a binding owns, and moving it is a migration rather than an encoding change",
+			got, want)
+	}
+}
+
 func TestTheDurableBindingKeyDoesNotMoveWithTheURLParser(t *testing.T) {
 	base := config.Target{ID: "app", RunnerGroup: "default"}
 	want := sourceBindingKey(base, "runpool-standard")

--- a/internal/app/budgets_test.go
+++ b/internal/app/budgets_test.go
@@ -96,7 +96,7 @@ func TestAnIncompatibleCapsuleIsHeldNotRetried(t *testing.T) {
 	lease, _ := runFaulted(t, h, caps, &fakeRegistry{}, &fakeWaiter{}, "job-1")
 
 	attempt := h.attemptByLease(lease.ID)
-	if attempt.State != "manual_review" {
+	if attempt.State != store.AttemptManualReview {
 		t.Fatalf("attempt state = %q, want it held rather than requeued", attempt.State)
 	}
 	if attempt.ReviewReason != store.ReviewReasonIncompatibleCapsule {
@@ -113,7 +113,7 @@ func TestAnOrdinaryPreparationFailureStillRetries(t *testing.T) {
 	lease, _ := runFaulted(t, h, caps, &fakeRegistry{}, &fakeWaiter{}, "job-1")
 
 	attempt := h.attemptByLease(lease.ID)
-	if attempt.State == "manual_review" {
+	if attempt.State == store.AttemptManualReview {
 		t.Errorf("a transient preparation failure was held as %q", attempt.ReviewReason)
 	}
 }

--- a/internal/app/durability_test.go
+++ b/internal/app/durability_test.go
@@ -38,7 +38,7 @@ func TestLateRedeliveryDoesNotRecreateWork(t *testing.T) {
 	if got := h.ready(); len(got) != 0 {
 		t.Errorf("a completed job was queued again by a late redelivery: %+v", got)
 	}
-	if got := attemptState(t, h, attemptID); got.State != "settled" || got.Resolution != assignment.ResolutionCompletedObserved {
+	if got := attemptState(t, h, attemptID); got.State != store.AttemptSettled || got.Resolution != assignment.ResolutionCompletedObserved {
 		t.Errorf("attempt = %s/%s; want settled/completed_observed", got.State, got.Resolution)
 	}
 }

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -159,67 +159,67 @@ func TestStartFaultMatrix(t *testing.T) {
 			// nothing could have run.
 			name: "jit generation fails",
 			caps: &fakeCapsule{}, reg: &fakeRegistry{jitErr: boom}, wait: &fakeWaiter{},
-			want: "ready",
+			want: store.AttemptReady,
 		},
 		{
 			// Preparation died building the capsule: by construction no
 			// start was possible.
 			name: "prepare fails",
 			caps: &fakeCapsule{prepareErr: boom}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
-			want: "ready",
+			want: store.AttemptReady,
 		},
 		{
 			// Start errored and the daemon shows the container never left
 			// created: the one provable requeue past the authorization.
 			name: "start error, runtime proven inert",
 			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedCreated}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
-			want: "ready",
+			want: store.AttemptReady,
 		},
 		{
 			// Start errored but the container ran and exited: the error
 			// was noise, the execution was real.
 			name: "start error, runtime ran and exited",
 			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedExited}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
-			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+			want: store.AttemptSettled, wantRes: assignment.ResolutionCompletedObserved,
 		},
 		{
 			// Start errored but the container is running: continue as if
 			// the start succeeded, await it, settle on its exit.
 			name: "start error, runtime running",
 			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedRunning}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 0},
-			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+			want: store.AttemptSettled, wantRes: assignment.ResolutionCompletedObserved,
 		},
 		{
 			// Start errored and the container is gone: nothing can be
 			// proven in either direction, so a person decides.
 			name: "start error, runtime absent",
 			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedAbsent}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
-			want: "manual_review",
+			want: store.AttemptManualReview,
 		},
 		{
 			// Start errored and the daemon cannot be asked: same ruling.
 			name: "start error, daemon unavailable",
 			caps: &fakeCapsule{startErr: boom, obs: assignment.ObservedUnavailable, obsErr: boom}, reg: &fakeRegistry{}, wait: &fakeWaiter{},
-			want: "manual_review",
+			want: store.AttemptManualReview,
 		},
 		{
 			// The runner started and the daemon was lost mid-run: running
 			// was observed, so the attempt settles as exactly that.
 			name: "wait fails after a clean start",
 			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{waitErr: boom},
-			want: "settled", wantRes: assignment.ResolutionStartedObserved,
+			want: store.AttemptSettled, wantRes: assignment.ResolutionStartedObserved,
 		},
 		{
 			// A non-zero exit is the job's business, not the machine's:
 			// the runner ran and completed.
 			name: "runner exits non-zero",
 			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 7},
-			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+			want: store.AttemptSettled, wantRes: assignment.ResolutionCompletedObserved,
 		},
 		{
 			name: "happy path",
 			caps: &fakeCapsule{}, reg: &fakeRegistry{}, wait: &fakeWaiter{exit: 0},
-			want: "settled", wantRes: assignment.ResolutionCompletedObserved,
+			want: store.AttemptSettled, wantRes: assignment.ResolutionCompletedObserved,
 		},
 	}
 	for _, tc := range cases {
@@ -270,7 +270,7 @@ func TestOperatorResolvesHeldAttempts(t *testing.T) {
 			_, attemptID := runFaulted(t, h,
 				&fakeCapsule{startErr: boom, obs: assignment.ObservedAbsent},
 				&fakeRegistry{}, &fakeWaiter{}, "job-held")
-			if got := attemptState(t, h, assignment.AttemptID(attemptID)); got.State != "manual_review" {
+			if got := attemptState(t, h, assignment.AttemptID(attemptID)); got.State != store.AttemptManualReview {
 				t.Fatalf("attempt = %s; want manual_review", got.State)
 			}
 
@@ -285,14 +285,14 @@ func TestOperatorResolvesHeldAttempts(t *testing.T) {
 			got := attemptState(t, h, assignment.AttemptID(attemptID))
 			switch decision {
 			case "retry":
-				if got.State != "ready" {
+				if got.State != store.AttemptReady {
 					t.Errorf("attempt = %s; want ready", got.State)
 				}
 				if len(h.ready()) != 1 {
 					t.Error("a retried attempt is not servable")
 				}
 			case "settle":
-				if got.State != "settled" || got.Resolution != assignment.ResolutionMayHaveExecuted {
+				if got.State != store.AttemptSettled || got.Resolution != assignment.ResolutionMayHaveExecuted {
 					t.Errorf("attempt = %s/%s; want settled/%s", got.State, got.Resolution, assignment.ResolutionMayHaveExecuted)
 				}
 			}
@@ -399,7 +399,7 @@ func TestPeriodicReconcileConvergesQuarantine(t *testing.T) {
 	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
 		t.Errorf("lease = %s after the periodic pass; want released", got.State)
 	}
-	if got := attemptState(t, h, attempt); got.State != "ready" {
+	if got := attemptState(t, h, attempt); got.State != store.AttemptReady {
 		t.Errorf("attempt = %s; want ready — nothing was ever authorized", got.State)
 	}
 }
@@ -429,7 +429,7 @@ func TestRemoteCancellationClosesOnlyReadyWork(t *testing.T) {
 	if len(idle) != 0 {
 		t.Errorf("a cancelled ready attempt is still servable: %+v", idle)
 	}
-	if got := attemptState(t, h, busyAttempt); got.State != "leased" {
+	if got := attemptState(t, h, busyAttempt); got.State != store.AttemptLeased {
 		t.Errorf("a serving attempt was touched by a remote cancellation: %s", got.State)
 	}
 }
@@ -468,7 +468,7 @@ func TestPeriodicReconcileConvergesAStrandedCleaningLease(t *testing.T) {
 	if !h.srv.alloc.TryReserve(h.bind.key) {
 		t.Error("the stranded lease's admission credit was never returned")
 	}
-	if got := attemptState(t, h, attempt); got.State == "leased" {
+	if got := attemptState(t, h, attempt); got.State == store.AttemptLeased {
 		t.Error("the attempt was left leased to a lease that no longer exists")
 	}
 }

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -151,8 +151,8 @@ func TestStartFaultMatrix(t *testing.T) {
 		caps    *fakeCapsule
 		reg     *fakeRegistry
 		wait    *fakeWaiter
-		want    string // attempt state afterwards
-		wantRes string // attempt resolution, when settled
+		want    store.AttemptState // attempt state afterwards
+		wantRes string             // attempt resolution, when settled
 	}{
 		{
 			// The credential could not be minted: nothing was prepared,
@@ -786,7 +786,7 @@ func TestALostWalkEdgeDoesNotAbortTheLaunch(t *testing.T) {
 	// test decides both, and this one takes the further of the two.
 	caps.onPrepare = func() {
 		h.inStore(func(tx *store.Tx) error {
-			return tx.Advance(attemptID, "preparing", "leased")
+			return tx.Advance(attemptID, store.AttemptPreparing, store.AttemptLeased)
 		})
 	}
 

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -171,7 +171,7 @@ func TestPrunePeriodicallyHonoursTheWindow(t *testing.T) {
 				return err
 			}
 		}
-		return tx.Settle(lease.AttemptID, "leased", "completed_observed")
+		return tx.Settle(lease.AttemptID, store.AttemptLeased, "completed_observed")
 	})
 
 	for _, window := range []time.Duration{0, 24 * time.Hour} {

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -70,16 +70,20 @@ func TestRecoveryMatrix(t *testing.T) {
 					t.Errorf("a %s lease ended %s; it still holds its credit", from, got.State)
 				}
 
-				var wantState, wantResolution string
+				var (
+					wantState      store.AttemptState
+					wantResolution string
+				)
 				switch evidence {
 				case store.EvidenceNotStarted, store.EvidenceRuntimePrepared:
-					wantState = "ready"
+					wantState = store.AttemptReady
 				case store.EvidenceStartAuthorized:
-					wantState = "manual_review" // no runtime remains; nothing can be proven
+					// No runtime remains; nothing can be proven.
+					wantState = store.AttemptManualReview
 				case store.EvidenceRunningObserved:
-					wantState, wantResolution = "settled", assignment.ResolutionStartedObserved
+					wantState, wantResolution = store.AttemptSettled, assignment.ResolutionStartedObserved
 				default:
-					wantState, wantResolution = "settled", assignment.ResolutionCompletedObserved
+					wantState, wantResolution = store.AttemptSettled, assignment.ResolutionCompletedObserved
 				}
 				got := attemptState(t, h, attemptID)
 				if got.State != wantState {

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -152,7 +152,7 @@ func TestReassignmentSupersedesAReadyPredecessor(t *testing.T) {
 	if len(ready) != 1 || ready[0].ID == old.ID {
 		t.Fatalf("ready = %+v; want exactly the new attempt", ready)
 	}
-	if got := attemptState(t, h, old.ID); got.State != "superseded" || got.Resolution != assignment.ResolutionSuperseded {
+	if got := attemptState(t, h, old.ID); got.State != store.AttemptSuperseded || got.Resolution != assignment.ResolutionSuperseded {
 		t.Errorf("predecessor = %s/%s; want superseded/%s", got.State, got.Resolution, assignment.ResolutionSuperseded)
 	}
 }
@@ -405,7 +405,7 @@ func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
 		attempt = attempts[0]
 		return nil
 	})
-	if attempt.State != "canceled" || attempt.Resolution != assignment.ResolutionRemoteCanceled {
+	if attempt.State != store.AttemptCanceled || attempt.Resolution != assignment.ResolutionRemoteCanceled {
 		t.Errorf("the attempt is %q/%q; want canceled/remote_canceled - the hint in the "+
 			"wedged redelivery never landed, and the binding will burn a capsule on a "+
 			"job the provider already cancelled", attempt.State, attempt.Resolution)
@@ -537,7 +537,7 @@ func TestACancellationIsDurableBeforeTheMessageIsAcknowledged(t *testing.T) {
 		}
 		return nil
 	})
-	if got.State != "canceled" {
+	if got.State != store.AttemptCanceled {
 		t.Errorf("the cancelled workload is %q; want canceled — the cancellation was lost "+
 			"with the message that carried it", got.State)
 	}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -35,11 +35,11 @@ func (s *Controller) createLease(ctx context.Context, b *binding, attempt store.
 // walk is what an operator watches, while disposition rests on evidence
 // and the terminal transitions, so a conflict is logged rather than
 // fatal.
-func (s *Controller) advanceAttempt(ctx context.Context, attemptID assignment.AttemptID, from, to string) {
+func (s *Controller) advanceAttempt(ctx context.Context, attemptID assignment.AttemptID, from, to store.AttemptState) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
 	defer cancel()
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		return tx.Advance(assignment.AttemptID(attemptID), from, to)
+		return tx.Advance(attemptID, from, to)
 	}); err != nil {
 		s.log.Warn("attempt did not advance", "attempt", attemptID,
 			"from", from, "to", to, "error", err)
@@ -134,7 +134,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	}
 
 	recorder := s.leases.Recorder(ctx, lease.ID)
-	s.advanceAttempt(ctx, attemptID, "leased", "preparing")
+	s.advanceAttempt(ctx, attemptID, store.AttemptLeased, store.AttemptPreparing)
 	sandbox, err := s.netSandbox.forLaunch(prepCtx)
 	if err != nil {
 		log.Error("network sandbox refresh failed", "error", err)
@@ -175,7 +175,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
-	s.advanceAttempt(ctx, attemptID, "preparing", "prepared")
+	s.advanceAttempt(ctx, attemptID, store.AttemptPreparing, store.AttemptPrepared)
 	// This one edge is authoritative, unlike every other in the walk. It
 	// is the last point before an effect that can begin execution, and
 	// by here the attempt has been out of this goroutine's sight for the
@@ -249,7 +249,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceRunningObserved); err != nil {
 		log.Error("cannot record that the runner is running", "error", err)
 	}
-	s.advanceAttempt(ctx, attemptID, "starting", "running")
+	s.advanceAttempt(ctx, attemptID, store.AttemptStarting, store.AttemptRunning)
 	if err := s.leases.Transition(ctx, lease.ID, store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning); err != nil {
 		log.Error("transition to running failed", "error", err)
 		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -48,6 +48,21 @@ func (a WorkloadAssignment) Validate() error {
 	return nil
 }
 
+// DeliveryKeyVersion prefixes the delivery key. It is named, and named
+// separately from the binding key's version, because the two are
+// unrelated encodings that happen to be at the same number — and the
+// cost of bumping them is not the same.
+//
+// Bumping this one re-keys deliveries. A message already recorded stops
+// matching, so it is processed again; the attempts it created are still
+// there, and the redelivery finds them by workload key rather than
+// creating a second set. Recoverable.
+//
+// Bumping the binding key's is a rename of every binding. See
+// bindingKeyVersion in internal/app, which says what that costs, and do not treat the
+// two as one value because they read alike.
+const DeliveryKeyVersion = "v2"
+
 // DeliveryKey encodes a provider's delivery identity as the opaque,
 // versioned key the store deduplicates on. The version prefix is what
 // lets the encoding evolve without two encodings of one delivery ever
@@ -59,7 +74,7 @@ func (a WorkloadAssignment) Validate() error {
 // on the id alone, a fresh message can collide with a delivery this
 // binding already recorded and confirmed.
 func DeliveryKey(sourceQueueID, sourceID int) string {
-	return fmt.Sprintf("v2|%d|%d", sourceQueueID, sourceID)
+	return fmt.Sprintf("%s|%d|%d", DeliveryKeyVersion, sourceQueueID, sourceID)
 }
 
 // Fingerprint digests the normalized content of a delivery: every field
@@ -123,10 +138,11 @@ type WorkloadLifecycleEvent struct {
 	SourceWorkloadKey string
 	TenantKey         string
 	ProjectKey        string
-	// RuntimeName and RuntimeID identify the provider-side runtime the
-	// observation names, opaque to the domain.
+	// RuntimeName identifies the provider-side runtime the observation
+	// names, opaque to the domain. It is the handle a late report
+	// correlates by, which is why the workload key travels beside it
+	// rather than instead of it.
 	RuntimeName RuntimeName
-	RuntimeID   int64
 	// Result is the provider's stated outcome, populated on completed
 	// observations only.
 	Result string

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -50,7 +50,7 @@ func (a WorkloadAssignment) Validate() error {
 
 // DeliveryKeyVersion prefixes the delivery key. It is named, and named
 // separately from the binding key's version, because the two are
-// unrelated encodings that happen to be at the same number — and the
+// unrelated encodings that happen to be at the same number, and the
 // cost of bumping them is not the same.
 //
 // Bumping this one re-keys deliveries. A message already recorded stops

--- a/internal/command/attempts.go
+++ b/internal/command/attempts.go
@@ -42,7 +42,7 @@ func viewOf(a store.Attempt, now time.Time) attemptView {
 		ID:           string(a.ID),
 		Workload:     string(a.SourceWorkloadKey),
 		Project:      a.TenantKey + "/" + a.ProjectKey,
-		State:        a.State,
+		State:        string(a.State),
 		ReviewReason: a.ReviewReason,
 		Resolution:   a.Resolution,
 		ReviewedBy:   a.ReviewedBy,

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -271,9 +271,10 @@ const (
 // wider set — the seven states that block a redelivery, `manual_review`
 // among them — and one word for two sets one grep apart is how the
 // wrong one gets copied.
-func servedByThisLease(state string) bool {
+func servedByThisLease(state store.AttemptState) bool {
 	switch state {
-	case "leased", "preparing", "prepared", "starting", "running":
+	case store.AttemptLeased, store.AttemptPreparing, store.AttemptPrepared,
+		store.AttemptStarting, store.AttemptRunning:
 		return true
 	}
 	return false

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -158,9 +158,10 @@ func (f *fixture) attemptState() store.Attempt {
 // advanceAttemptTo walks the attempt through the real transitions the
 // serving path uses, so a test never writes a state the product cannot
 // reach.
-func (f *fixture) advanceAttemptTo(target string) {
+func (f *fixture) advanceAttemptTo(target store.AttemptState) {
 	f.t.Helper()
-	ladder := []string{"leased", "preparing", "prepared", "starting", "running"}
+	ladder := []store.AttemptState{store.AttemptLeased, store.AttemptPreparing,
+		store.AttemptPrepared, store.AttemptStarting, store.AttemptRunning}
 	f.tx(func(tx *store.Tx) error {
 		for i := 1; i < len(ladder); i++ {
 			if err := tx.Advance(assignment.AttemptID(f.attempt), ladder[i-1], ladder[i]); err != nil {
@@ -199,7 +200,7 @@ func TestFinalizeDisposesByEvidence(t *testing.T) {
 		toState        store.LeaseState
 		startObs       assignment.ExecutionObservation
 		wantErr        bool
-		wantState      string
+		wantState      store.AttemptState
 		wantResolution string
 	}{
 		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, "", false, "settled", assignment.ResolutionCompletedObserved},
@@ -511,7 +512,7 @@ func TestAHeldAttemptDoesNotPinItsLease(t *testing.T) {
 // decision is one function now; this is what says so.
 func TestBothDispositionPathsAgree(t *testing.T) {
 	for name, tc := range map[string]struct {
-		state    string
+		state    store.AttemptState
 		evidence store.Evidence
 		obs      assignment.ExecutionObservation
 		want     disposition
@@ -601,7 +602,7 @@ func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
 			continue
 		}
 		walked++
-		t.Run(state, func(t *testing.T) {
+		t.Run(string(state), func(t *testing.T) {
 			f := newFixture(t, nopRemover{})
 			f.driveTo(store.LeaseCleaning)
 			if state != "leased" {

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -203,13 +203,13 @@ func TestFinalizeDisposesByEvidence(t *testing.T) {
 		wantState      store.AttemptState
 		wantResolution string
 	}{
-		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, "", false, "settled", assignment.ResolutionCompletedObserved},
-		{"running observed", store.EvidenceRunningObserved, store.LeaseCleaning, "", false, "settled", assignment.ResolutionStartedObserved},
-		{"nothing was prepared", store.EvidenceNotStarted, store.LeaseCleaning, "", false, "ready", ""},
-		{"prepared but never authorized", store.EvidenceRuntimePrepared, store.LeaseCleaning, "", false, "ready", ""},
-		{"authorized and unprovable", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedAbsent, false, "manual_review", ""},
-		{"authorized and proven inert", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedCreated, false, "ready", ""},
-		{"lease not yet cleaning", store.EvidenceNotStarted, store.LeaseQuarantined, "", true, "leased", ""},
+		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, "", false, store.AttemptSettled, assignment.ResolutionCompletedObserved},
+		{"running observed", store.EvidenceRunningObserved, store.LeaseCleaning, "", false, store.AttemptSettled, assignment.ResolutionStartedObserved},
+		{"nothing was prepared", store.EvidenceNotStarted, store.LeaseCleaning, "", false, store.AttemptReady, ""},
+		{"prepared but never authorized", store.EvidenceRuntimePrepared, store.LeaseCleaning, "", false, store.AttemptReady, ""},
+		{"authorized and unprovable", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedAbsent, false, store.AttemptManualReview, ""},
+		{"authorized and proven inert", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedCreated, false, store.AttemptReady, ""},
+		{"lease not yet cleaning", store.EvidenceNotStarted, store.LeaseQuarantined, "", true, store.AttemptLeased, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -260,7 +260,7 @@ func TestFinalizeIsAtomic(t *testing.T) {
 	if got := f.reload(); got.State != store.LeaseCleaning {
 		t.Errorf("lease = %s; want still cleaning — nothing may commit", got.State)
 	}
-	if got := f.attemptState(); got.State != "leased" {
+	if got := f.attemptState(); got.State != store.AttemptLeased {
 		t.Errorf("attempt = %s; want still leased — nothing may commit", got.State)
 	}
 }
@@ -295,7 +295,7 @@ func TestReleaseRemovesEverythingAndDisposes(t *testing.T) {
 		}
 		return nil
 	})
-	if got := f.attemptState(); got.State != "settled" {
+	if got := f.attemptState(); got.State != store.AttemptSettled {
 		t.Errorf("attempt = %s; want settled", got.State)
 	}
 }
@@ -322,7 +322,7 @@ func TestReleaseQuarantinesOnAWedgedDaemon(t *testing.T) {
 	if got := f.reload(); got.State != store.LeaseQuarantined {
 		t.Fatalf("lease = %s; want quarantined", got.State)
 	}
-	if got := f.attemptState(); got.State != "leased" {
+	if got := f.attemptState(); got.State != store.AttemptLeased {
 		t.Errorf("attempt = %s; want still leased — nothing was resolved", got.State)
 	}
 
@@ -423,7 +423,7 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 			attempt, err = tx.Get(assignment.AttemptID(f.attempt))
 			return err
 		})
-		if attempt.State == "manual_review" {
+		if attempt.State == store.AttemptManualReview {
 			if attempt.ReviewReason != store.ReviewReasonRetryBudgetExhausted {
 				t.Fatalf("held for review as %q; want %q, so an operator knows the "+
 					"question is whether retrying will ever stop",
@@ -431,7 +431,7 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 			}
 			return
 		}
-		if attempt.State != "ready" {
+		if attempt.State != store.AttemptReady {
 			t.Fatalf("after serving %d the attempt is %q; want ready or manual_review", serving, attempt.State)
 		}
 		if serving > 5 {
@@ -459,14 +459,14 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 func TestAReservedExitRequeuesAnAttemptTheWalkAlreadyCalledRunning(t *testing.T) {
 	f := newFixture(t, nopRemover{})
 	f.driveTo(store.LeaseCleaning)
-	f.advanceAttemptTo("running")
+	f.advanceAttemptTo(store.AttemptRunning)
 	f.recordEvidence(store.EvidenceRunningObserved)
 
 	if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.ObservedCreated); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}
 
-	if got := f.attemptState(); got.State != "ready" {
+	if got := f.attemptState(); got.State != store.AttemptReady {
 		t.Errorf("attempt state = %s (resolution %q); want it back in the queue as ready",
 			got.State, got.Resolution)
 	}
@@ -498,7 +498,7 @@ func TestAHeldAttemptDoesNotPinItsLease(t *testing.T) {
 	if got := f.reload().State; got != store.LeaseReleased {
 		t.Errorf("lease = %s; want released — a held attempt must not pin the lease serving it", got)
 	}
-	if got := f.attemptState(); got.State != "manual_review" {
+	if got := f.attemptState(); got.State != store.AttemptManualReview {
 		t.Errorf("attempt = %s; want it left in manual_review for the person who holds it", got.State)
 	}
 }
@@ -518,25 +518,25 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 		want     disposition
 	}{
 		"proven inert outranks a running observation": {
-			"running", store.EvidenceRunningObserved, assignment.ObservedCreated, dispositionRequeue},
+			store.AttemptRunning, store.EvidenceRunningObserved, assignment.ObservedCreated, dispositionRequeue},
 		"an observed exit settles as completed": {
-			"running", store.EvidenceExitObserved, "", dispositionSettleCompleted},
+			store.AttemptRunning, store.EvidenceExitObserved, "", dispositionSettleCompleted},
 		"a running observation settles as started": {
-			"running", store.EvidenceRunningObserved, "", dispositionSettleStarted},
+			store.AttemptRunning, store.EvidenceRunningObserved, "", dispositionSettleStarted},
 		"nothing prepared returns to the queue": {
-			"leased", store.EvidenceNotStarted, "", dispositionRequeue},
+			store.AttemptLeased, store.EvidenceNotStarted, "", dispositionRequeue},
 		"a running runtime settles as started": {
-			"starting", store.EvidenceStartAuthorized, assignment.ObservedRunning, dispositionSettleStarted},
+			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.ObservedRunning, dispositionSettleStarted},
 		"an unprovable start is held": {
-			"starting", store.EvidenceStartAuthorized, assignment.ObservedAbsent, dispositionReview},
+			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.ObservedAbsent, dispositionReview},
 		"an attempt an operator returned to the queue is left alone": {
-			"ready", store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptReady, store.EvidenceNotStarted, "", dispositionNone},
 		"a superseded attempt is left alone": {
-			"superseded", store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptSuperseded, store.EvidenceNotStarted, "", dispositionNone},
 		"a held attempt is left alone": {
-			"manual_review", store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptManualReview, store.EvidenceNotStarted, "", dispositionNone},
 		"a settled attempt is left alone": {
-			"settled", store.EvidenceExitObserved, "", dispositionNone},
+			store.AttemptSettled, store.EvidenceExitObserved, "", dispositionNone},
 	} {
 		t.Run(name, func(t *testing.T) {
 			attempt := store.Attempt{State: tc.state, Evidence: tc.evidence}
@@ -564,12 +564,12 @@ func TestAProvenInertStartIsRequeuedFromEitherPath(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := newFixture(t, nopRemover{})
 			f.driveTo(store.LeaseCleaning)
-			f.advanceAttemptTo("running")
+			f.advanceAttemptTo(store.AttemptRunning)
 			f.recordEvidence(store.EvidenceRunningObserved)
 
 			end(f)
 
-			if got := f.attemptState(); got.State != "ready" {
+			if got := f.attemptState(); got.State != store.AttemptReady {
 				t.Errorf("attempt = %s (resolution %q); want it back in the queue",
 					got.State, got.Resolution)
 			}
@@ -605,7 +605,7 @@ func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
 		t.Run(string(state), func(t *testing.T) {
 			f := newFixture(t, nopRemover{})
 			f.driveTo(store.LeaseCleaning)
-			if state != "leased" {
+			if state != store.AttemptLeased {
 				f.advanceAttemptTo(state)
 			}
 
@@ -644,7 +644,7 @@ func TestAnAttemptReturnedToTheQueueDoesNotPinItsLease(t *testing.T) {
 	if got := f.reload().State; got != store.LeaseReleased {
 		t.Errorf("lease = %s; want released — an attempt already servable must not pin it", got)
 	}
-	if got := f.attemptState().State; got != "ready" {
+	if got := f.attemptState().State; got != store.AttemptReady {
 		t.Errorf("attempt = %s; want it left where the operator put it", got)
 	}
 }

--- a/internal/platform/githubactions/message.go
+++ b/internal/platform/githubactions/message.go
@@ -85,10 +85,10 @@ func translate(msg *scaleset.RunnerScaleSetMessage) (Message, []assignment.Workl
 		out.Assigned = append(out.Assigned, workload(j.JobMessageBase))
 	}
 	for _, j := range msg.JobStartedMessages {
-		out.Started = append(out.Started, observation(assignment.LifecycleStarted, j.JobMessageBase, j.RunnerName, j.RunnerID, ""))
+		out.Started = append(out.Started, observation(assignment.LifecycleStarted, j.JobMessageBase, j.RunnerName, ""))
 	}
 	for _, j := range msg.JobCompletedMessages {
-		out.Completed = append(out.Completed, observation(assignment.LifecycleCompleted, j.JobMessageBase, j.RunnerName, j.RunnerID, j.Result))
+		out.Completed = append(out.Completed, observation(assignment.LifecycleCompleted, j.JobMessageBase, j.RunnerName, j.Result))
 	}
 	return out, available
 }
@@ -113,14 +113,13 @@ func workload(b scaleset.JobMessageBase) assignment.WorkloadAssignment {
 // events that named only the runner could not be correlated to the
 // attempt they belong to, and a cancellation aimed at an old attempt
 // could then hit a new one.
-func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runnerName string, runnerID int, result string) assignment.WorkloadLifecycleEvent {
+func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runnerName, result string) assignment.WorkloadLifecycleEvent {
 	return assignment.WorkloadLifecycleEvent{
 		Kind:              kind,
 		SourceWorkloadKey: b.JobID,
 		TenantKey:         b.OwnerName,
 		ProjectKey:        b.RepositoryName,
 		RuntimeName:       assignment.RuntimeName(runnerName),
-		RuntimeID:         int64(runnerID),
 		Result:            result,
 	}
 }

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -396,7 +396,7 @@ func TestResourceIntentLifecycleAndReleaseRule(t *testing.T) {
 	// With every intent absent and the attempt resolved, the lease is
 	// purgeable.
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(lease.AttemptID, "leased", "completed_observed"); err != nil {
+		if err := tx.Settle(lease.AttemptID, AttemptLeased, "completed_observed"); err != nil {
 			return err
 		}
 		return tx.PurgeLease(lease.ID)

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -12,6 +12,29 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 )
 
+// AttemptState is where an attempt stands in the walk from queued to
+// resolved.
+//
+// It is a type for the reason LeaseState is one. These values are
+// compared against literals in guards spread across three packages, and
+// every one of those must agree with a list written in SQL — where a
+// typo is not a compile error but a guard that matches nothing and
+// reports success.
+type AttemptState string
+
+const (
+	AttemptReady        AttemptState = "ready"
+	AttemptLeased       AttemptState = "leased"
+	AttemptPreparing    AttemptState = "preparing"
+	AttemptPrepared     AttemptState = "prepared"
+	AttemptStarting     AttemptState = "starting"
+	AttemptRunning      AttemptState = "running"
+	AttemptManualReview AttemptState = "manual_review"
+	AttemptSuperseded   AttemptState = "superseded"
+	AttemptSettled      AttemptState = "settled"
+	AttemptCanceled     AttemptState = "canceled"
+)
+
 // AllAttemptStates lists every state an attempt can hold, terminal ones
 // included, in the order the walk reaches them.
 //
@@ -22,9 +45,10 @@ import (
 // TestAttemptStatesCoverTheSchema holds it against the constraint the
 // database enforces, so the list cannot drift from what a row may
 // actually contain.
-var AllAttemptStates = []string{
-	"ready", "leased", "preparing", "prepared", "starting", "running",
-	"manual_review", "superseded", "settled", "canceled",
+var AllAttemptStates = []AttemptState{
+	AttemptReady, AttemptLeased, AttemptPreparing, AttemptPrepared,
+	AttemptStarting, AttemptRunning, AttemptManualReview,
+	AttemptSuperseded, AttemptSettled, AttemptCanceled,
 }
 
 // Attempt is the store's domain-facing view of one attempt row. It is a
@@ -37,7 +61,7 @@ type Attempt struct {
 	SourceWorkloadKey assignment.SourceWorkloadKey
 	TenantKey         string
 	ProjectKey        string
-	State             string
+	State             AttemptState
 	Evidence          Evidence
 	ReviewReason      string
 	Resolution        string
@@ -58,7 +82,7 @@ func fromRow(r sqlitedb.AssignmentAttempt) Attempt {
 		SourceWorkloadKey: assignment.SourceWorkloadKey(r.SourceWorkloadKey),
 		TenantKey:         r.TenantKey,
 		ProjectKey:        r.ProjectKey,
-		State:             r.State,
+		State:             AttemptState(r.State),
 		Evidence:          Evidence(r.ExecutionEvidence),
 		ReviewReason:      r.ReviewReason,
 		Resolution:        r.Resolution,
@@ -164,9 +188,9 @@ func (t *Tx) StrandedAttempts() ([]Attempt, error) {
 // Advance walks the attempt state machine one edge, compare-and-swap.
 // The walk is observability — disposition rests on evidence and the
 // terminal transitions — so a conflict here reports rather than blocks.
-func (t *Tx) Advance(attemptID assignment.AttemptID, from, to string) error {
+func (t *Tx) Advance(attemptID assignment.AttemptID, from, to AttemptState) error {
 	affected, err := t.q.TransitionAttempt(t.ctx, sqlitedb.TransitionAttemptParams{
-		Next: to, AttemptID: string(attemptID), Current: from,
+		Next: string(to), AttemptID: string(attemptID), Current: string(from),
 	})
 	if err != nil {
 		return err
@@ -374,9 +398,9 @@ func (t *Tx) ResolveReviewToSettled(attemptID assignment.AttemptID, resolution, 
 }
 
 // Settle closes an attempt with an evidence-accurate resolution.
-func (t *Tx) Settle(attemptID assignment.AttemptID, currentState, resolution string) error {
+func (t *Tx) Settle(attemptID assignment.AttemptID, currentState AttemptState, resolution string) error {
 	affected, err := t.q.SettleAttempt(t.ctx, sqlitedb.SettleAttemptParams{
-		Resolution: resolution, AttemptID: string(attemptID), Current: currentState,
+		Resolution: resolution, AttemptID: string(attemptID), Current: string(currentState),
 	})
 	if err != nil {
 		return err
@@ -404,7 +428,7 @@ func (t *Tx) Settle(attemptID assignment.AttemptID, currentState, resolution str
 // by walking that set and requiring each of them to dispose.
 func (t *Tx) RequeueServing(attempt Attempt) error {
 	switch attempt.State {
-	case "starting", "running":
+	case AttemptStarting, AttemptRunning:
 		return t.RequeueProvenInert(attempt.ID)
 	default:
 		return t.Requeue(attempt.ID)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -398,7 +398,7 @@ func TestPurgeLeaseRefusesWhileItsAttemptIsUnresolved(t *testing.T) {
 	}
 
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(attempt, "leased", "completed_observed"); err != nil {
+		if err := tx.Settle(attempt, AttemptLeased, "completed_observed"); err != nil {
 			return err
 		}
 		return tx.PurgeLease(leaseID)
@@ -742,10 +742,10 @@ func TestRetentionMeasuresFromTheFinish(t *testing.T) {
 	backdateLease(t, s, resolved, longAgo, time.Now().Add(-time.Minute))
 
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(settledAttempt, "leased", "completed_observed"); err != nil {
+		if err := tx.Settle(settledAttempt, AttemptLeased, "completed_observed"); err != nil {
 			return err
 		}
-		return tx.Settle(resolvedAttempt, "leased", "completed_observed")
+		return tx.Settle(resolvedAttempt, AttemptLeased, "completed_observed")
 	})
 
 	var removed int
@@ -802,13 +802,13 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 	prunable, prunableAttempt := releasedLease(t, s, binding, "old")
 	backdateLease(t, s, prunable, old, old)
 	inTx(t, s, func(tx *Tx) error {
-		return tx.Settle(prunableAttempt, "leased", "completed_observed")
+		return tx.Settle(prunableAttempt, AttemptLeased, "completed_observed")
 	})
 
 	// Finished, but recent: outside the window.
 	recent, recentAttempt := releasedLease(t, s, binding, "recent")
 	inTx(t, s, func(tx *Tx) error {
-		return tx.Settle(recentAttempt, "leased", "completed_observed")
+		return tx.Settle(recentAttempt, AttemptLeased, "completed_observed")
 	})
 
 	// Old and released, but its attempt is still open — the crash window.
@@ -819,7 +819,7 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 	wedged, wedgedAttempt := releasedLease(t, s, binding, "wedged")
 	backdateLease(t, s, wedged, old, old)
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(wedgedAttempt, "leased", "completed_observed"); err != nil {
+		if err := tx.Settle(wedgedAttempt, AttemptLeased, "completed_observed"); err != nil {
 			return err
 		}
 		_, err := tx.PlanResource(wedged, ResourceContainer, "runner", "runpool-wedged")
@@ -867,7 +867,7 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 		if err != nil {
 			t.Fatalf("the pruned lease's attempt disappeared with it: %v", err)
 		}
-		if attempt.State != "settled" {
+		if attempt.State != AttemptSettled {
 			t.Errorf("attempt state = %q; want the disposition preserved", attempt.State)
 		}
 		events, err := tx.Events(prunableAttempt)
@@ -1092,7 +1092,7 @@ func TestAnOperatorRetryIsNotOverruledByTheBudget(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if a.State != "ready" {
+		if a.State != AttemptReady {
 			t.Errorf("after an operator retry the attempt is %q; the budget overruled a human", a.State)
 		}
 		if a.Evidence != EvidenceNotStarted {
@@ -1195,7 +1195,7 @@ func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 		}},
 		{"proven inert from starting", "starting", func(tx *Tx, id string) error {
 			for _, step := range [][2]AttemptState{
-				{"leased", "preparing"}, {"preparing", "prepared"}, {"prepared", "starting"},
+				{AttemptLeased, AttemptPreparing}, {AttemptPreparing, AttemptPrepared}, {AttemptPrepared, AttemptStarting},
 			} {
 				if err := tx.Advance(assignment.AttemptID(id), step[0], step[1]); err != nil {
 					return err
@@ -1364,7 +1364,7 @@ func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
 				if err != nil {
 					t.Fatalf("the redelivery was refused: %v", err)
 				}
-				if got.State != "superseded" {
+				if got.State != AttemptSuperseded {
 					t.Errorf("held attempt = %s; want superseded so the queue moves", got.State)
 				}
 				return
@@ -1372,7 +1372,7 @@ func TestSupersedingAHeldAttemptTurnsOnWhatItConsumed(t *testing.T) {
 			if err == nil {
 				t.Fatal("the redelivery replaced an attempt whose start was authorized")
 			}
-			if got.State != "manual_review" {
+			if got.State != AttemptManualReview {
 				t.Errorf("held attempt = %s; want it left in manual_review", got.State)
 			}
 		})

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1194,7 +1194,7 @@ func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 			return tx.Requeue(assignment.AttemptID(id))
 		}},
 		{"proven inert from starting", "starting", func(tx *Tx, id string) error {
-			for _, step := range [][2]string{
+			for _, step := range [][2]AttemptState{
 				{"leased", "preparing"}, {"preparing", "prepared"}, {"prepared", "starting"},
 			} {
 				if err := tx.Advance(assignment.AttemptID(id), step[0], step[1]); err != nil {
@@ -1508,7 +1508,7 @@ func TestTheRetryCountIsIndexed(t *testing.T) {
 // here fails rather than defaulting to one.
 func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 	cases := []struct {
-		state     string
+		state     AttemptState
 		authorize bool
 		because   string
 	}{
@@ -1526,7 +1526,7 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 
 	// The universe comes from the one list, which its own test holds
 	// against the schema.
-	decided := make(map[string]bool, len(cases))
+	decided := make(map[AttemptState]bool, len(cases))
 	for _, c := range cases {
 		decided[c.state] = true
 	}
@@ -1541,7 +1541,7 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 
 	// Each case gets a real lease, because the authorization is scoped to
 	// one: an attempt in a servable state is not enough on its own.
-	leased := func(t *testing.T, name, state string) (assignment.LeaseID, assignment.AttemptID) {
+	leased := func(t *testing.T, name string, state AttemptState) (assignment.LeaseID, assignment.AttemptID) {
 		t.Helper()
 		id := seedAttempt(t, s, binding, "msg-"+name, assignment.SourceWorkloadKey("job-"+name))
 		var leaseID assignment.LeaseID
@@ -1551,17 +1551,17 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 				return err
 			}
 			leaseID = lease.ID
-			if state == "leased" {
+			if state == AttemptLeased {
 				return nil
 			}
-			return tx.Advance(id, "leased", state)
+			return tx.Advance(id, AttemptLeased, state)
 		})
 		return leaseID, id
 	}
 
 	for _, c := range cases {
-		t.Run(c.state, func(t *testing.T) {
-			leaseID, id := leased(t, c.state, c.state)
+		t.Run(string(c.state), func(t *testing.T) {
+			leaseID, id := leased(t, string(c.state), c.state)
 
 			var err error
 			inTx(t, s, func(tx *Tx) error {
@@ -1583,7 +1583,7 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 	// the attempt is still this lease's, and that is the half that keeps
 	// a job from being run twice.
 	t.Run("a lease that has been released", func(t *testing.T) {
-		leaseID, id := leased(t, "released-lease", "prepared")
+		leaseID, id := leased(t, "released-lease", AttemptPrepared)
 		// reserved -> failed -> cleaning -> released is the shortest real
 		// path to a released lease; the state machine refuses shortcuts.
 		inTx(t, s, func(tx *Tx) error {
@@ -1607,8 +1607,8 @@ func TestOnlyAnUnstartedAttemptOfThisServingIsAuthorized(t *testing.T) {
 	})
 
 	t.Run("a lease that never held this attempt", func(t *testing.T) {
-		_, id := leased(t, "wrong-lease-a", "prepared")
-		other, _ := leased(t, "wrong-lease-b", "prepared")
+		_, id := leased(t, "wrong-lease-a", AttemptPrepared)
+		other, _ := leased(t, "wrong-lease-b", AttemptPrepared)
 		inTx(t, s, func(tx *Tx) error {
 			if err := tx.AuthorizeStart(other, id); !errors.Is(err, ErrConflict) {
 				t.Errorf("AuthorizeStart with another lease's id = %v; want ErrConflict", err)
@@ -1651,7 +1651,7 @@ func TestEveryLeaseKeepsItsAttempt(t *testing.T) {
 		}
 		// Back to the queue and served again, which is the whole of how
 		// one attempt comes to have two leases.
-		if err := tx.Advance(id, "leased", "ready"); err != nil {
+		if err := tx.Advance(id, AttemptLeased, AttemptReady); err != nil {
 			return err
 		}
 		second, err = tx.LeaseAttempt(id, binding, "tier-a")
@@ -1769,7 +1769,7 @@ func TestAttemptStatesCoverTheSchema(t *testing.T) {
 	}
 	constraint := body[start : start+strings.Index(body[start:], "))")]
 
-	listed := make(map[string]bool, len(AllAttemptStates))
+	listed := make(map[AttemptState]bool, len(AllAttemptStates))
 	for _, s := range AllAttemptStates {
 		listed[s] = true
 	}
@@ -1779,7 +1779,7 @@ func TestAttemptStatesCoverTheSchema(t *testing.T) {
 			continue
 		}
 		found++
-		if !listed[state] {
+		if !listed[AttemptState(state)] {
 			t.Errorf("the schema allows attempt state %q and AllAttemptStates omits it", state)
 		}
 	}


### PR DESCRIPTION
## What changes

`Attempt.State` becomes a named type with named constants, the two `v2`
version prefixes stop being loose literals, and a field that gave one
name to two different things is deleted rather than renamed, because
nothing read it.

No behaviour change: every value written and read is identical.

## What was found

**`Attempt.State` was a string while `LeaseState` sat beside it doing the
opposite.** The lease state machine has a type and nine named constants.
The attempt state machine had ten string literals, compared in three
packages, each of which has to agree with a list written in SQL:

```sql
WHERE id = @attempt_id AND state IN ('leased', 'preparing', 'prepared')
```

A typo on the Go side is not a compile error there. It is a guard that
matches no row and reports success — which is the exact failure this
work has already fixed twice, once when `ready` was in a set it should
not have been and once when a totality guard walked a hand-copied list.

It is `AttemptState` with ten constants now. `Advance`, `Settle`,
`servedByThisLease`, `RequeueServing`, `advanceAttempt` and every table
in the suites take them.

The first version of this said that and left most of the tables holding
bare literals. They were type-checked, so their values were right — and
`"reddy"` still compiled at every one of those sites, which is the whole
difference a named constant makes. What still spells a state as a string
is a different vocabulary sharing a word: a CLI filter (`manual-review`,
hyphenated), a JSON field name, the provider's `"canceled"` result.

**The two `v2` prefixes were loose literals in two packages, and bumping
them costs different things.** Anyone grepping to move one finds both:

```go
fmt.Sprintf("v2|%d|%d", sourceQueueID, sourceID)          // delivery key
fmt.Sprintf("v2|%s|%s|%s", target.ID, ...)                 // binding key
```

Bumping the delivery key's is recoverable. A recorded message stops
matching and is processed again; the attempts it created are still there
and the redelivery finds them by workload key rather than making a second
set.

Bumping the binding key's is a migration. The new key matches no row, so
a row is written and the old one is unclaimed —
`ForgetUnclaimedBindings` deletes it on the same startup, taking the
scale set id recorded against it, unless it still holds deliveries. Each
binding then meets a provider that already has its scale set under the
unchanged name and refuses to adopt one it has no record of creating,
once, before settling. The contact history does not come back.

Both are named, each says what its own bump costs, and each points at the
other so the next person does not treat them as one value because they
read alike.

**And the costly one was the one nothing pinned.** `DeliveryKey` had a
golden assertion — `DeliveryKey(7, 41) == "v2|7|41"` — so moving the
cheap version fails a test. `sourceBindingKey`'s test compared its output
to its own output, so moving the expensive version left the whole suite
green. It has a golden assertion now.

**`RuntimeID` named two things in one package.**
`assignment.RuntimeID` is the daemon's id for a container, a string.
`assignment.WorkloadLifecycleEvent.RuntimeID` was the provider's id for a
runner, an int64.

The second is written once by the GitHub adapter and read nowhere. So the
clash goes by deleting the field rather than renaming it, along with the
parameter that existed to fill it — the same class as a record kept for
an assertion nobody wrote.

## Symmetry check

| Path | Result |
|---|---|
| `LeaseState` | the pattern this follows; unchanged |
| every attempt-state literal outside the constants | audited. What remains shares a word and not a vocabulary: the provider's `"canceled"` result, Docker's `"running"` container status, the supervisor protocol's `StateRunning`/`StateReady`, `ResolutionSuperseded`, `ObservedRunning`, and a JSON field name |
| `AllAttemptStates` | now `[]AttemptState`, and its schema guard still holds it against the `CHECK` constraint |
| the SQL guards | unchanged, and still the thing the Go side must agree with — the type does not reach into a query, it makes the Go side of the agreement checkable |
| `capsule/protocol`'s states | a different machine with its own vocabulary; deliberately untouched |
| `assignment`'s value objects | still hold a workload key, a tenant key and a project key as bare strings. 106 sites, a different question, and the reason a map keyed by one of them could not be typed in the pass before this |

## Evidence

The compiler, for a change whose point is that a mistake stops
compiling — every literal it rejected is a place the old code accepted
anything:

```text
internal/lease/lease.go:296: cannot use attempt.State as string in servedByThisLease
internal/app/runtime.go:42:  cannot use from (string) as store.AttemptState in tx.Advance
internal/command/attempts.go:45: cannot use a.State as string in struct literal
```

And for the version prefixes, that the bytes did not move:

```text
DeliveryKey(7, 42) == "v2|7|42"
```

The full suite passes. Every test rewritten was rewritten to name a
constant, not to accept a different value.

## What would notice this regressing

- The compiler. An attempt state where a lease state belongs, or a
  literal that is not one of the ten, is now a build failure.
- `TestAttemptStatesCoverTheSchema` still holds the constant list against
  the database's own `CHECK`, so a state added to one and not the other
  fails.
- `TestNoDocCommentBelongsToAnotherDeclaration` caught both new constants
  landing in front of the doc comments of the functions they belong to —
  the fourth time in this work, and the first time a gate said so
  instead of a reviewer.
- `TestTheBindingKeyIsVersionedAndPinned` fails if the binding key's
  encoding moves at all, version included.

Nothing new is asserted at runtime, because nothing changes at runtime.

## Risk, compatibility and operations

**No behaviour change.** `AttemptState` is a `string`; every value stored,
compared and rendered is identical. The deleted field was written and
never read, so nothing observed it.

**The risk is a mechanical diff.** It is bounded by being type-only: every
edit followed a compiler error rather than a search and replace, and the
one block where a regex changed an assignment into a declaration was
caught by the build and rewritten by hand.

**Schema, migrations, credentials, CLI, configuration, status API:
untouched.** The status document's JSON is byte-identical — the state
reaches it through a conversion at the DTO, where it was already a
string.

## Changelog

```text
NONE - types and names only, with no effect a deployment can observe.
```

## Notes for your reviewer

Worth checking hardest that no literal changed meaning. The ten constants
were transcribed from the schema's `CHECK` constraint, and
`TestAttemptStatesCoverTheSchema` holds them to it. That worry — a
constant whose value is wrong and whose name is right — turned out to be
covered, and it is worth saying how rather than asserting it: the test
requires the schema's set to be a subset of the constants *and* the
counts to match, so a wrong value drops a schema state out of the listed
set. Checked by mutation:

```text
AttemptPrepared = "prepped"
  -> FAIL: the schema allows attempt state "prepared" and AllAttemptStates omits it
```

The values were also read directly against the migration, not only
through the test.

Second, the two version constants. They are equal today, which is exactly
what makes them easy to treat as one. The comments are the whole
mechanism keeping them apart; if either reads as boilerplate, it has
failed at its job.
