### PR TITLE
fix(app): waiting to refresh the policy can be given up, and the sweep sees the daemon before it reads the books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,11 +255,28 @@ by its public and operational effects.
   for an exec is handed over once and stops consulting the caller's
   context, so a container that accepts a command and answers nothing
   held the call open indefinitely — including the gateway control calls
-  a policy refresh makes while holding the lock every launch waits on.
+  a policy refresh makes while every launch waits for it.
   The connection now ends with the context, and each gateway call
   carries its own bound. Inside a capsule the readiness probe is bounded
   the same way, so a daemon that never answers cannot spend the whole
   readiness budget in one call.
+- **Shutdown is never held up by a launch it cannot see.** A launch runs
+  on a context that deliberately outlives the serve loop, so its cleanup
+  still completes once a shutdown has begun; the pass that maintains the
+  egress policy waits for the same thing that launch holds. Waiting for
+  it can now be given up, because the wait for the serve loops has no
+  bound of its own — the budget is a claim about what they cost, not a
+  timer — and past the deployment's grace period the difference is a
+  kill, which leaves every message session open for the next start to
+  wait out as a conflict.
+- **A lease that starts while the sweep is looking keeps its capsule.**
+  The sweep enumerates the daemon before it reads which leases are live,
+  because an object exists only after the lease that owns it committed.
+  Read the other way round, a lease committing between the two reads owns
+  a container the sweep cannot account for: it would force-remove a
+  capsule whose job is running and delete the records that clean up after
+  it. Cache lane collection already stated that order for the same
+  reason.
 - **One rule decides what becomes of an attempt.** The two paths that end
   a serving — the finalizing transaction and the sweep that finds a lease
   nobody is driving — reach the same decision through the same function,

