### PR TITLE
fix(gateway): a revoked destination stops mid-transfer, and no install is missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,11 @@ by its public and operational effects.
   So both shapes the relay serves re-check the address they are joined to
   while they run — a CONNECT tunnel and a plain HTTP transfer alike — and
   the longest a revoked destination keeps flowing is one poll interval,
-  whatever it is carrying.
+  whatever it is carrying. A transfer stopped that way reaches the job as
+  a failed read rather than as a complete response with a short body:
+  once the status line is out there is nothing left to say "this was
+  cut" except how the connection ends, so it ends without the terminator
+  a client would otherwise read as the end of the data.
 - **An install takes effect whenever it lands.** Whether a new policy is
   in force is decided by the document's contents rather than by its
   modification time and size. Two documents of equal length installed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,9 @@ by its public and operational effects.
   inside one clock tick carry the same modification time, so deciding on
   that pair meant the second never reached the relay at all: the
   tightening would have been reported as installed and silently not
-  applied.
+  applied. A document larger than a policy may be is refused rather than
+  cut down to the limit, since a cut one can still parse as a policy
+  nobody wrote.
 - **The two policy installers cannot overwrite each other.** A reload
   and an emergency close arrive as separate processes into the same
   container, so the install is serialized by a lock the kernel holds and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,26 @@ by its public and operational effects.
   gateway that could be named, so a pass that could not name one leaves
   the books where they were and the next pass installs the change
   instead of comparing it against itself.
