### PR TITLE
fix(store): uninstall clears every child of what it deletes, and the durability suite qualifies the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,9 @@ by its public and operational effects.
 - Install, backup, restore, upgrade and uninstall are **executed** by
   the lifecycle drills, not merely documented.
 - **Uninstall clears the whole machine, including what an instance
-  learned about its provider.** It runs once, after the containers and
+  recorded about reaching its provider** — a success and a failure write
+  the same row, so this is every instance that ever ran. It runs once,
+  after the containers and
   the scale sets are already gone, so a row left behind is not a
   cosmetic leftover: a child table its foreign key still points at fails
   the delete of its parent and aborts the rest, leaving a half-removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,18 @@ by its public and operational effects.
   an unknown build is refused with instructions rather than repaired.
 - Install, backup, restore, upgrade and uninstall are **executed** by
   the lifecycle drills, not merely documented.
+- **Uninstall clears the whole machine, including what an instance
+  learned about its provider.** It runs once, after the containers and
+  the scale sets are already gone, so a row left behind is not a
+  cosmetic leftover: a child table its foreign key still points at fails
+  the delete of its parent and aborts the rest, leaving a half-removed
+  instance and a database no supported command will clear. Which tables
+  are children is now read from the database rather than kept in a list
+  by hand, so one added later is covered without anyone remembering.
+- **The durability configuration the release qualifies is the one the
+  product opens with.** The suite and the store share a single
+  connection string rather than each holding a copy, so a pragma changed
+  in the product is a pragma the qualification sees.
 - The lease machine, the cleanup saga and disposition-by-evidence live
   in **`internal/lease`**, with their own tests. They know nothing about
   providers, which is what keeps cleanup working when one is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,13 +327,12 @@ by its public and operational effects.
 - **Uninstall clears the whole machine, including what an instance
   recorded about reaching its provider** — a success and a failure write
   the same row, so this is every instance that ever ran. It runs once,
-  after the containers and
-  the scale sets are already gone, so a row left behind is not a
-  cosmetic leftover: a child table its foreign key still points at fails
-  the delete of its parent and aborts the rest, leaving a half-removed
-  instance and a database no supported command will clear. Which tables
-  are children is now read from the database rather than kept in a list
-  by hand, so one added later is covered without anyone remembering.
+  after the containers and the scale sets are already gone, so a row left
+  behind is not a cosmetic leftover: a child table its foreign key still
+  points at fails the delete of its parent and aborts the rest, leaving a
+  half-removed instance and a database no supported command will clear.
+  A table added later that references something uninstall deletes has to
+  be cleared before it, and the build refuses a release where one is not.
 - **The durability configuration the release qualifies is the one the
   product opens with.** The suite and the store share a single
   connection string rather than each holding a copy, so a pragma changed

