### PR TITLE
fix(capsule): a capsule says when it has accepted a start, and only `waiting` requeues an assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ by its public and operational effects.
   would put the assignment back in the queue while the capsule was
   handing it to a runner, and it would run twice. The controller now
   holds such an attempt for a person, because at that moment neither
-  answer is available.
+  answer is available — and an authorization that could not be written at
+  all says so, so an assignment nothing ever started is still simply
+  served again.
 - Under the restricted network profile a capsule has **no route out**.
   Its only egress is a per-capsule gateway that resolves and connects
   on its behalf under a default-deny policy, which is also the DNS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ by its public and operational effects.
   once the job's own Docker daemon is up, so readiness is something the
   capsule proves rather than something it announces on the way to
   proving it.
+- **An assignment is requeued only on proof that no runner ever
+  started.** A capsule that has accepted a start authorization says so
+  before the authorization lands, and keeps saying it until the runner is
+  forked or the attempt is abandoned. Without that the whole preamble —
+  reading the credential bundle, materializing it, removing it, forking —
+  answered with the same state as a capsule holding an unstarted runner,
+  so an authorization whose call returned an error after taking effect
+  would put the assignment back in the queue while the capsule was
+  handing it to a runner, and it would run twice. The controller now
+  holds such an attempt for a person, because at that moment neither
+  answer is available.
 - Under the restricted network profile a capsule has **no route out**.
   Its only egress is a per-capsule gateway that resolves and connects
   on its behalf under a default-deny policy, which is also the DNS

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -9,12 +9,15 @@
 // The control surface is the filesystem under /run/runpool, all tmpfs:
 //
 //	protocol   written at boot, before any state: the protocol version
-//	state      booting | waiting | running | exited:<code>
+//	state      booting | waiting | starting | running | exited:<code>
 //	           | failed:<reason> | aborted:<reason>
 //	           `booting` is the control surface answering before the
 //	           daemon is proven; `waiting` is written only once dockerd
 //	           answers, because it is the state on which the launcher
-//	           delivers a credential and authorizes a start.
+//	           delivers a credential and authorizes a start; `starting`
+//	           is that authorization accepted and the runner not yet
+//	           forked, which is the only stretch in which neither answer
+//	           is available.
 //	           `aborted` is a failure before the runner started, so the job
 //	           was never handed over and must be retried; `failed` is a
 //	           failure after it started, which is an execution outcome.
@@ -125,8 +128,7 @@ func runSubcommand(args []string) int {
 		// Writing it here rather than in PID 1 is what keeps the other
 		// direction true: an authorization that never landed leaves
 		// `waiting` behind, and that assignment is still retried.
-		setState(protocol.StateStarting)
-		if err := atomicfile.Replace(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
+		if err := authorizeStart(stateFile, startFile, atomicfile.Replace); err != nil {
 			fmt.Fprintln(os.Stderr, "start:", err)
 			return 1
 		}
@@ -608,6 +610,37 @@ func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int)
 		links = append(links, link)
 	}
 	return cleanup, nil
