### PR TITLE
fix(egress): an allowance through link-local reaches it, and one that reaches nothing is refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ by its public and operational effects.
   whole range as a side effect; a policy carrying one is refused. The
   rule belongs to the policy rather than to the configuration file, so
   the live reload channel is held to it too.
+  An entry naming what no connection reaches — loopback, multicast,
+  broadcast, the unspecified address — is refused for the opposite
+  reason: it cannot take effect, and accepting it would leave an allow
+  rule in the rendered firewall while the gateway refused every request
+  through it. Link-local is not in that group: it stays denied by
+  default, because a cloud instance keeps its own credentials there, and
+  an allowance naming one address in it now reaches that address rather
+  than being accepted and quietly ignored.
   Public prefixes are accepted because the profile already permits the
   public internet — which is how a capsule reaches a service on the
   host's own public address, an address the runtime deny set withholds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,14 @@ by its public and operational effects.
   through it. Link-local is not in that group: it stays denied by
   default, because a cloud instance keeps its own credentials there, and
   an allowance naming one address in it now reaches that address rather
-  than being accepted and quietly ignored.
+  than being accepted and quietly ignored. One address is the whole of
+  what it can reach: an entry covering more of the range is refused,
+  which the rule above does not do for it, since the baseline withholds
+  link-local as a single range and an entry of exactly that is broader
+  than nothing.
+  Both lists are also held to being written as IPv4. An address in the
+  v4-in-v6 form renders into the ruleset and matches nothing at decision
+  time, which is the same split arrived at through notation.
   Public prefixes are accepted because the profile already permits the
   public internet — which is how a capsule reaches a service on the
   host's own public address, an address the runtime deny set withholds

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -405,6 +405,19 @@ effect — `0.0.0.0/0` readmits every private network while `profile` still
 reads `public-internet-only` — so the validator refuses any entry that
 strictly contains a denied range.
 
+An entry that names something no connection reaches is refused for a
+different reason: it cannot take effect. Loopback is the gateway itself, and
+multicast, broadcast and the unspecified address are not destinations a relay
+connects to. Accepting one would put an allow rule in the rendered firewall
+while the gateway refused every request through it, with nothing anywhere
+saying why.
+
+Link-local is not in that group. It is denied by default — a cloud instance
+keeps its own credentials there, and a job that wanders into it should not
+arrive — and a deployment with a reason to reach one address in it names that
+address. The range itself cannot be reopened, because an entry broader than a
+withheld range is refused by the rule above.
+
 Narrower entries are the intended use, and public prefixes are accepted
 because they change nothing: the profile already permits the public internet.
 That is also how a capsule reaches a service on the host's own public

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -415,8 +415,10 @@ saying why.
 Link-local is not in that group. It is denied by default — a cloud instance
 keeps its own credentials there, and a job that wanders into it should not
 arrive — and a deployment with a reason to reach one address in it names that
-address. The range itself cannot be reopened, because an entry broader than a
-withheld range is refused by the rule above.
+address, as a single `/32`. Anything wider is refused: not by the rule above,
+which only catches an entry *broader* than a withheld range, but by a rule of
+its own, because the baseline withholds link-local as a `/16` and an entry of
+exactly that would be broader than nothing.
 
 Narrower entries are the intended use, and public prefixes are accepted
 because they change nothing: the profile already permits the public internet.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -121,8 +121,8 @@ capsule addresses beyond that bridge — public destinations included.
 Egress happens through the capsule's own gateway container, which
 resolves names and opens connections on its behalf, refusing any
 address in the deny set that no allowance names (private ranges,
-link-local metadata, the host's
-own networks, every Docker subnet, the uplink itself).
+link-local metadata, the host's own networks, every Docker subnet, the
+uplink itself).
 
 The capsule is created with `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`
 pointing at that gateway, inherited by the runner, the job and the inner

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -120,7 +120,8 @@ capsule has **no route to anything**. Its bridge is internal in Engine
 capsule addresses beyond that bridge — public destinations included.
 Egress happens through the capsule's own gateway container, which
 resolves names and opens connections on its behalf, refusing any