--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -245,11 +245,17 @@ type fakeObjects struct {
 	// listErr fails the container inventory, which is the failure a sweep
 	// must treat as fatal rather than as an empty daemon.
 	listErr error
+	// onList fires as the daemon answers, which is where a lease that
+	// commits mid-sweep falls.
+	onList func()
 
 	removed []string
 }
 
 func (f *fakeObjects) ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error) {
+	if f.onList != nil {
+		f.onList()
+	}
 	return f.containers, f.listErr
 }
 func (f *fakeObjects) ListOwnedNetworks(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error) {

--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -245,8 +245,8 @@ type fakeObjects struct {
 	// listErr fails the container inventory, which is the failure a sweep
 	// must treat as fatal rather than as an empty daemon.
 	listErr error
-	// onList fires as the daemon answers, which is where a lease that
-	// commits mid-sweep falls.
+	// onList fires as the daemon answers, once per kind, which is where
+	// a lease that commits mid-sweep falls.
 	onList func()
 
 	removed []string
@@ -259,9 +259,15 @@ func (f *fakeObjects) ListOwnedContainers(context.Context, assignment.InstanceID
 	return f.containers, f.listErr
 }
 func (f *fakeObjects) ListOwnedNetworks(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error) {
+	if f.onList != nil {
+		f.onList()
+	}
 	return f.networks, nil
 }
 func (f *fakeObjects) ListOwnedVolumes(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error) {
+	if f.onList != nil {
+		f.onList()
+	}
 	return f.volumes, nil
 }
 func (f *fakeObjects) RemoveContainer(_ context.Context, id string) error { return f.remove(id) }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -104,7 +104,10 @@ func (s *Controller) reconcile(ctx context.Context) error {
 		s.resolveInterrupted(ctx, b, lease, runner, hasRunner)
 	}
 
-	return s.sweepOrphans(ctx, adopted)
+	// Nothing else runs yet at this point, so the set cannot move under
+	// the enumeration; it is passed as a reader so one sweep serves both
+	// callers.
+	return s.sweepOrphans(ctx, func() (map[assignment.LeaseID]bool, error) { return adopted, nil })
 }
 
 // reportAdoption says when a restart has left the instance holding more
@@ -332,7 +335,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 // released, and retention refuses a lease that still owns an intent —
 // deliberately, so the leak stays visible in `status` rather than being
 // quietly forgotten.
-func (s *Controller) sweepOrphans(ctx context.Context, keep map[assignment.LeaseID]bool) error {
+func (s *Controller) sweepOrphans(ctx context.Context, liveLeases func() (map[assignment.LeaseID]bool, error)) error {
 	wedged := 0
 	fail := func(kind, name string, err error) {
 		wedged++
@@ -340,10 +343,32 @@ func (s *Controller) sweepOrphans(ctx context.Context, keep map[assignment.Lease
 			"kind", kind, "id", name, "error", err)
 	}
 
+	// The daemon is enumerated before the live set is read, and all of it
+	// before any of it is judged. An object exists only after the lease
+	// that owns it committed, so an object seen now whose lease is absent
+	// in the later read is genuinely ownerless. Read the other way round,
+	// every lease that commits between the two reads owns objects the
+	// sweep cannot account for: it force-removes a capsule whose job is
+	// running and deletes the records that would have cleaned up after
+	// it. Cache lane collection states the same order for the same
+	// reason.
 	containers, err := s.objects.ListOwnedContainers(ctx, s.store.InstanceID())
 	if err != nil {
 		return err
 	}
+	networks, err := s.objects.ListOwnedNetworks(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+	volumes, err := s.objects.ListOwnedVolumes(ctx, s.store.InstanceID())
+	if err != nil {
+		return err
+	}
+	keep, err := liveLeases()
+	if err != nil {
+		return err
+	}
+
 	for _, c := range containers {
 		if keep[c.LeaseID] {
 			continue
@@ -364,10 +389,6 @@ func (s *Controller) sweepOrphans(ctx context.Context, keep map[assignment.Lease
 			return err
 		}
 	}
-	networks, err := s.objects.ListOwnedNetworks(ctx, s.store.InstanceID())
-	if err != nil {
-		return err
-	}
 	for _, n := range networks {
 		if keep[n.LeaseID] {
 			continue
@@ -382,10 +403,6 @@ func (s *Controller) sweepOrphans(ctx context.Context, keep map[assignment.Lease
 		if err := s.leases.ForgetResource(ctx, n.LeaseID, n.ID); err != nil {
 			return err
 		}
-	}
-	volumes, err := s.objects.ListOwnedVolumes(ctx, s.store.InstanceID())
-	if err != nil {
-		return err
 	}
 	for _, v := range volumes {
 		if keep[v.LeaseID] {
@@ -482,20 +499,21 @@ func (s *Controller) prunePeriodically(ctx context.Context) {
 // What is left is a genuine orphan — an object whose lease is released or
 // gone entirely.
 func (s *Controller) sweepPeriodically(ctx context.Context) {
-	var live []store.Lease
-	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		var err error
-		live, err = tx.LeasesInStates(store.LiveLeaseStates...)
-		return err
+	if err := s.sweepOrphans(ctx, func() (map[assignment.LeaseID]bool, error) {
+		var live []store.Lease
+		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+			var err error
+			live, err = tx.LeasesInStates(store.LiveLeaseStates...)
+			return err
+		}); err != nil {
+			return nil, err
+		}
+		keep := make(map[assignment.LeaseID]bool, len(live))
+		for _, lease := range live {
+			keep[lease.ID] = true
+		}
+		return keep, nil
 	}); err != nil {
-		s.log.Error("periodic sweep cannot list live leases", "error", err)
-		return
-	}
-	keep := make(map[assignment.LeaseID]bool, len(live))
-	for _, lease := range live {
-		keep[lease.ID] = true
-	}
-	if err := s.sweepOrphans(ctx, keep); err != nil {
 		s.log.Error("periodic sweep failed", "error", err)
 	}
 }

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -307,7 +307,10 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 // object stranded by a crash between creation and recording — in
 // dependency order: containers, then networks, then volumes.
 //
-// Three kinds of failure, three answers.
+// Four kinds of failure, four answers. Reading which leases are live is
+// one of them, and it is fatal for the same reason an unreadable
+// inventory is: a pass that cannot say what is in use has proved nothing
+// about what is garbage.
 //
 // One object that will not die does not stop the controller. A single
 // wedged container — a dind in uninterruptible sleep, a volume held by a
@@ -506,7 +509,9 @@ func (s *Controller) sweepPeriodically(ctx context.Context) {
 			live, err = tx.LeasesInStates(store.LiveLeaseStates...)
 			return err
 		}); err != nil {
-			return nil, err
+			// Named, because the caller now has one message for every
+			// fatal cause and two of them are store failures.
+			return nil, fmt.Errorf("list live leases: %w", err)
 		}
 		keep := make(map[assignment.LeaseID]bool, len(live))
 		for _, lease := range live {

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -50,17 +50,26 @@ type sandboxDaemon interface {
 
 // sandboxState owns the current restricted-network snapshot. Capsule
 // launches receive deep copies, so a rediscovery cannot mutate policy while
-// a concurrent launch is serializing it. refreshMu also serializes the
+// a concurrent launch is serializing it. refreshing also serializes the
 // external discovery/reload operation: policy changes must be applied in the
 // same order in which they are observed.
+//
+// It is a channel rather than a mutex because waiting for it has to be
+// abandonable. A launch holds it for as long as a discovery and a
+// gateway fan-out take, on a context that deliberately outlives the
+// serve loop so cleanup can still run; a mutex would park the shutdown
+// pass on that launch with no way to give up, and the wait for the serve
+// loops is unbounded by design. Past the grace period that is a SIGKILL,
+// which leaves every message session open for the next start to wait out
+// as a conflict.
 type sandboxState struct {
-	mu        sync.RWMutex
-	refreshMu sync.Mutex
-	current   *capsule.Sandbox
+	mu         sync.RWMutex
+	refreshing chan struct{}
+	current    *capsule.Sandbox
 }
 
 func newSandboxState(initial *capsule.Sandbox) *sandboxState {
-	return &sandboxState{current: cloneSandbox(initial)}
+	return &sandboxState{current: cloneSandbox(initial), refreshing: make(chan struct{}, 1)}
 }
 
 func (s *sandboxState) snapshot() *capsule.Sandbox {
@@ -328,8 +337,16 @@ func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error
 }
 
 func (n *networkSandbox) refresh(ctx context.Context) error {
-	n.state.refreshMu.Lock()
-	defer n.state.refreshMu.Unlock()
+	select {
+	case n.state.refreshing <- struct{}{}:
+	case <-ctx.Done():
+		// Whoever holds it is a launch, running on a context of its own,
+		// and it will finish in its own time. This caller's context is
+		// what says the wait is over.
+		return ctx.Err()
+	}
+	defer func() { <-n.state.refreshing }()
+
 	next, err := n.build(ctx, sandboxRefreshBudget)
 	if err != nil {
 		return err
@@ -410,14 +427,15 @@ func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox)
 
 // gatewayFanout is how many gateway control commands run at once.
 //
-// A refresh pass holds the refresh lock, and every launch waits on that
-// lock with a plain mutex that takes no context and cannot be given up.
-// So the pass's duration is a launch's worst-case wait — and walking the
+// A refresh pass holds the refresh slot and every launch waits for it, so
+// the pass's duration is a launch's worst-case wait — and walking the
 // gateways one at a time made that duration the number of gateways times
 // the exec bound. There is one gateway per running capsule, so it grew
 // with exactly the parallelism the host was configured for: at
 // thirty-two in flight, sixteen minutes with every launch stopped, for
-// one policy change.
+// one policy change. A launch waiting on its own context can give that
+// wait up; a launch that still needs the policy cannot, which is why the
+// duration is bounded here rather than only survivable.
 //
 // Bounded rather than unbounded. These are execs into containers on a
 // single daemon, and a pass that opens one per capsule trades a slow

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -55,7 +55,10 @@ type sandboxDaemon interface {
 // same order in which they are observed.
 //
 // It is a channel rather than a mutex because waiting for it has to be
-// abandonable. A launch holds it for as long as a discovery and a
+// abandonable. What that costs is ownership: the token is bare, so a
+// drain anywhere other than the send's own defer releases it whoever
+// holds it, and two refreshes then run at once with nothing to say so.
+// refresh is the only place that takes it. A launch holds it for as long as a discovery and a
 // gateway fan-out take, on a context that deliberately outlives the
 // serve loop so cleanup can still run; a mutex would park the shutdown
 // pass on that launch with no way to give up, and the wait for the serve
@@ -195,14 +198,15 @@ const rediscoverInterval = 5 * time.Minute
 //
 // They differ because their callers do. The first build runs from
 // newNetworkSandbox, before the state exists and before any binding does:
-// nothing holds the refresh lock, nothing waits on it, and the probe
+// nothing holds the refresh slot, nothing waits for it, and the probe
 // image may still have to be pulled — it is the capsule image, which is
 // hundreds of megabytes. Failing that for being slow is a controller
 // that will not start on a cold host with an ordinary link.
 //
-// Every later build runs from refresh, under the lock that every launch
-// takes with a plain mutex — no context, no way out — so an unbounded
-// step there is a host on which nothing new can start. By then the image
+// Every later build runs from refresh, holding the slot every launch
+// waits for — and a launch waits without a bound on purpose, since one
+// that skipped the policy would run unconfined — so an unbounded step
+// there is a host on which nothing new can start. By then the image
 // is present, so what remains is creating a network, inspecting it,
 // running a small container to completion and listing subnets. The bound
 // stays under rediscoverInterval so a build that hangs cannot leave two
@@ -360,6 +364,16 @@ func (n *networkSandbox) rediscover(ctx context.Context) {
 	if err == nil {
 		return
 	}
+	if ctx.Err() != nil {
+		// The pass is being stopped, not failing. Closing every gateway
+		// needs the same context to reach the daemon, so the attempt
+		// below could not do anything even if it were right to try -- and
+		// what it would leave behind is an error line announcing that all
+		// egress was cut, on an ordinary shutdown, for a thing that
+		// provably did not happen.
+		n.log.Info("sandbox rediscovery stopped", "reason", ctx.Err())
+		return
+	}
 
 	// Discovery failed. The environment may have grown a network this
 	// policy does not deny, and there is no way to tell — so every
@@ -399,7 +413,7 @@ func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox)
 	}
 	// Recorded only now: the set has reached every gateway that could be
 	// named, so this is what is in force rather than what was intended.
-	// The refresh lock is held across both, so no launch can observe the
+	// The refresh slot is held across both, so no launch can observe the
 	// window between them.
 	n.state.replace(next)
 	if len(failed) == 0 {
@@ -504,20 +518,21 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 
 // gatewayControlTimeout bounds one gateway control operation — an exec
 // into it, or its removal — so a refresh pass costs a known number of
-// these rather than an unknown amount. The pass holds the refresh lock
-// and every launch waits on that lock with a plain mutex, which takes no
-// context of its own, so anything unbounded under it is unbounded for
-// every launch on the host.
+// these rather than an unknown amount. The pass holds the refresh slot,
+// a launch waits for it without a bound of its own, and the context this
+// runs on carries no deadline: anything unbounded under it is unbounded
+// for every launch on the host.
 const gatewayControlTimeout = 30 * time.Second
 
 // ownedContainers asks the daemon what this instance owns, under a bound.
 //
-// Both callers run inside the refresh lock, and enumerating is the first
-// thing each does — so a daemon that accepts the request and answers
-// nothing would hold that lock before any gateway had been reached, with
-// every launch on the host waiting on it and none able to time out. It
-// is the same reason the exec and the removal below are bounded, and
-// leaving it out left the pass unbounded at its very first step.
+// Both callers run holding the refresh slot, and enumerating is the
+// first thing each does — so a daemon that accepts the request and
+// answers nothing would hold that slot before any gateway had been
+// reached, with every launch on the host waiting for it and no deadline
+// on the context to end the wait. It is the same reason the exec and the
+// removal below are bounded, and leaving it out left the pass unbounded
+// at its very first step.
 func (n *networkSandbox) ownedContainers(ctx context.Context) ([]docker.OwnedContainer, error) {
 	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
 	defer cancel()
@@ -552,12 +567,11 @@ func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) e
 			"container", containerID, "exit", code, "error", err, "output", out)
 	}
 	// Bounded like the exec above it, and for the same reason. This runs
-	// under the refresh lock, and every launch waits on that lock with a
-	// plain mutex that takes no context: a daemon that accepts the
-	// removal and then answers nothing would hold it for the life of the
-	// process, and no launch could time out of it. That is the failure
-	// the fan-out above exists to bound, and leaving it here left it in
-	// the same function.
+	// holding the refresh slot, which every launch waits for: a daemon
+	// that accepts the removal and then answers nothing would hold it for
+	// the life of the process, on a context with no deadline to end the
+	// wait. That is the failure the fan-out above exists to bound, and
+	// leaving it here left it in the same function.
 	//
 	// A removal that cannot be confirmed is reported. The gateway is
 	// still there, so the next pass finds it and closes it again.

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -771,3 +771,44 @@ func TestARefreshGivesUpWhenItsCallerIsDone(t *testing.T) {
 			"and the grace period ends in a kill with every session still open")
 	}
 }
+
+// TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency: a pass that
+// is being stopped is not a pass that failed.
+//
+// A discovery that cannot say what is installed closes every gateway,
+// and says so at error level, because a capsule may be reaching
+// something the policy now denies. On the way down neither half holds.
+// Against a real daemon the attempt cannot even be made — the context it
+// would travel on is already done — so all that is left is an error line
+// announcing that every gateway was cut, on every ordinary shutdown that
+// lands inside a rediscovery, for something that provably did not
+// happen. The watch loop waits for the refresh slot for much of its
+// life, so that is not a rare landing.
+//
+// What is asserted here is therefore that the pass does not try. The
+// daemon answers, so a pass that reached it would close and remove the
+// gateway, and the announcement would be the one thing about the whole
+// sequence that was true.
+func TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency(t *testing.T) {
+	// A gateway to close, so "nothing was closed" is an observation
+	// rather than an empty daemon answering emptily.
+	daemon := &fakeSandboxDaemon{
+		containers: []docker.OwnedContainer{{ID: "gw-1", Role: capsule.RoleGateway, LeaseID: "lse-1", Running: true}},
+	}
+	n := newTestSandbox(t, daemon, &capsule.Sandbox{})
+
+	// Held by a launch, which is what leaves the pass waiting.
+	n.state.refreshing <- struct{}{}
+	defer func() { <-n.state.refreshing }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	n.rediscover(ctx)
+
+	daemon.mu.Lock()
+	defer daemon.mu.Unlock()
+	if len(daemon.events) != 0 || len(daemon.removed) != 0 {
+		t.Errorf("a stopped rediscovery reached the daemon: %v, removed %v",
+			daemon.events, daemon.removed)
+	}
+}

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -730,3 +730,44 @@ func TestEnumeratingGatewaysIsBounded(t *testing.T) {
 		})
 	}
 }
+
+// TestARefreshGivesUpWhenItsCallerIsDone: waiting to refresh has to be
+// abandonable, because the wait is on work that outlives the caller.
+//
+// A launch holds the refresh while it discovers the daemon and reloads
+// every gateway, on a context deliberately derived from no parent so its
+// cleanup still runs after a shutdown begins. The pass that maintains
+// the policy is a serve loop, and shutdown waits for the serve loops
+// without a bound — the budget is a claim about what they cost, not a
+// timer. Parked on a lock, that loop does not stop when its context is
+// cancelled: it stops when a launch it cannot see finishes, and past the
+// deployment's grace period the difference is a SIGKILL, which leaves
+// every message session open for the next start to wait out.
+func TestARefreshGivesUpWhenItsCallerIsDone(t *testing.T) {
+	n := newTestSandbox(t, &fakeSandboxDaemon{}, &capsule.Sandbox{})
+
+	// Stand in for the launch that is holding it.
+	n.state.refreshing <- struct{}{}
+	defer func() { <-n.state.refreshing }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	gaveUp := make(chan error, 1)
+	go func() { gaveUp <- n.refresh(ctx) }()
+
+	select {
+	case err := <-gaveUp:
+		t.Fatalf("the refresh did not wait for the one in flight: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-gaveUp:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("gave up with %v; want the caller's own cancellation", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the refresh never gave up; shutdown waits on a launch it cannot see, " +
+			"and the grace period ends in a kill with every session still open")
+	}
+}

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -95,11 +95,23 @@ func TestALeaseCommittedDuringTheSweepKeepsItsObjects(t *testing.T) {
 	h.objects.containers = []docker.OwnedContainer{
 		{ID: "runner-committing", Role: "capsule", LeaseID: "lse-committing", Running: true},
 	}
-	committed := false
-	h.objects.onList = func() { committed = true }
+	h.objects.networks = []docker.OwnedResource{
+		{ID: "net-committing", Role: "capsule-net", LeaseID: "lse-committing"},
+	}
+	h.objects.volumes = []docker.OwnedResource{
+		{ID: "vol-committing", Role: "dind-data", LeaseID: "lse-committing"},
+	}
+
+	// The lease is visible only once every kind has been listed, so a
+	// read that runs after the containers but before the volumes is as
+	// much a failure as one that runs first: an object listed after the
+	// read is an object the read could not account for, whichever kind
+	// it is.
+	listed := 0
+	h.objects.onList = func() { listed++ }
 
 	if err := h.srv.sweepOrphans(t.Context(), func() (map[assignment.LeaseID]bool, error) {
-		if !committed {
+		if listed < 3 {
 			return nil, nil
 		}
 		return map[assignment.LeaseID]bool{"lse-committing": true}, nil
@@ -107,7 +119,7 @@ func TestALeaseCommittedDuringTheSweepKeepsItsObjects(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(h.objects.removed) != 0 {
-		t.Errorf("swept %v; the lease committed before its container was listed, so the sweep "+
+		t.Errorf("swept %v; the lease committed before every kind had been listed, so the sweep "+
 			"tore down a capsule whose job is running and deleted the records that clean up after it",
 			h.objects.removed)
 	}

--- a/internal/app/sweep_test.go
+++ b/internal/app/sweep_test.go
@@ -32,7 +32,9 @@ func TestSweepOrphansSparesWhatIsNotGarbage(t *testing.T) {
 		{ID: "vol-gone", Role: "dind-data", LeaseID: "lse-gone"},
 	}
 
-	if err := h.srv.sweepOrphans(t.Context(), map[assignment.LeaseID]bool{"lse-adopted": true}); err != nil {
+	if err := h.srv.sweepOrphans(t.Context(), func() (map[assignment.LeaseID]bool, error) {
+		return map[assignment.LeaseID]bool{"lse-adopted": true}, nil
+	}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -55,7 +57,7 @@ func TestSweepOrphansSurvivesAnObjectThatWillNotDie(t *testing.T) {
 	h.objects.volumes = []docker.OwnedResource{{ID: "vol-gone", Role: "dind-data", LeaseID: "lse-gone"}}
 	h.objects.wedged["wedged"] = true
 
-	if err := h.srv.sweepOrphans(t.Context(), nil); err != nil {
+	if err := h.srv.sweepOrphans(t.Context(), func() (map[assignment.LeaseID]bool, error) { return nil, nil }); err != nil {
 		t.Fatalf("one object that would not die failed the whole pass: %v", err)
 	}
 	if !slices.Equal(h.objects.removed, []string{"net-gone", "vol-gone"}) {
@@ -70,7 +72,43 @@ func TestSweepOrphansFailsOnAnUnreadableInventory(t *testing.T) {
 	h := newHarness(t, 1)
 	h.objects.listErr = errors.New("daemon unreachable")
 
-	if err := h.srv.sweepOrphans(t.Context(), nil); err == nil {
+	if err := h.srv.sweepOrphans(t.Context(), func() (map[assignment.LeaseID]bool, error) { return nil, nil }); err == nil {
 		t.Error("an unreadable inventory was reported as nothing to sweep")
+	}
+}
+
+// TestALeaseCommittedDuringTheSweepKeepsItsObjects: the daemon is
+// enumerated before the live set is read.
+//
+// An object exists only after the lease that owns it committed, so an
+// object seen now whose lease is absent in the later read is genuinely
+// ownerless. Read the other way round, a lease that commits between the
+// two reads owns a container the sweep cannot account for, and the sweep
+// force-removes a capsule whose job is running, then deletes the records
+// that would have cleaned up after it.
+//
+// The commit is modelled where it actually falls: the fake daemon
+// registers the lease as it answers, so the lease exists only for a
+// reader that runs after the enumeration.
+func TestALeaseCommittedDuringTheSweepKeepsItsObjects(t *testing.T) {
+	h := newHarness(t, 1)
+	h.objects.containers = []docker.OwnedContainer{
+		{ID: "runner-committing", Role: "capsule", LeaseID: "lse-committing", Running: true},
+	}
+	committed := false
+	h.objects.onList = func() { committed = true }
+
+	if err := h.srv.sweepOrphans(t.Context(), func() (map[assignment.LeaseID]bool, error) {
+		if !committed {
+			return nil, nil
+		}
+		return map[assignment.LeaseID]bool{"lse-committing": true}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.objects.removed) != 0 {
+		t.Errorf("swept %v; the lease committed before its container was listed, so the sweep "+
+			"tore down a capsule whose job is running and deleted the records that clean up after it",
+			h.objects.removed)
 	}
 }


### PR DESCRIPTION
## What changes

Waiting to refresh the egress policy can be abandoned by the caller's context,
so a shutdown is not held up by a launch it cannot see. And the orphan sweep
enumerates the daemon before it reads which leases are live, so a lease that
commits mid-pass keeps its capsule.

## What was found

**Shutdown could park on a launch and stay there.** `refresh` acquired a
plain `sync.Mutex`. Acquiring one takes no context and cannot be given up.
What holds it is `forLaunch`, reached from `runCapsule`, whose context is
`context.WithCancel(context.Background())` — deliberately parentless, because
"the lease's own context outlives every step: cleanup and the failure paths
need one that is not the step's". So cancelling the serve context does not
release it.

The consequence is on the shutdown path. `watch` checks `ctx.Done()` at the
top of each turn, but a cancellation arriving while it is inside `rediscover`
finds it about to park on that mutex. `serve` then blocks on `loops.Wait()`,
and that wait is unbounded **by design** — the comment on `LoopStopBudget`
says so: *"Unlike its two neighbours this is a claim rather than a timer …
the wait stays unbounded and this number states what the loops must cost."*
So the loop stops when a launch finishes, not when the budget says. Worst
case a launch holds it for `sandboxFirstBuildBudget`/`sandboxRefreshBudget`
plus the gateway fan-out, and the watch then takes its own turn — past the
compose `stop_grace_period` of 150 s, which is a SIGKILL, which leaves every
message session open for the next start to wait out as a session conflict.

It is a one-slot channel now: the wait ends when the holder finishes or when
the caller's own context does. A launch still waits without a bound, which is
right — a launch that skipped the policy would run unconfined.

**The sweep judged the daemon against a list it read first.**
`sweepPeriodically` read `LeasesInStates(LiveLeaseStates...)` and then called
`sweepOrphans`, which enumerated the daemon. An object exists only after the
lease that owns it committed, so a lease committing between the two reads owns
a container the sweep cannot account for: `keep[c.LeaseID]` is false, the
container is force-removed mid-job, and `ForgetResource` deletes the intent
rows that would have driven its cleanup. The job dies with no record of why.

The correct order is already written down in this repository, for the same
reason. `internal/cache/gc.go`'s `PlanGC`: *"The daemon is listed before the
store on purpose: a volume is created only after its row committed, so a
volume seen now whose row is absent in the later read is a true orphan — the
reverse order would misread every lane created between the two reads as one."*
Capsule objects have the identical property — the recorder plans the intent
row before the object is created.

All three enumerations now happen before the live set is read, not just the
first, so the same window cannot open between the containers and the volumes
either. Both callers pass a reader rather than a set; the startup caller's set
cannot move under it, since nothing else runs at that point, and passing a
closure is what keeps one sweep serving both.

**Something that looked like a third item and is not.** `applyPolicy` records
the new set as in force before it inspects which gateways rejected it, and I
expected that to be a torn read against a launch. It is not: `replace` takes
`s.mu.Lock()` and `snapshot` takes `s.mu.RLock()`, so the data is guarded by
the lock its readers take. And a gateway that rejected a restriction is closed
and removed, so recording the set is right for the gateways that remain. The
residual case — a `closeGateway` that also fails — is already logged as an
error and has nothing further to try. Nothing changed here.

## Evidence

Hermetic. Both mechanisms are exercised in-process; the sweep against the fake
daemon the existing sweep tests use, the refresh against a held slot.

Each mutation was applied alone. The second one is scoped to `sweepOrphans` by
its harness, because the enumeration call appears in more than one function and
an unscoped edit landed in the wrong one and failed to build — measuring
nothing.

```text
MUTATION 1: the refresh waits on a mutex again
--- FAIL: TestARefreshGivesUpWhenItsCallerIsDone (10.05s)
    the refresh never gave up; shutdown waits on a launch it cannot see,
    and the grace period ends in a kill with every session still open

MUTATION 2: the live set is read before the daemon is enumerated
--- FAIL: TestALeaseCommittedDuringTheSweepKeepsItsObjects
    swept [runner-committing]; the lease committed before its container
    was listed, so the sweep tore down a capsule whose job is running and
    deleted the records that clean up after it
```

The full local gate set mirroring `ci.yml` is green, including
`go test -race -shuffle=on ./...`.

## What would notice this regressing

- `TestARefreshGivesUpWhenItsCallerIsDone` — with the slot held, a refresh
  parks; when its context is cancelled it returns `context.Canceled` within
  ten seconds. Fails on a plain mutex, and fails if the wait stops waiting.
- `TestALeaseCommittedDuringTheSweepKeepsItsObjects` — the commit is modelled
  where it actually falls: the fake daemon registers the lease as it answers,
  and the lease is visible only once every kind has been listed. So it fails
  both when the read moves ahead of everything and when it moves between the
  containers and the volumes — the partial fix, which is what the claim about
  all three enumerations exists to rule out.
- `TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency` — a stopped pass
  does not reach the daemon. The fake answers, so a pass that tried would close
  and remove the gateway; against a real daemon the attempt cannot be made at
  all, which is what would leave the announcement standing alone.
- The existing sweep tests keep their properties through the new signature:
  `TestSweepOrphansSparesWhatIsNotGarbage`,
  `TestSweepOrphansSurvivesAnObjectThatWillNotDie`,
  `TestSweepOrphansFailsOnAnUnreadableInventory` and
  `TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn`.

## Risk, compatibility and operations

**Failure behaviour.** One path changes: a refresh whose caller is already
done returns that caller's cancellation instead of waiting. `forLaunch`
refuses the launch, and it never sees this — it runs on a context derived from
no parent, so a shutdown cannot cancel it; its only cancellation is the
preparation timeout, which failed the same way before.

`rediscover` needed the other half. It reads any refresh failure as "nothing
can be said about what is installed", announces at error level that every
gateway is being closed to all egress, and then cannot close any, because
closing them travels on the same done context. That pair was reachable before
this change too, but only after the park; now it is reached promptly on every
shutdown that lands inside a rediscovery, which on a busy host is most of them
— the watch loop waits for the slot for much of its life. A stopped pass now
returns saying so, at info level.

**Fail-closed.** Unchanged. A launch that cannot refresh is still refused, and
a rediscovery that cannot say what is installed still closes every gateway. A
launch's wait is deliberately still unbounded: giving it up would run a capsule
under a policy nobody proved current.

**Resource limits, networking, credentials, trust boundary.** N/A. No object
is created or removed differently; the sweep removes strictly fewer things
than it could before, never more.

**Ownership and cleanup.** This is the ownership surface, and the reordering
is not one-directional. A lease that *commits* in the window was swept before
and is spared now — the fix. A lease that *releases* in the window was spared
before and is swept now, which is strictly more, so it is worth saying why
that is safe rather than asserting that it cannot happen: `Finalize` refuses
to commit `released` while any resource record remains, so a released lease's
objects are already gone; all three `Remove*` calls are no-ops on an object
that has vanished; and `ForgetResource` returns nil when no intent matches.
The cost is a spurious `sweeping orphan container` line at info level.

**CLI, configuration, status API, schema, migration, deployment, rollback.**
None. No stored state, no wire format, no operator command.

**Runbook.** No new step. A shutdown that previously ran past its grace period
under this race now completes inside it, which is what the documented budget
already describes.

**Decision record.** No ADR is needed and none is amended. The shutdown
budgets and the ownership model are unchanged in what they promise; this makes
two paths keep promises they already made.

## Changelog

```text
### State and operations

- **Shutdown is never held up by a launch it cannot see.** A launch runs
  on a context that deliberately outlives the serve loop, so its cleanup
  still completes once a shutdown has begun; the pass that maintains the
  egress policy waits for the same thing that launch holds. Waiting for
  it can now be given up, because the wait for the serve loops has no
  bound of its own — the budget is a claim about what they cost, not a
  timer — and past the deployment's grace period the difference is a
  kill, which leaves every message session open for the next start to
  wait out as a conflict.
- **A lease that starts while the sweep is looking keeps its capsule.**
  The sweep enumerates the daemon before it reads which leases are live,
  because an object exists only after the lease that owns it committed.
  Read the other way round, a lease committing between the two reads owns
  a container the sweep cannot account for: it would force-remove a
  capsule whose job is running and delete the records that clean up after
  it. Cache lane collection already stated that order for the same
  reason.
```

## Notes for your reviewer

Four comments elsewhere in `sandbox.go` justified their bounds by naming the
mutex and its no-way-out property. The conclusions survive — the pass runs on
a context with no deadline — but the premise did not, so they now argue from
what is there. Under "docs describe code only" that was the part of this
change that should not have merged as first written.

The thing I would look at first is whether one slot is still the right shape.
It serializes refreshes as the mutex did, and a launch still waits without a
bound on purpose — but the two waiters now have different rights, and that
asymmetry is carried by which context each passes rather than by anything
structural. The token is also bare: a drain anywhere other than the send's own
defer would release it whoever holds it, which a mutex would have caught. Only
`refresh` takes it, and the type's doc now says so.

Second, the sweep's new signature moves a store read inside a function that
previously did no store reads. It runs before any object is judged and after
all of them are listed, which is the point, but it does mean the pass now
holds the daemon's answer across a transaction.

Deliberately left alone: the gateway fan-out bound and the deny set that grows
with live capsules. Those are about how long a refresh takes, not about who
can stop waiting for one, and they belong with the scalability work.