--- a/internal/store/fingerprint_test.go
+++ b/internal/store/fingerprint_test.go
@@ -116,7 +116,7 @@ func openRaw(t *testing.T, dir string) *Store {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	db, err := sql.Open("sqlite", dsn(filepath.Join(dir, DatabaseFile)))
+	db, err := sql.Open("sqlite", DSN(filepath.Join(dir, DatabaseFile)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/open.go
+++ b/internal/store/open.go
@@ -42,11 +42,15 @@ import (
 // committed transition survives abrupt termination, enforced foreign
 // keys, immediate transactions, and a shared busy timeout.
 //
-// It is exported so that suite opens the same string this package does.
-// Qualifying a copy of it proves nothing about the product: every pragma
-// the suite asserts would still hold on its own connection after one was
+// It is exported so that the suite opens the same string this package
+// does. Qualifying a copy of it proves nothing about the product: every
+// pragma the suite asserts would still hold on the copy after one was
 // dropped from here, which is the single change the suite exists to
 // refuse.
+//
+// It is not a way to open the store. Open is, and what it adds is not
+// optional: the single writer connection, the directory lock, and the
+// migrations. A connection made from this string alone has none of them.
 func DSN(path string) string {
 	return "file:" + path +
 		"?_txlock=immediate" +

--- a/internal/store/open.go
+++ b/internal/store/open.go
@@ -36,12 +36,18 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 )
 
-// dsn is the connection contract the durability suite in
+// DSN is the connection contract the durability suite in
 // test/contract/sqlite qualifies (see
 // docs/adrs/2026-08-11-sqlite-driver.md): WAL with synchronous=FULL so a
 // committed transition survives abrupt termination, enforced foreign
 // keys, immediate transactions, and a shared busy timeout.
-func dsn(path string) string {
+//
+// It is exported so that suite opens the same string this package does.
+// Qualifying a copy of it proves nothing about the product: every pragma
+// the suite asserts would still hold on its own connection after one was
+// dropped from here, which is the single change the suite exists to
+// refuse.
+func DSN(path string) string {
 	return "file:" + path +
 		"?_txlock=immediate" +
 		"&_pragma=journal_mode(wal)" +
@@ -160,7 +166,7 @@ func (s *Store) loadIdentityReadOnly() error {
 // smaller budget but no budget at all, reopening the unbounded retry the
 // counter exists to close.
 func Open(dir string, retryBudget int) (*Store, error) {
-	db, err := sql.Open("sqlite", dsn(filepath.Join(dir, DatabaseFile)))
+	db, err := sql.Open("sqlite", DSN(filepath.Join(dir, DatabaseFile)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/purge.go
+++ b/internal/store/purge.go
@@ -13,6 +13,7 @@ func (t *Tx) PurgeEverything() error {
 		t.q.PurgeAttempts,
 		t.q.PurgeDeliveries,
 		t.q.PurgeGitHubBindingMetadata,
+		t.q.PurgeBindingContact,
 		t.q.PurgeBindings,
 		// Uninstall deletes the lane volumes, so the rows must go with
 		// them. A lane row whose volume is gone still counts against the

--- a/internal/store/query/purge.sql
+++ b/internal/store/query/purge.sql
@@ -27,6 +27,18 @@ DELETE FROM broker_deliveries;
 -- name: PurgeGitHubBindingMetadata :exec
 DELETE FROM github_actions_binding_metadata;
 
+-- Everything a binding owns goes before the binding. The contact row is
+-- written by the binding's own poll loop, so every instance that ever
+-- reached its provider has one, and the foreign key is enforced: leaving
+-- it behind fails the delete of its parent and aborts uninstall partway
+-- through, after the Docker objects are already gone.
+--
+-- Keep these comments ASCII. See the note further down about byte
+-- offsets.
+
+-- name: PurgeBindingContact :exec
+DELETE FROM provider_binding_contact;
+
 -- name: PurgeBindings :exec
 DELETE FROM provider_bindings;
 

--- a/internal/store/query/purge.sql
+++ b/internal/store/query/purge.sql
@@ -32,9 +32,6 @@ DELETE FROM github_actions_binding_metadata;
 -- reached its provider has one, and the foreign key is enforced: leaving
 -- it behind fails the delete of its parent and aborts uninstall partway
 -- through, after the Docker objects are already gone.
---
--- Keep these comments ASCII. See the note further down about byte
--- offsets.
 
 -- name: PurgeBindingContact :exec
 DELETE FROM provider_binding_contact;

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -575,6 +575,17 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 	return c
 }
 
+// bindingChildren are the tables that reference provider_bindings. A row
+// in any of them outlives its binding only until the binding's own
+// delete, which the foreign key then refuses, so every one of them has
+// to go first.
+//
+// It is one declaration because two paths delete a binding and both need
+// the same list: the startup pass that forgets unclaimed bindings, and
+// uninstall. A table added later that names provider_bindings has to be
+// added here, or excluded with a reason.
+var bindingChildren = []string{"github_actions_binding_metadata", "provider_binding_contact"}
+
 // ForgetUnclaimedBindings removes the binding rows configuration no
 // longer claims, with the adapter metadata and reach records that hang
 // off them, and reports how many went.
@@ -606,9 +617,9 @@ func (t *Tx) ForgetUnclaimedBindings(claimed []assignment.BindingID) (int, error
 		WHERE id NOT IN (` + held + `)
 		  AND NOT EXISTS (SELECT 1 FROM broker_deliveries d WHERE d.binding_id = provider_bindings.id)`
 
-	// The dependents first: both reference the binding row, so the
+	// The dependents first: each references the binding row, so the
 	// delete order is what the foreign keys allow.
-	for _, table := range []string{"github_actions_binding_metadata", "provider_binding_contact"} {
+	for _, table := range bindingChildren {
 		if _, err := t.tx.Exec(
 			`DELETE FROM `+table+` WHERE binding_id IN (`+unclaimed+`)`, args...); err != nil {
 			return 0, err

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -583,8 +583,8 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 // It is named rather than written inline so there is one place to state
 // it and one place to check it against the schema. Uninstall clears the
 // same parent through its own sequence, which is wider: it runs when
-// nothing is left, so it takes the deliveries and leases this pass is
-// defined never to meet.
+// nothing is left, so it also takes the deliveries this pass is defined
+// never to meet, and the leases that follow from them.
 var bindingChildren = []string{"github_actions_binding_metadata", "provider_binding_contact"}
 
 // ForgetUnclaimedBindings removes the binding rows configuration no

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -580,10 +580,11 @@ func providerContactFromRow(bindingID, contactMs int64, lastError string, errorM
 // delete, which the foreign key then refuses, so every one of them has
 // to go first.
 //
-// It is one declaration because two paths delete a binding and both need
-// the same list: the startup pass that forgets unclaimed bindings, and
-// uninstall. A table added later that names provider_bindings has to be
-// added here, or excluded with a reason.
+// It is named rather than written inline so there is one place to state
+// it and one place to check it against the schema. Uninstall clears the
+// same parent through its own sequence, which is wider: it runs when
+// nothing is left, so it takes the deliveries and leases this pass is
+// defined never to meet.
 var bindingChildren = []string{"github_actions_binding_metadata", "provider_binding_contact"}
 
 // ForgetUnclaimedBindings removes the binding rows configuration no

--- a/internal/store/sqlitedb/purge.sql.go
+++ b/internal/store/sqlitedb/purge.sql.go
@@ -37,9 +37,6 @@ DELETE FROM provider_binding_contact
 // reached its provider has one, and the foreign key is enforced: leaving
 // it behind fails the delete of its parent and aborts uninstall partway
 // through, after the Docker objects are already gone.
-//
-// Keep these comments ASCII. See the note further down about byte
-// offsets.
 func (q *Queries) PurgeBindingContact(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, purgeBindingContact)
 	return err

--- a/internal/store/sqlitedb/purge.sql.go
+++ b/internal/store/sqlitedb/purge.sql.go
@@ -27,6 +27,24 @@ func (q *Queries) PurgeAttempts(ctx context.Context) error {
 	return err
 }
 
+const purgeBindingContact = `-- name: PurgeBindingContact :exec
+
+DELETE FROM provider_binding_contact
+`
+
+// Everything a binding owns goes before the binding. The contact row is
+// written by the binding's own poll loop, so every instance that ever
+// reached its provider has one, and the foreign key is enforced: leaving
+// it behind fails the delete of its parent and aborts uninstall partway
+// through, after the Docker objects are already gone.
+//
+// Keep these comments ASCII. See the note further down about byte
+// offsets.
+func (q *Queries) PurgeBindingContact(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, purgeBindingContact)
+	return err
+}
+
 const purgeBindings = `-- name: PurgeBindings :exec
 DELETE FROM provider_bindings
 `

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,6 +6,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1894,6 +1897,83 @@ func TestUninstallClearsABindingThatReachedItsProvider(t *testing.T) {
 	}
 }
 
+// executedPurgeOrder reads the sequence PurgeEverything actually runs and
+// pairs each step with the table it clears.
+//
+// The order comes from the slice literal the function walks, parsed from
+// the source, because that is what executes. Reading it from the query
+// file instead would check the order of a declaration: the two are
+// independent, and a step moved in the Go code alone would leave every
+// assertion below passing while uninstall aborts. Parsing also means a
+// step that has been commented out is a step that is not there, where
+// searching the text for its name would still find it.
+//
+// The query file supplies only the table each name clears. A name whose
+// table cannot be read is a failure rather than a skip, since a step
+// silently dropped here would take its whole subtree of foreign keys out
+// of the rule with it.
+func executedPurgeOrder(t *testing.T) map[string]int {
+	t.Helper()
+
+	body, err := parser.ParseFile(token.NewFileSet(), "purge.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var steps []string
+	ast.Inspect(body, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		for _, el := range lit.Elts {
+			if sel, ok := el.(*ast.SelectorExpr); ok {
+				steps = append(steps, sel.Sel.Name)
+			}
+		}
+		return true
+	})
+	if len(steps) < 2 {
+		t.Fatalf("read %d steps out of PurgeEverything; the rule below would hold vacuously", len(steps))
+	}
+
+	raw, err := os.ReadFile(filepath.Join("query", "purge.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Split on the name markers so a delete is read as belonging to the
+	// query above it, whatever comments or whitespace sit in between.
+	deletes := map[string]string{}
+	chunks := regexp.MustCompile(`(?m)^-- name: (\w+) :exec\b`).FindAllStringSubmatchIndex(string(raw), -1)
+	for i, at := range chunks {
+		end := len(raw)
+		if i+1 < len(chunks) {
+			end = chunks[i+1][0]
+		}
+		name := string(raw[at[2]:at[3]])
+		if m := regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+"?(\w+)"?`).FindStringSubmatch(string(raw[at[1]:end])); m != nil {
+			deletes[name] = m[1]
+		}
+	}
+
+	order := map[string]int{}
+	for _, name := range steps {
+		table, ok := deletes[name]
+		if !ok {
+			t.Errorf("PurgeEverything runs %s and query/purge.sql does not show it deleting from any "+
+				"table; every child of whatever it clears is outside the rule below", name)
+			continue
+		}
+		order[table] = len(order)
+	}
+	for name := range deletes {
+		if !slices.Contains(steps, name) {
+			t.Errorf("query/purge.sql declares %s and PurgeEverything never runs it; the statement "+
+				"exists and the table it clears does not get cleared", name)
+		}
+	}
+	return order
+}
+
 // TestUninstallReachesEveryChildOfWhatItDeletes states the rule the case
 // above is one instance of.
 //
@@ -1909,78 +1989,11 @@ func TestUninstallClearsABindingThatReachedItsProvider(t *testing.T) {
 // to add it here.
 func TestUninstallReachesEveryChildOfWhatItDeletes(t *testing.T) {
 	s := newStore(t)
-
-	raw, err := os.ReadFile(filepath.Join("query", "purge.sql"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	order := map[string]int{}
-	for _, m := range regexp.MustCompile(`(?m)^DELETE FROM (\w+);`).FindAllStringSubmatch(string(raw), -1) {
-		order[m[1]] = len(order)
-	}
-	if len(order) < 2 {
-		t.Fatalf("read %d deletes from query/purge.sql; the rule below would hold vacuously", len(order))
-	}
-
-	// Declaring a delete is not running one, and the rule below is about
-	// what uninstall does. Every query the file declares has to appear in
-	// the list PurgeEverything walks, or this test would be reasoning
-	// about statements nothing executes.
-	body, err := os.ReadFile("purge.go")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, m := range regexp.MustCompile(`(?m)^-- name: (\w+) :exec`).FindAllStringSubmatch(string(raw), -1) {
-		if !strings.Contains(string(body), "t.q."+m[1]+",") {
-			t.Errorf("query/purge.sql declares %s and PurgeEverything never runs it; "+
-				"the statement exists and the table it clears does not get cleared", m[1])
-		}
-	}
-
-	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var tables []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			t.Fatal(err)
-		}
-		tables = append(tables, name)
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatal(err)
-	}
-	if err := rows.Close(); err != nil {
-		t.Fatal(err)
-	}
+	order := executedPurgeOrder(t)
 
 	checked := 0
-	for _, child := range tables {
-		parents, err := s.db.Query("PRAGMA foreign_key_list(" + child + ")")
-		if err != nil {
-			t.Fatal(err)
-		}
-		var refers []string
-		for parents.Next() {
-			// The pragma's shape is fixed: id, seq, table, from, to,
-			// on_update, on_delete, match.
-			var id, seq int
-			var parent, from, to, onUpdate, onDelete, match sql.NullString
-			if err := parents.Scan(&id, &seq, &parent, &from, &to, &onUpdate, &onDelete, &match); err != nil {
-				t.Fatal(err)
-			}
-			refers = append(refers, parent.String)
-		}
-		if err := parents.Err(); err != nil {
-			t.Fatal(err)
-		}
-		if err := parents.Close(); err != nil {
-			t.Fatal(err)
-		}
-
-		for _, parent := range refers {
+	for child, parents := range foreignKeys(t, s) {
+		for _, parent := range parents {
 			parentAt, purged := order[parent]
 			if !purged {
 				continue // uninstall leaves the parent alone, so the child may stay too
@@ -1999,5 +2012,119 @@ func TestUninstallReachesEveryChildOfWhatItDeletes(t *testing.T) {
 	}
 	if checked == 0 {
 		t.Fatal("no child of a purged table was found; the rule proved nothing")
+	}
+}
+
+// TestForgettingABindingReachesEveryChildOfIt: the startup pass that
+// drops bindings nobody claimed deletes the same parent uninstall does,
+// so it needs the same children — and it runs on every start rather than
+// once at the end of an instance's life.
+func TestForgettingABindingReachesEveryChildOfIt(t *testing.T) {
+	s := newStore(t)
+
+	// Two children are deliberately not cleared, because the pass cannot
+	// meet them: it selects only bindings with no deliveries, and a lease
+	// exists only for an attempt of a delivery. Naming them here rather
+	// than leaving them out is the point — a child that appears later and
+	// is neither cleared nor excluded for a stated reason fails this test,
+	// which is the moment someone has to decide which it is.
+	excluded := []string{"broker_deliveries", "capsule_leases"}
+
+	var children []string
+	for child, parents := range foreignKeys(t, s) {
+		if slices.Contains(parents, "provider_bindings") {
+			children = append(children, child)
+		}
+	}
+	if len(children) == 0 {
+		t.Fatal("provider_bindings has no children in the schema; the rule proved nothing")
+	}
+	slices.Sort(children)
+
+	for _, child := range children {
+		switch {
+		case slices.Contains(bindingChildren, child) && slices.Contains(excluded, child):
+			t.Errorf("%s is both cleared and excluded; one of the two is wrong", child)
+		case slices.Contains(bindingChildren, child), slices.Contains(excluded, child):
+		default:
+			t.Errorf("%s references provider_bindings and is neither cleared before a binding is "+
+				"forgotten nor excluded for a reason; if the pass can meet a row of it, the delete "+
+				"of the binding fails on every controller start", child)
+		}
+	}
+	for _, cleared := range bindingChildren {
+		if !slices.Contains(children, cleared) {
+			t.Errorf("a binding is forgotten by clearing %s, which does not reference "+
+				"provider_bindings; the statement deletes rows nothing required it to", cleared)
+		}
+	}
+}
+
+// foreignKeys maps each table to the tables it references, read from the
+// database so a table added later is covered without being named here.
+func foreignKeys(t *testing.T, s *Store) map[string][]string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	// Closed before the pragma below: the pool is one connection, so a
+	// second query while these rows are open would deadlock.
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	graph := map[string][]string{}
+	for _, child := range tables {
+		parents, err := s.db.Query("PRAGMA foreign_key_list(" + child + ")")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for parents.Next() {
+			// The pragma's shape is fixed: id, seq, table, from, to,
+			// on_update, on_delete, match.
+			var id, seq int
+			var parent, from, to, onUpdate, onDelete, match sql.NullString
+			if err := parents.Scan(&id, &seq, &parent, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+				t.Fatal(err)
+			}
+			graph[child] = append(graph[child], parent.String)
+		}
+		if err := parents.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if err := parents.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return graph
+}
+
+// TestTheConnectionStringStillAsksForFullSynchronous: the durability
+// suite cannot see this one.
+//
+// It reads PRAGMA synchronous from a live connection, and the pinned
+// driver already answers 2 with no pragma set at all, so deleting the
+// pragma passes every assertion there. Setting it to something else does
+// fail, which is the case the suite does cover. What it cannot cover is
+// the pragma quietly going away and the guarantee then resting on a
+// driver default that a later version is free to change. So the string
+// itself is what states it here.
+func TestTheConnectionStringStillAsksForFullSynchronous(t *testing.T) {
+	if got := DSN("/state/runpool.db"); !strings.Contains(got, "_pragma=synchronous(full)") {
+		t.Errorf("the connection string no longer asks for synchronous=FULL: %s\n"+
+			"A committed lease transition would survive a crash only for as long as the "+
+			"driver keeps defaulting to it, and no suite would notice the change.", got)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1915,23 +1915,37 @@ func TestUninstallClearsABindingThatReachedItsProvider(t *testing.T) {
 func executedPurgeOrder(t *testing.T) map[string]int {
 	t.Helper()
 
-	body, err := parser.ParseFile(token.NewFileSet(), "purge.go", nil, 0)
+	file, err := parser.ParseFile(token.NewFileSet(), "purge.go", nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var steps []string
-	ast.Inspect(body, func(n ast.Node) bool {
-		lit, ok := n.(*ast.CompositeLit)
-		if !ok {
-			return true
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "PurgeEverything" {
+			continue
 		}
-		for _, el := range lit.Elts {
-			if sel, ok := el.(*ast.SelectorExpr); ok {
-				steps = append(steps, sel.Sel.Name)
+		// Scoped to this function, and to selectors on its query set. A
+		// walk of the whole file would collect any other slice of
+		// selectors as though it were part of the sequence, and one more
+		// mention of a step is enough to move it past its own child.
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			lit, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
 			}
-		}
-		return true
-	})
+			for _, el := range lit.Elts {
+				sel, ok := el.(*ast.SelectorExpr)
+				if !ok {
+					continue
+				}
+				if on, ok := sel.X.(*ast.SelectorExpr); ok && on.Sel.Name == "q" {
+					steps = append(steps, sel.Sel.Name)
+				}
+			}
+			return true
+		})
+	}
 	if len(steps) < 2 {
 		t.Fatalf("read %d steps out of PurgeEverything; the rule below would hold vacuously", len(steps))
 	}
@@ -1943,27 +1957,50 @@ func executedPurgeOrder(t *testing.T) map[string]int {
 	// Split on the name markers so a delete is read as belonging to the
 	// query above it, whatever comments or whitespace sit in between.
 	deletes := map[string]string{}
-	chunks := regexp.MustCompile(`(?m)^-- name: (\w+) :exec\b`).FindAllStringSubmatchIndex(string(raw), -1)
+	marker := regexp.MustCompile(`(?m)^-- name: (\w+) :exec\b`)
+	deleted := regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+"?(\w+)"?`)
+	chunks := marker.FindAllStringSubmatchIndex(string(raw), -1)
 	for i, at := range chunks {
 		end := len(raw)
 		if i+1 < len(chunks) {
 			end = chunks[i+1][0]
 		}
-		name := string(raw[at[2]:at[3]])
-		if m := regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+"?(\w+)"?`).FindStringSubmatch(string(raw[at[1]:end])); m != nil {
-			deletes[name] = m[1]
+		// Comment lines go first. This file explains itself at length,
+		// and a comment may legally sit between a name and its statement
+		// -- the generator turns one into the doc on what it emits -- so
+		// a scan that let a comment win would map a step to a table it
+		// does not clear and check the rule against that.
+		var stmt strings.Builder
+		for _, line := range strings.Split(string(raw[at[1]:end]), "\n") {
+			if !strings.HasPrefix(strings.TrimSpace(line), "--") {
+				stmt.WriteString(line)
+				stmt.WriteByte('\n')
+			}
+		}
+		if m := deleted.FindStringSubmatch(stmt.String()); m != nil {
+			deletes[string(raw[at[2]:at[3]])] = m[1]
 		}
 	}
 
+	// Position in the sequence, not a count of the tables seen. A table
+	// reached twice would otherwise take the later index, which is how a
+	// parent mentioned again ends up ranked after the child that has to
+	// precede it, with nothing to say so.
 	order := map[string]int{}
-	for _, name := range steps {
+	for i, name := range steps {
 		table, ok := deletes[name]
 		if !ok {
 			t.Errorf("PurgeEverything runs %s and query/purge.sql does not show it deleting from any "+
 				"table; every child of whatever it clears is outside the rule below", name)
 			continue
 		}
-		order[table] = len(order)
+		if at, twice := order[table]; twice {
+			t.Errorf("steps %d and %d both clear %s; which one the rule below is about is "+
+				"undecidable, and the later one outranks every child ordered against the earlier",
+				at, i, table)
+			continue
+		}
+		order[table] = i
 	}
 	for name := range deletes {
 		if !slices.Contains(steps, name) {
@@ -2022,12 +2059,23 @@ func TestUninstallReachesEveryChildOfWhatItDeletes(t *testing.T) {
 func TestForgettingABindingReachesEveryChildOfIt(t *testing.T) {
 	s := newStore(t)
 
-	// Two children are deliberately not cleared, because the pass cannot
-	// meet them: it selects only bindings with no deliveries, and a lease
-	// exists only for an attempt of a delivery. Naming them here rather
-	// than leaving them out is the point — a child that appears later and
-	// is neither cleared nor excluded for a stated reason fails this test,
-	// which is the moment someone has to decide which it is.
+	// Two children are deliberately not cleared. The pass selects only
+	// bindings with no deliveries, so broker_deliveries is excluded by
+	// its own query and needs no argument beyond that.
+	//
+	// capsule_leases is excluded on a narrower footing, worth stating
+	// because the schema does not hold it: a lease carries binding_id and
+	// attempt_id as two independent references, so a row naming a
+	// delivery-free binding is accepted, and the pass would then fail on
+	// every controller start. What keeps that from arising is the one
+	// call site — attempts are read for a binding and leased under that
+	// same binding — rather than a constraint. assignment_attempts, by
+	// contrast, carries a composite reference for exactly this reason.
+	//
+	// Naming both here rather than leaving them out is the point: a child
+	// that appears later and is neither cleared nor excluded for a stated
+	// reason fails this test, which is the moment someone has to decide
+	// which it is.
 	excluded := []string{"broker_deliveries", "capsule_leases"}
 
 	var children []string
@@ -2056,6 +2104,12 @@ func TestForgettingABindingReachesEveryChildOfIt(t *testing.T) {
 		if !slices.Contains(children, cleared) {
 			t.Errorf("a binding is forgotten by clearing %s, which does not reference "+
 				"provider_bindings; the statement deletes rows nothing required it to", cleared)
+		}
+	}
+	for _, skipped := range excluded {
+		if !slices.Contains(children, skipped) {
+			t.Errorf("%s is excused from being cleared and does not reference provider_bindings; "+
+				"the reason given above is about a table that is not in the way", skipped)
 		}
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -6,9 +6,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1897,158 +1894,168 @@ func TestUninstallClearsABindingThatReachedItsProvider(t *testing.T) {
 	}
 }
 
-// executedPurgeOrder reads the sequence PurgeEverything actually runs and
-// pairs each step with the table it clears.
-//
-// The order comes from the slice literal the function walks, parsed from
-// the source, because that is what executes. Reading it from the query
-// file instead would check the order of a declaration: the two are
-// independent, and a step moved in the Go code alone would leave every
-// assertion below passing while uninstall aborts. Parsing also means a
-// step that has been commented out is a step that is not there, where
-// searching the text for its name would still find it.
-//
-// The query file supplies only the table each name clears. A name whose
-// table cannot be read is a failure rather than a skip, since a step
-// silently dropped here would take its whole subtree of foreign keys out
-// of the rule with it.
-func executedPurgeOrder(t *testing.T) map[string]int {
+// seedEverything writes one row into every table an instance fills, so
+// what uninstall does can be observed instead of read.
+func seedEverything(t *testing.T, s *Store) {
 	t.Helper()
-
-	file, err := parser.ParseFile(token.NewFileSet(), "purge.go", nil, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var steps []string
-	for _, decl := range file.Decls {
-		fn, ok := decl.(*ast.FuncDecl)
-		if !ok || fn.Name.Name != "PurgeEverything" {
-			continue
+	binding := seedBinding(t, s)
+	attempt := seedAttempt(t, s, binding, "msg-seed", "job-seed")
+	inTx(t, s, func(tx *Tx) error {
+		if err := tx.RecordProviderContact(binding, time.Now()); err != nil {
+			return err
 		}
-		// Scoped to this function, and to selectors on its query set. A
-		// walk of the whole file would collect any other slice of
-		// selectors as though it were part of the sequence, and one more
-		// mention of a step is enough to move it past its own child.
-		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			lit, ok := n.(*ast.CompositeLit)
-			if !ok {
-				return true
-			}
-			for _, el := range lit.Elts {
-				sel, ok := el.(*ast.SelectorExpr)
-				if !ok {
-					continue
-				}
-				if on, ok := sel.X.(*ast.SelectorExpr); ok && on.Sel.Name == "q" {
-					steps = append(steps, sel.Sel.Name)
-				}
-			}
-			return true
-		})
-	}
-	if len(steps) < 2 {
-		t.Fatalf("read %d steps out of PurgeEverything; the rule below would hold vacuously", len(steps))
-	}
-
-	raw, err := os.ReadFile(filepath.Join("query", "purge.sql"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Split on the name markers so a delete is read as belonging to the
-	// query above it, whatever comments or whitespace sit in between.
-	deletes := map[string]string{}
-	marker := regexp.MustCompile(`(?m)^-- name: (\w+) :exec\b`)
-	deleted := regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+"?(\w+)"?`)
-	chunks := marker.FindAllStringSubmatchIndex(string(raw), -1)
-	for i, at := range chunks {
-		end := len(raw)
-		if i+1 < len(chunks) {
-			end = chunks[i+1][0]
+		if err := tx.RecordGitHubBindingMetadata(binding, "repository",
+			"https://github.com/acme/app", "default", "runpool-standard", 41); err != nil {
+			return err
 		}
-		// Comment lines go first. This file explains itself at length,
-		// and a comment may legally sit between a name and its statement
-		// -- the generator turns one into the doc on what it emits -- so
-		// a scan that let a comment win would map a step to a table it
-		// does not clear and check the rule against that.
-		var stmt strings.Builder
-		for _, line := range strings.Split(string(raw[at[1]:end]), "\n") {
-			if !strings.HasPrefix(strings.TrimSpace(line), "--") {
-				stmt.WriteString(line)
-				stmt.WriteByte('\n')
-			}
+		// A second binding recorded before its scale set was ensured, so
+		// its metadata row carries no scale set id. A statement narrowed
+		// to the rows an instance provisioned would pass over exactly
+		// this one, and pass over it in every real deployment too.
+		unprovisioned, err := tx.EnsureBinding("default", "github_actions",
+			"v1|repository|https://github.com/acme/other||runpool-standard")
+		if err != nil {
+			return err
 		}
-		if m := deleted.FindStringSubmatch(stmt.String()); m != nil {
-			deletes[string(raw[at[2]:at[3]])] = m[1]
+		if err := tx.RecordGitHubBindingMetadata(unprovisioned, "repository",
+			"https://github.com/acme/other", "default", "runpool-standard", 0); err != nil {
+			return err
 		}
-	}
-
-	// Position in the sequence, not a count of the tables seen. A table
-	// reached twice would otherwise take the later index, which is how a
-	// parent mentioned again ends up ranked after the child that has to
-	// precede it, with nothing to say so.
-	order := map[string]int{}
-	for i, name := range steps {
-		table, ok := deletes[name]
-		if !ok {
-			t.Errorf("PurgeEverything runs %s and query/purge.sql does not show it deleting from any "+
-				"table; every child of whatever it clears is outside the rule below", name)
-			continue
+		if err := tx.RecordGitHubAttemptMetadata(attempt, "job-seed", 7, 9); err != nil {
+			return err
 		}
-		if at, twice := order[table]; twice {
-			t.Errorf("steps %d and %d both clear %s; which one the rule below is about is "+
-				"undecidable, and the later one outranks every child ordered against the earlier",
-				at, i, table)
-			continue
+		if err := tx.RecordRepeatableEvent(attempt, "runtime_observation_failed", map[string]string{"why": "seeding"}); err != nil {
+			return err
 		}
-		order[table] = i
-	}
-	for name := range deletes {
-		if !slices.Contains(steps, name) {
-			t.Errorf("query/purge.sql declares %s and PurgeEverything never runs it; the statement "+
-				"exists and the table it clears does not get cleared", name)
+		lease, err := tx.LeaseAttempt(attempt, binding, "standard")
+		if err != nil {
+			return err
 		}
-	}
-	return order
+		if _, err := tx.PlanResource(lease.ID, ResourceContainer, "capsule", "runpool-seed"); err != nil {
+			return err
+		}
+		project, err := tx.EnsureCacheProject("acme/app")
+		if err != nil {
+			return err
+		}
+		_, err = tx.LeaseCacheLane(project, "default", lease.ID, 2)
+		return err
+	})
 }
 
-// TestUninstallReachesEveryChildOfWhatItDeletes states the rule the case
-// above is one instance of.
-//
-// A table whose parent uninstall deletes must be deleted too, and first.
-// Neither half is optional: a child left behind fails its parent's
-// delete, and a child deleted after its parent never runs, because the
-// transaction has already aborted. Both are silent until an operator
-// runs uninstall on an instance that did some work, which is the one
-// moment when nothing can be retried.
-//
-// The relationships come from the database rather than from a list kept
-// by hand, so a table added later is covered without anyone remembering
-// to add it here.
-func TestUninstallReachesEveryChildOfWhatItDeletes(t *testing.T) {
-	s := newStore(t)
-	order := executedPurgeOrder(t)
+// tablesOf is every table the schema declares.
+func tablesOf(t *testing.T, s *Store) []string {
+	t.Helper()
+	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return names
+}
 
-	checked := 0
-	for child, parents := range foreignKeys(t, s) {
-		for _, parent := range parents {
-			parentAt, purged := order[parent]
-			if !purged {
-				continue // uninstall leaves the parent alone, so the child may stay too
-			}
-			checked++
-			childAt, ok := order[child]
-			switch {
-			case !ok:
-				t.Errorf("uninstall deletes %s but never deletes %s, which references it; "+
-					"the foreign key fails the delete and the whole uninstall aborts", parent, child)
-			case childAt > parentAt:
-				t.Errorf("uninstall deletes %s before %s, which references it; the parent's "+
-					"delete fails and nothing after it runs", parent, child)
-			}
+func rowsIn(t *testing.T, s *Store, table string) int {
+	t.Helper()
+	var n int
+	if err := s.db.QueryRow("SELECT count(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// TestUninstallClearsEveryTableItOwns runs the purge against a database
+// holding a row everywhere an instance writes one, and requires it to
+// finish and to leave nothing of itself behind.
+//
+// It watches the database rather than reading the statements, which is
+// what makes it total. Every way of getting this wrong arrives at the
+// same two observations: a step that clears only some of its rows, one
+// that names its table in a spelling the schema does not use, one
+// declared in a form the generator emits differently, or a sequence
+// that runs in an order the source does not show. Either a foreign key
+// refuses a parent whose child is still present, or a table asserted
+// empty is not.
+func TestUninstallClearsEveryTableItOwns(t *testing.T) {
+	s := newStore(t)
+
+	// What uninstall deliberately leaves. meta carries the schema
+	// fingerprint, and a database whose meta was cleared is refused on
+	// every later open; pressure is one row whose retention keeps the
+	// disk hysteresis across a restart; audit_log is a record of what an
+	// operator did, which outlives the machine it describes.
+	kept := []string{"audit_log", "meta", "pressure"}
+
+	seedEverything(t, s)
+
+	// The seed has to keep up with the schema, so an unseeded table is a
+	// failure here rather than a silent gap: uninstall would be neither
+	// observed against it nor observed to skip it.
+	for _, table := range tablesOf(t, s) {
+		if slices.Contains(kept, table) {
+			continue
+		}
+		if rowsIn(t, s, table) == 0 {
+			t.Errorf("nothing seeded %s, so what uninstall does to it is not observed; "+
+				"seed it above, or say why uninstall leaves it", table)
 		}
 	}
-	if checked == 0 {
-		t.Fatal("no child of a purged table was found; the rule proved nothing")
+
+	if err := s.Tx(t.Context(), func(tx *Tx) error { return tx.PurgeEverything() }); err != nil {
+		t.Fatalf("uninstall did not finish: %v\nThe containers and the scale sets are already "+
+			"gone by the time this runs, so what is left is a half-removed instance and a "+
+			"state database no supported command will clear.", err)
+	}
+
+	for _, table := range tablesOf(t, s) {
+		if slices.Contains(kept, table) {
+			continue
+		}
+		if n := rowsIn(t, s, table); n != 0 {
+			t.Errorf("%s still holds %d row(s) after uninstall; a reinstall onto a retained "+
+				"state volume inherits them", table, n)
+		}
+	}
+}
+
+// TestEveryPurgeStatementIsTotal: uninstall names the whole instance, so
+// each of its deletes takes a whole table.
+//
+// It reads the generated statements rather than the queries they came
+// from, because those are what run: a document that reaches the
+// generator damaged produces a statement nobody wrote, and comparing
+// the two sources would not show it. A narrowed delete is the natural
+// mistake here -- clearing only the rows an instance provisioned reads
+// as caution -- and it leaves the rest behind for the foreign key of
+// whatever they hang from to refuse.
+func TestEveryPurgeStatementIsTotal(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("sqlitedb", "purge.sql.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	statements := regexp.MustCompile(`(?is)DELETE\s+FROM\s+([^\n`+"`"+`]*)`).FindAllStringSubmatch(string(raw), -1)
+	if len(statements) < 2 {
+		t.Fatalf("read %d delete statements out of the generated layer; "+
+			"the rule below would hold vacuously", len(statements))
+	}
+	for _, stmt := range statements {
+		rest := strings.TrimSpace(stmt[1])
+		if fields := strings.Fields(rest); len(fields) != 1 {
+			t.Errorf("uninstall runs `DELETE FROM %s`, which does not clear a whole table. "+
+				"Every row it passes over stays behind for the foreign key of whatever "+
+				"references it to refuse, and the delete of that parent is what aborts "+
+				"the rest of the uninstall.", rest)
+		}
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,9 +3,12 @@ package store
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -1857,5 +1860,144 @@ func TestASecondReviewCycleIsItsOwnHistory(t *testing.T) {
 		if !strings.Contains(joined, actor) {
 			t.Errorf("the record does not name %s: %v", actor, resolves)
 		}
+	}
+}
+
+// TestUninstallClearsABindingThatReachedItsProvider: uninstall runs once
+// and has to finish.
+//
+// The contact row is written by a binding's own poll loop, so every
+// instance that ever reached its provider has one. It is a child of
+// provider_bindings with the foreign key enforced, so leaving it behind
+// fails the delete of its parent and aborts the whole transaction. By
+// then the Docker objects are gone and the scale sets are deleted, and
+// the operator is left with a half-removed instance and a state database
+// no supported command will clear.
+func TestUninstallClearsABindingThatReachedItsProvider(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	inTx(t, s, func(tx *Tx) error {
+		return tx.RecordProviderContact(binding, time.Now())
+	})
+
+	if err := s.Tx(t.Context(), func(tx *Tx) error { return tx.PurgeEverything() }); err != nil {
+		t.Fatalf("uninstall failed on a binding that had reached its provider: %v", err)
+	}
+	for _, table := range []string{"provider_binding_contact", "provider_bindings"} {
+		var n int
+		if err := s.db.QueryRow("SELECT count(*) FROM " + table).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Errorf("%s still holds %d row(s) after uninstall", table, n)
+		}
+	}
+}
+
+// TestUninstallReachesEveryChildOfWhatItDeletes states the rule the case
+// above is one instance of.
+//
+// A table whose parent uninstall deletes must be deleted too, and first.
+// Neither half is optional: a child left behind fails its parent's
+// delete, and a child deleted after its parent never runs, because the
+// transaction has already aborted. Both are silent until an operator
+// runs uninstall on an instance that did some work, which is the one
+// moment when nothing can be retried.
+//
+// The relationships come from the database rather than from a list kept
+// by hand, so a table added later is covered without anyone remembering
+// to add it here.
+func TestUninstallReachesEveryChildOfWhatItDeletes(t *testing.T) {
+	s := newStore(t)
+
+	raw, err := os.ReadFile(filepath.Join("query", "purge.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	order := map[string]int{}
+	for _, m := range regexp.MustCompile(`(?m)^DELETE FROM (\w+);`).FindAllStringSubmatch(string(raw), -1) {
+		order[m[1]] = len(order)
+	}
+	if len(order) < 2 {
+		t.Fatalf("read %d deletes from query/purge.sql; the rule below would hold vacuously", len(order))
+	}
+
+	// Declaring a delete is not running one, and the rule below is about
+	// what uninstall does. Every query the file declares has to appear in
+	// the list PurgeEverything walks, or this test would be reasoning
+	// about statements nothing executes.
+	body, err := os.ReadFile("purge.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range regexp.MustCompile(`(?m)^-- name: (\w+) :exec`).FindAllStringSubmatch(string(raw), -1) {
+		if !strings.Contains(string(body), "t.q."+m[1]+",") {
+			t.Errorf("query/purge.sql declares %s and PurgeEverything never runs it; "+
+				"the statement exists and the table it clears does not get cleared", m[1])
+		}
+	}
+
+	rows, err := s.db.Query(`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tables []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		tables = append(tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if err := rows.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	checked := 0
+	for _, child := range tables {
+		parents, err := s.db.Query("PRAGMA foreign_key_list(" + child + ")")
+		if err != nil {
+			t.Fatal(err)
+		}
+		var refers []string
+		for parents.Next() {
+			// The pragma's shape is fixed: id, seq, table, from, to,
+			// on_update, on_delete, match.
+			var id, seq int
+			var parent, from, to, onUpdate, onDelete, match sql.NullString
+			if err := parents.Scan(&id, &seq, &parent, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+				t.Fatal(err)
+			}
+			refers = append(refers, parent.String)
+		}
+		if err := parents.Err(); err != nil {
+			t.Fatal(err)
+		}
+		if err := parents.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, parent := range refers {
+			parentAt, purged := order[parent]
+			if !purged {
+				continue // uninstall leaves the parent alone, so the child may stay too
+			}
+			checked++
+			childAt, ok := order[child]
+			switch {
+			case !ok:
+				t.Errorf("uninstall deletes %s but never deletes %s, which references it; "+
+					"the foreign key fails the delete and the whole uninstall aborts", parent, child)
+			case childAt > parentAt:
+				t.Errorf("uninstall deletes %s before %s, which references it; the parent's "+
+					"delete fails and nothing after it runs", parent, child)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no child of a purged table was found; the rule proved nothing")
 	}
 }

--- a/test/contract/sqlite/contract_test.go
+++ b/test/contract/sqlite/contract_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/rhobuild/runpool/internal/store"
 )
 
 const (
@@ -44,19 +46,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// dsn configures every connection identically: WAL for crash-safe
-// concurrency, synchronous=FULL so a committed state transition survives
-// power loss, enforced foreign keys, a shared busy timeout, and immediate
-// transactions so writers never hit the deferred-upgrade deadlock.
-func dsn(path string) string {
-	return "file:" + path +
-		"?_txlock=immediate" +
-		"&_pragma=journal_mode(wal)" +
-		"&_pragma=synchronous(full)" +
-		"&_pragma=foreign_keys(1)" +
-		"&_pragma=busy_timeout(10000)"
-}
-
 func contractDir(t *testing.T) string {
 	dir := os.Getenv(envContractDir)
 	if dir == "" {
@@ -67,7 +56,7 @@ func contractDir(t *testing.T) string {
 
 func open(t *testing.T, path string) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite", dsn(path))
+	db, err := sql.Open("sqlite", store.DSN(path))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +86,7 @@ func runWriter() {
 		fmt.Fprintln(os.Stderr, "writer:", err)
 		os.Exit(1)
 	}
-	db, err := sql.Open("sqlite", dsn(os.Getenv(envWriterDB)))
+	db, err := sql.Open("sqlite", store.DSN(os.Getenv(envWriterDB)))
 	if err != nil {
 		fail(err)
 	}
@@ -146,7 +135,7 @@ func runWriter() {
 // torn rows, the meta counter matches the last entry (multi-statement
 // atomicity), and it contains at least every commit the log confirmed.
 func verifyDB(dbPath, logPath string) error {
-	db, err := sql.Open("sqlite", dsn(dbPath))
+	db, err := sql.Open("sqlite", store.DSN(dbPath))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What changes

`runpool uninstall` completes on an instance that ever reached its provider,
where before it aborted partway through with a foreign key failure. And the
SQLite durability suite now opens with the same connection string the store
does, so a pragma changed in the product is a pragma the qualification sees.

## What was found

**Uninstall never deleted `provider_binding_contact`.** It is a child of
`provider_bindings` (`binding_id INTEGER PRIMARY KEY REFERENCES
provider_bindings (id)`), foreign keys are enforced on every connection, and
the row is written by a binding's own poll loop at
`internal/app/bindings.go:277` — and a failure writes the same row through
`RecordProviderFailure`, so this is every instance that ever ran, not only the
ones that reached their provider. Reproduced on a seeded database:

```text
PurgeEverything with a contact row: constraint failed: FOREIGN KEY constraint failed (787)
```

The consequence is worse than one table surviving. `PurgeBindings` is not the
last statement: `PurgeCacheLanes` and `PurgeCacheProjects` are ordered after
it, and the abort means they never run — so the lane rows the CHANGELOG
promises uninstall removes are left behind too, each holding a `leased_by`
naming a lease that no longer exists. And the whole thing happens *after* the
Docker objects are removed and the scale sets deleted, which is the point
past which nothing can be retried: the operator is left with a half-removed
instance and a state database no supported command will clear.
`ForgetUnclaimedBindings` at `internal/store/serving.go:611` already deletes
both child tables, so the correct shape existed in the same package.

I enumerated every table rather than fixing the one. Of the fourteen in the
schema, `provider_binding_contact` was the only child of a purged parent that
was missing. `resource_intents` references `capsule_leases` and is already
deleted first; `audit_log` has no foreign key at all; `pressure` is a single
row (`CHECK (id = 1)`) whose retention preserves the disk hysteresis across a
restart. `meta` is not merely deliberate but required: it holds the schema
fingerprint, and a database whose `meta` was cleared fails `Open` permanently
with "written from different migrations", which would brick a retained state
volume. Those three staying is unchanged.

**The durability suite qualified a copy of the connection string.**
`test/contract/sqlite/contract_test.go` defined its own `dsn()`,
byte-identical to `internal/store/open.go`'s, and opened its connections with
it. So `TestPragmas` asserted the pragmas of the test's own string. The
production comment claimed the opposite — "the connection contract the
durability suite in test/contract/sqlite qualifies" — which was the one thing
it was not. Measured after pointing the suite at the product's declaration,
each mutation applied to the product alone:

```text
busy_timeout(10000) -> busy_timeout(500)     FAIL  busy_timeout = 500; want 10000
journal_mode(wal)   -> journal_mode(delete)  FAIL  journal_mode = "delete"; want wal
foreign_keys(1)     -> foreign_keys(0)       FAIL  foreign_keys = 0; want 1
                                             FAIL  orphan insert error = <nil>; want FOREIGN KEY violation
```

Before this, all four of those passed.

One pragma remains invisible to this route, and it is the one worth naming
because it is the reason the durability suite exists: **removing
`synchronous(full)` changes nothing observable**, because the driver already
returns 2. Measured directly — a connection with no `synchronous` pragma, one
with `synchronous(full)`, and one with no pragmas at all all report
`synchronous = 2`. Setting it explicitly to `off` does fail the suite. So the
guarantee would rest on a default a later driver is free to change, which is
why the string itself now asserts the pragma is present.

**The startup pass that forgets unclaimed bindings deletes the same parent**
and kept its own list of children by hand, at `internal/store/serving.go:610`.
It runs on every controller start, not once at the end of an instance's life,
and removing an entry from that list passed the whole suite. The two lists are
now one declaration, and the rule reaches it.

Something that looked like a third item and is not. `RecentReleasedLeases`
binds the state as a parameter where the retention query writes it as a
literal, which looked like it would cost the partial index. It does not:
`EXPLAIN QUERY PLAN` gives `SEARCH capsule_leases USING INDEX
capsule_leases_released_by_age (state=?)` for both forms, identically. The
`USE TEMP B-TREE FOR LAST TERM OF ORDER BY` both also carry is the `id`
tie-break, not a sort of the history. Nothing to change.

## Evidence

Hermetic. The uninstall failure and the plans above were reproduced in-process
against a migrated database; the pragma mutations ran the gated durability
suite with `RUNPOOL_SQLITE_CONTRACT_DIR` set, which is how
`scripts/contracts/sqlite.sh` runs it.

Each mutation was applied alone, and the harness asserts its pattern matched
exactly once before running — one attempt matched two sites (`foreign_keys(1)`
appears in `readOnlyDSN` too) and was refused rather than silently measuring
the wrong thing.

```text
MUTATION A: PurgeEverything stops running the contact delete
--- FAIL: TestUninstallClearsABindingThatReachedItsProvider
    uninstall failed on a binding that had reached its provider:
    constraint failed: FOREIGN KEY constraint failed (787)
--- FAIL: TestUninstallReachesEveryChildOfWhatItDeletes
    query/purge.sql declares PurgeBindingContact and PurgeEverything never
    runs it; the statement exists and the table it clears does not get cleared

MUTATION B: the delete is declared, but ordered after its parent
--- FAIL: TestUninstallReachesEveryChildOfWhatItDeletes
    uninstall deletes provider_bindings before provider_binding_contact,
    which references it; the parent's delete fails and nothing after it runs

MUTATION C: the child table is never declared at all
--- FAIL: TestUninstallReachesEveryChildOfWhatItDeletes
    uninstall deletes provider_bindings but never deletes
    provider_binding_contact, which references it; the foreign key fails the
    delete and the whole uninstall aborts
```

The full local gate set mirroring `ci.yml` is green.

## What would notice this regressing

- `TestUninstallClearsABindingThatReachedItsProvider` — seeds the contact row
  the poll loop writes, purges, and requires both tables empty. Fails with the
  actual foreign key error if the delete stops running. It is the narrow case;
  the two below are the rule.
- `TestUninstallClearsEveryTableItOwns` — a row in every table an instance
  writes, the purge run against it, and the requirement that it finished and
  left nothing behind. It watches the database rather than reading the
  statements, which is what makes it total: a step that clears only some of
  its rows, one that names its table in a spelling the schema does not use,
  one declared in a form the generator emits differently, or a sequence that
  runs in an order the source does not show all arrive at one of two
  observations — a foreign key refuses a parent whose child is still there,
  or a table asserted empty is not. The seed has to keep up with the schema:
  a table nothing writes to fails this test rather than being skipped by it,
  and one of the rows it writes is the shape a narrowed delete would pass
  over.
- `TestEveryPurgeStatementIsTotal` — uninstall names the whole instance, so
  each of its deletes takes a whole table. It reads the generated statements
  rather than the queries behind them, because those are what run.
- `TestForgettingABindingReachesEveryChildOfIt` — the startup pass deletes the
  same parent and now shares one declaration of its children with uninstall.
  Every table referencing a binding must be either cleared before it or
  excluded with a stated reason; `broker_deliveries` and `capsule_leases` are
  the two exclusions. Deliveries are excluded by the pass's own query.
  Leases are excluded on a narrower footing, stated in full because the
  schema does not hold it: a lease references its binding and its attempt
  independently, so a row naming a delivery-free binding is accepted and
  the pass would fail on every controller start. One call site keeps that
  from arising — attempts are read for a binding and leased under that same
  binding — where `assignment_attempts` carries a composite reference
  instead. An excused table must also reference a binding at all, or the
  reason given is about something never in the way.
- `TestTheConnectionStringStillAsksForFullSynchronous` — the one pragma the
  durability suite cannot see, asserted on the string instead of on a
  connection.
- `TestPragmas` in `test/contract/sqlite` now fails on a change to the
  product's own connection string, which is what it was written to do. It is
  gated on `RUNPOOL_SQLITE_CONTRACT_DIR` and runs in the `sqlite durability`
  workflow.

## Risk, compatibility and operations

**Data.** One additional `DELETE FROM provider_binding_contact` inside the
uninstall transaction, ordered before its parent. Nothing else deletes more
than it did; no path outside uninstall is touched. An operator whose previous
uninstall aborted can now run it again and have it complete.

**Trust boundary, credentials, networking, resource limits.** N/A — this is a
delete ordering inside one transaction and a shared function declaration. No
process boundary, no credential, no socket, no limit is involved.

**Failure behaviour.** Unchanged. The purge is one transaction and still is;
if any statement fails the whole thing rolls back, which is what made the
missing delete visible as a stuck uninstall rather than as silent data loss.

**Schema and migration.** None. `provider_binding_contact` already exists;
this only deletes from it. No migration, no fingerprint change — `sqlc diff`
is clean and the schema snapshot is untouched.

**CLI, configuration, status API, deployment, rollback.** No flag, key, field
or command changes. `store.DSN` is a rename of an unexported function to an
exported one, consumed by the contract suite; nothing outside the module can
reach `internal/store`.

**Runbook.** Worth knowing, and stated in the changelog entry: an uninstall
that previously aborted left the instance half-removed. Re-running it now
completes.

**Decision record.** No new ADR. `2026-08-11-sqlite-driver.md` already names
the durability suite as what qualifies the connection contract; this makes
that literally true rather than true of a copy. Exporting `DSN` is what the
ADR's claim requires, so the ADR is unamended.

## Changelog

```text
### Lifecycle

- **Uninstall clears the whole machine, including what an instance
  learned about its provider.** It runs once, after the containers and
  the scale sets are already gone, so a row left behind is not a
  cosmetic leftover: a child table its foreign key still points at fails
  the delete of its parent and aborts the rest, leaving a half-removed
  instance and a database no supported command will clear. Which tables
  are children is now read from the database rather than kept in a list
  by hand, so one added later is covered without anyone remembering.
- **The durability configuration the release qualifies is the one the
  product opens with.** The suite and the store share a single
  connection string rather than each holding a copy, so a pragma changed
  in the product is a pragma the qualification sees.
```

## Notes for your reviewer

The rule was reconstructed from source text through three shapes before this
one, and each shape could be right about a product that was wrong: it read the
order from the query file rather than the sequence that executes; it then
ranked steps by a count of tables reached rather than by position, so a table
mentioned twice outranked its own child; and it modelled a step as a table,
which has no way to notice a statement that is not total. It now watches the
database instead, and the only thing still read from text is whether a
generated delete carries a `WHERE`.

Deliberately not done here, and it is a real gap rather than a judgement I am
comfortable with: `capsule_leases` carries `binding_id` and `attempt_id` as
two independent references, so the schema accepts a lease whose binding is not
its attempt's binding. `assignment_attempts` is protected against exactly this
with `FOREIGN KEY (delivery_id, binding_id) REFERENCES broker_deliveries (id,
binding_id)`. Closing it on `capsule_leases` is a migration and a fingerprint
change, and it touches lease creation, so it wants its own qualification
rather than riding along here. Until then the invariant rests on one call
site, and the exclusion comment says so.

The thing I would look at first is where the rule test gets its order from.
It parses the slice literal `PurgeEverything` walks rather than reading the
query file, because the query file declares statements and the literal runs
them; reading the file instead let a step move in the Go code with everything
still green. The remaining coupling is the name-to-table map, which does come
from the query file — and a name whose table cannot be read fails rather than
being skipped, which is the case I would attack next.

Also worth a look: whether `audit_log`, `pressure` and `meta` staying out of
the purge is right. `meta` in particular is not optional — clearing it makes
`Open` refuse the database permanently — and the test deliberately does not
enforce any of it, since a table with no foreign key to a purged parent is
outside the rule.

Deliberately left alone: the four tables that grow without bound across an
instance's life. That is a retention question rather than an uninstall one and
belongs with the pruning work.