-address in the deny set (private ranges, link-local metadata, the host's
+address in the deny set that no allowance names (private ranges,
+link-local metadata, the host's
 own networks, every Docker subnet, the uplink itself).
 
 The capsule is created with `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY`

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -332,11 +332,18 @@ func Validate(c *Config) error {
 	// what runs. Accepting "enforced" would promise parity that does
 	// not exist.
 	// The egress policy is rendered into an IPv4 ruleset, and an allow
-	// prefix is a hole punched through the baseline deny. Both facts have
+	// prefix is a hole punched through the baseline deny. Three facts have
 	// to be checked here: an IPv6 prefix passes CIDR parsing and then fails
-	// at gateway boot pointing at iptables instead of at the config line,
-	// and a public or over-wide allow silently reopens what the restricted
-	// profile exists to close.
+	// at gateway boot pointing at iptables instead of at the config line;
+	// a public or over-wide allow silently reopens what the restricted
+	// profile exists to close; and an allow through a range no relay
+	// reaches is a line that does nothing, while the ruleset still carries
+	// its accept -- a firewall that agrees with the file and a gateway
+	// that refuses every request, with nothing saying why.
+	//
+	// The policy holds the same two rules, because a gateway takes one
+	// from its reload channel as well as from here. This names the
+	// configuration field an operator has to fix.
 	for i, p := range c.Network.AllowPrivateCIDRs {
 		path := fmt.Sprintf("network.allowPrivateCIDRs[%d]", i)
 		switch {
@@ -345,6 +352,10 @@ func Validate(c *Config) error {
 		case egress.WidensBaselineDeny(p.Prefix):
 			v.errf(path, "%s is broader than a range the restricted profile withholds, "+
 				"so allowing it would reopen that whole range; name the specific addresses instead", p)
+		case egress.RefusedOutright(p.Prefix):
+			v.errf(path, "%s names addresses no relay reaches, so it cannot take effect: "+
+				"loopback is the gateway itself, and link-local, multicast, broadcast and the "+
+				"unspecified range are not destinations a connection can have", p)
 		}
 	}
 	for i, p := range c.Network.DenyCIDRs {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -347,19 +347,27 @@ func Validate(c *Config) error {
 	for i, p := range c.Network.AllowPrivateCIDRs {
 		path := fmt.Sprintf("network.allowPrivateCIDRs[%d]", i)
 		switch {
-		case !p.Addr().Unmap().Is4():
-			v.errf(path, "must be IPv4: the capsule egress ruleset is IPv4 only")
+		case !p.Addr().Is4():
+			// Not Unmap: the v4-in-v6 form unmaps to IPv4 and then never
+			// matches an address at decision time, because a 128-bit
+			// prefix contains no 32-bit one. It renders into the ruleset
+			// all the same.
+			v.errf(path, "must be IPv4: the capsule egress ruleset is IPv4 only, and an "+
+				"address written in the v4-in-v6 form is not one the relay matches")
 		case egress.WidensBaselineDeny(p.Prefix):
 			v.errf(path, "%s is broader than a range the restricted profile withholds, "+
 				"so allowing it would reopen that whole range; name the specific addresses instead", p)
 		case egress.RefusedOutright(p.Prefix):
 			v.errf(path, "%s names addresses no relay reaches, so it cannot take effect: "+
-				"loopback is the gateway itself, and link-local, multicast, broadcast and the "+
-				"unspecified range are not destinations a connection can have", p)
+				"loopback is the gateway itself, and multicast, broadcast and the unspecified "+
+				"address are not destinations a connection can have", p)
+		case egress.ReopensLinkLocal(p.Prefix):
+			v.errf(path, "%s reaches more of link-local than one address, which would hand a "+
+				"job the range its instance keeps its own credentials in; name the address", p)
 		}
 	}
 	for i, p := range c.Network.DenyCIDRs {
-		if !p.Addr().Unmap().Is4() {
+		if !p.Addr().Is4() {
 			v.errf(fmt.Sprintf("network.denyCIDRs[%d]", i), "must be IPv4: the capsule egress ruleset is IPv4 only")
 		}
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -299,9 +299,19 @@ func TestNetworkCIDRValidation(t *testing.T) {
 		"everything":                  {allow: "0.0.0.0/0", wantErr: true},
 		"swallows a whole deny range": {allow: "10.0.0.0/7", wantErr: true},
 		"swallows link-local":         {allow: "169.254.0.0/15", wantErr: true},
-		"ipv6 allow":                  {allow: "fd00::/8", wantErr: true},
-		"ipv4 deny is fine":           {deny: "203.0.113.0/24"},
-		"ipv6 deny":                   {deny: "fd00::/8", wantErr: true},
+		// Exactly the withheld range is not broader than anything, so the
+		// rule above lets it through: link-local carries its own, and it
+		// has to be checked here as well as on the policy, because this
+		// is the file an operator edits.
+		"the whole of link-local": {allow: "169.254.0.0/16", wantErr: true},
+		"half of link-local":      {allow: "169.254.0.0/17", wantErr: true},
+		"ipv6 allow":              {allow: "fd00::/8", wantErr: true},
+		// The v4-in-v6 form unmaps to IPv4 and then matches no address at
+		// decision time, while rendering into the ruleset verbatim.
+		"mapped v4 allow":   {allow: "::ffff:198.18.5.0/120", wantErr: true},
+		"mapped v4 deny":    {deny: "::ffff:198.18.5.0/120", wantErr: true},
+		"ipv4 deny is fine": {deny: "203.0.113.0/24"},
+		"ipv6 deny":         {deny: "fd00::/8", wantErr: true},
 	} {
 		cfg := validConfig()
 		if tc.allow != "" {

--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -81,6 +81,16 @@ func (p Policy) Validate() error {
 			return fmt.Errorf("allow %s is broader than a range the restricted profile withholds, "+
 				"so allowing it would reopen that whole range", prefix)
 		}
+		// And an allow the decider can never honour is refused here
+		// rather than accepted and ignored. Left in, the kernel ruleset
+		// carries the matching accept while the relay refuses every
+		// request, so the operator has a firewall rule that agrees with
+		// the configuration and a gateway that does not.
+		if RefusedOutright(prefix) {
+			return fmt.Errorf("allow %s names addresses no relay reaches, so it cannot take "+
+				"effect: loopback is the gateway itself, and link-local, multicast, broadcast "+
+				"and the unspecified range are not destinations a connection can have", prefix)
+		}
 	}
 	return nil
 }
@@ -116,22 +126,31 @@ func (p Policy) Compile() (*Decider, error) {
 }
 
 // Allowed reports whether the gateway may connect to an address.
-// Anything that is not an ordinary global unicast IPv4 address is
-// refused outright: IPv6 has no path here, and the special-purpose
-// forms (loopback, link-local, multicast, unspecified) are the ones an
-// attacker reaches for. An explicit allow prefix wins over a deny;
-// otherwise a deny match refuses; otherwise the address is public and
-// permitted.
+//
+// Three questions, in this order. Is it an address a connection can have
+// at all -- IPv6 has no path here, and loopback, multicast, broadcast
+// and the unspecified address name no destination a relay could carry.
+// Then, does the policy name it: an explicit allow wins over everything
+// below. Then link-local, which is refused unless the policy named it,
+// because a cloud instance keeps its own credentials there and a job
+// that wanders into it should not arrive.
+//
+// The order is the point. Refusing link-local before the allow list is
+// consulted makes an operator's entry for it inert -- accepted by
+// validation, rendered into the kernel ruleset as an accept, and refused
+// by the relay on every request with nothing to say why.
 func (d *Decider) Allowed(addr netip.Addr) bool {
-	addr = addr.Unmap()
-	if !addr.Is4() || !addr.IsGlobalUnicast() || addr.IsLoopback() ||
-		addr.IsLinkLocalUnicast() || addr.IsMulticast() || addr.IsUnspecified() {
+	if !reachable(addr) {
 		return false
 	}
+	addr = addr.Unmap()
 	for _, p := range d.allow {
 		if p.Contains(addr) {
 			return true
 		}
+	}
+	if addr.IsLinkLocalUnicast() {
+		return false
 	}
 	for _, p := range d.deny {
 		if p.Contains(addr) {
@@ -141,11 +160,50 @@ func (d *Decider) Allowed(addr netip.Addr) bool {
 	return true
 }
 
+// ipv4Broadcast is the address a datagram goes to when it goes to
+// everyone, which is not something a relay connects to.
+var ipv4Broadcast = netip.AddrFrom4([4]byte{255, 255, 255, 255})
+
+// reachable reports whether an address is the kind a relay can carry at
+// all, which is the one question no policy answers differently.
+// Loopback is the gateway itself, unspecified names no destination, and
+// multicast and broadcast are not connections. Link-local is not here:
+// it is a real destination on the link, refused by default and
+// reopenable by naming it.
+//
+// It is named so the two places that must agree can share it. A policy
+// allowing a range this refuses is not a narrower policy, it is a policy
+// with a line that does nothing -- and the kernel ruleset carries the
+// matching accept, so the operator has a rule in the firewall, a clean
+// validation, and a relay that refuses every request with nothing saying
+// why.
+func reachable(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.Is4() && !addr.IsLoopback() && !addr.IsMulticast() &&
+		!addr.IsUnspecified() && addr != ipv4Broadcast
+}
+
+// RefusedOutright reports whether an allow prefix names only addresses
+// the decider refuses whatever the policy says.
+//
+// The prefix's own network address decides it, which is enough because
+// an allow broader than the range it sits in is already refused for
+// widening: what reaches here is either inside one of these ranges or
+// outside all of them.
+func RefusedOutright(prefix netip.Prefix) bool {
+	return !reachable(prefix.Masked().Addr())
+}
+
 // baselineDeny is every IPv4 range that is never a legitimate public
 // destination for a CI job: the private ranges, loopback, link-local
 // (cloud metadata lives there), CGNAT, benchmarking, multicast,
-// reserved, and broadcast. Operator allowPrivateCIDRs punch holes
-// through it at decision time; nothing widens the list away.
+// reserved, and broadcast. Nothing widens the list away.
+//
+// Operator allowPrivateCIDRs punch holes through it at decision time,
+// link-local included -- a deployment with a reason to reach one address
+// in it names that address. What they cannot reopen is what no
+// connection reaches at all, and a policy naming one of those is refused
+// rather than accepted and ignored.
 var baselineDeny = []string{
 	"0.0.0.0/8",
 	"10.0.0.0/8",

--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -39,9 +39,10 @@ const ProxyPort = 3128
 
 // Policy is what the gateway needs: the subnets that identify its two
 // legs, and the allow/deny sets it applies to every destination. Allow
-// is consulted before Deny, so an operator's allowPrivateCIDRs punch a
-// named hole through the private-range denies without weakening
-// anything else.
+// is consulted before Deny, and before the refusal of link-local, so an
+// operator's allowPrivateCIDRs punch a named hole through both. What it
+// cannot reach past is the question of whether an address is one a
+// connection can have at all.
 type Policy struct {
 	InternalSubnet string   `json:"internal_subnet"`
 	UplinkSubnet   string   `json:"uplink_subnet"`
@@ -62,8 +63,12 @@ func (p Policy) Validate() error {
 		return fmt.Errorf("deny set is empty; a policy that denies nothing is not a policy")
 	}
 	for _, c := range p.Deny {
-		if _, err := netip.ParsePrefix(c); err != nil {
+		prefix, err := netip.ParsePrefix(c)
+		if err != nil {
 			return fmt.Errorf("cidr %q: %w", c, err)
+		}
+		if !prefix.Addr().Is4() {
+			return fmt.Errorf("deny %s is not IPv4: the capsule egress ruleset is IPv4 only", prefix)
 		}
 	}
 	for _, c := range p.Allow {
@@ -88,8 +93,25 @@ func (p Policy) Validate() error {
 		// the configuration and a gateway that does not.
 		if RefusedOutright(prefix) {
 			return fmt.Errorf("allow %s names addresses no relay reaches, so it cannot take "+
-				"effect: loopback is the gateway itself, and link-local, multicast, broadcast "+
-				"and the unspecified range are not destinations a connection can have", prefix)
+				"effect: loopback is the gateway itself, and multicast, broadcast and the "+
+				"unspecified address are not destinations a connection can have", prefix)
+		}
+		// Link-local one address at a time. The widening rule does not
+		// reach this: the baseline withholds link-local as a /16, so an
+		// allow of exactly that is broader than nothing.
+		if ReopensLinkLocal(prefix) {
+			return fmt.Errorf("allow %s reaches more of link-local than one address, which "+
+				"would hand a job the range its instance keeps its own credentials in; "+
+				"name the address", prefix)
+		}
+		// The ruleset is IPv4. A prefix written in the v4-in-v6 form
+		// renders into it verbatim and never matches at decision time,
+		// because a 128-bit prefix contains no 32-bit address -- the same
+		// firewall-agrees, relay-refuses split, arrived at through
+		// notation.
+		if !prefix.Addr().Is4() {
+			return fmt.Errorf("allow %s is not IPv4: the capsule egress ruleset is IPv4 only, "+
+				"and an address written in the v4-in-v6 form is not one the relay matches", prefix)
 		}
 	}
 	return nil
@@ -160,16 +182,26 @@ func (d *Decider) Allowed(addr netip.Addr) bool {
 	return true
 }
 
-// ipv4Broadcast is the address a datagram goes to when it goes to
-// everyone, which is not something a relay connects to.
-var ipv4Broadcast = netip.AddrFrom4([4]byte{255, 255, 255, 255})
+// unreachable are the ranges no connection reaches, whatever a policy
+// says: the unspecified address names no destination, loopback is the
+// gateway itself, and multicast and broadcast are not connections.
+//
+// Link-local is deliberately absent. It is a real destination on the
+// link, refused by default because a cloud instance keeps its own
+// credentials there, and reopenable one address at a time.
+var unreachable = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/32"),
+	netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+	netip.MustParsePrefix("255.255.255.255/32"),
+}
+
+// linkLocal is the range an allowance reaches only by naming a single
+// address inside it.
+var linkLocal = netip.MustParsePrefix("169.254.0.0/16")
 
 // reachable reports whether an address is the kind a relay can carry at
 // all, which is the one question no policy answers differently.
-// Loopback is the gateway itself, unspecified names no destination, and
-// multicast and broadcast are not connections. Link-local is not here:
-// it is a real destination on the link, refused by default and
-// reopenable by naming it.
 //
 // It is named so the two places that must agree can share it. A policy
 // allowing a range this refuses is not a narrower policy, it is a policy
@@ -179,19 +211,54 @@ var ipv4Broadcast = netip.AddrFrom4([4]byte{255, 255, 255, 255})
 // why.
 func reachable(addr netip.Addr) bool {
 	addr = addr.Unmap()
-	return addr.Is4() && !addr.IsLoopback() && !addr.IsMulticast() &&
-		!addr.IsUnspecified() && addr != ipv4Broadcast
+	if !addr.Is4() {
+		return false
+	}
+	for _, r := range unreachable {
+		if r.Contains(addr) {
+			return false
+		}
+	}
+	return true
 }
 
 // RefusedOutright reports whether an allow prefix names only addresses
 // the decider refuses whatever the policy says.
 //
-// The prefix's own network address decides it, which is enough because
-// an allow broader than the range it sits in is already refused for
-// widening: what reaches here is either inside one of these ranges or
-// outside all of them.
+// Every address in the prefix, not the one it starts at: 0.0.0.0/8
+// begins at an address no connection reaches and holds 16 million that
+// do, and refusing it for its first address would refuse a range an
+// operator may legitimately name.
 func RefusedOutright(prefix netip.Prefix) bool {
-	return !reachable(prefix.Masked().Addr())
+	if !prefix.Addr().Unmap().Is4() {
+		return false
+	}
+	base := prefix.Masked().Addr().Unmap()
+	for _, r := range unreachable {
+		if r.Bits() <= prefix.Bits() && r.Contains(base) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReopensLinkLocal reports whether an allow prefix would reach more of
+// link-local than one named address.
+//
+// The widening rule does not cover this. It refuses a prefix strictly
+// broader than a range the baseline withholds, and link-local is
+// withheld as a /16 -- so an allow of exactly 169.254.0.0/16 is not
+// broader than anything and passes. Before the allow list was consulted
+// ahead of the link-local refusal that entry was inert, and accepting it
+// cost nothing. Now it would hand a job the whole range its instance
+// keeps its credentials in.
+//
+// One address at a time is what the field promises and what a
+// deployment with a reason for it needs. Half the range is not a
+// narrower version of that; it is the same reopening with a longer
+// prefix.
+func ReopensLinkLocal(prefix netip.Prefix) bool {
+	return prefix.Overlaps(linkLocal) && prefix.Bits() != prefix.Addr().BitLen()
 }
 
 // baselineDeny is every IPv4 range that is never a legitimate public

--- a/internal/egress/egress.go
+++ b/internal/egress/egress.go
@@ -82,6 +82,14 @@ func (p Policy) Validate() error {
 		// one of the paths that produce one: a gateway takes a policy
 		// from its reload channel as well as from configuration, and a
 		// check at a single entry point is not a rule.
+		// The family first, as the configuration validator asks it. The
+		// rules below reason about IPv4 ranges, and a prefix in the
+		// v4-in-v6 form compares its 128-bit width against their 32-bit
+		// one -- so it would be refused, but for a reason untrue of it.
+		if !prefix.Addr().Is4() {
+			return fmt.Errorf("allow %s is not IPv4: the capsule egress ruleset is IPv4 only, "+
+				"and an address written in the v4-in-v6 form is not one the relay matches", prefix)
+		}
 		if WidensBaselineDeny(prefix) {
 			return fmt.Errorf("allow %s is broader than a range the restricted profile withholds, "+
 				"so allowing it would reopen that whole range", prefix)
@@ -103,15 +111,6 @@ func (p Policy) Validate() error {
 			return fmt.Errorf("allow %s reaches more of link-local than one address, which "+
 				"would hand a job the range its instance keeps its own credentials in; "+
 				"name the address", prefix)
-		}
-		// The ruleset is IPv4. A prefix written in the v4-in-v6 form
-		// renders into it verbatim and never matches at decision time,
-		// because a 128-bit prefix contains no 32-bit address -- the same
-		// firewall-agrees, relay-refuses split, arrived at through
-		// notation.
-		if !prefix.Addr().Is4() {
-			return fmt.Errorf("allow %s is not IPv4: the capsule egress ruleset is IPv4 only, "+
-				"and an address written in the v4-in-v6 form is not one the relay matches", prefix)
 		}
 	}
 	return nil
@@ -289,14 +288,26 @@ var baselineDeny = []string{
 // BuildDeny composes the deny set: the baseline, the host's own
 // interface networks, every Docker network subnet the daemon knows,
 // and the uplink subnet. Duplicates are dropped, order is stable.
+//
+// IPv4 only, and dropped rather than refused. The set renders into an
+// IPv4 ruleset, so a v6 subnet in it is a line no filter accepts -- and
+// what supplies these is a daemon, not an operator: a host with one
+// IPv6-enabled network would otherwise fail every capsule launch over
+// something nobody in the deployment chose. Nothing is left reachable by
+// leaving one out, because a capsule has no IPv6 at all: the sandbox
+// denies the protocol and the v6 ruleset drops everything.
 func BuildDeny(uplinkSubnet string, hostCIDRs, dockerSubnets []string) []string {
 	seen := map[string]bool{}
 	var out []string
 	add := func(c string) {
-		if c != "" && !seen[c] {
-			seen[c] = true
-			out = append(out, c)
+		if c == "" || seen[c] {
+			return
 		}
+		if prefix, err := netip.ParsePrefix(c); err != nil || !prefix.Addr().Is4() {
+			return
+		}
+		seen[c] = true
+		out = append(out, c)
 	}
 	for _, c := range baselineDeny {
 		add(c)

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -220,9 +220,71 @@ func TestLinkLocalIsRefusedUntilItIsNamed(t *testing.T) {
 		t.Error("an allow naming one link-local address does not take effect, so the entry is " +
 			"accepted, rendered into the ruleset, and refused on every request")
 	}
-	// One address, not the range it sits in.
-	if named.Allowed(netip.MustParseAddr("169.254.1.1")) {
+	// One address, not the range it sits in -- and against the thin deny
+	// set, so the refusal is the decider's rather than the list's.
+	thin.Allow = append(thin.Allow, "169.254.169.254/32")
+	one, err := thin.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !one.Allowed(metadata) {
+		t.Fatal("the named address is not reachable; nothing below means anything")
+	}
+	if one.Allowed(netip.MustParseAddr("169.254.1.1")) {
 		t.Error("naming one link-local address reopened the rest of the range")
+	}
+}
+
+// TestLinkLocalCannotBeReopenedWholesale: the widening rule does not
+// reach this one, and without it the range is one line away.
+//
+// The baseline withholds link-local as a /16, and an allow of exactly
+// that is broader than nothing, so it passes the rule that refuses an
+// allow for what it would take with it. While the decider refused
+// link-local before consulting the allow list such an entry was inert
+// and costing nothing; consulted first, it hands a job the whole range
+// its instance keeps its own credentials in.
+func TestLinkLocalCannotBeReopenedWholesale(t *testing.T) {
+	for _, allow := range []string{
+		"169.254.0.0/16",   // exactly the withheld range: not broader than anything
+		"169.254.0.0/17",   // half of it
+		"169.254.169.0/24", // the neighbourhood of the metadata address
+		"169.254.169.254/31",
+	} {
+		p := policy()
+		p.Allow = append(p.Allow, allow)
+		if err := p.Validate(); err == nil {
+			t.Errorf("allow %s was accepted; it reaches link-local addresses nobody named", allow)
+		}
+	}
+	// And the one shape that is the point of the field.
+	p := policy()
+	p.Allow = append(p.Allow, "169.254.169.254/32")
+	if err := p.Validate(); err != nil {
+		t.Errorf("naming one link-local address was refused: %v", err)
+	}
+}
+
+// TestAnAllowInTheV4InV6FormIsRefused: it renders into the ruleset and
+// never matches at decision time, because a 128-bit prefix contains no
+// 32-bit address. That is the firewall agreeing with the file while the
+// relay refuses everything, reached through notation rather than order.
+func TestAnAllowInTheV4InV6FormIsRefused(t *testing.T) {
+	mapped := "::ffff:198.18.5.0/120"
+	p := policy()
+	p.Allow = append(p.Allow, mapped)
+	if err := p.Validate(); err == nil {
+		d, cerr := p.Compile()
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+		t.Errorf("allow %s was accepted; the ruleset carries its accept and the relay "+
+			"reaches 198.18.5.7 = %v", mapped, d.Allowed(netip.MustParseAddr("198.18.5.7")))
+	}
+	q := policy()
+	q.Deny = append(q.Deny, mapped)
+	if err := q.Validate(); err == nil {
+		t.Errorf("deny %s was accepted; it renders into an IPv4 ruleset and matches nothing", mapped)
 	}
 }
 
@@ -245,6 +307,17 @@ func TestWhatNoConnectionReachesCannotBeAllowed(t *testing.T) {
 		if !RefusedOutright(netip.MustParsePrefix(allow)) {
 			t.Errorf("%s is not reported as unreachable, so the configuration validator "+
 				"would accept it too", allow)
+		}
+	}
+
+	// A prefix that begins at one of those addresses and holds ordinary
+	// ones is not the same thing. 0.0.0.0/8 starts at an address no
+	// connection reaches and covers sixteen million that do, so deciding
+	// from the first address would refuse a range an operator may name.
+	for _, allow := range []string{"0.0.0.0/8", "0.0.0.0/31", "224.0.0.0/3"} {
+		if RefusedOutright(netip.MustParsePrefix(allow)) {
+			t.Errorf("%s is reported as unreachable, but it holds addresses a relay reaches; "+
+				"an operator naming it would be refused with a reason that is not true of it", allow)
 		}
 	}
 }

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -148,3 +148,103 @@ func contains(list []string, want string) bool {
 	}
 	return false
 }
+
+// TestTheKernelAndTheRelayAgreeAboutAnAllow: an operator gets one
+// answer, or the configuration is a lie.
+//
+// The ruleset and the decider are two renderings of one policy, and the
+// operator sees only the first. An allow the kernel accepts and the
+// relay refuses leaves a rule in the firewall that matches the file, and
+// a gateway that answers 403 to every request through it with nothing
+// anywhere saying why.
+func TestTheKernelAndTheRelayAgreeAboutAnAllow(t *testing.T) {
+	for _, allow := range []string{
+		"10.9.8.0/24",        // the ordinary case: a hole in a private range
+		"169.254.169.254/32", // one address of link-local, named
+		"100.64.7.0/24",      // CGNAT
+		"198.18.5.0/24",      // benchmarking
+	} {
+		p := policy()
+		p.Allow = append(p.Allow, allow)
+		if err := p.Validate(); err != nil {
+			t.Errorf("allow %s: rejected by the policy: %v", allow, err)
+			continue
+		}
+		d, err := p.Compile()
+		if err != nil {
+			t.Fatal(err)
+		}
+		prefix := netip.MustParsePrefix(allow)
+		addr := prefix.Masked().Addr()
+		accepted := strings.Contains(p.RenderIPTables("eth0", 3128),
+			"-A OUTPUT -d "+allow+" -j ACCEPT")
+		if reached := d.Allowed(addr); accepted != reached {
+			t.Errorf("allow %s: the ruleset accepts it = %v, the relay reaches %s = %v. "+
+				"An operator reading the firewall and an operator reading the logs "+
+				"see different policies.", allow, accepted, addr, reached)
+		}
+	}
+}
+
+// TestLinkLocalIsRefusedUntilItIsNamed: the default is what matters
+// here, since a cloud instance keeps its own credentials there.
+func TestLinkLocalIsRefusedUntilItIsNamed(t *testing.T) {
+	metadata := netip.MustParseAddr("169.254.169.254")
+
+	// A deny set that does not mention link-local, so the refusal has to
+	// come from the decider. BuildDeny always includes the range, and a
+	// policy carrying it would refuse the address through the list --
+	// proving the list works, not this. The reload channel takes whatever
+	// deny set it is handed, so a policy without it is reachable.
+	thin := policy()
+	thin.Deny = []string{"10.0.0.0/8"}
+	if err := thin.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	plain, err := thin.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain.Allowed(metadata) {
+		t.Error("link-local is reachable with nothing denying it and nothing naming it; " +
+			"a job that wanders into the metadata service arrives")
+	}
+
+	p := policy()
+	p.Allow = append(p.Allow, "169.254.169.254/32")
+	named, err := p.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !named.Allowed(metadata) {
+		t.Error("an allow naming one link-local address does not take effect, so the entry is " +
+			"accepted, rendered into the ruleset, and refused on every request")
+	}
+	// One address, not the range it sits in.
+	if named.Allowed(netip.MustParseAddr("169.254.1.1")) {
+		t.Error("naming one link-local address reopened the rest of the range")
+	}
+}
+
+// TestWhatNoConnectionReachesCannotBeAllowed: an allow through one of
+// these is a line that does nothing, so it is refused rather than
+// accepted and ignored.
+func TestWhatNoConnectionReachesCannotBeAllowed(t *testing.T) {
+	for _, allow := range []string{
+		"127.0.0.1/32",       // the gateway itself
+		"224.0.0.1/32",       // multicast
+		"255.255.255.255/32", // broadcast
+		"0.0.0.0/32",         // no destination
+	} {
+		p := policy()
+		p.Allow = append(p.Allow, allow)
+		if err := p.Validate(); err == nil {
+			t.Errorf("allow %s was accepted; the ruleset would carry its accept while the "+
+				"relay refused every request through it", allow)
+		}
+		if !RefusedOutright(netip.MustParsePrefix(allow)) {
+			t.Errorf("%s is not reported as unreachable, so the configuration validator "+
+				"would accept it too", allow)
+		}
+	}
+}

--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -278,13 +279,29 @@ func TestAnAllowInTheV4InV6FormIsRefused(t *testing.T) {
 		if cerr != nil {
 			t.Fatal(cerr)
 		}
-		t.Errorf("allow %s was accepted; the ruleset carries its accept and the relay "+
-			"reaches 198.18.5.7 = %v", mapped, d.Allowed(netip.MustParseAddr("198.18.5.7")))
+		t.Errorf("allow %s was accepted; it renders into the ruleset verbatim while the "+
+			"relay reaches 198.18.5.7 = %v", mapped, d.Allowed(netip.MustParseAddr("198.18.5.7")))
 	}
 	q := policy()
 	q.Deny = append(q.Deny, mapped)
 	if err := q.Validate(); err == nil {
 		t.Errorf("deny %s was accepted; it renders into an IPv4 ruleset and matches nothing", mapped)
+	}
+
+	// The reason has to be the true one. The rules about ranges compare a
+	// prefix's width against IPv4 widths, so a mapped prefix reaches them
+	// as something 128 bits wide and is refused for covering ranges it
+	// does not cover: ::ffff:127.0.0.0/97 spans two billion addresses a
+	// relay would reach, and being told it is loopback helps nobody.
+	wide := policy()
+	wide.Allow = append(wide.Allow, "::ffff:127.0.0.0/97")
+	err := wide.Validate()
+	if err == nil {
+		t.Fatal("a mapped prefix spanning most of IPv4 was accepted")
+	}
+	if !strings.Contains(err.Error(), "IPv4") {
+		t.Errorf("refused with %q; the prefix is refused for its notation, and any other "+
+			"reason is one that is not true of it", err)
 	}
 }
 
@@ -319,5 +336,43 @@ func TestWhatNoConnectionReachesCannotBeAllowed(t *testing.T) {
 			t.Errorf("%s is reported as unreachable, but it holds addresses a relay reaches; "+
 				"an operator naming it would be refused with a reason that is not true of it", allow)
 		}
+	}
+}
+
+// TestTheDenySetIsIPv4Whatever TheDaemonReports: what fills this set is
+// a daemon, not an operator.
+//
+// A deny set renders into an IPv4 ruleset, and the policy refuses one
+// carrying an address that is not IPv4 — so a host with a single
+// IPv6-enabled Docker network would fail every capsule launch over
+// something nobody in the deployment chose. Nothing is left reachable by
+// dropping it: a capsule has no IPv6 at all.
+func TestTheDenySetIsIPv4WhateverTheDaemonReports(t *testing.T) {
+	deny := BuildDeny("172.21.0.0/24",
+		[]string{"203.0.113.0/24", "2001:db8::/32"},
+		[]string{"172.17.0.0/16", "fd00::/64"})
+
+	for _, c := range deny {
+		p, err := netip.ParsePrefix(c)
+		if err != nil {
+			t.Errorf("deny set carries %q, which is not a prefix at all", c)
+			continue
+		}
+		if !p.Addr().Is4() {
+			t.Errorf("deny set carries %s; the ruleset it renders into is IPv4, and the "+
+				"policy refuses a set carrying it, so every launch on this host fails", c)
+		}
+	}
+	// And the v4 ones it was given are still there.
+	for _, want := range []string{"172.21.0.0/24", "203.0.113.0/24", "172.17.0.0/16"} {
+		if !slices.Contains(deny, want) {
+			t.Errorf("deny set lost %s; another network on this daemon is never a legitimate "+
+				"capsule destination", want)
+		}
+	}
+	if err := (Policy{
+		InternalSubnet: "172.20.0.0/24", UplinkSubnet: "172.21.0.0/24", Deny: deny,
+	}).Validate(); err != nil {
+		t.Errorf("the policy built from what the daemon reported does not validate: %v", err)
 	}
 }


### PR DESCRIPTION
## What changes

An `allowPrivateCIDRs` entry naming a link-local address now reaches that
address, where before the entry was accepted, rendered into the firewall, and
refused by the relay on every request. An entry naming something no connection
reaches — loopback, multicast, broadcast, the unspecified address — is now
refused instead of accepted and ignored.

## What was found

**The decider refused link-local before it consulted the allow list.**
`Allowed` opened with a single guard rejecting anything that is not ordinary
global unicast IPv4, and link-local is in that set, so the allow loop below it
was unreachable for those addresses. Three things then disagreed about one
configuration:

- `internal/config/validate.go` accepted `169.254.169.254/32` — and
  `TestNetworkCIDRValidation` has asserted `"link-local may be reopened"` since
  the field existed.
- `RenderIPTables` emitted `-A OUTPUT -d 169.254.169.254/32 -j ACCEPT`, ahead
  of the denies, exactly as it does for any other allow.
- `Decider.Allowed` returned false, so the relay answered 403.

`docs/reference/configuration.md` describes the field as punching holes
through the built-in deny set with no exception, and `baselineDeny`'s own
comment said the same — *"Operator allowPrivateCIDRs punch holes through it at
decision time"* — while listing link-local among what it withholds. So the
operator has a rule in the firewall that matches the file, a validator that
agreed, and a gateway that refuses, with nothing anywhere naming which is in
force.

The fix is the order, not a new list. Whether an address is one a connection
can have at all is asked first and no policy changes that answer; then the
allow list; then link-local, which stays refused unless the policy named it.
Naming one address reopens that address and not the range around it — but not
for the reason it first appeared to. `WidensBaselineDeny` refuses an allow
*strictly* broader than a withheld range, and the baseline withholds link-local
as a `/16`, so an allow of exactly `169.254.0.0/16` is broader than nothing and
passes it. `/15` is refused and is the only case the existing suite asserts.
Reordering alone therefore turned an inert entry into a live one covering the
whole range an instance keeps its credentials in — the opposite of the point.
So link-local carries a rule of its own: an allow overlapping it is refused
unless it names a single address. Half a range is not a narrower version of
naming an address; it is the same reopening with a longer prefix.

**Keeping link-local denied by default is the point of the default.** A cloud
instance keeps its own credentials at `169.254.169.254`, and a CI job that
wanders into it should not arrive. What changes is only that a deployment with
a reason to reach one address there can now say so and have it mean something.

**A prefix is judged by every address in it.** `RefusedOutright` first decided
from the prefix's own network address, which is wrong the other way round:
`0.0.0.0/8` begins at an address no connection reaches and holds sixteen
million that do, so refusing it gave a reason untrue of it. Containment in one
of the unreachable ranges decides it now.

**And the same split is reachable through notation.** A prefix written
`::ffff:198.18.5.0/120` passed both validators — the configuration validator
unmapped before testing for IPv4 — rendered into the ruleset verbatim, and
matched nothing at decision time, because a 128-bit prefix contains no 32-bit
address. That is the firewall agreeing with the file while the relay refuses
everything, arrived at by writing an address differently. Both lists are now
held to being written as IPv4 at both entry points.

**The same disagreement exists in the other direction.** An allow through
loopback, multicast, broadcast or the unspecified address is a line that can
never take effect, and until now it was accepted: the ruleset carried its
`ACCEPT` while the relay refused every request through it. Those are refused
now, with a reason. The rule sits on `egress.Policy.Validate`, where a gateway
taking a policy from its reload channel meets it as well as one built from
configuration — the same reason `WidensBaselineDeny` moved there. The
configuration validator applies it too, because it names the field an operator
has to fix.

What decides reachability is one predicate both sides call, so the question
the decider asks and the question the validator asks cannot drift apart.

## Evidence

Hermetic. The decider, the renderer and both validators are exercised
in-process; the disagreement is asserted by comparing the two renderings of
one policy rather than by reading either.

Each mutation was applied alone.

```text
MUTATION 1: link-local refused before the allow list is consulted (as shipped)
--- FAIL: TestTheKernelAndTheRelayAgreeAboutAnAllow
    allow 169.254.169.254/32: the ruleset accepts it = true, the relay
    reaches 169.254.169.254 = false. An operator reading the firewall and
    an operator reading the logs see different policies.
--- FAIL: TestLinkLocalIsRefusedUntilItIsNamed
    an allow naming one link-local address does not take effect, so the
    entry is accepted, rendered into the ruleset, and refused on every
    request

MUTATION 2: link-local reachable with nothing naming it
--- FAIL: TestLinkLocalIsRefusedUntilItIsNamed
    link-local is reachable with nothing denying it and nothing naming it;
    a job that wanders into the metadata service arrives

MUTATION 3: what no connection reaches becomes allowable
--- FAIL: TestWhatNoConnectionReachesCannotBeAllowed
    allow 127.0.0.1/32 was accepted; the ruleset would carry its accept
    while the relay refused every request through it
    allow 224.0.0.1/32 was accepted; ...

MUTATION 4: link-local reopenable wholesale
--- FAIL: TestLinkLocalCannotBeReopenedWholesale
    allow 169.254.0.0/16 was accepted; it reaches link-local addresses
    nobody named
    allow 169.254.0.0/17 was accepted; ...

MUTATION 5: reachability decided from the prefix's first address
--- FAIL: TestWhatNoConnectionReachesCannotBeAllowed
    0.0.0.0/8 is reported as unreachable, but it holds addresses a relay
    reaches; an operator naming it would be refused with a reason that is
    not true of it

MUTATION 6: the v4-in-v6 allow is accepted again
--- FAIL: TestAnAllowInTheV4InV6FormIsRefused
    allow ::ffff:198.18.5.0/120 was accepted; the ruleset carries its
    accept and the relay reaches 198.18.5.7 = false
```

Two of those measured nothing on the first attempt and were redone. Mutation 5
passed because no case covered a prefix that *begins* unreachable and holds
reachable addresses; mutation 6 did not apply at all, because the pattern it
edited appears once per list and the harness now asserts a unique match inside
the loop it means to change.

Mutation 2 passed on the first attempt, against a test that names it. The
fixture's deny set is built by `BuildDeny`, which always includes
`169.254.0.0/16`, so the address was refused by the list and the decider's own
guard proved nothing. That case now runs against a policy whose deny set does
not mention link-local — reachable, since the reload channel takes whatever
deny set it is handed — so the guard is the only thing that can refuse it.

The full local gate set mirroring `ci.yml` is green.

## What would notice this regressing

- `TestTheKernelAndTheRelayAgreeAboutAnAllow` — for each of four allow shapes,
  whether `RenderIPTables` emits its `ACCEPT` and whether `Allowed` reaches its
  address must be the same answer. This is the defect stated directly: two
  renderings of one policy, and the operator only sees the first.
- `TestLinkLocalIsRefusedUntilItIsNamed` — denied with nothing naming it,
  reached when named, and naming one address does not reopen the rest. All
  three assertions run against a deny set that does not mention link-local;
  the third did not, and could not fail from the code under test.
- `TestLinkLocalCannotBeReopenedWholesale` — the range itself, half of it, the
  metadata address's neighbourhood and a `/31` are all refused, and the `/32`
  is not.
- `TestAnAllowInTheV4InV6FormIsRefused` — on both lists, since a mapped prefix
  renders into an IPv4 ruleset and matches nothing; and that the reason given
  is its notation rather than a range rule, because the range rules compare a
  128-bit width against IPv4 ones and would refuse it for covering ranges it
  does not cover.
- `TestNetworkCIDRValidation` gains four cases at the configuration entry
  point: the whole of link-local, half of it, and a mapped prefix on each
  list. The two rules this change added there had no case of their own, and
  both could be reverted with the suite green — the file an operator edits is
  the path that matters most for both.
- `TestTheDenySetIsIPv4WhateverTheDaemonReports` — the set is filled by a
  daemon, and holding it to IPv4 without dropping what is not would fail every
  launch on a host with one IPv6-enabled Docker network.
- `TestWhatNoConnectionReachesCannotBeAllowed` — the policy refuses those four
  shapes, and `RefusedOutright` reports them, which is what carries the same
  rule into the configuration validator.
- `TestNetworkCIDRValidation` keeps its existing cases, including
  `"link-local may be reopened"` and `"swallows link-local"`.
- `TestDecide` and `TestRenderRules` are unchanged and still pass, which is
  what says the default posture did not move.

## Risk, compatibility and operations

**Trust boundary.** One thing becomes reachable that was not: a link-local
address an operator has explicitly named in `allowPrivateCIDRs`. It was
already accepted by validation and already in the rendered ruleset, so this
does not widen what an operator can ask for — it makes what they asked for
true. Nothing becomes reachable without such an entry: with no allow naming
it, link-local is refused by the decider even if the policy's deny set omits
the range, which is stricter than relying on the list.

**What an operator must know.** Naming a link-local address is naming the
metadata service, and the documentation now says so where the field is
described. A deployment that had such an entry and relied on it being inert
would find it live after this; a deployment that had one expecting it to work
would find it working. Nothing is released, so neither exists yet.

**Failure behaviour.** A policy with an allow that cannot take effect is now
refused at both entry points rather than installed. On the reload channel that
means the install fails and the previous policy stays in force, which is the
existing fail-closed shape — the stricter of the two is what remains.

**Networking, resource limits, credentials, ownership.** No change to the
ruleset's shape, the relay's bounds, the port set, or what is created or
removed.

**CLI, status API, schema, migration, deployment, rollback.** None. One
configuration field changes what it accepts and what it does; no key is added
or renamed.

**Decision record.** No ADR is needed and none is amended.
`2026-08-13-egress-relay` places the address decision in the relay and does not
enumerate the special ranges, so which of them a policy may reopen is below
it. `2026-08-11-network-sandbox-proxy` argues the other way about the kernel —
egress is denied by the host, not by rules Runpool installs — and says nothing
about the two agreeing, so it neither supports nor contradicts this.

## Changelog

```text
### Isolation and egress

- **An operator allowance is bounded by what it reopens.**
  `network.allowPrivateCIDRs` punches holes through the built-in deny
  set, so an entry *broader* than a withheld range would reopen that
  whole range as a side effect; a policy carrying one is refused. The
  rule belongs to the policy rather than to the configuration file, so
  the live reload channel is held to it too.
  An entry naming what no connection reaches — loopback, multicast,
  broadcast, the unspecified address — is refused for the opposite
  reason: it cannot take effect, and accepting it would leave an allow
  rule in the rendered firewall while the gateway refused every request
  through it. Link-local is not in that group: it stays denied by
  default, because a cloud instance keeps its own credentials there, and
  an allowance naming one address in it now reaches that address rather
  than being accepted and quietly ignored. One address is the whole of
  what it can reach: an entry covering more of the range is refused,
  which the rule above does not do for it, since the baseline withholds
  link-local as a single range and an entry of exactly that is broader
  than nothing.
  Both lists are also held to being written as IPv4. An address in the
  v4-in-v6 form renders into the ruleset and matches nothing at decision
  time, which is the same split arrived at through notation.
```

## Notes for your reviewer

The rule that bounds link-local is a second rule rather than a strengthening
of the widening one, because the widening rule is about what an entry takes
*with* it and this is about what an entry may cover at all. `10.0.0.0/8` is
accepted wholesale and is the field's ordinary use, so equality with a
withheld range cannot be refused in general.

The thing I would look at first is whether link-local belongs on the
reopenable side at all. The test that decided it for me is
`TestNetworkCIDRValidation`'s `"link-local may be reopened"`, which predates
this change, and the configuration reference describes the field with no
exception — so the alternative reading, that the decider was right and the
validator and the documentation were wrong, would mean refusing the entry
instead. I went with what the product says twice over rather than what one
guard did, and the default is unchanged either way.

Second, `reachable` no longer calls `IsGlobalUnicast`; it tests containment in
a named list of ranges instead, and that list is also what decides a whole
prefix. It is meant to be equivalent for IPv4 minus link-local, which moved;
worth checking against the standard library's own definition rather than
taking my word for it.

Third, the deny set's family is settled where the set is assembled rather than
at `AllNetworkSubnets`, which is one of the things that fills it. Its sibling
`NetworkSubnet` does guard, so the asymmetry there is real — but a producer-side
guard would have been unreachable from any test that does not need a daemon,
and the invariant belongs to the set rather than to any one source of it.

Deliberately left alone: `RenderIPTables` still emits an `ACCEPT` for whatever
allow it is given, and does not itself refuse an unreachable one. Validation at
both entry points is what keeps one from arriving, and putting the rule in the
renderer as well would be a third place for it to drift.