+}
+
+// authorizeStart records the authorization and then lands it, in that
+// order.
+//
+// PID 1 does not learn of an authorization until it polls for the file,
+// and it writes nothing of its own until fork/exec has returned, so
+// between those two moments the capsule answers with whatever state was
+// last written. Left at `waiting`, that reads as proof no runner ever
+// started, and an authorization whose exec landed but whose call failed
+// requeues an assignment this capsule is already starting a runner for.
+//
+// A file that does not land undoes the record. This is the one place
+// that knows nothing took effect -- PID 1 is still waiting for a file
+// that will never appear -- and it is the likely shape of a full control
+// tmpfs rather than a remote one, because the replacement below needs an
+// inode that the state's own in-place fallback does not. Left saying
+// `starting`, an assignment that could simply be served again would be
+// held for a person instead.
+//
+// replace is a parameter for the same reason replaceState takes one: the
+// order of these writes, and the undo, are what this does, and neither
+// is observable through a control directory a test cannot create.
+func authorizeStart(statePath, startPath string,
+	replace func(string, []byte, os.FileMode, int, int) error) error {
+	replaceState(statePath, protocol.StateStarting, replace)
+	if err := replace(startPath, []byte(protocolVersion), 0o600, -1, -1); err != nil {
+		replaceState(statePath, protocol.StateWaiting, replace)
+		return err
+	}
+	return nil
 }
 
 // replaceState records the supervisor's own account of itself, and

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -128,7 +128,7 @@ func runSubcommand(args []string) int {
 		// Writing it here rather than in PID 1 is what keeps the other
 		// direction true: an authorization that never landed leaves
 		// `waiting` behind, and that assignment is still retried.
-		if err := authorizeStart(stateFile, startFile, atomicfile.Replace); err != nil {
+		if err := authorizeStart(atomicfile.Replace); err != nil {
 			fmt.Fprintln(os.Stderr, "start:", err)
 			return 1
 		}
@@ -625,19 +625,38 @@ func prepareRunnerConfig(encoded, runnerRoot, volatileRoot string, uid, gid int)
 // A file that does not land undoes the record. This is the one place
 // that knows nothing took effect -- PID 1 is still waiting for a file
 // that will never appear -- and it is the likely shape of a full control
-// tmpfs rather than a remote one, because the replacement below needs an
-// inode that the state's own in-place fallback does not. Left saying
-// `starting`, an assignment that could simply be served again would be
-// held for a person instead.
+// tmpfs rather than a remote one. On a full one the temporary file is
+// still created; what fails is writing the bytes into it. The state gets
+// through anyway because its fallback truncates the file already there,
+// which frees the page the old value held and leaves room for the new
+// one, where the authorization has no old value to reclaim. So the write
+// that fails is the authorization and the write that succeeds is the
+// record. Left saying `starting`, an assignment that could simply be
+// served again would be held for a person instead.
 //
-// replace is a parameter for the same reason replaceState takes one: the
-// order of these writes, and the undo, are what this does, and neither
-// is observable through a control directory a test cannot create.
-func authorizeStart(statePath, startPath string,
-	replace func(string, []byte, os.FileMode, int, int) error) error {
-	replaceState(statePath, protocol.StateStarting, replace)
-	if err := replace(startPath, []byte(protocolVersion), 0o600, -1, -1); err != nil {
-		replaceState(statePath, protocol.StateWaiting, replace)
+// It names the two files itself. They were parameters until it became
+// clear what that costs: two adjacent strings, and one call site passing
+// two constants a letter apart. Exchanged, it writes the protocol
+// version into the state and the word `starting` into the authorization
+// -- and the in-place fallback creates the file it cannot fill, so the
+// capsule ends up saying `waiting` with a start file present. PID 1
+// forks the runner and the launcher requeues, which is the double
+// execution this exists to stop, arrived at through the thing that stops
+// it. Nothing about the swap is visible to a compiler or to a capsule
+// running against a real daemon.
+//
+// What is a parameter is the writer, for the same reason replaceState
+// takes one: the order of these writes and the undo are what this does,
+// and neither is observable through a control directory a test cannot
+// create.
+//
+// One authorization per capsule. It writes over whatever state is there,
+// so a second one against a running capsule would say `waiting` while a
+// runner holds the job.
+func authorizeStart(replace func(string, []byte, os.FileMode, int, int) error) error {
+	replaceState(stateFile, protocol.StateStarting, replace)
+	if err := replace(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
+		replaceState(stateFile, protocol.StateWaiting, replace)
 		return err
 	}
 	return nil

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -114,6 +114,18 @@ func runSubcommand(args []string) int {
 		}
 		return 0
 	case "start":
+		// The state goes first. PID 1 does not learn of an authorization
+		// until it polls for the file below, and it writes nothing of its
+		// own until fork/exec has returned, so between those two moments
+		// the capsule would answer `waiting` -- which a launcher reads as
+		// proof that no runner ever started. An authorization whose exec
+		// landed but whose call returned an error would then requeue an
+		// assignment this capsule is already starting a runner for.
+		//
+		// Writing it here rather than in PID 1 is what keeps the other
+		// direction true: an authorization that never landed leaves
+		// `waiting` behind, and that assignment is still retried.
+		setState(protocol.StateStarting)
 		if err := atomicfile.Replace(startFile, []byte(protocolVersion), 0o600, -1, -1); err != nil {
 			fmt.Fprintln(os.Stderr, "start:", err)
 			return 1

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -5,11 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +96,7 @@ func TestPrepareRunnerConfigRejectsPathsAndCollisions(t *testing.T) {
 func TestTerminalFailureDistinguishesUnstartedRunners(t *testing.T) {
 	err := errors.New("no credential was delivered")
 
-	for _, state := range []string{"", "waiting"} {
+	for _, state := range []string{"", "waiting", "starting"} {
 		if got := terminalFailure(state, err); !strings.HasPrefix(got, "aborted:") {
 			t.Errorf("failure from state %q = %q; want an aborted state", state, got)
 		}
@@ -356,57 +358,95 @@ func TestEveryFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
 // ever started: an authorization whose exec landed but whose call
 // returned an error requeues an assignment this capsule is at that
 // moment starting a runner for.
-//
-// The order is what carries it, so the order is what is checked. It
-// cannot be reached without the control directory this runs against, so
-// it is read out of the source instead.
 func TestTheStartAuthorizationRecordsItselfBeforeItLands(t *testing.T) {
-	file, err := parser.ParseFile(token.NewFileSet(), "main.go", nil, 0)
+	var wrote []string
+	record := func(path string, body []byte, _ os.FileMode, _, _ int) error {
+		wrote = append(wrote, filepath.Base(path)+"="+string(body))
+		return nil
+	}
+	if err := authorizeStart("/c/state", "/c/start", record); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"state=" + protocol.StateStarting, "start=" + protocolVersion}
+	if !slices.Equal(wrote, want) {
+		t.Errorf("the authorization wrote %v; want %v.\nUntil the state is recorded the capsule "+
+			"answers `waiting`, which is read as proof that no runner ever started.", wrote, want)
+	}
+}
+
+// TestAnAuthorizationThatCannotLandSaysSo: a file that never appears
+// leaves the state where an assignment can still be served again.
+//
+// This is the one place that knows nothing took effect, and it is the
+// likely shape of a full control tmpfs rather than a remote one: the
+// start file needs a fresh inode, and the state's own in-place fallback
+// does not. Left saying `starting`, an assignment that could simply be
+// requeued is held for a person instead.
+func TestAnAuthorizationThatCannotLandSaysSo(t *testing.T) {
+	full := errors.New("no space left on device")
+	var wrote []string
+	record := func(path string, body []byte, _ os.FileMode, _, _ int) error {
+		if filepath.Base(path) == "start" {
+			return full
+		}
+		wrote = append(wrote, string(body))
+		return nil
+	}
+	if err := authorizeStart("/c/state", "/c/start", record); !errors.Is(err, full) {
+		t.Fatalf("authorize returned %v; want the write's own failure", err)
+	}
+	if len(wrote) == 0 || wrote[len(wrote)-1] != protocol.StateWaiting {
+		t.Errorf("the capsule was left saying %v after an authorization that never landed; "+
+			"it has to say the state a launcher requeues from", wrote)
+	}
+}
+
+// TestTheStartSubcommandAuthorizesThroughTheOrderedPath: the two
+// properties above belong to authorizeStart, so the verb has to go
+// through it.
+//
+// Writing the start file from the clause directly is a working
+// authorization with none of the ordering: the capsule answers `waiting`
+// for the whole preamble again, and nothing else would notice, because
+// the function keeps its own tests either way.
+func TestTheStartSubcommandAuthorizesThroughTheOrderedPath(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var clause *ast.CaseClause
-	ast.Inspect(file, func(n ast.Node) bool {
-		c, ok := n.(*ast.CaseClause)
-		if !ok {
-			return true
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "runSubcommand" {
+			continue
 		}
-		for _, expr := range c.List {
-			if lit, ok := expr.(*ast.BasicLit); ok && lit.Value == `"start"` {
-				clause = c
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			c, ok := n.(*ast.CaseClause)
+			if !ok || clause != nil {
+				return true
 			}
-		}
-		return true
-	})
-	if clause == nil {
-		t.Fatal("no `start` subcommand found; this checks the order of something that is not there")
-	}
-
-	recorded, landed := -1, -1
-	for i, stmt := range clause.Body {
-		ast.Inspect(stmt, func(n ast.Node) bool {
-			switch node := n.(type) {
-			case *ast.CallExpr:
-				if id, ok := node.Fun.(*ast.Ident); ok && id.Name == "setState" && recorded < 0 {
-					recorded = i
-				}
-			case *ast.Ident:
-				if node.Name == "startFile" && landed < 0 {
-					landed = i
+			for _, expr := range c.List {
+				if lit, ok := expr.(*ast.BasicLit); ok && lit.Value == `"start"` {
+					clause = c
 				}
 			}
 			return true
 		})
 	}
-	switch {
-	case recorded < 0:
-		t.Error("the start authorization records no state of its own, so the capsule answers " +
-			"`waiting` for the whole preamble and an assignment already being started is requeued")
-	case landed < 0:
-		t.Error("the start authorization writes no start file; nothing would ever launch a runner")
-	case recorded > landed:
-		t.Errorf("the start authorization writes its file at statement %d and records its state "+
-			"at %d; between the two the capsule answers `waiting`, which is read as proof that "+
-			"no runner ever started", landed, recorded)
+	if clause == nil {
+		t.Fatal("no `start` subcommand in the dispatcher; there is nothing here to authorize with")
+	}
+	authorizes := false
+	ast.Inspect(clause, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == "authorizeStart" {
+			authorizes = true
+		}
+		return true
+	})
+	if !authorizes {
+		t.Errorf("%s: the start subcommand does not authorize through authorizeStart, so the "+
+			"order of the state and the file, and the undo when the file cannot land, are "+
+			"whatever this clause happens to do", fset.Position(clause.Pos()))
 	}
 }

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -345,3 +345,68 @@ func TestEveryFileIsWrittenThroughTheAtomicHelper(t *testing.T) {
 		t.Error("no file-creating call found at all; this test asserted nothing")
 	}
 }
+
+// TestTheStartAuthorizationRecordsItselfBeforeItLands: the state is
+// written before the file that carries the authorization.
+//
+// PID 1 learns of an authorization only by polling for that file, and it
+// writes nothing of its own until fork/exec has returned. Between those
+// two moments the capsule answers with whatever state was last written,
+// and if that is still `waiting` a launcher reads it as proof no runner
+// ever started: an authorization whose exec landed but whose call
+// returned an error requeues an assignment this capsule is at that
+// moment starting a runner for.
+//
+// The order is what carries it, so the order is what is checked. It
+// cannot be reached without the control directory this runs against, so
+// it is read out of the source instead.
+func TestTheStartAuthorizationRecordsItselfBeforeItLands(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "main.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var clause *ast.CaseClause
+	ast.Inspect(file, func(n ast.Node) bool {
+		c, ok := n.(*ast.CaseClause)
+		if !ok {
+			return true
+		}
+		for _, expr := range c.List {
+			if lit, ok := expr.(*ast.BasicLit); ok && lit.Value == `"start"` {
+				clause = c
+			}
+		}
+		return true
+	})
+	if clause == nil {
+		t.Fatal("no `start` subcommand found; this checks the order of something that is not there")
+	}
+
+	recorded, landed := -1, -1
+	for i, stmt := range clause.Body {
+		ast.Inspect(stmt, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CallExpr:
+				if id, ok := node.Fun.(*ast.Ident); ok && id.Name == "setState" && recorded < 0 {
+					recorded = i
+				}
+			case *ast.Ident:
+				if node.Name == "startFile" && landed < 0 {
+					landed = i
+				}
+			}
+			return true
+		})
+	}
+	switch {
+	case recorded < 0:
+		t.Error("the start authorization records no state of its own, so the capsule answers " +
+			"`waiting` for the whole preamble and an assignment already being started is requeued")
+	case landed < 0:
+		t.Error("the start authorization writes no start file; nothing would ever launch a runner")
+	case recorded > landed:
+		t.Errorf("the start authorization writes its file at statement %d and records its state "+
+			"at %d; between the two the capsule answers `waiting`, which is read as proof that "+
+			"no runner ever started", landed, recorded)
+	}
+}

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -364,7 +364,7 @@ func TestTheStartAuthorizationRecordsItselfBeforeItLands(t *testing.T) {
 		wrote = append(wrote, filepath.Base(path)+"="+string(body))
 		return nil
 	}
-	if err := authorizeStart("/c/state", "/c/start", record); err != nil {
+	if err := authorizeStart(record); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{"state=" + protocol.StateStarting, "start=" + protocolVersion}
@@ -378,10 +378,11 @@ func TestTheStartAuthorizationRecordsItselfBeforeItLands(t *testing.T) {
 // leaves the state where an assignment can still be served again.
 //
 // This is the one place that knows nothing took effect, and it is the
-// likely shape of a full control tmpfs rather than a remote one: the
-// start file needs a fresh inode, and the state's own in-place fallback
-// does not. Left saying `starting`, an assignment that could simply be
-// requeued is held for a person instead.
+// likely shape of a full control tmpfs rather than a remote one: on a
+// full one the state's fallback truncates the file already there and
+// writes into the page that frees, where the authorization has no old
+// value to reclaim. Left saying `starting`, an assignment that could
+// simply be requeued is held for a person instead.
 func TestAnAuthorizationThatCannotLandSaysSo(t *testing.T) {
 	full := errors.New("no space left on device")
 	var wrote []string
@@ -392,7 +393,7 @@ func TestAnAuthorizationThatCannotLandSaysSo(t *testing.T) {
 		wrote = append(wrote, string(body))
 		return nil
 	}
-	if err := authorizeStart("/c/state", "/c/start", record); !errors.Is(err, full) {
+	if err := authorizeStart(record); !errors.Is(err, full) {
 		t.Fatalf("authorize returned %v; want the write's own failure", err)
 	}
 	if len(wrote) == 0 || wrote[len(wrote)-1] != protocol.StateWaiting {
@@ -437,10 +438,22 @@ func TestTheStartSubcommandAuthorizesThroughTheOrderedPath(t *testing.T) {
 	if clause == nil {
 		t.Fatal("no `start` subcommand in the dispatcher; there is nothing here to authorize with")
 	}
-	authorizes := false
+	authorizes, writesTheFileItself := false, false
 	ast.Inspect(clause, func(n ast.Node) bool {
-		if id, ok := n.(*ast.Ident); ok && id.Name == "authorizeStart" {
+		id, ok := n.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		switch id.Name {
+		case "authorizeStart":
 			authorizes = true
+		case "startFile", "stateFile":
+			// The authorization owns both names. A clause that still
+			// reaches for one is writing the control surface beside the
+			// function that orders those writes -- which is how a call
+			// left in a branch nothing takes reads as authorizing while
+			// the line below it does the real work, unordered.
+			writesTheFileItself = true
 		}
 		return true
 	})
@@ -448,5 +461,10 @@ func TestTheStartSubcommandAuthorizesThroughTheOrderedPath(t *testing.T) {
 		t.Errorf("%s: the start subcommand does not authorize through authorizeStart, so the "+
 			"order of the state and the file, and the undo when the file cannot land, are "+
 			"whatever this clause happens to do", fset.Position(clause.Pos()))
+	}
+	if writesTheFileItself {
+		t.Errorf("%s: the start subcommand names the control files itself. Whatever it does with "+
+			"them is outside the order authorizeStart exists to keep, and a call to it can sit "+
+			"beside that and prove nothing", fset.Position(clause.Pos()))
 	}
 }

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -60,10 +60,22 @@ func ClassifyExit(code int) assignment.ExecutionObservation {
 // writes `running` once fork/exec has returned, so `aborted` means the job was
 // never handed over and `failed` means it was. Collapsing the two settles an
 // attempt that never ran as complete, and nothing requeues it.
+//
+// `waiting` and `starting` are the same distinction one step earlier. Only
+// `waiting` proves an authorization never took effect; `starting` says one
+// did and its outcome is not yet knowable, which is not something to guess
+// at when guessing wrong runs a job twice.
 func classifySupervisorState(state string) (assignment.ExecutionObservation, error) {
 	switch {
 	case state == protocol.StateBooting, state == protocol.StateWaiting:
 		return assignment.ObservedCreated, nil
+	case state == protocol.StateStarting:
+		// The authorization landed and the runner is not yet forked, so
+		// neither answer is available: it did not never start, and it has
+		// not started. Reporting it as unavailable is what holds the
+		// assignment for a person instead of requeueing one the capsule
+		// is at that moment handing to a runner.
+		return assignment.ObservedUnavailable, nil
 	case state == protocol.StateRunning:
 		return assignment.ObservedRunning, nil
 	case strings.HasPrefix(state, protocol.AbortedPrefix):

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -17,8 +17,9 @@ import (
 // it — a job GitHub handed over, that never ran, and that nobody retries.
 func TestClassifySupervisorStateSeparatesAbortFromExit(t *testing.T) {
 	for state, want := range map[string]assignment.ExecutionObservation{
-		"waiting": assignment.ObservedCreated,
-		"running": assignment.ObservedRunning,
+		"waiting":  assignment.ObservedCreated,
+		"starting": assignment.ObservedUnavailable,
+		"running":  assignment.ObservedRunning,
 		"aborted:start authorized but no credential": assignment.ObservedCreated,
 		"aborted:prepare volatile runner config":     assignment.ObservedCreated,
 		"exited:0":                                   assignment.ObservedExited,
@@ -152,5 +153,39 @@ func TestAwaitStateGivesUpOnEveryTerminalState(t *testing.T) {
 				t.Errorf("error = %q, want it to contain %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestOnlyWaitingProvesTheRunnerNeverStarted: the launcher requeues an
+// assignment on exactly one answer, so no other state may reach it.
+//
+// `starting` is the near miss. It sits between an authorization landing
+// and fork/exec returning, and for that stretch the capsule genuinely
+// cannot say whether the job was handed over. Classifying it with
+// `waiting` reads "not yet" as "never", and the assignment is served a
+// second time while the first capsule starts its runner.
+func TestOnlyWaitingProvesTheRunnerNeverStarted(t *testing.T) {
+	requeues := map[string]bool{}
+	for _, state := range []string{
+		protocol.StateBooting, protocol.StateWaiting, protocol.StateStarting,
+		protocol.StateRunning, protocol.AbortedPrefix + "no credential",
+		protocol.ExitedPrefix + "0", protocol.FailedPrefix + "drained",
+	} {
+		obs, err := classifySupervisorState(state)
+		if err != nil {
+			t.Fatalf("state %q: %v", state, err)
+		}
+		requeues[state] = obs == assignment.ObservedCreated
+	}
+	if requeues[protocol.StateStarting] {
+		t.Error("a capsule that has accepted a start authorization is classified as one that " +
+			"never started; the assignment is requeued while the runner is being forked")
+	}
+	for _, proves := range []string{protocol.StateBooting, protocol.StateWaiting,
+		protocol.AbortedPrefix + "no credential"} {
+		if !requeues[proves] {
+			t.Errorf("state %q no longer requeues; a job that was never handed over is left "+
+				"for a person or settled as though it ran", proves)
+		}
 	}
 }

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -26,10 +26,17 @@ import "strings"
 // Version 2 moved when StateWaiting is written. A version 1 supervisor
 // wrote it at boot, ahead of its daemon, so a launcher that treats the
 // state as readiness would deliver a credential and authorize a start
-// against a capsule whose daemon may never come up. The two builds are
-// not interchangeable in either direction, which is what the equality
-// check enforces.
-const Version = "2"
+// against a capsule whose daemon may never come up.
+//
+// Version 3 separates StateStarting from StateWaiting. A version 2
+// supervisor answers `waiting` for the whole start preamble, which a
+// launcher reads as proof the runner never started, so an authorization
+// whose exec landed but whose call failed would requeue an assignment
+// the capsule was already forking a runner for.
+//
+// The builds are not interchangeable in either direction, which is what
+// the equality check enforces.
+const Version = "3"
 
 // The states a supervisor-family container writes to its control
 // directory. The capsule's supervisor and the gateway are the same
@@ -54,6 +61,22 @@ const (
 	// it. The distinction this state carries is the difference between
 	// a job retried and a job silently gone.
 	StateRunning = "running"
+	// StateStarting is the start authorization accepted and the runner
+	// not yet forked: the bundle is being read, its files materialized,
+	// the credential removed, and fork/exec attempted.
+	//
+	// Without it that whole stretch reads as `waiting`, and `waiting` is
+	// the proof a launcher uses to say the runner never started. An
+	// authorization whose exec landed but whose call returned an error
+	// would be answered with `waiting` while the supervisor was forking
+	// the runner, so the assignment would be requeued and served a second
+	// time while the first one ran. It is written by the authorization
+	// itself, before the file that carries it, so an authorization that
+	// never landed still leaves `waiting` behind and is still retried.
+	//
+	// It settles on its own: the next state is `running` if fork/exec
+	// returned, and an abort if it did not.
+	StateStarting = "starting"
 	// StateReady is the gateway's: ruleset installed and relay listening.
 	StateReady = "ready"
 )


### PR DESCRIPTION
## What changes

The capsule control vocabulary gains a state for "a start authorization has
been accepted and the runner is not yet forked". The authorization writes it
before it writes the file that carries it. The launcher reports that state as
unobservable rather than as proof the runner never started, so an assignment
is requeued only on the one answer that proves it. The protocol version moves
from 2 to 3.

## What was found

**The supervisor wrote nothing for the whole start preamble.** `case "start"`
wrote the start file and returned; `awaitStart` polls for that file every
200 ms, and nothing writes a new state until after fork/exec returns
(`cmd/capsule-supervisor/main.go`, the `setState(protocol.StateRunning)` that
follows `reap.start`). Between the authorization landing and the runner
existing, the capsule therefore answered `waiting` — the state
`classifySupervisorState` maps to `ObservedCreated`, which `runtime.go` reads
as *"the runtime was never started; the assignment stays servable"* and
requeues.

That stretch is reachable. `docker exec` starts the command at `ExecAttach`
and can still return an error afterwards from `demux` or `ExecInspect`, so
`caps.Start` can fail with the exec already running. The launcher then
observes the capsule to decide what happened, reads `waiting`, requeues, and
`RemoveResources` races the runner's registration with the provider. The
requeued attempt is served by a second capsule while the first one runs the
job. That is the double-execution path, and nothing in the vocabulary could
express the difference: `classifySupervisorState` had no state between
`waiting` and `running`, and the existing tests hard-code `"waiting":
ObservedCreated`, so the case was unmodelled rather than mis-modelled.

**Recording the acceptance is only half of it.** If the record lands and the
file does not, the capsule says it accepted an authorization that never took
effect — PID 1 is still waiting for a file that will never appear — and the
launcher holds for a person an assignment it could simply serve again. Before
the record existed, that same case read as `waiting` and was requeued
automatically, so this half of the change makes one case worse unless the
record is undone.

It is also the likely shape of a full control tmpfs rather than a remote one,
measured on the product's own mount (`rw,size=1m`): the temporary file is
still created, and what fails is writing the bytes into it. The state gets
through anyway because `replaceState` falls back to a write that truncates the
file already there, freeing the page the old value held, where the
authorization has no old value to reclaim. So the write that fails is the
authorization and the write that succeeds is the record. The authorization
undoes its record when the file cannot land, which is the one place that knows
nothing took effect.

**Why the ordering carries it, and why it is in the authorization rather than
in PID 1.** PID 1 learns of an authorization only by polling for the start
file, so a state written by PID 1 after it notices would leave the same gap,
only narrower. Writing it in the authorization, before the file, closes it
from the first moment. It also keeps the other direction true: an
authorization that never landed writes neither the state nor the file, so it
still leaves `waiting` behind and that assignment is still retried — which is
the case the requeue exists for.

**Why unobservable rather than running.** During the preamble the outcome is
genuinely unknown: the state settles to `running` if fork/exec returns and to
an abort if it does not. Reporting it as running would settle an attempt whose
runner may never have existed; reporting it as created is the defect above.
`ObservedUnavailable` routes through the branch `runtime.go` already has for
an unprovable outcome, which holds the attempt for a person. A bounded re-poll
would resolve most of these automatically and was deliberately not added: it
would put load-bearing logic in a call site no test can reach without a
daemon, to save an operator a rare notification about a genuinely ambiguous
outcome.

**The version moves because the meaning of `waiting` narrowed.** A version 2
supervisor answers `waiting` through the same stretch. The launcher's check is
equality, so the pairing is refused rather than misread; without the bump a
version 2 capsule would be accepted by a launcher that now trusts `waiting`
to mean something it does not.

## Evidence

Hermetic, plus the live capsule contract in CI. The whole supervisor
lifecycle — prepare, the pre-start observation, the authorized start, the
drain — runs against a real daemon and the first-party image in the `outer
capsule, JIT and the egress sandbox` job, which is where a protocol change is
proved end to end. The suite asserts the pre-start observation is `created`
and that the post-start observation reaches `running`, both of which this
change sits between.

The subcommand writes to a control directory a test cannot create, so the
authorization takes its paths and its writer as parameters — the same reason
`replaceState` already takes one. Both properties are then observed as a
recorded sequence of writes rather than inferred from where a call sits.

Each mutation was applied alone:

```text
MUTATION 1: the record moves after the file lands
--- FAIL: TestTheStartAuthorizationRecordsItselfBeforeItLands
    the authorization wrote [start=3 state=starting]; want
    [state=starting start=3]

MUTATION 2: an authorization that cannot land keeps saying it started
--- FAIL: TestAnAuthorizationThatCannotLandSaysSo
    the capsule was left saying [starting] after an authorization that
    never landed; it has to say the state a launcher requeues from

MUTATION 3: the subcommand writes the start file itself
--- FAIL: TestTheStartSubcommandAuthorizesThroughTheOrderedPath
    the start subcommand does not authorize through authorizeStart, so the
    order of the state and the file, and the undo when the file cannot
    land, are whatever this clause happens to do

MUTATION 4: a call to it sits in a branch nothing takes, beside a direct write
--- FAIL: TestTheStartSubcommandAuthorizesThroughTheOrderedPath
    the start subcommand names the control files itself. Whatever it does
    with them is outside the order authorizeStart exists to keep, and a
    call to it can sit beside that and prove nothing

MUTATION 4: the new state is classified with `waiting` again
--- FAIL: TestOnlyWaitingProvesTheRunnerNeverStarted
    a capsule that has accepted a start authorization is classified as one
    that never started; the assignment is requeued while the runner is
    being forked
```

The full local gate set mirroring `ci.yml` is green.

## What would notice this regressing

- `TestTheStartAuthorizationRecordsItselfBeforeItLands` — the sequence of
  writes an authorization makes: the state first, then the file.
- `TestAnAuthorizationThatCannotLandSaysSo` — a start file that refuses leaves
  the capsule saying the state a launcher requeues from, not the one it holds
  for a person.
- `TestTheStartSubcommandAuthorizesThroughTheOrderedPath` — the verb goes
  through the function that owns both properties, and does not name either
  control file itself. Writing the file directly is a working authorization
  with none of the ordering, and the function keeps its own tests either way;
  requiring the call alone was not enough, because one left in a branch
  nothing takes reads as authorizing while the line below it does the work.
- `TestOnlyWaitingProvesTheRunnerNeverStarted` — exactly one state classifies
  as "never started", and it is not the one that means "accepted". It also
  asserts the other direction, so a fix that stopped requeueing on `waiting`
  or on an abort fails here too.
- `TestClassifySupervisorStateSeparatesAbortFromExit` carries the new state in
  its table.
- The capsule contract's `TestCapsuleLifecycle` runs the whole protocol
  against the shipped image, so a supervisor that stops writing the state, or
  writes one the launcher does not recognize, fails there.

## Risk, compatibility and operations

**Compatibility.** This is a protocol break, and deliberately so. A capsule
image built against version 2 is refused by this controller, and a capsule
built now is refused by an older one. Nothing is released, so no deployment
is carrying either; an operator whose image derives from the published capsule
rebuilds from the digest a release ships, which is what the substitution ADR
already requires.

**Failure behaviour.** One disposition changes: a start authorization that
failed *after* taking effect was a requeue and is now a hold for a person.
Nothing that previously held is now requeued, and an authorization that failed
*before* taking effect is still requeued — that is what the undo is for, and it
is the case a full control tmpfs actually produces.

One window remains, and it is milliseconds wide: a SIGTERM landing while an
authorization's exec is in flight lets the exec's record overwrite the abort
PID 1 has already written, so the capsule reads as ambiguous where the truth is
"never handed over". It closes itself — once the container stops, the reserved
exit code answers instead of the file — and narrowing it further would mean a
read-modify-write between two processes, which is a race of its own.

**Operations.** An attempt in that state appears as `manual_review` with the
start outcome unproven, which is the existing shape for an unprovable outcome
and needs no new runbook step. It is rare by construction: it requires the
authorization's exec to land and its call to fail.

**Trust boundary, credentials, resource limits, networking.** N/A. The change
is one state written earlier and one classification; no new file, no new
capability, no new network path, no change to what the capsule may reach.

**CLI, configuration, status API, schema, migration.** None.

**Decision record.** No new ADR, and none amended.
`2026-08-17-capsule-image-substitution` already makes the protocol version a
compatibility surface and already requires that the controller refuse a
version it does not speak; this is that mechanism doing its job. The version
constant's own comment carries the reason, as it did for the previous move.

## Changelog

```text
### Isolation and egress

- **An assignment is requeued only on proof that no runner ever
  started.** A capsule that has accepted a start authorization says so
  before the authorization lands, and keeps saying it until the runner is
  forked or the attempt is abandoned. Without that the whole preamble —
  reading the credential bundle, materializing it, removing it, forking —
  answered with the same state as a capsule holding an unstarted runner,
  so an authorization whose call returned an error after taking effect
  would put the assignment back in the queue while the capsule was
  handing it to a runner, and it would run twice. The controller now
  holds such an attempt for a person, because at that moment neither
  answer is available.
```

## Notes for your reviewer

`authorizeStart` names its own two files rather than taking them. They were
parameters, and that put two adjacent strings next to a call site passing two
constants a letter apart: exchanged, it writes the protocol version into the
state and `starting` into the file PID 1 polls for, and because the state's
fallback creates the file it cannot fill, the capsule says `waiting` with a
start file present — PID 1 forks, the launcher requeues, and the job runs
twice, arrived at through the thing meant to prevent it. Nothing catches that:
not the compiler, not the gates, not the capsule contract against a real
daemon. Testing for it would have been the wrong answer; there is nothing left
to exchange.

What still reads the source is one thing only: that the subcommand calls
`authorizeStart` and names neither control file. That is a call being present rather than an order being
inferred from where it sits, which is the shape that went wrong first — a
guard comparing statement positions was satisfied by an authorization that
recorded its state only on the failure path, because the call and the file
then sit inside one statement, and every gate stayed green while the preamble
answered `waiting` for every authorization that worked.

Deliberately left alone, and belonging to its own change: the control surface
is reachable from inside the capsule through the job's own daemon. The
supervisor's package comment says the protocol has "nothing a job inside dind
can reach — the control directory is outside the runner's uid and the daemon
socket's group", and the uid half holds; a container the job starts through
that daemon runs as real root, with no user namespace remapping, and can bind
mount the control directory. Closing that is a mount namespace for the inner
daemon, which wants qualification against a real host rather than riding along
here.