-- **A revoked address stops being reachable.** A destination the policy
-  no longer allows is checked when a connection is dialled, and the pool
-  a job keeps warm never dials again — the kernel does not intervene
-  either, since the ruleset accepts established traffic ahead of every
-  reject. A policy that moves therefore retires the pool it authorised
-  rather than closing the connections that happen to be idle in it.
+- **A revoked address stops being reachable, transfers under way
+  included.** A destination the policy no longer allows is checked when a
+  connection is dialled, and the pool a job keeps warm never dials again
+  — the kernel does not intervene either, since the ruleset accepts
+  established traffic ahead of every reject. A policy that moves
+  therefore retires the pool it authorised rather than closing the
+  connections that happen to be idle in it. Retiring the pool does not
+  reach a transfer already running: the connection carrying it is left
+  alone, and a large download can hold one for as long as the job likes.
+  So both shapes the relay serves re-check the address they are joined to
+  while they run — a CONNECT tunnel and a plain HTTP transfer alike — and
+  the longest a revoked destination keeps flowing is one poll interval,
+  whatever it is carrying.
+- **An install takes effect whenever it lands.** Whether a new policy is
+  in force is decided by the document's contents rather than by its
+  modification time and size. Two documents of equal length installed
+  inside one clock tick carry the same modification time, so deciding on
+  that pair meant the second never reached the relay at all: the
+  tightening would have been reported as installed and silently not
+  applied.
 - **The two policy installers cannot overwrite each other.** A reload
   and an emergency close arrive as separate processes into the same
   container, so the install is serialized by a lock the kernel holds and

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -52,7 +53,7 @@ type PolicyStore struct {
 
 	mu      sync.Mutex
 	decider *egress.Decider
-	stamp   string
+	stamp   [sha256.Size]byte
 	// generation counts installed policies. A pooled HTTP connection was
 	// authorised by whichever policy was in force when it was dialled, and
 	// http.Transport reuses it without consulting the dialer again, so the
@@ -61,32 +62,34 @@ type PolicyStore struct {
 	generation uint64
 }
 
-// Current returns the compiled policy in force, reloading it if the
-// file changed since the last read.
+// Current returns the compiled policy in force, recompiling it when the
+// document's bytes have changed since the last read.
 //
-// The stat is inside the lock, with the read it decides. Outside it, two
-// readers crossing an install can stat different files and finish in the
-// other order, so the one that stat'd first stores what the other read
-// under the stamp of what it did not: the decider is never stale, since
-// the read is under the lock, but the stamp no longer describes it. The
-// next call then reloads a file that has not changed and advances the
-// generation for it, which retires the pooled transport and every idle
-// connection in it for nothing.
+// What counts as a change is the hash of the contents, not the pair of
+// modification time and size. Linux stamps mtime from the coarse clock,
+// which advances once per tick, so two documents of equal length
+// installed inside one tick carry the same pair — and the second install
+// would then never reach the relay at all: the decider would stay as it
+// was, the generation would not move, and the pooled transport would not
+// be retired either. A tightening would silently not take effect. The
+// document is a few kilobytes on tmpfs, so reading it every time costs
+// less than the case it rules out.
+//
+// The read is inside the lock, with the decision it feeds. Outside it,
+// two readers crossing an install can read different documents and
+// finish in the other order, so the one that read first would store what
+// the other read under the stamp of what it did not.
 func (s *PolicyStore) Current() (*egress.Decider, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	info, err := os.Stat(s.Path)
-	if err != nil {
-		return nil, err
-	}
-	stamp := fmt.Sprintf("%d/%d", info.ModTime().UnixNano(), info.Size())
-	if s.decider != nil && s.stamp == stamp {
-		return s.decider, nil
-	}
 	raw, err := os.ReadFile(s.Path)
 	if err != nil {
 		return nil, err
+	}
+	stamp := sha256.Sum256(raw)
+	if s.decider != nil && s.stamp == stamp {
+		return s.decider, nil
 	}
 	policy, err := ParsePolicy(string(raw))
 	if err != nil {

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -83,7 +83,7 @@ func (s *PolicyStore) Current() (*egress.Decider, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	raw, err := os.ReadFile(s.Path)
+	raw, err := readPolicy(s.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -102,6 +102,20 @@ func (s *PolicyStore) Current() (*egress.Decider, error) {
 	s.decider, s.stamp = decider, stamp
 	s.generation++
 	return decider, nil
+}
+
+// readPolicy reads a policy document, refusing to hold more of one than
+// a policy may be. The bound is the same MaxPolicyBytes ParsePolicy
+// applies, taken before the bytes are resident rather than after: this
+// read now happens on every call rather than once per change, and the
+// gateway it happens in has 128 MiB.
+func readPolicy(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return io.ReadAll(io.LimitReader(f, MaxPolicyBytes+1))
 }
 
 // Generation is how many policies this store has installed. It changes

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -104,11 +104,16 @@ func (s *PolicyStore) Current() (*egress.Decider, error) {
 	return decider, nil
 }
 
-// readPolicy reads a policy document, refusing to hold more of one than
-// a policy may be. The bound is the same MaxPolicyBytes ParsePolicy
-// applies, taken before the bytes are resident rather than after: this
-// read now happens on every call rather than once per change, and the
-// gateway it happens in has 128 MiB.
+// readPolicy reads a policy document without holding more of one than a
+// policy may be. The bound is taken before the bytes are resident rather
+// than after: this read happens on every call rather than once per
+// change, and the gateway it happens in has 128 MiB.
+//
+// One byte past MaxPolicyBytes, which is what makes the bound a refusal
+// instead of a truncation. Reading exactly the limit returns the same
+// length for a document that fits and for one that was cut off there,
+// and the cut one can still be valid JSON describing a policy nobody
+// installed. The extra byte is what ParsePolicy sees to reject it.
 func readPolicy(path string) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -139,7 +144,11 @@ func (s *PolicyStore) Generation() uint64 {
 // the relay still applies the old ones. A capsule therefore never sees
 // a moment in which a newly denied destination is reachable.
 func Reload(controlDir string, r io.Reader) error {
-	payload, err := io.ReadAll(io.LimitReader(r, MaxPolicyBytes))
+	// One byte past the bound, so a document that exceeds it is refused
+	// by ParsePolicy rather than silently truncated into a different one:
+	// reading exactly MaxPolicyBytes cannot tell a document that fits
+	// from one that was cut off at the limit.
+	payload, err := io.ReadAll(io.LimitReader(r, MaxPolicyBytes+1))
 	if err != nil {
 		return err
 	}

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,25 +81,20 @@ func TestRelayNoticesAPolicyChangeWithoutDialing(t *testing.T) {
 	write("10.0.0.0/8")
 
 	r := &Relay{Policy: &PolicyStore{Path: path}, Log: discardLogger()}
-	r.roundTripper() // the transport must exist before the pool can be dropped
 
 	// Two observations settle the baseline; no dial happens in either.
-	r.expireStaleConnections()
-	r.expireStaleConnections()
-	baseline := r.policyGen.Load()
+	r.transportInForce()
+	baseline := r.transportInForce().gen
 	if baseline == 0 {
 		t.Fatal("the relay never read the policy; a pooled request would keep the old one forever")
 	}
 
-	r.expireStaleConnections()
-	if got := r.policyGen.Load(); got != baseline {
+	if got := r.transportInForce().gen; got != baseline {
 		t.Errorf("generation moved to %d with an unchanged policy; the pool would be dropped every request", got)
 	}
 
-	time.Sleep(10 * time.Millisecond) // distinct mtime
 	write("192.168.0.0/16")
-	r.expireStaleConnections()
-	if got := r.policyGen.Load(); got == baseline {
+	if got := r.transportInForce().gen; got == baseline {
 		t.Error("the relay did not notice a new policy without dialing; pooled connections would keep the old one")
 	}
 }
@@ -261,19 +257,15 @@ func TestAPolicyMoveRetiresTheTransport(t *testing.T) {
 	write("10.0.0.0/8")
 
 	r := &Relay{Policy: &PolicyStore{Path: path}, Log: discardLogger()}
-	first := r.roundTripper()
+	first := r.transportInForce()
 
-	// Two observations settle the baseline; neither is a policy move.
-	r.expireStaleConnections()
-	r.expireStaleConnections()
-	if got := r.roundTripper(); got != first {
+	// A second observation of the same policy is not a move.
+	if got := r.transportInForce(); got != first {
 		t.Fatal("the transport was replaced without the policy moving; every request would start a new pool")
 	}
 
-	time.Sleep(10 * time.Millisecond) // distinct mtime
 	write("192.168.0.0/16")
-	r.expireStaleConnections()
-	if got := r.roundTripper(); got == first {
+	if got := r.transportInForce(); got == first {
 		t.Error("the transport survived a policy move; a connection pooled under the old one " +
 			"still carries the next request past the dialer, where the address is checked")
 	}
@@ -420,5 +412,66 @@ func TestAReaderCrossingAnInstallDoesNotOverCountGenerations(t *testing.T) {
 		t.Errorf("generation = %d after %d installs; want at most %d. "+
 			"The extra reloads are pooled transports retired for a policy that did not move",
 			got, installs, max)
+	}
+}
+
+// TestAnEqualLengthInstallIsNotMissed: what counts as a policy change is
+// the document's bytes, not its modification time and size.
+//
+// Linux stamps mtime from the coarse clock, which advances once per tick,
+// so two documents of equal length installed inside one tick carry the
+// same pair. Deciding on that pair, the second install never reaches the
+// relay at all: the decider stays as it was, the generation does not
+// move, and the pooled transport is not retired either — a tightening
+// that silently does not take effect.
+func TestAnEqualLengthInstallIsNotMissed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "policy.json")
+	doc := func(deny string) string {
+		return `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`
+	}
+	first, second := doc("10.20.20.0/24"), doc("10.30.30.0/24")
+	if len(first) != len(second) {
+		t.Fatalf("the two documents differ in length (%d vs %d); size alone would "+
+			"separate them and the test would prove nothing", len(first), len(second))
+	}
+
+	// One instant for both installs: the tick they would have shared.
+	tick := time.Unix(1_700_000_000, 0)
+	install := func(body string) {
+		t.Helper()
+		if err := atomicfile.Replace(path, []byte(body), 0o600, -1, -1); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, tick, tick); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	s := &PolicyStore{Path: path}
+	install(first)
+	decider, err := s.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decider.Allowed(netip.MustParseAddr("10.20.20.5")) {
+		t.Fatal("the first policy did not take effect; nothing after this means anything")
+	}
+	baseline := s.Generation()
+
+	install(second)
+	decider, err = s.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decider.Allowed(netip.MustParseAddr("10.20.20.5")) {
+		t.Error("the second install never reached the relay; the range it stopped denying is still refused")
+	}
+	if decider.Allowed(netip.MustParseAddr("10.30.30.5")) {
+		t.Error("the second install never reached the relay; the range it began denying is still permitted")
+	}
+	if s.Generation() == baseline {
+		t.Error("the generation did not move on the second install; the pooled transport " +
+			"keeps every connection the previous policy authorised")
 	}
 }

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -52,7 +52,6 @@ func TestPolicyGenerationAdvancesOnlyOnChange(t *testing.T) {
 	}
 
 	// A restriction that actually changed must advance it.
-	time.Sleep(10 * time.Millisecond) // distinct mtime
 	write("192.168.0.0/16")
 	if _, err := s.Current(); err != nil {
 		t.Fatal(err)
@@ -405,9 +404,12 @@ func TestAReaderCrossingAnInstallDoesNotOverCountGenerations(t *testing.T) {
 	}
 	settle()
 
-	// One for the first read, and at most one per install. Two installs
-	// inside the same nanosecond-and-size stamp are indistinguishable to
-	// the store, so this is an upper bound rather than an equality.
+	// One for the first read, and at most one per install. It is an upper
+	// bound rather than an equality because a reader only learns of a
+	// document by reading it: installs that land between two reads are
+	// collapsed into one move, and the loop cycles through a small set of
+	// denies, so an install that restores the document a reader last saw
+	// is not a change at all.
 	if got, max := store.Generation(), uint64(installs+1); got > max {
 		t.Errorf("generation = %d after %d installs; want at most %d. "+
 			"The extra reloads are pooled transports retired for a policy that did not move",

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -285,27 +285,6 @@ type closeWriter interface{ CloseWrite() error }
 // through a tunnel that is already open.
 const tunnelPollInterval = 30 * time.Second
 
-// tunnel copies both directions and returns when both of them have
-// ended.
-//
-// A clean EOF on one direction is a half-close, not the end of the
-// tunnel. Propagating it as CloseWrite is what lets the peer finish its
-// own reply; returning there truncated the response of every client
-// that shuts down its write side once its request is out — an ordinary
-// thing for an HTTP client to do, and the reason both directions are
-// now waited on: the deferred closes around this call fire when it
-// returns, so ending early closes the connection the peer was still
-// answering on.
-//
-// The idle bound is the tunnel's, not each direction's. A long one-way
-// transfer is silent in the other direction for its whole duration, so
-// a per-direction deadline severed a large upload or a slow download
-// while it was actively streaming. Each direction now reads in short
-// intervals and consults a clock both of them write.
-// stillAllowed is consulted once per poll interval by each direction:
-// a tunnel is authorised at CONNECT and then runs for as long as both
-// ends keep talking, so without it a policy tightened underneath one
-// applies only to destinations nobody had reached yet.
 // tunnelClock is the activity clock two directions of one tunnel share:
 // traffic either way is what keeps the other alive.
 //
@@ -328,6 +307,28 @@ func (c *tunnelClock) mark()                     { c.last.Store(int64(time.Since
 func (c *tunnelClock) sinceStart() time.Duration { return time.Since(c.start) }
 func (c *tunnelClock) idleFor() time.Duration    { return c.sinceStart() - time.Duration(c.last.Load()) }
 
+// tunnelWith copies both directions and returns when both of them have
+// ended.
+//
+// A clean EOF on one direction is a half-close, not the end of the
+// tunnel. Propagating it as CloseWrite is what lets the peer finish its
+// own reply; returning there truncated the response of every client
+// that shuts down its write side once its request is out — an ordinary
+// thing for an HTTP client to do, and the reason both directions are
+// now waited on: the deferred closes around this call fire when it
+// returns, so ending early closes the connection the peer was still
+// answering on.
+//
+// The idle bound is the tunnel's, not each direction's. A long one-way
+// transfer is silent in the other direction for its whole duration, so
+// a per-direction deadline severed a large upload or a slow download
+// while it was actively streaming. Each direction now reads in short
+// intervals and consults a clock both of them write.
+//
+// stillAllowed is consulted once per poll interval by each direction:
+// a tunnel is authorised at CONNECT and then runs for as long as both
+// ends keep talking, so without it a policy tightened underneath one
+// applies only to destinations nobody had reached yet.
 func tunnelWith(client, upstream net.Conn, idle, poll time.Duration, stillAllowed func() bool) {
 	clock := newTunnelClock()
 
@@ -450,7 +451,13 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 		// chunked reader reports an unexpected EOF and a Content-Length
 		// reader reports a short read. It is the same answer the tunnel
 		// gives by resetting rather than draining.
-		panic(http.ErrAbortHandler)
+		//
+		// Only under a server, which is the one thing that recovers it.
+		// Driven directly — by a test holding a recorder, say — the panic
+		// would take the process down instead of ending one response.
+		if req.Context().Value(http.ServerContextKey) != nil {
+			panic(http.ErrAbortHandler)
+		}
 	}
 }
 

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"net/netip"
 	"os"
 	"strconv"
@@ -91,11 +92,34 @@ type Relay struct {
 	Policy *PolicyStore
 	Log    *slog.Logger
 
-	once      sync.Once
-	transport atomic.Pointer[http.Transport]
-	// policyGen is the policy generation the pooled connections were
-	// authorised under.
-	policyGen atomic.Uint64
+	pool atomic.Pointer[pool]
+
+	// pollInterval overrides how often a transfer already in flight
+	// re-checks its destination. Zero means tunnelPollInterval, which is
+	// what production runs; a test sets it so a revocation can be
+	// observed without waiting out the real interval.
+	pollInterval time.Duration
+}
+
+func (r *Relay) poll() time.Duration {
+	if r.pollInterval > 0 {
+		return r.pollInterval
+	}
+	return tunnelPollInterval
+}
+
+// pool is a connection pool together with the policy generation its
+// connections were authorised under.
+//
+// The two are one value because they are read as one. Held in separate
+// atomics, a caller that observed the new generation could still be
+// handed the pool that generation retired — it reads them in two steps,
+// and the install can land in between — so its request would travel on a
+// connection dialled under the policy that no longer applies, which the
+// kernel then accepts as established traffic.
+type pool struct {
+	gen       uint64
+	transport *http.Transport
 }
 
 // Listen starts the relay on the internal leg.
@@ -205,35 +229,44 @@ func (r *Relay) establishTunnel(w http.ResponseWriter, upstream net.Conn) {
 }
 
 // tunnelDestinationAllowed builds the check a running tunnel repeats
-// against the policy in force. It closes over the peer address the
-// tunnel is actually joined to rather than the name that was resolved:
-// a name can be made to resolve somewhere else between the dial and the
+// against the policy in force.
+func (r *Relay) tunnelDestinationAllowed(upstream net.Conn) func() bool {
+	remote := upstream.RemoteAddr().String()
+	return func() bool { return r.destinationAllowed(remote) }
+}
+
+// destinationAllowed reports whether the policy in force still allows a
+// destination that a transfer is already joined to. It reads the peer
+// address off the socket rather than the name that was resolved: a name
+// can be made to resolve somewhere else between the dial and the
 // re-check, and the address is what the policy decides about anyway.
+//
+// Both shapes the relay serves outlive the decision that authorised
+// them, so both repeat this one: a tunnel per poll interval, and a plain
+// HTTP transfer on the same period through stopOnRevocation.
 //
 // Anything it cannot answer is a denial. A policy that cannot be read is
 // not in force — the same rule dial applies — and an address that cannot
 // be parsed cannot be checked at all.
-func (r *Relay) tunnelDestinationAllowed(upstream net.Conn) func() bool {
-	peer, parseErr := netip.ParseAddrPort(upstream.RemoteAddr().String())
-	addr := peer.Addr().Unmap()
-	return func() bool {
-		if parseErr != nil {
-			r.Log.Warn("egress tunnel closed: peer address unreadable",
-				"peer", upstream.RemoteAddr().String(), "error", parseErr)
-			return false
-		}
-		policy, err := r.Policy.Current()
-		if err != nil {
-			r.Log.Warn("egress tunnel closed: policy unavailable",
-				"address", addr.String(), "error", err)
-			return false
-		}
-		if policy.Allowed(addr) {
-			return true
-		}
-		r.Log.Warn("egress tunnel closed: destination no longer allowed", "address", addr.String())
+func (r *Relay) destinationAllowed(remote string) bool {
+	peer, err := netip.ParseAddrPort(remote)
+	if err != nil {
+		r.Log.Warn("egress transfer stopped: peer address unreadable",
+			"peer", remote, "error", err)
 		return false
 	}
+	addr := peer.Addr().Unmap()
+	policy, err := r.Policy.Current()
+	if err != nil {
+		r.Log.Warn("egress transfer stopped: policy unavailable",
+			"address", addr.String(), "error", err)
+		return false
+	}
+	if policy.Allowed(addr) {
+		return true
+	}
+	r.Log.Warn("egress transfer stopped: destination no longer allowed", "address", addr.String())
+	return false
 }
 
 // closeWriter is the half-close a tunnel propagates. Every connection a
@@ -387,15 +420,12 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 		http.Error(w, "runpool egress relay: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	outbound := req.Clone(req.Context())
+	outbound, stop := r.tracedRequest(req)
+	defer stop()
 	outbound.RequestURI = ""
 	stripHopByHop(outbound.Header)
 
-	// The check runs first and the transport is read after it: the check
-	// can replace the transport, and reading it beforehand sends this
-	// request through the pool that was just retired.
-	r.expireStaleConnections()
-	resp, err := r.roundTripper().RoundTrip(outbound)
+	resp, err := r.transportInForce().transport.RoundTrip(outbound)
 	if err != nil {
 		r.refuse(w, err)
 		return
@@ -411,7 +441,71 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 	_, _ = io.Copy(w, resp.Body)
 }
 
-// expireStaleConnections retires the pool once the policy moves.
+// tracedRequest clones a request onto a context that is cancelled as
+// soon as the destination it actually reaches stops being allowed.
+//
+// The trace is what makes the address knowable. The dial happens inside
+// the transport, so nothing here sees the connection until the transport
+// reports it, and the name the client asked for is not what the policy
+// decides about: it can be made to resolve elsewhere between the dial
+// and the re-check.
+//
+// The watch starts before the round trip rather than after it. A request
+// body the client streams is written during the round trip, so a body
+// that never ends is a round trip that never returns, and a watch hung
+// off its result would never start.
+func (r *Relay) tracedRequest(req *http.Request) (*http.Request, context.CancelFunc) {
+	ctx, stop := context.WithCancel(req.Context())
+	var peer atomic.Pointer[string]
+	traced := httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			remote := info.Conn.RemoteAddr().String()
+			peer.Store(&remote)
+		},
+	})
+	go r.stopOnRevocation(ctx, stop, &peer)
+	return req.Clone(traced), stop
+}
+
+// stopOnRevocation cancels a transfer whose destination has stopped
+// being allowed.
+//
+// It is what the poll interval does for a tunnel, applied to the plain
+// HTTP shape. A request is authorised once, at dial, and http.Transport
+// then streams the request body and the response with no further
+// reference to the policy. Retiring the pool does not reach a transfer
+// already under way: CloseIdleConnections leaves a connection carrying a
+// request alone by contract, and a job can carry one for as long as it
+// likes. Neither does the kernel, whose ruleset accepts established
+// traffic ahead of every reject. Without this, a destination revoked
+// mid-download kept flowing until the job chose to stop.
+//
+// Cancelling the request context is what ends it, and that covers both
+// directions at once — the response body, and a request body the client
+// is still streaming.
+func (r *Relay) stopOnRevocation(ctx context.Context, stop context.CancelFunc, peer *atomic.Pointer[string]) {
+	if r.Policy == nil {
+		return
+	}
+	tick := time.NewTicker(r.poll())
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			// No connection yet is nothing to check: the dial has not
+			// happened, so no traffic is flowing to anywhere.
+			if remote := peer.Load(); remote != nil && !r.destinationAllowed(*remote) {
+				stop()
+				return
+			}
+		}
+	}
+}
+
+// transportInForce returns the pool authorised by the policy in force,
+// replacing it when the policy has moved.
 //
 // The address check lives in the transport's dialer, and http.Transport
 // only dials when it has no connection for the destination — so a
@@ -424,51 +518,55 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 // traffic ahead of every reject. A revoked address therefore stayed
 // reachable for as long as a job kept using it.
 //
-// Replacing the transport is what makes the old pool unreachable:
-// nothing routes through it again, whatever state its connections were
-// in. The ones already carrying a request finish it and go with it.
-func (r *Relay) expireStaleConnections() {
+// Replacing the pool is what makes the old one unreachable: nothing
+// routes through it again, whatever state its connections were in. The
+// ones already carrying a request are ended by stopOnRevocation.
+func (r *Relay) transportInForce() *pool {
 	if r.Policy == nil {
-		return
+		return r.poolAt(0)
 	}
-	// Current() is what notices the file changed, and it is otherwise only
-	// reached from dial() — which a pooled request never calls. Reading it
-	// here is the whole point: without it the generation could not move in
-	// exactly the case this function exists for. A cached hit is one stat.
+	// Current() is what notices the document changed, and it is otherwise
+	// only reached from dial() — which a pooled request never calls.
+	// Reading it here is the whole point: without it the generation could
+	// not move in exactly the case this function exists for.
 	if _, err := r.Policy.Current(); err != nil {
-		// An unreadable policy is not in force. Retire the pool so the
-		// next request must dial, where that error refuses it.
-		r.retireTransport()
-		return
+		// An unreadable policy is not in force, and generation zero is a
+		// pool nothing was authorised under: the next request has to dial,
+		// where that same error refuses it.
+		return r.poolAt(0)
 	}
-	gen := r.Policy.Generation()
-	// The first observation only records where the policy started; there is
-	// nothing pooled under an older one yet.
-	if prev := r.policyGen.Swap(gen); prev != 0 && prev != gen {
-		r.retireTransport()
-	}
+	return r.poolAt(r.Policy.Generation())
 }
 
-// retireTransport puts a fresh pool in place and releases what the old
-// one still holds idle.
-func (r *Relay) retireTransport() {
-	if old := r.transport.Swap(r.newTransport()); old != nil {
-		old.CloseIdleConnections()
+// poolAt returns the pool for a generation, installing a fresh one when
+// what is in force belongs to another. A transport per request — the
+// shape this replaces — leaks a connection pool and its idle goroutines
+// on every call, which is unbounded growth driven by the workload.
+func (r *Relay) poolAt(gen uint64) *pool {
+	for {
+		cur := r.pool.Load()
+		// Equal is the ordinary case. Greater means this caller read the
+		// policy late — generations only ever advance — so what is in
+		// force already supersedes the pool it would install, and
+		// installing it would retire a newer pool for nothing and hand
+		// the next caller an older tag than the one it observed.
+		// Generation zero is the document being unreadable, which is
+		// ordered against nothing: it replaces, and is replaced, on any
+		// difference.
+		if cur != nil && (cur.gen == gen || (gen > 0 && cur.gen > gen)) {
+			return cur
+		}
+		next := &pool{gen: gen, transport: r.newTransport()}
+		if r.pool.CompareAndSwap(cur, next) {
+			if cur != nil {
+				cur.transport.CloseIdleConnections()
+			}
+			return next
+		}
+		// Another caller installed one first. Ours never carried a
+		// connection; take the winner's on the next turn.
+		next.transport.CloseIdleConnections()
 	}
-}
-
-// roundTripper returns the transport in force, building the first one on
-// demand. A transport per request — the shape this replaces — leaks a
-// connection pool and its idle goroutines on every call, which is
-// unbounded growth driven by the workload.
-func (r *Relay) roundTripper() http.RoundTripper {
-	// CompareAndSwap rather than Store: a policy that moved before the
-	// first request has already installed one through retireTransport,
-	// and storing over it would discard the pool in force.
-	r.once.Do(func() {
-		r.transport.CompareAndSwap(nil, r.newTransport())
-	})
-	return r.transport.Load()
 }
 
 func (r *Relay) newTransport() *http.Transport {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -95,9 +95,11 @@ type Relay struct {
 	pool atomic.Pointer[pool]
 
 	// pollInterval overrides how often a transfer already in flight
-	// re-checks its destination. Zero means tunnelPollInterval, which is
-	// what production runs; a test sets it so a revocation can be
-	// observed without waiting out the real interval.
+	// re-checks its destination — a tunnel and a plain HTTP transfer
+	// alike, so the two shapes cannot drift apart. Zero means
+	// tunnelPollInterval, which is what production runs; a test sets it
+	// so a revocation can be observed without waiting out the real
+	// interval.
 	pollInterval time.Duration
 }
 
@@ -225,7 +227,7 @@ func (r *Relay) establishTunnel(w http.ResponseWriter, upstream net.Conn) {
 		}
 		_ = upstream.SetWriteDeadline(time.Time{})
 	}
-	tunnel(client, upstream, r.tunnelDestinationAllowed(upstream))
+	tunnelWith(client, upstream, TunnelIdleTimeout, r.poll(), r.tunnelDestinationAllowed(upstream))
 }
 
 // tunnelDestinationAllowed builds the check a running tunnel repeats
@@ -304,10 +306,6 @@ const tunnelPollInterval = 30 * time.Second
 // a tunnel is authorised at CONNECT and then runs for as long as both
 // ends keep talking, so without it a policy tightened underneath one
 // applies only to destinations nobody had reached yet.
-func tunnel(client, upstream net.Conn, stillAllowed func() bool) {
-	tunnelWith(client, upstream, TunnelIdleTimeout, tunnelPollInterval, stillAllowed)
-}
-
 // tunnelClock is the activity clock two directions of one tunnel share:
 // traffic either way is what keeps the other alive.
 //
@@ -438,7 +436,22 @@ func (r *Relay) forward(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		// A body that stops partway must not reach the capsule looking
+		// whole. The status line and headers are already out, so there is
+		// no way left to say "this failed" except in how the connection
+		// ends — and a response with no Content-Length ends when the
+		// chunk stream is terminated, which is what returning normally
+		// from here would make the server do. The job would then see a
+		// well-formed 200 carrying a truncated artifact.
+		//
+		// Aborting the handler is how the standard library says this: the
+		// server closes the connection without a terminator, so a
+		// chunked reader reports an unexpected EOF and a Content-Length
+		// reader reports a short read. It is the same answer the tunnel
+		// gives by resetting rather than draining.
+		panic(http.ErrAbortHandler)
+	}
 }
 
 // tracedRequest clones a request onto a context that is cancelled as

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -717,15 +718,23 @@ func TestATransferWithoutAConnectionIsNotCancelled(t *testing.T) {
 	}
 }
 
-// TestAGenerationIsNeverServedByTwoPools: the pool and the generation it
-// was authorised under are one value because they are read as one.
+// TestConcurrentReadersNeverSplitThePoolFromItsGeneration: the pool and
+// the generation it was authorised under are one value because they are
+// read as one.
 //
 // Held in two atomics, a caller that observed the new generation could
 // still be handed the pool that generation retired — it reads them in two
 // steps and the install lands in between — so its request would travel on
 // a connection dialled under the policy that no longer applies, which the
 // kernel then accepts as established traffic.
-func TestAGenerationIsNeverServedByTwoPools(t *testing.T) {
+//
+// The document here is only ever replaced, never removed, so every read
+// succeeds and the generation only advances. That is what makes one pool
+// per generation the right thing to assert: it is a consequence of this
+// sequence rather than a property of poolAt, whose full condition —
+// including what an unreadable document does to it — is stated case by
+// case in TestAPoolIsNeverOlderThanTheGenerationItServes.
+func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 	store, install := policyFile(t, "10.0.0.0/8")
 	r := &Relay{Policy: store, Log: discardLogger()}
 
@@ -771,5 +780,115 @@ func TestAGenerationIsNeverServedByTwoPools(t *testing.T) {
 	if len(served) < 2 {
 		t.Fatalf("only %d generation(s) were observed; the policy never moved under the readers "+
 			"and the race this rules out was never given a chance", len(served))
+	}
+}
+
+// TestARevokedTransferDoesNotReachTheCapsuleLookingWhole drives the real
+// handler: a real http.Transport, the trace that reports its dial, the
+// watch forward installs, and the copy that has to stop.
+//
+// The body is chunked deliberately. With no Content-Length, the only
+// thing that tells a client where the body ended is how the connection
+// ended — so a relay that cancels the transfer and then returns normally
+// has the server terminate the chunk stream for it, and the job receives
+// a well-formed 200 carrying a truncated artifact it cannot tell from a
+// whole one. Git's smart-HTTP pack responses and anything gzipped on the
+// fly arrive this way.
+//
+// The relay's own dialer refuses loopback outright — the decider does so
+// before it consults any allow list — so the upstream is reached through
+// a plain transport installed at the generation in force. That leaves the
+// re-check exactly as production runs it, and it denies loopback on the
+// first tick, which is the revocation this test needs.
+func TestARevokedTransferDoesNotReachTheCapsuleLookingWhole(t *testing.T) {
+	const (
+		chunk  = 32 << 10
+		chunks = 200
+	)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		body := bytes.Repeat([]byte("x"), chunk)
+		for range chunks {
+			if _, err := w.Write(body); err != nil {
+				return
+			}
+			w.(http.Flusher).Flush()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}))
+	defer upstream.Close()
+
+	store, _ := policyFile(t, "10.0.0.0/8")
+	if _, err := store.Current(); err != nil {
+		t.Fatal(err)
+	}
+	r := &Relay{Policy: store, Log: discardLogger(), pollInterval: 20 * time.Millisecond}
+	r.pool.Store(&pool{gen: store.Generation(), transport: &http.Transport{}})
+
+	relay := httptest.NewServer(r)
+	defer relay.Close()
+	via, err := url.Parse(relay.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(via)}}
+	resp, err := client.Get(upstream.URL + "/big")
+	if err != nil {
+		t.Fatalf("the request never reached the upstream: %v", err)
+	}
+	defer resp.Body.Close()
+	n, readErr := io.Copy(io.Discard, resp.Body)
+
+	if n >= int64(chunk)*chunks {
+		t.Fatalf("the transfer delivered its whole body (%d bytes); the revocation never reached it", n)
+	}
+	if readErr == nil {
+		t.Errorf("the revoked transfer ended cleanly after %d of %d bytes; the capsule cannot "+
+			"tell a cut artifact from a whole one", n, chunk*chunks)
+	}
+}
+
+// TestAPoolIsNeverOlderThanTheGenerationItServes states what poolAt's
+// condition means, case by case, where the concurrent test can only
+// sample it.
+//
+// The property that matters is not that a generation is served by one
+// pool for all time — restoring a document a reader had already seen
+// leaves the generation where it was while the pool moved through zero,
+// and that is harmless because every connection is checked at its dial.
+// It is that a caller which observed a generation is never handed a pool
+// built for an older one.
+func TestAPoolIsNeverOlderThanTheGenerationItServes(t *testing.T) {
+	for _, c := range []struct {
+		name       string
+		inForce    uint64 // zero means nothing pooled yet
+		ask        uint64
+		wantReused bool
+	}{
+		{"nothing pooled yet", 0, 5, false},
+		{"same generation", 5, 5, true},
+		{"the policy moved on", 3, 5, false},
+		{"a caller that read the policy late", 5, 3, true},
+		{"the document became unreadable", 5, 0, false},
+		{"still unreadable", 0, 0, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			r := &Relay{Log: discardLogger()}
+			var before *pool
+			if c.inForce > 0 || c.name == "still unreadable" {
+				before = &pool{gen: c.inForce, transport: r.newTransport()}
+				r.pool.Store(before)
+			}
+			got := r.poolAt(c.ask)
+			if reused := before != nil && got == before; reused != c.wantReused {
+				t.Errorf("reused the pool in force = %v; want %v", reused, c.wantReused)
+			}
+			if got.gen < c.ask {
+				t.Errorf("a caller that observed generation %d was handed a pool built for %d; "+
+					"its connections were authorised by a policy that no longer applies", c.ask, got.gen)
+			}
+		})
 	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -3,16 +3,22 @@ package gateway
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 // TestParseAuthority is the strictest surface in the gateway: this
@@ -616,5 +622,154 @@ func TestTheTunnelClockIsMonotonic(t *testing.T) {
 	c.mark()
 	if after := c.idleFor(); after >= before {
 		t.Errorf("idleFor = %v after marking traffic and %v before; a mark must reset it", after, before)
+	}
+}
+
+// dialedTo stands in for the connection an http.Transport reports
+// through its trace. Only the remote address is ever read: it is the one
+// thing a re-check needs and the one thing a net.Pipe cannot supply.
+type dialedTo struct {
+	net.Conn
+	remote net.Addr
+}
+
+func (c dialedTo) RemoteAddr() net.Addr { return c.remote }
+
+// policyFile writes a gateway policy denying one range and returns a
+// store reading it, plus the installer for later revisions.
+//
+// Installs go through atomicfile.Replace because that is what Reload
+// does. os.WriteFile truncates before it writes, so a reader crossing
+// one sees an empty document, refuses to compile it, and treats the
+// policy as unavailable — a denial arrived at through a shape production
+// cannot produce, which would let these tests pass for a reason that is
+// not the one they name.
+func policyFile(t *testing.T, deny string) (*PolicyStore, func(string)) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "policy.json")
+	write := func(deny string) {
+		body := `{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24",` +
+			`"allow":[],"deny":["` + deny + `"]}`
+		if err := atomicfile.Replace(path, []byte(body), 0o600, -1, -1); err != nil {
+			t.Error(err)
+		}
+	}
+	write(deny)
+	return &PolicyStore{Path: path}, write
+}
+
+// TestARevokedDestinationEndsALiveTransfer: a plain HTTP transfer is
+// authorised once, at the dial, and then streams with no further
+// reference to the policy.
+//
+// Nothing else reaches it. Retiring the pool does not: CloseIdleConnections
+// leaves a connection carrying a request alone by contract, and a job can
+// carry one for as long as it likes. The kernel does not either: the
+// ruleset accepts established traffic ahead of every reject. So without
+// this re-check, a destination revoked mid-download kept flowing until the
+// job chose to stop, which is the promise in Reload's own doc — that a
+// capsule never sees a moment in which a newly denied destination is
+// reachable — going unkept on the one path that carries bulk traffic.
+func TestARevokedDestinationEndsALiveTransfer(t *testing.T) {
+	store, install := policyFile(t, "10.0.0.0/8")
+	r := &Relay{Policy: store, Log: discardLogger(), pollInterval: 20 * time.Millisecond}
+
+	outbound, stop := r.tracedRequest(httptest.NewRequest(http.MethodGet, "http://example.com/big", nil))
+	defer stop()
+
+	// Report the connection the way http.Transport does once it has
+	// dialled. Until this lands there is no address to re-check.
+	httptrace.ContextClientTrace(outbound.Context()).GotConn(httptrace.GotConnInfo{
+		Conn: dialedTo{remote: &net.TCPAddr{IP: net.IPv4(203, 0, 113, 7), Port: 80}},
+	})
+
+	// While the destination is allowed the transfer is left alone.
+	select {
+	case <-outbound.Context().Done():
+		t.Fatal("an allowed transfer was cancelled; every plain HTTP download would be cut at the poll interval")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	install("203.0.113.0/24")
+
+	select {
+	case <-outbound.Context().Done():
+	case <-time.After(10 * time.Second):
+		t.Fatal("the transfer outlived the revocation of its destination; " +
+			"the body keeps streaming from an address the policy now denies")
+	}
+}
+
+// TestATransferWithoutAConnectionIsNotCancelled: the re-check has
+// nothing to decide about until the transport reports a dial, and a
+// denial in that gap would refuse requests the policy allows.
+func TestATransferWithoutAConnectionIsNotCancelled(t *testing.T) {
+	store, _ := policyFile(t, "10.0.0.0/8")
+	r := &Relay{Policy: store, Log: discardLogger(), pollInterval: 10 * time.Millisecond}
+
+	outbound, stop := r.tracedRequest(httptest.NewRequest(http.MethodGet, "http://example.com/", nil))
+	defer stop()
+
+	select {
+	case <-outbound.Context().Done():
+		t.Fatal("a request was cancelled before it had a connection; a slow dial would never complete")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestAGenerationIsNeverServedByTwoPools: the pool and the generation it
+// was authorised under are one value because they are read as one.
+//
+// Held in two atomics, a caller that observed the new generation could
+// still be handed the pool that generation retired — it reads them in two
+// steps and the install lands in between — so its request would travel on
+// a connection dialled under the policy that no longer applies, which the
+// kernel then accepts as established traffic.
+func TestAGenerationIsNeverServedByTwoPools(t *testing.T) {
+	store, install := policyFile(t, "10.0.0.0/8")
+	r := &Relay{Policy: store, Log: discardLogger()}
+
+	var mu sync.Mutex
+	served := map[uint64]*http.Transport{}
+
+	stop := make(chan struct{})
+	var installers sync.WaitGroup
+	installers.Add(1)
+	go func() {
+		defer installers.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			install(fmt.Sprintf("10.%d.0.0/16", i%256))
+		}
+	}()
+
+	var readers sync.WaitGroup
+	for range 8 {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for range 400 {
+				got := r.transportInForce()
+				mu.Lock()
+				if prev, seen := served[got.gen]; seen && prev != got.transport {
+					t.Errorf("generation %d was served by two pools; a request took a connection "+
+						"dialled under the policy that generation replaced", got.gen)
+				}
+				served[got.gen] = got.transport
+				mu.Unlock()
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	installers.Wait()
+
+	if len(served) < 2 {
+		t.Fatalf("only %d generation(s) were observed; the policy never moved under the readers "+
+			"and the race this rules out was never given a chance", len(served))
 	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -841,6 +841,13 @@ func TestARevokedTransferDoesNotReachTheCapsuleLookingWhole(t *testing.T) {
 	defer resp.Body.Close()
 	n, readErr := io.Copy(io.Discard, resp.Body)
 
+	// Prove the transfer happened before judging how it ended. A relay
+	// that refused the request outright also reports a short body that
+	// stopped, and blaming that on the ending would hide the refusal.
+	if resp.StatusCode != http.StatusOK || n == 0 {
+		t.Fatalf("the request never streamed: status %d, %d bytes; the upstream was not reached, "+
+			"so nothing here says anything about how a cut transfer ends", resp.StatusCode, n)
+	}
 	if n >= int64(chunk)*chunks {
 		t.Fatalf("the transfer delivered its whole body (%d bytes); the revocation never reached it", n)
 	}
@@ -863,28 +870,35 @@ func TestARevokedTransferDoesNotReachTheCapsuleLookingWhole(t *testing.T) {
 func TestAPoolIsNeverOlderThanTheGenerationItServes(t *testing.T) {
 	for _, c := range []struct {
 		name       string
-		inForce    uint64 // zero means nothing pooled yet
+		pooled     bool // whether anything is in force to begin with
+		inForce    uint64
 		ask        uint64
 		wantReused bool
 	}{
-		{"nothing pooled yet", 0, 5, false},
-		{"same generation", 5, 5, true},
-		{"the policy moved on", 3, 5, false},
-		{"a caller that read the policy late", 5, 3, true},
-		{"the document became unreadable", 5, 0, false},
-		{"still unreadable", 0, 0, true},
+		{name: "nothing pooled yet", ask: 5},
+		{name: "same generation", pooled: true, inForce: 5, ask: 5, wantReused: true},
+		{name: "the policy moved on", pooled: true, inForce: 3, ask: 5},
+		{name: "a caller that read the policy late", pooled: true, inForce: 5, ask: 3, wantReused: true},
+		{name: "the document became unreadable", pooled: true, inForce: 5, ask: 0},
+		{name: "still unreadable", pooled: true, inForce: 0, ask: 0, wantReused: true},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			r := &Relay{Log: discardLogger()}
 			var before *pool
-			if c.inForce > 0 || c.name == "still unreadable" {
+			if c.pooled {
 				before = &pool{gen: c.inForce, transport: r.newTransport()}
 				r.pool.Store(before)
 			}
 			got := r.poolAt(c.ask)
+			if got == nil {
+				t.Fatal("no pool at all; the next request would have nothing to travel on")
+			}
 			if reused := before != nil && got == before; reused != c.wantReused {
 				t.Errorf("reused the pool in force = %v; want %v", reused, c.wantReused)
 			}
+			// A reused pool is the only way to be handed a generation
+			// other than the one asked for, and it must never be an older
+			// one: its connections were authorised by that policy.
 			if got.gen < c.ask {
 				t.Errorf("a caller that observed generation %d was handed a pool built for %d; "+
 					"its connections were authorised by a policy that no longer applies", c.ask, got.gen)

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -283,13 +283,50 @@ func TestNoDocCommentBelongsToAnotherDeclaration(t *testing.T) {
 				return
 			}
 			first := strings.Trim(words[0], "`*.,:")
-			if first == name || !declared[first] {
+			if first != name && declared[first] {
+				found = append(found, fmt.Sprintf(
+					"%s: the doc comment on %s begins with %q, which is another declaration in this file. "+
+						"Something was inserted between %q's comment and %q",
+					fset.Position(pos), name, first, first, first))
 				return
 			}
-			found = append(found, fmt.Sprintf(
-				"%s: the doc comment on %s begins with %q, which is another declaration in this file. "+
-					"Something was inserted between %q's comment and %q",
-				fset.Position(pos), name, first, first, first))
+			// The same detachment happens by deletion, and the rule above
+			// cannot see it: a comment left behind by a declaration that
+			// no longer exists opens with a name nothing declares any
+			// more. What gives it away is where this declaration's own
+			// introduction sits. A comment that opens by naming its
+			// subject is describing it from the first line, and a later
+			// paragraph starting with the same word is prose — "Version 2
+			// moved ..." under Version. A comment that opens with some
+			// other word and then introduces this one partway down has
+			// two subjects, and only the second is here.
+			if first == name {
+				return
+			}
+			for i, line := range doc.List {
+				if i == 0 {
+					continue
+				}
+				text := strings.Fields(strings.TrimPrefix(line.Text, "//"))
+				if len(text) == 0 || strings.Trim(text[0], "`*.,:") != name {
+					continue
+				}
+				// A sentence opening, not a wrapped line that happens to
+				// break before the name. Requiring a blank line above
+				// would miss the shape this is for: a deleted
+				// declaration leaves its comment butted straight against
+				// the next one, with no blank line anywhere.
+				prev := strings.TrimSpace(strings.TrimPrefix(doc.List[i-1].Text, "//"))
+				if prev != "" && !strings.HasSuffix(prev, ".") && !strings.HasSuffix(prev, ":") {
+					continue
+				}
+				found = append(found, fmt.Sprintf(
+					"%s: the doc comment on %s introduces it partway through, at %s. "+
+						"Everything above that line describes something else, and was left "+
+						"behind when whatever it named went away",
+					fset.Position(pos), name, fset.Position(line.Pos())))
+				return
+			}
 		}
 		for _, decl := range file.Decls {
 			switch decl := decl.(type) {


### PR DESCRIPTION
## What changes

A plain HTTP transfer that is already running now ends when its destination
stops being allowed, on the same poll interval a CONNECT tunnel has always
used — and it ends as a failed read, not as a complete response with a short
body. The relay's connection pool and the policy generation it was authorised
under become one value rather than two atomics read in two steps. And whether
a policy document changed is decided by hashing its contents instead of by its
modification time and size.

## What was found

**A transfer under way outlived the revocation of its destination.** The
tunnel path re-checks the address it is joined to every `tunnelPollInterval`;
`forward` checked once, at the dial, and then ran `io.Copy` with no bound and
no second look. Nothing else reaches such a transfer. `CloseIdleConnections`
leaves a connection carrying a request alone by contract, and this request
need never finish. The kernel does not intervene either: `RenderIPTables`
puts `-A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT` ahead
of every reject, which the comment beside the copy already said. No timeout
covered it — `ResponseHeaderTimeout` is spent by then, and `IdleConnTimeout`
and `IdleTimeout` bound idle connections only.

Measured against a real `Relay` with a real upstream: **6,782,976 bytes
continued to arrive 35 s after `0.0.0.0/0` was installed**, while a fresh
request through the same relay was refused with 403. A 300 s run showed the
same transfer still going. Because `req.Clone` shares `Body`, a chunked
`POST` gave the same unbounded channel in the other direction, so the pair
was full-duplex over port 80.

The trigger is ordinary: any job using `HTTP_PROXY` for plain HTTP, plus any
restriction the controller installs. The successful path in `applyPolicy`
does not remove the gateway, so the transfer survived indefinitely rather
than for a removal window, and it also survived the deny-all `closeGateway`
installs before it removes the container.

**Stopping the transfer is only half of it.** Once the status line and
headers are out, the only thing that can still report a cut body is how the
connection ends. A response with no `Content-Length` ends when the chunk
stream is terminated, which is what returning normally from the copy makes
`http.Server` do — so a cancelled transfer arrived as a well-formed 200
carrying a truncated artifact, indistinguishable from a whole one. Measured
through the handler:

```text
chunked:        status=200 bytes=163840 readErr=<nil>
content-length: status=200 bytes=147456 readErr=unexpected EOF
```

Git's smart-HTTP pack responses, on-the-fly gzip, and many registry and CDN
paths arrive chunked. The handler now aborts, which closes the connection
without a terminator; both shapes of response then fail the client's read.
That is the answer the tunnel already gives by resetting rather than
draining, and it also covers a body cut short by the upstream rather than by
a revocation.

**A caller could be handed the pool the generation it observed had
retired.** `policyGen.Swap(gen)` and `transport.Swap(...)` were independent.
The caller that lost the `policyGen` race saw `prev == gen`, skipped the
retire, and then loaded a transport that could still be the previous one.
That request travels on a connection dialled under the old policy, which the
kernel accepts as established. Measured with eight concurrent callers doing
what `forward` does: **5 of 595 generations were served by two distinct
pools.**

Unifying them exposed a second, benign source of the same shape: a caller
that read the generation and was then descheduled would install its pool at
that older generation on top of a newer one. Generations only advance among
themselves, so that is always churn, and the install refuses it. Generation
zero is not ordered against them — it means the document could not be read —
so it both replaces and is replaced on any difference.

**An install of equal length inside one clock tick never reached the relay.**
`Current()` skipped the read when `(mtime, size)` matched. Linux stamps mtime
from `current_time()`, which uses the coarse clock and advances once per
tick, so identical modification times are a property of the filesystem, not
of a contrived probe. With an identical mtime forced and two same-length
documents, `Allowed(10.20.20.5)` stayed `true` after a tightening that denies
it and `Generation()` did not advance, so the pooled transport was not
retired either. Hashing the bytes is a few kilobytes read from tmpfs. That
read is now taken on every `Current()` rather than once per change — from the
dial, from each poll of each live transfer, and once per plain HTTP request —
so it is bounded at `MaxPolicyBytes` before the bytes are resident rather
than after, in a gateway with 128 MiB.

Two things nearby that look like they should have changed and did not. The
`AllowedConnectPorts` set is still checked only at dial: it is a compile-time
constant, so a policy move cannot invalidate a port that was allowed. And
`dial` still snapshots the policy before resolution: the address it reaches
is checked after resolution against that snapshot, and `installPolicyWith`
applies the kernel ruleset before writing the file, so a newly denied address
is rejected by iptables even while the snapshot is stale.

## Evidence

Hermetic only — the relay, the policy store and their concurrency are
exercised in-process, including one test that drives the handler end to end
through a real `http.Transport`. The measurements quoted above came from
probes; each is now a committed test, which is the better record.

Every mutation below was applied on its own, with the other mechanisms left
intact, so no test can be passing on another's behalf.

```text
MUTATION A: forward does not install the watch
--- FAIL: TestARevokedTransferDoesNotReachTheCapsuleLookingWhole (1.31s)
    the transfer delivered its whole body (6553600 bytes); the revocation
    never reached it

MUTATION B: the cut body is allowed to end cleanly
--- FAIL: TestARevokedTransferDoesNotReachTheCapsuleLookingWhole (0.04s)
    the revoked transfer ended cleanly after 131072 of 6553600 bytes; the
    capsule cannot tell a cut artifact from a whole one

MUTATION C: drop the monotonic clause from poolAt   (3 of 3 runs)
--- FAIL: TestAPoolIsNeverOlderThanTheGenerationItServes/a_caller_that_read_the_policy_late

MUTATION D: the trace fires but the address is not captured
--- FAIL: TestARevokedDestinationEndsALiveTransfer (10.20s)
    the transfer outlived the revocation of its destination

MUTATION E: pool and generation back to two independent atomics
--- FAIL: TestConcurrentReadersNeverSplitThePoolFromItsGeneration (0.15s)
    generation 62 was served by two pools; a request took a connection
    dialled under the policy that generation replaced

MUTATION F: decide changes by mtime and size again
--- FAIL: TestAnEqualLengthInstallIsNotMissed (0.00s)
    the second install never reached the relay; the range it stopped
    denying is still refused
    the second install never reached the relay; the range it began
    denying is still permitted
    the generation did not move on the second install; the pooled
    transport keeps every connection the previous policy authorised
```

The full local gate set mirroring `ci.yml` is green, and `go test -race
-shuffle=on ./...` was run three further times against the final tree with no
failures.

## What would notice this regressing

- `TestARevokedTransferDoesNotReachTheCapsuleLookingWhole` — the handler
  itself, with a real transport and a chunked upstream. Fails if the watch is
  not installed on the request path (the body arrives whole) or if the cut
  body is allowed to end cleanly (the read succeeds). This is the one that
  covers the call site rather than the helper.
- `TestARevokedDestinationEndsALiveTransfer` — an allowed destination is left
  alone and a revoked one is cancelled within a poll interval, driven by the
  policy rather than by loopback.
- `TestATransferWithoutAConnectionIsNotCancelled` — the re-check does not
  refuse a request that has not dialled yet, so a slow dial still completes.
- `TestAPoolIsNeverOlderThanTheGenerationItServes` — `poolAt`'s condition
  case by case, including both generation-zero directions, asserting that a
  caller which observed a generation is never handed a pool built for an
  older one. Deterministic, where the concurrent test reached the monotonic
  clause only sometimes — the rate depends on the machine, which is the
  reason for a table rather than a sample.
- `TestConcurrentReadersNeverSplitThePoolFromItsGeneration` — under eight
  concurrent readers and a concurrent installer, the pool and its generation
  do not come apart.
- `TestAnEqualLengthInstallIsNotMissed` — two same-length documents under one
  forced modification time, both taking effect.
- `TestNoDocCommentBelongsToAnotherDeclaration` in `test/consistency` now also
  fails when a doc comment introduces its declaration partway through, which
  is what a deleted declaration leaves behind. Verified by putting the orphan
  back in the shape the deletion produced.
- `TestRelayNoticesAPolicyChangeWithoutDialing` and
  `TestAPolicyMoveRetiresTheTransport` keep their existing properties through
  the new accessor. Three `time.Sleep` calls that existed only to force a
  distinct mtime are gone, which the hash makes unnecessary.

The test policy installer writes through `atomicfile.Replace` rather than
`os.WriteFile`. The latter truncates before writing, so a concurrent reader
saw an empty document, refused to compile it and treated the policy as
unavailable — a denial reached through a shape production cannot produce,
which would have let two of these tests pass for a reason other than the one
they name.

## Risk, compatibility and operations

**Trust boundary.** This tightens it. A destination the operator has revoked
stops being reachable within one poll interval on every shape the relay
serves, where before one shape had no bound at all. Nothing becomes reachable
that was not reachable before.

**What a job sees.** A transfer stopped by a revocation now fails the job's
read instead of completing short. That is a behaviour change for a job whose
egress is revoked mid-download, and it is the intended one: a silent
truncation is worse than an error. A job whose destinations stay allowed is
unaffected.

**Failure behaviour.** Unchanged and still fail-closed: an unreadable policy
is not in force, the pool is dropped so the next request must dial, and the
dial refuses. A destination the re-check cannot decide about — an unparseable
peer, an unreadable policy — is a denial, as it already was for tunnels.

**Resource limits.** One goroutine and one 30 s ticker per in-flight plain
HTTP request, bounded by `MaxProxyConnections` (256) and released with the
request. `Current()` now reads a bounded few kilobytes from tmpfs where it
previously stat'd.

**Networking.** No change to the ruleset, the port set, the parser or any
bound. The gateway container image and control surface are untouched.

**CLI, configuration, status API, schema, migration, deployment, rollback.**
None. No configuration key, no stored state, no wire format and no operator
command is affected; the change is entirely inside the relay process.

**Log text.** Three warnings change wording from `egress tunnel closed: ...`
to `egress transfer stopped: ...`, because the same check now serves both
shapes. Nothing in `docs/` or `deploy/` matches the old strings.

**Decision record.** No ADR is needed. `2026-06-19-network-sandbox-proxy` and
`2026-06-26-egress-relay` already place the address decision in the relay and
already require that a revocation binds; this closes the one path on which
that requirement was not met. The 30 s bound is the existing
`tunnelPollInterval`, reused rather than introduced.

## Changelog

```text
### Isolation and egress

- **A revoked address stops being reachable, transfers under way
  included.** A destination the policy no longer allows is checked when a
  connection is dialled, and the pool a job keeps warm never dials again
  — the kernel does not intervene either, since the ruleset accepts
  established traffic ahead of every reject. A policy that moves
  therefore retires the pool it authorised rather than closing the
  connections that happen to be idle in it. Retiring the pool does not
  reach a transfer already running: the connection carrying it is left
  alone, and a large download can hold one for as long as the job likes.
  So both shapes the relay serves re-check the address they are joined to
  while they run — a CONNECT tunnel and a plain HTTP transfer alike — and
  the longest a revoked destination keeps flowing is one poll interval,
  whatever it is carrying. A transfer stopped that way reaches the job as
  a failed read rather than as a complete response with a short body:
  once the status line is out there is nothing left to say "this was
  cut" except how the connection ends, so it ends without the terminator
  a client would otherwise read as the end of the data.
- **An install takes effect whenever it lands.** Whether a new policy is
  in force is decided by the document's contents rather than by its
  modification time and size. Two documents of equal length installed
  inside one clock tick carry the same modification time, so deciding on
  that pair meant the second never reached the relay at all: the
  tightening would have been reported as installed and silently not
  applied.
```

## Notes for your reviewer

Three things carried over from the first commit and corrected on the branch
rather than by rewriting it. The abort now happens only under a server —
driven directly, as a test holding a recorder would, an unrecovered panic
takes the process down instead of ending one response, which is the guard the
standard library's own proxy applies. `Reload`'s read was one byte short of
the bound, so a document cut off at the limit installed as a policy nobody
wrote; both reads now take one byte more than the bound so the length check
has something to refuse. And removing the `tunnel` wrapper left its doc
comment on the next declaration, which the consistency guard could not see
because it only knew how to spot an *inserted* declaration.

`Relay.pollInterval` is a seam only tests set; production reads
`tunnelPollInterval` through `poll()`. It now governs both shapes — the
`tunnel` wrapper that took the constant directly is gone, since it had one
caller and could have drifted from the HTTP path without anything noticing.

The first commit's message says installation is monotonic without qualifying
it, and puts a specific ratio on how often the concurrent test reaches that
clause; the ratio is machine-dependent and should be read as "sometimes". That is true among nonzero generations only: generation zero means the
document could not be read and is ordered against nothing. The code comment
on `poolAt` and the case table in
`TestAPoolIsNeverOlderThanTheGenerationItServes` are the accurate statement.

Deliberately left alone, both belonging to their own areas: the
`allowPrivateCIDRs` entries for loopback and link-local, which the decider
refuses before it consults the allow list while `RenderIPTables` still emits
the matching ACCEPT rule — that refusal is also why the end-to-end test has
to install its own transport; and the `INPUT` chain under `DenyAll`, which
still accepts 53/udp, 53/tcp and 3128 from the capsule subnet, so whether the
DNS relay keeps resolving externally is a question for a Linux host.
