### PR TITLE
fix(app): a session that will not clear says so in the report, and an unrelated outage does not age the wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,15 @@ by its public and operational effects.
   capsule whose job is running and delete the records that clean up after
   it. Cache lane collection already stated that order for the same
   reason.
+- **A binding stops waiting for a session that will not clear.** The
+  broker holds a crashed predecessor's session until it expires by
+  inactivity, and waiting that out is the ordinary shape of a restart.
+  Waiting for ever is not: past a deadline the binding stops trying and
+  records why, where `runpool status` reports it, while the other
+  bindings keep serving. A controller whose every binding has stopped
+  ends rather than staying up serving nothing — not because a restart
+  clears the broker's session, which it does not, but because a process
+  that is up and doing nothing is invisible to whatever supervises it.
 - **The provider's own answer outranks the capsule's.** Every other
   account of whether a job was handed over comes from inside the capsule
   — the state it reports, the code it exits with — and the capsule is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,15 +305,16 @@ by its public and operational effects.
   capsule whose job is running and delete the records that clean up after
   it. Cache lane collection already stated that order for the same
   reason.
-- **A binding stops waiting for a session that will not clear.** The
-  broker holds a crashed predecessor's session until it expires by
-  inactivity, and waiting that out is the ordinary shape of a restart.
-  Waiting for ever is not: past a deadline the binding stops trying and
-  records why, where `runpool status` reports it, while the other
-  bindings keep serving. A controller whose every binding has stopped
-  ends rather than staying up serving nothing — not because a restart
-  clears the broker's session, which it does not, but because a process
-  that is up and doing nothing is invisible to whatever supervises it.
+- **A session that will not clear says so in the report, not only in the
+  log.** The broker holds a crashed predecessor's session until it
+  expires by inactivity, and waiting that out is the ordinary shape of a
+  restart. Past the point one expires by, it is not: the reason recorded
+  against the binding changes to say the session is not clearing on its
+  own and that only work already queued is being served, so
+  `runpool status` distinguishes waiting from stuck instead of showing
+  the same line either way. The binding keeps waiting, because the work
+  it can serve without a broker is work it would otherwise stop serving,
+  and the other bindings are unaffected.
 - **The provider's own answer outranks the capsule's.** Every other
   account of whether a job was handed over comes from inside the capsule
   — the state it reports, the code it exits with — and the capsule is

--- a/docs/adrs/2026-08-11-session-conflict.md
+++ b/docs/adrs/2026-08-11-session-conflict.md
@@ -39,8 +39,34 @@ removed — during the wait, and the job concluded successfully.
 
 - The retry deadline bounds how long a fresh start tolerates a stuck
   session before giving up and letting the platform restart it.
+
 - This is distinct from local controller contention: here the singleton
   lock is already held and only the remote session lingers. Standby and
   handover between two controllers are not implemented.
 - Reconcile-before-session is now a load-bearing ordering, not an
   incidental one, and is documented as such.
+
+## Amendment
+
+**Date:** 2026-08-20
+
+The deadline above needed a unit, and giving up needed something to
+mean. Both are now decided.
+
+The deadline belongs to a binding, not to the process. A controller may
+serve several scale sets, and one broker holding one session is not a
+reason to stop serving the others: the binding that cannot open a
+session stops trying, records the reason where `runpool status` reports
+it, and leaves the rest running.
+
+Giving up ends the process only when every binding has. That is the one
+shape a restart is the right answer to — and the honest reason is not
+that a restart clears the session, because it does not. It is that a
+process which is up and serving nothing is invisible to whatever
+supervises it, and one that exits is not.
+
+The value is fifteen minutes: three times the point at which the wait
+stops being ordinary, which is itself well past the inactivity the
+broker expires a session on. Long enough that a broker recovering
+slowly is not mistaken for one that will not, short enough that an
+operator is not an hour into an outage before anything says so.

--- a/docs/adrs/2026-08-11-session-conflict.md
+++ b/docs/adrs/2026-08-11-session-conflict.md
@@ -39,34 +39,8 @@ removed — during the wait, and the job concluded successfully.
 
 - The retry deadline bounds how long a fresh start tolerates a stuck
   session before giving up and letting the platform restart it.
-
 - This is distinct from local controller contention: here the singleton
   lock is already held and only the remote session lingers. Standby and
   handover between two controllers are not implemented.
 - Reconcile-before-session is now a load-bearing ordering, not an
   incidental one, and is documented as such.
-
-## Amendment
-
-**Date:** 2026-08-20
-
-The deadline above needed a unit, and giving up needed something to
-mean. Both are now decided.
-
-The deadline belongs to a binding, not to the process. A controller may
-serve several scale sets, and one broker holding one session is not a
-reason to stop serving the others: the binding that cannot open a
-session stops trying, records the reason where `runpool status` reports
-it, and leaves the rest running.
-
-Giving up ends the process only when every binding has. That is the one
-shape a restart is the right answer to — and the honest reason is not
-that a restart clears the session, because it does not. It is that a
-process which is up and serving nothing is invisible to whatever
-supervises it, and one that exits is not.
-
-The value is fifteen minutes: three times the point at which the wait
-stops being ordinary, which is itself well past the inactivity the
-broker expires a session on. Long enough that a broker recovering
-slowly is not mistaken for one that will not, short enough that an
-operator is not an hour into an outage before anything says so.

--- a/docs/adrs/2026-08-20-the-session-wait-has-no-deadline.md
+++ b/docs/adrs/2026-08-20-the-session-wait-has-no-deadline.md
@@ -1,0 +1,67 @@
+# The session wait has no deadline; what changes is what it reports
+
+**Status:** accepted, supersedes one consequence of
+[session conflict](2026-08-11-session-conflict.md)
+
+**Date:** 2026-08-20
+
+## Context
+
+[Session conflict](2026-08-11-session-conflict.md) decided that session
+creation retries a broker 409 with a fixed backoff, and listed among its
+consequences:
+
+> The retry deadline bounds how long a fresh start tolerates a stuck
+> session before giving up and letting the platform restart it.
+
+The retry and the backoff were built. The deadline was not, and building
+it showed why the consequence does not hold for this controller.
+
+Two things were measured against the code as it stands.
+
+**A binding cannot end the process by returning.** The serve loop waits
+on every loop it started, and three of them — the periodic reconciler,
+the disk monitor and the sandbox watch — return only when the serve
+context is done. A binding that gave up therefore left `loops.Wait()`
+blocked, so the process stayed up serving nothing, which is the state a
+deadline exists to end. Worse, the error it left behind surfaced only
+after a signal, so an operator's clean shutdown of that controller
+exited non-zero.
+
+**A binding whose session is stuck is not serving nothing.** The loop
+drains ready attempts before it requires a session, deliberately — its
+own comment says local work drains whether or not the broker is
+reachable. Work already delivered and queued is served with no broker
+involved at all. Returning from the loop discards that: attempts sit
+ready with nobody to launch them until the process restarts.
+
+And a restart does not clear the broker's session. Nothing on this side
+can; the session expires by inactivity on the provider's, on the
+provider's schedule.
+
+## Decision
+
+There is no deadline. A binding waits a conflict out for as long as it
+lasts, because waiting costs nothing it was otherwise doing and stopping
+costs the work it was.
+
+What the five-minute grace marks is a change in what is reported, not in
+what is done. Past it the reason recorded against the binding says the
+session is not clearing on its own and that only work already queued is
+being served — a different string from the 409 recorded while the wait
+is still ordinary, so `runpool status` distinguishes the two states
+rather than showing the same line for ten minutes and then for ever.
+
+A run of conflicts is a run of conflicts: a failure to open a session
+that is not a conflict ends it, so time a binding spent unable to reach
+the broker at all is not counted as time it spent waiting one out.
+
+## Consequences
+
+- A permanently stuck session is an operator's decision, not the
+  controller's. The report names the state and the runbook says what to
+  check; nothing exits on its own.
+- The five-minute grace now has two effects rather than one: the log
+  level it always changed, and the reported reason.
+- A controller with one stuck binding keeps serving its other bindings,
+  and the stuck one keeps serving what it already holds.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -8,7 +8,7 @@ justified it usually still holds even when the remedy does not.
 | Date | Decision | Status |
 | --- | --- | --- |
 | 2026-08-11 | [SQLite driver](2026-08-11-sqlite-driver.md) — modernc, pinned and tested on a Linux named volume | accepted |
-| 2026-08-11 | [Session conflict](2026-08-11-session-conflict.md) — one session per scale set, and what a conflict means | accepted |
+| 2026-08-11 | [Session conflict](2026-08-11-session-conflict.md) — one session per scale set, and what a conflict means | accepted; its retry deadline superseded |
 | 2026-08-11 | [Shared network namespace](2026-08-11-shared-network-namespace.md) — the runner joins dind rather than attaching itself | accepted |
 | 2026-08-11 | [Advertised capacity](2026-08-11-advertised-capacity.md) — capacity is a total, not a delta | accepted |
 | 2026-08-11 | [Capacity floor](2026-08-11-capacity-floor.md) — every binding floored at one | superseded by admission credits |
@@ -23,3 +23,4 @@ justified it usually still holds even when the remedy does not.
 | 2026-08-17 | [Job timeout](2026-08-17-job-timeout.md) — the lease ceiling is a backstop above the provider's own maximum | accepted |
 | 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; implementation pending |
 | 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |
+| 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -182,6 +182,29 @@ encrypted host swap where CI secrets may be paged to disk, and investigate
 sustained swap activity as resource pressure rather than treating it as normal
 capacity.
 
+## A binding that cannot open its session
+
+GitHub's broker allows one active message session per scale set, and a
+controller killed without a clean shutdown leaves its session marked
+active until the broker expires it by inactivity. A successor sees `409
+Conflict` on every attempt to open one. This is ordinary on a restart:
+the binding logs that it is waiting, and the wait costs nothing, because
+adopted capsules are recovered before session creation is reached.
+
+Past five minutes the wait stops being ordinary and the binding reports
+a provider failure, which `runpool status` shows against it. Past fifteen
+it stops waiting: that binding serves nothing until the controller is
+restarted, and the reason stays in the report. Other bindings are
+unaffected and keep serving.
+
+If **every** binding reaches that point the controller exits non-zero,
+so whatever supervises it can act. Restarting does not clear the
+broker's session — nothing on this side can — but a process that is up
+and serving nothing is invisible, and one that has exited is not. If a
+restart loops, the session is genuinely stuck on the provider's side:
+check whether another controller is running against the same scale set,
+and otherwise wait the broker out rather than restarting into it.
+
 ## Manual review
 
 `runpool status` lists attempts held for a person. Inspect one with

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -191,19 +191,21 @@ Conflict` on every attempt to open one. This is ordinary on a restart:
 the binding logs that it is waiting, and the wait costs nothing, because
 adopted capsules are recovered before session creation is reached.
 
-Past five minutes the wait stops being ordinary and the binding reports
-a provider failure, which `runpool status` shows against it. Past fifteen
-it stops waiting: that binding serves nothing until the controller is
-restarted, and the reason stays in the report. Other bindings are
-unaffected and keep serving.
+Past five minutes it stops being ordinary. The log moves to error level
+and the reason recorded against the binding changes to say the session is
+not clearing on its own — which is what `runpool status` shows, so
+waiting and stuck are distinguishable there rather than only in the log.
 
-If **every** binding reaches that point the controller exits non-zero,
-so whatever supervises it can act. Restarting does not clear the
-broker's session — nothing on this side can — but a process that is up
-and serving nothing is invisible, and one that has exited is not. If a
-restart loops, the session is genuinely stuck on the provider's side:
-check whether another controller is running against the same scale set,
-and otherwise wait the broker out rather than restarting into it.
+The binding keeps waiting, and keeps serving what it already holds: work
+already delivered and queued is launched without the broker. What it
+cannot do is take new work, because that arrives over the session.
+
+Nothing times this out, and nothing restarts on it. Restarting does not
+clear the broker's session — only inactivity on the provider's side
+does — so a controller reporting this needs a decision rather than a
+kick. Check whether another controller is running against the same scale
+set; if none is, the session expires on the provider's schedule and the
+binding recovers on its next attempt.
 
 ## Manual review
 

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
@@ -90,30 +91,35 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 					// past that the binding serves nothing for a reason
 					// nothing else would carry.
 					b.conflictSince = firstOf(b.conflictSince, time.Now())
-					held := time.Since(b.conflictSince)
-					switch {
-					case held > s.conflictDeadline():
-						// Past here the wait has stopped being useful.
-						// The binding serves nothing either way, and a
-						// loop that keeps saying so on a schedule is a
-						// process that looks alive to whatever supervises
-						// it. It stops, and the report carries why.
-						s.log.Error("the broker has held this binding's session beyond the point "+
-							"waiting can help; the binding stops trying",
-							"binding", b.key, "held", held.Round(time.Second),
-							"deadline", s.conflictDeadline())
-						s.recordProviderFailure(ctx, b, err)
-						b.gaveUpOnSession = true
-						return
-					case held > sessionConflictGrace:
+					if held := time.Since(b.conflictSince); held > s.sessionGrace() {
 						s.log.Error("the broker has held this binding's session past the point it expires by inactivity",
 							"binding", b.key, "held", held.Round(time.Second))
-						s.recordProviderFailure(ctx, b, err)
-					default:
+						// A different reason, not the same 409 the wait
+						// has been recording. The report is one string
+						// per binding, so an operator reading it sees
+						// what the log level already said only if the
+						// two states say different things: waiting one
+						// out is ordinary, and a session that outlasts
+						// what a session can outlast is not. It carries
+						// no elapsed time on purpose -- the record is
+						// written when the reason changes, and a reason
+						// that changes every pass would be written every
+						// pass.
+						s.recordProviderFailure(ctx, b, fmt.Errorf(
+							"the broker has held this binding's session past the point one expires "+
+								"by inactivity, so it is not clearing on its own; only work already "+
+								"queued is being served: %w", err))
+					} else {
 						s.log.Info("the broker still holds this binding's previous session; waiting for it to expire",
 							"binding", b.key)
 					}
 				} else {
+					// Not a conflict, so the run of conflicts is over
+					// whatever else is wrong. Left standing, an outage
+					// between two conflicts counts toward the run, and a
+					// binding that has waited out nothing reports a
+					// session that will not clear.
+					b.conflictSince = time.Time{}
 					s.log.Error("cannot open a message session; the binding keeps retrying",
 						"binding", b.key, "error", err)
 					s.recordProviderFailure(ctx, b, err)
@@ -518,6 +524,16 @@ func (s *Controller) scheduleReadyAttempts(ctx context.Context, b *binding) {
 		s.wg.Add(1)
 		go s.launch(b, lease)
 	}
+}
+
+// sessionGrace is how long a run of broker session conflicts stays the
+// ordinary shape of a restart. Held on the controller for the same
+// reason as backoff below.
+func (s *Controller) sessionGrace() time.Duration {
+	if s.conflictGrace != 0 {
+		return s.conflictGrace
+	}
+	return sessionConflictGrace
 }
 
 // backoff is the pause between failed polls. Held on the controller so a

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -90,11 +90,26 @@ func (s *Controller) loop(ctx context.Context, b *binding) {
 					// past that the binding serves nothing for a reason
 					// nothing else would carry.
 					b.conflictSince = firstOf(b.conflictSince, time.Now())
-					if held := time.Since(b.conflictSince); held > sessionConflictGrace {
+					held := time.Since(b.conflictSince)
+					switch {
+					case held > s.conflictDeadline():
+						// Past here the wait has stopped being useful.
+						// The binding serves nothing either way, and a
+						// loop that keeps saying so on a schedule is a
+						// process that looks alive to whatever supervises
+						// it. It stops, and the report carries why.
+						s.log.Error("the broker has held this binding's session beyond the point "+
+							"waiting can help; the binding stops trying",
+							"binding", b.key, "held", held.Round(time.Second),
+							"deadline", s.conflictDeadline())
+						s.recordProviderFailure(ctx, b, err)
+						b.gaveUpOnSession = true
+						return
+					case held > sessionConflictGrace:
 						s.log.Error("the broker has held this binding's session past the point it expires by inactivity",
 							"binding", b.key, "held", held.Round(time.Second))
 						s.recordProviderFailure(ctx, b, err)
-					} else {
+					default:
 						s.log.Info("the broker still holds this binding's previous session; waiting for it to expire",
 							"binding", b.key)
 					}

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -117,23 +117,6 @@ const (
 	// session by inactivity well inside this, so past it the binding is
 	// serving nothing for a reason no report would otherwise carry.
 	sessionConflictGrace = 5 * time.Minute
-	// sessionConflictDeadline is how long a binding waits for a session
-	// it cannot open before it stops waiting.
-	//
-	// Three times the point at which the wait stopped being ordinary.
-	// The broker expires a session by inactivity in well under a minute,
-	// so a run of conflicts lasting a quarter of an hour is not a
-	// predecessor's session clearing slowly; it is one that is not going
-	// to clear. Long enough that a broker recovering slowly is not
-	// mistaken for that, short enough that an operator is not an hour
-	// into an outage before anything says so.
-	//
-	// Giving up does not fix it: a restart does not clear the broker's
-	// session either. What it buys is a signal. A process that is up and
-	// serving nothing is invisible to whatever supervises it, and one
-	// that exits is not -- so a controller whose every binding has given
-	// up ends, rather than logging into a void on a schedule.
-	sessionConflictDeadline = 15 * time.Minute
 )
 
 type Options struct {
@@ -190,13 +173,9 @@ type binding struct {
 	// broker expires a session on is not, and only elapsed time tells the
 	// two apart. Owned by the binding's own loop.
 	conflictSince time.Time
-	// gaveUpOnSession records that this binding stopped waiting for a
-	// session it could not open. Written by the binding's own loop as it
-	// returns, read after every loop has, which is what makes it safe.
-	gaveUpOnSession bool
-	bindingID       assignment.BindingID
-	cacheEnabled    bool
-	generation      string
+	bindingID     assignment.BindingID
+	cacheEnabled  bool
+	generation    string
 	// capsuleImage is what this binding launches: its tier's image where
 	// one is configured, and the image this build ships otherwise. It is
 	// resolved once, per binding, so the launch path never re-decides it.
@@ -401,39 +380,7 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 		}(b)
 	}
 	loops.Wait()
-	if err := s.drain(); err != nil {
-		return err
-	}
-	return s.everyBindingGaveUp()
-}
-
-func (s *Controller) conflictDeadline() time.Duration {
-	if s.conflictDeadlineOverride != 0 {
-		return s.conflictDeadlineOverride
-	}
-	return sessionConflictDeadline
-}
-
-// everyBindingGaveUp reports the controller serving nothing, which is
-// the one shape a restart is the right answer to.
-//
-// A binding that stops waiting for a session it cannot open leaves its
-// own work unserved and says so durably, which is enough while another
-// binding is still working: the loops that remain keep this process
-// alive and the report names the one that does not. When none remain,
-// the process is up and serving nothing, and nothing supervising it can
-// tell -- so it ends instead.
-func (s *Controller) everyBindingGaveUp() error {
-	if len(s.bindings) == 0 {
-		return nil
-	}
-	for _, b := range s.bindings {
-		if !b.gaveUpOnSession {
-			return nil
-		}
-	}
-	return fmt.Errorf("no binding could open a message session within %s; "+
-		"the broker still holds a session for each of them", sessionConflictDeadline)
+	return s.drain()
 }
 
 func newAllocator(cfg *config.Config) *allocator.Allocator {
@@ -528,11 +475,12 @@ type Controller struct {
 	// reopen path; zero means the package default. Held for the same
 	// reason as pollBackoff: ten seconds is not something a test waits.
 	conflictBackoff time.Duration
-	// conflictDeadlineOverride overrides sessionConflictDeadline; zero
-	// means the package default. A quarter of an hour is not something a
-	// test waits either, and the behaviour past it is a return.
-	conflictDeadlineOverride time.Duration
-	store                    *store.Store
+	// conflictGrace overrides sessionConflictGrace; zero means the
+	// package default. Held for the same reason as the two above: five
+	// minutes is not something a test waits, and what happens past it is
+	// the whole of this behaviour.
+	conflictGrace time.Duration
+	store         *store.Store
 	// objects is the daemon as reconciliation sees it: an inventory and
 	// a way to remove from it. Creating capsules goes through caps, and
 	// awaiting them through wait.

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -115,7 +115,11 @@ const (
 	// sessionConflictGrace is how long a broker may hold a predecessor's
 	// session before the wait stops being ordinary. The broker expires a
 	// session by inactivity well inside this, so past it the binding is
-	// serving nothing for a reason no report would otherwise carry.
+	// taking no new work for a reason that will not resolve itself. It
+	// keeps serving what it already holds, and the reason it records
+	// changes to say both of those things -- the report holds one string
+	// per binding, and waiting one out and being stuck behind one have to
+	// read differently in it.
 	sessionConflictGrace = 5 * time.Minute
 )
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -117,6 +117,23 @@ const (
 	// session by inactivity well inside this, so past it the binding is
 	// serving nothing for a reason no report would otherwise carry.
 	sessionConflictGrace = 5 * time.Minute
+	// sessionConflictDeadline is how long a binding waits for a session
+	// it cannot open before it stops waiting.
+	//
+	// Three times the point at which the wait stopped being ordinary.
+	// The broker expires a session by inactivity in well under a minute,
+	// so a run of conflicts lasting a quarter of an hour is not a
+	// predecessor's session clearing slowly; it is one that is not going
+	// to clear. Long enough that a broker recovering slowly is not
+	// mistaken for that, short enough that an operator is not an hour
+	// into an outage before anything says so.
+	//
+	// Giving up does not fix it: a restart does not clear the broker's
+	// session either. What it buys is a signal. A process that is up and
+	// serving nothing is invisible to whatever supervises it, and one
+	// that exits is not -- so a controller whose every binding has given
+	// up ends, rather than logging into a void on a schedule.
+	sessionConflictDeadline = 15 * time.Minute
 )
 
 type Options struct {
@@ -173,9 +190,13 @@ type binding struct {
 	// broker expires a session on is not, and only elapsed time tells the
 	// two apart. Owned by the binding's own loop.
 	conflictSince time.Time
-	bindingID     assignment.BindingID
-	cacheEnabled  bool
-	generation    string
+	// gaveUpOnSession records that this binding stopped waiting for a
+	// session it could not open. Written by the binding's own loop as it
+	// returns, read after every loop has, which is what makes it safe.
+	gaveUpOnSession bool
+	bindingID       assignment.BindingID
+	cacheEnabled    bool
+	generation      string
 	// capsuleImage is what this binding launches: its tier's image where
 	// one is configured, and the image this build ships otherwise. It is
 	// resolved once, per binding, so the launch path never re-decides it.
@@ -380,7 +401,39 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 		}(b)
 	}
 	loops.Wait()
-	return s.drain()
+	if err := s.drain(); err != nil {
+		return err
+	}
+	return s.everyBindingGaveUp()
+}
+
+func (s *Controller) conflictDeadline() time.Duration {
+	if s.conflictDeadlineOverride != 0 {
+		return s.conflictDeadlineOverride
+	}
+	return sessionConflictDeadline
+}
+
+// everyBindingGaveUp reports the controller serving nothing, which is
+// the one shape a restart is the right answer to.
+//
+// A binding that stops waiting for a session it cannot open leaves its
+// own work unserved and says so durably, which is enough while another
+// binding is still working: the loops that remain keep this process
+// alive and the report names the one that does not. When none remain,
+// the process is up and serving nothing, and nothing supervising it can
+// tell -- so it ends instead.
+func (s *Controller) everyBindingGaveUp() error {
+	if len(s.bindings) == 0 {
+		return nil
+	}
+	for _, b := range s.bindings {
+		if !b.gaveUpOnSession {
+			return nil
+		}
+	}
+	return fmt.Errorf("no binding could open a message session within %s; "+
+		"the broker still holds a session for each of them", sessionConflictDeadline)
 }
 
 func newAllocator(cfg *config.Config) *allocator.Allocator {
@@ -475,7 +528,11 @@ type Controller struct {
 	// reopen path; zero means the package default. Held for the same
 	// reason as pollBackoff: ten seconds is not something a test waits.
 	conflictBackoff time.Duration
-	store           *store.Store
+	// conflictDeadlineOverride overrides sessionConflictDeadline; zero
+	// means the package default. A quarter of an hour is not something a
+	// test waits either, and the behaviour past it is a return.
+	conflictDeadlineOverride time.Duration
+	store                    *store.Store
 	// objects is the daemon as reconciliation sees it: an inventory and
 	// a way to remove from it. Creating capsules goes through caps, and
 	// awaiting them through wait.

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -415,25 +416,21 @@ func TestAReopenConflictWaitsAtItsOwnInterval(t *testing.T) {
 
 // TestASessionThatWillNotClearReportsSomethingElse: the report is one
 // string per binding, so waiting a conflict out and being stuck behind
-// one have to say different things in it.
+// one have to read differently in it.
 //
-// A conflict is the ordinary shape of a restart, and the binding says so
-// while it waits. Past the point a session expires by inactivity it is
-// not ordinary any more — but the log level is the only place that ever
-// changed, and an operator reading `runpool status` saw the same 409
-// either way. The binding is still serving what was already queued,
-// which is the part the report has to be able to say.
+// A conflict is the ordinary shape of a restart, and while the wait is
+// ordinary nothing is recorded at all — the binding is not failing to
+// reach its provider, and saying so would put every restart in the
+// report. Past the point a session expires by inactivity it is not
+// ordinary any more, and that is what the record has to carry: an
+// operator reading `runpool status` decides whether to act, and the log
+// level is not where they look.
+//
+// Both halves are asserted, and each is gated on the loop's own attempt
+// count rather than on the clock, so neither can pass by sampling at a
+// convenient moment.
 func TestASessionThatWillNotClearReportsSomethingElse(t *testing.T) {
-	h := newHarness(t, 1)
-	h.srv.pollBackoff = time.Hour
-	h.srv.conflictBackoff = time.Millisecond
-	h.srv.conflictGrace = 30 * time.Millisecond
-
-	h.bind.newSession = func(context.Context) (providerSession, error) {
-		return nil, errors.New(`the session "abc" already exists, status="409 Conflict"`)
-	}
-
-	read := func() string {
+	read := func(t *testing.T, h *harness) string {
 		t.Helper()
 		var reason string
 		if err := h.srv.store.Tx(t.Context(), func(tx *store.Tx) error {
@@ -450,33 +447,65 @@ func TestASessionThatWillNotClearReportsSomethingElse(t *testing.T) {
 		return reason
 	}
 
-	ctx, cancel := context.WithCancel(t.Context())
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		h.srv.loop(ctx, h.bind)
-	}()
+	// conflicting runs the loop against a broker that always answers 409,
+	// and returns once it has answered n times.
+	conflicting := func(t *testing.T, h *harness, grace time.Duration, n int64) {
+		t.Helper()
+		h.srv.pollBackoff = time.Hour
+		h.srv.conflictBackoff = time.Millisecond
+		h.srv.conflictGrace = grace
 
-	var stuck string
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		if r := read(); strings.Contains(r, "not clearing on its own") {
-			stuck = r
-			break
+		var attempts atomic.Int64
+		reached := make(chan struct{})
+		var once sync.Once
+		h.bind.newSession = func(context.Context) (providerSession, error) {
+			if attempts.Add(1) >= n {
+				once.Do(func() { close(reached) })
+			}
+			return nil, errors.New(`the session "abc" already exists, status="409 Conflict"`)
 		}
-		time.Sleep(2 * time.Millisecond)
-	}
-	cancel()
-	<-done
 
-	if stuck == "" {
-		t.Fatalf("the report never distinguished a session that will not clear from one being "+
-			"waited out; it says %q either way", read())
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			h.srv.loop(ctx, h.bind)
+		}()
+		select {
+		case <-reached:
+		case <-time.After(10 * time.Second):
+			cancel()
+			<-done
+			t.Fatalf("the loop answered fewer than %d conflicts", n)
+		}
+		cancel()
+		<-done
 	}
-	if !strings.Contains(stuck, "already queued") {
-		t.Errorf("the reason is %q; it has to say the binding is still serving what it has, "+
-			"because an operator reading it decides whether to act", stuck)
-	}
+
+	t.Run("while the wait is ordinary", func(t *testing.T) {
+		h := newHarness(t, 1)
+		// An hour of grace, so every one of these conflicts is inside it.
+		conflicting(t, h, time.Hour, 5)
+		if got := read(t, h); got != "" {
+			t.Errorf("five conflicts inside the grace recorded %q. Waiting one out is the "+
+				"ordinary shape of a restart, and an operator reading the report cannot tell "+
+				"it from a session that will not clear.", got)
+		}
+	})
+
+	t.Run("once it is not", func(t *testing.T) {
+		h := newHarness(t, 1)
+		conflicting(t, h, 20*time.Millisecond, 200)
+		got := read(t, h)
+		if !strings.Contains(got, "not clearing on its own") {
+			t.Fatalf("the report says %q past the grace; it never distinguished a session that "+
+				"will not clear from one being waited out", got)
+		}
+		if !strings.Contains(got, "already queued") {
+			t.Errorf("the reason is %q; it has to say the binding is still serving what it "+
+				"has, because an operator reading it decides whether to act", got)
+		}
+	})
 }
 
 // TestAnUnrelatedOutageDoesNotAgeTheConflict: the run of conflicts is a

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -10,6 +11,8 @@ import (
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+
+	"github.com/rhobuild/runpool/internal/store"
 )
 
 // stubSession is a message session a test can break on purpose. The
@@ -410,62 +413,103 @@ func TestAReopenConflictWaitsAtItsOwnInterval(t *testing.T) {
 	<-done
 }
 
-// TestABindingStopsWaitingForASessionThatWillNotClear: waiting past the
-// point it can help is a process that looks alive to whatever supervises
-// it while serving nothing.
+// TestASessionThatWillNotClearReportsSomethingElse: the report is one
+// string per binding, so waiting a conflict out and being stuck behind
+// one have to say different things in it.
 //
-// A conflict is the ordinary shape of a restart, and the loop is right
-// to wait one out. What it must not do is wait forever: the broker
-// expires a session by inactivity in well under a minute, so a run of
-// conflicts lasting past the deadline is not a predecessor's session
-// clearing slowly. The binding stops, records why, and says so where the
-// serve loop can act on it.
-func TestABindingStopsWaitingForASessionThatWillNotClear(t *testing.T) {
+// A conflict is the ordinary shape of a restart, and the binding says so
+// while it waits. Past the point a session expires by inactivity it is
+// not ordinary any more — but the log level is the only place that ever
+// changed, and an operator reading `runpool status` saw the same 409
+// either way. The binding is still serving what was already queued,
+// which is the part the report has to be able to say.
+func TestASessionThatWillNotClearReportsSomethingElse(t *testing.T) {
 	h := newHarness(t, 1)
 	h.srv.pollBackoff = time.Hour
 	h.srv.conflictBackoff = time.Millisecond
-	h.srv.conflictDeadlineOverride = 50 * time.Millisecond
+	h.srv.conflictGrace = 30 * time.Millisecond
 
-	var attempts int
 	h.bind.newSession = func(context.Context) (providerSession, error) {
-		attempts++
 		return nil, errors.New(`the session "abc" already exists, status="409 Conflict"`)
 	}
 
+	read := func() string {
+		t.Helper()
+		var reason string
+		if err := h.srv.store.Tx(t.Context(), func(tx *store.Tx) error {
+			bindings, err := tx.Bindings()
+			for _, b := range bindings {
+				if b.ID == h.bind.bindingID {
+					reason = b.Contact.LastError
+				}
+			}
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return reason
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		h.srv.loop(t.Context(), h.bind)
+		h.srv.loop(ctx, h.bind)
 	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("the binding never stopped waiting for a session it could not open; " +
-			"the process stays up serving nothing and nothing supervising it can tell")
-	}
 
-	if attempts < 2 {
-		t.Errorf("the loop tried %d time(s) before giving up; a conflict is the ordinary "+
-			"shape of a restart and has to be waited out first", attempts)
+	var stuck string
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if r := read(); strings.Contains(r, "not clearing on its own") {
+			stuck = r
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
 	}
-	if !h.bind.gaveUpOnSession {
-		t.Error("the binding returned without recording that it stopped waiting, so a " +
-			"controller left with nothing to serve cannot tell it is in that state")
+	cancel()
+	<-done
+
+	if stuck == "" {
+		t.Fatalf("the report never distinguished a session that will not clear from one being "+
+			"waited out; it says %q either way", read())
+	}
+	if !strings.Contains(stuck, "already queued") {
+		t.Errorf("the reason is %q; it has to say the binding is still serving what it has, "+
+			"because an operator reading it decides whether to act", stuck)
 	}
 }
 
-// TestAControllerThatCanServeNothingEnds: one binding that gave up is a
-// report, and every binding that gave up is a process that should not be
-// running.
-func TestAControllerThatCanServeNothingEnds(t *testing.T) {
+// TestAnUnrelatedOutageDoesNotAgeTheConflict: the run of conflicts is a
+// run of conflicts.
+//
+// Whether a session is clearing is judged from how long this binding has
+// been conflicting. A failure that is not a conflict says nothing about
+// that, and counting the time it lasted would have a binding report a
+// session that will not clear before it has waited out a single one.
+func TestAnUnrelatedOutageDoesNotAgeTheConflict(t *testing.T) {
 	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Millisecond
+	h.srv.conflictBackoff = time.Millisecond
+	h.srv.conflictGrace = time.Hour
 
-	if err := h.srv.everyBindingGaveUp(); err != nil {
-		t.Errorf("a controller whose binding is working reported %v", err)
+	// One conflict starts the run; an unrelated failure has to end it.
+	h.bind.conflictSince = time.Now().Add(-2 * time.Hour)
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		return nil, errors.New("the broker is unreachable")
 	}
-	h.bind.gaveUpOnSession = true
-	if err := h.srv.everyBindingGaveUp(); err == nil {
-		t.Error("every binding gave up and the controller reported nothing; it stays up " +
-			"serving nothing, which is the one shape a restart answers")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(ctx, h.bind)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if !h.bind.conflictSince.IsZero() {
+		t.Error("a failure that was not a conflict left the run of conflicts standing, so the " +
+			"next conflict is judged against time this binding spent not conflicting")
 	}
 }

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -409,3 +409,63 @@ func TestAReopenConflictWaitsAtItsOwnInterval(t *testing.T) {
 	cancel()
 	<-done
 }
+
+// TestABindingStopsWaitingForASessionThatWillNotClear: waiting past the
+// point it can help is a process that looks alive to whatever supervises
+// it while serving nothing.
+//
+// A conflict is the ordinary shape of a restart, and the loop is right
+// to wait one out. What it must not do is wait forever: the broker
+// expires a session by inactivity in well under a minute, so a run of
+// conflicts lasting past the deadline is not a predecessor's session
+// clearing slowly. The binding stops, records why, and says so where the
+// serve loop can act on it.
+func TestABindingStopsWaitingForASessionThatWillNotClear(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.pollBackoff = time.Hour
+	h.srv.conflictBackoff = time.Millisecond
+	h.srv.conflictDeadlineOverride = 50 * time.Millisecond
+
+	var attempts int
+	h.bind.newSession = func(context.Context) (providerSession, error) {
+		attempts++
+		return nil, errors.New(`the session "abc" already exists, status="409 Conflict"`)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.srv.loop(t.Context(), h.bind)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the binding never stopped waiting for a session it could not open; " +
+			"the process stays up serving nothing and nothing supervising it can tell")
+	}
+
+	if attempts < 2 {
+		t.Errorf("the loop tried %d time(s) before giving up; a conflict is the ordinary "+
+			"shape of a restart and has to be waited out first", attempts)
+	}
+	if !h.bind.gaveUpOnSession {
+		t.Error("the binding returned without recording that it stopped waiting, so a " +
+			"controller left with nothing to serve cannot tell it is in that state")
+	}
+}
+
+// TestAControllerThatCanServeNothingEnds: one binding that gave up is a
+// report, and every binding that gave up is a process that should not be
+// running.
+func TestAControllerThatCanServeNothingEnds(t *testing.T) {
+	h := newHarness(t, 1)
+
+	if err := h.srv.everyBindingGaveUp(); err != nil {
+		t.Errorf("a controller whose binding is working reported %v", err)
+	}
+	h.bind.gaveUpOnSession = true
+	if err := h.srv.everyBindingGaveUp(); err == nil {
+		t.Error("every binding gave up and the controller reported nothing; it stays up " +
+			"serving nothing, which is the one shape a restart answers")
+	}
+}


### PR DESCRIPTION
## What changes

A binding that cannot open its message session now records a different reason
once the wait stops being ordinary, so `runpool status` distinguishes waiting a
conflict out from being stuck behind one. A run of conflicts is ended by a
failure that is not a conflict. And a new decision record supersedes the one
consequence of `2026-08-11-session-conflict` that this work found does not hold.

The branch is named for a deadline. There is none; the name is what the work
started as.

## What was found

**The accepted record lists a consequence that was never built**, and building
it is what showed it does not hold. `2026-08-11-session-conflict` says:

> The retry deadline bounds how long a fresh start tolerates a stuck session
> before giving up and letting the platform restart it.

The retry and its backoff exist. `internal/app/delivery.go`'s loop is `for {`
with `ctx.Err()` as its only exit, and what stands in for a deadline is
`sessionConflictGrace` — five minutes, after which the log moves from `Info` to
`Error`. An escalation, not a deadline.

Implementing the deadline as written produced two measured results, both
against the code as it stands.

**A binding returning cannot end the process.** `serve` waits on every loop it
started, and three of them — `periodicReconcile`, `disk.run`,
`netSandbox.watch` — return only when the serve context is done. So every
binding giving up left `loops.Wait()` blocked and the process up, serving
nothing: exactly the state the deadline exists to end. The error it left
behind surfaced only after a signal, which inverted it — an operator's clean
shutdown of that controller exited non-zero. And `deploy/compose/compose.yaml`
uses `restart: unless-stopped`, which restarts on any exit, so the exit code
was never the lever there either.

**A binding whose session is stuck is not serving nothing.** The loop drains
ready attempts *before* it requires a session, and says so: *"Local work drains
whether or not the broker is reachable."* Work already delivered and queued is
served with no broker involved. Returning from the loop discards that —
measured with two queued attempts and an always-conflicting session, one
launched and one left ready with nobody to launch it until a restart.

And a restart does not clear the broker's session. Nothing on this side can.

**What was actually missing is smaller and is here.** The report holds one
reason per binding, and both states wrote the same 409 into it, so an operator
reading `runpool status` saw no difference between a wait that is ordinary and
one that is not — the log level was the only thing that ever changed. Past the
grace the reason now says the session is not clearing on its own and that only
work already queued is being served. It carries no elapsed time on purpose: the
record is written when the reason changes, and a reason that changes every pass
would be written every pass.

**And the wait was ageing on the wrong events.** `conflictSince` survived a
failure that was not a conflict, so an outage between two conflicts counted
toward the run: a binding that had waited out nothing could report a session
that would not clear. It is reset on that path now.

## Evidence

Hermetic. The loop is driven with a stub session and a grace override, the same
seam shape the existing conflict test uses for the backoff.

```text
MUTATION 1: the grace guard removed, so stuck is reported from the first conflict
--- FAIL: .../while_the_wait_is_ordinary
    five conflicts inside the grace recorded "...not clearing on its own;
    only work already queued is being served: ...409 Conflict". Waiting
    one out is the ordinary shape of a restart, and an operator reading
    the report cannot tell it from a session that will not clear.

MUTATION 2: the grace never elapses, so stuck is never reported
--- FAIL: .../once_it_is_not
    the report says "" past the grace; it never distinguished a session
    that will not clear from one being waited out

MUTATION 5: an unrelated outage still ages the run
--- FAIL: TestAnUnrelatedOutageDoesNotAgeTheConflict
    a failure that was not a conflict left the run of conflicts standing,
    so the next conflict is judged against time this binding spent not
    conflicting

MUTATION 3: the reason stops naming what is still being served
--- FAIL: TestASessionThatWillNotClearReportsSomethingElse
    the reason is "...not clearing on its own: ..."; it has to say the
    binding is still serving what it has, because an operator reading it
    decides whether to act
```

Two of these measured nothing on a first attempt and were redone. Removing the
wrapped error left `fmt` unused, so that package did not build. And the first
version of the test asserted only the reason recorded *past* the grace, so
mutation 1 — the defect this exists to fix, restored — passed it and passed the
suite. Both halves are asserted now, each gated on the loop's own attempt count
rather than on the clock, so neither can pass by sampling at a convenient
moment.

Restating the first half is what corrected my account of it: the two states are
told apart by one recording *nothing* and the other recording a reason, not by
two different reasons. The test written against the wrong account passed
against the code and failed against the mutation, which is how it surfaced.

The full local gate set mirroring `ci.yml` is green. One of its own checks
caught the new decision record left untracked, and the consistency guard caught
a doc comment orphaned by inserting a function above the one it belonged to.

## What would notice this regressing

- `TestASessionThatWillNotClearReportsSomethingElse` — two subtests reading the
  recorded reason out of the store, not a log or an in-memory field. Five
  conflicts inside an hour of grace must record nothing; two hundred past
  twenty milliseconds of it must record the reason that says the session is not
  clearing on its own and that queued work is still being served. Each is gated
  on the loop's attempt count, so neither depends on when it samples.
- `TestAnUnrelatedOutageDoesNotAgeTheConflict` — a non-conflict failure clears
  the run.
- `TestAReopenConflictWaitsAtItsOwnInterval` is unchanged and still passes,
  which is what says the ordinary restart case still waits at the conflict's
  own interval.

## Risk, compatibility and operations

**Behaviour.** No control flow changes. The loop retries as it did, for as long
as it did. What changes is one string written to the binding's contact record
past the grace, and one field reset on a path that did not reset it.

**Operations.** `runpool status` gains a distinguishable state — nothing is
recorded while the wait is ordinary, and the stuck reason appears past the
grace. The runbook
section says the binding keeps serving what it holds, that nothing times this
out, and that restarting does not clear the broker's session — so a controller
reporting it needs a decision rather than a kick, and what to check first.

**Failure behaviour, trust boundary, credentials, networking, resource limits,
ownership, cleanup.** N/A or unchanged. No object, call, credential or bound is
touched.

**Status API and schema.** The reason travels through `RecordProviderFailure`,
which already exists and already has the field. No migration.

**CLI, configuration, deployment, rollback.** None.

**Decision record.** A new record,
`2026-08-20-the-session-wait-has-no-deadline.md`, supersedes the one
consequence and carries the two measurements. The original keeps its text, as
`docs/adrs/README.md` requires — *"amended only by another record — a
superseded ADR keeps its text"* — and its index row now says which part is
superseded. An in-place amendment was written first and removed; the rule is
explicit and the change is a reversal of the original's rationale, not a
clarification of it.

## Changelog

```text
### State and operations

- **A session that will not clear says so in the report, not only in the
  log.** The broker holds a crashed predecessor's session until it
  expires by inactivity, and waiting that out is the ordinary shape of a
  restart. Past the point one expires by, it is not: the reason recorded
  against the binding changes to say the session is not clearing on its
  own and that only work already queued is being served, so
  `runpool status` distinguishes waiting from stuck instead of showing
  the same line either way. The binding keeps waiting, because the work
  it can serve without a broker is work it would otherwise stop serving,
  and the other bindings are unaffected.
```

## Notes for your reviewer

The thing I would look at first is whether superseding is the right call rather
than building the deadline somewhere it works — cancelling the serve context
when every binding is stuck, say, which would genuinely end the process. I did
not, because the second measurement stands whatever the mechanism: a stuck
binding is still serving queued work, and ending the process stops that too. If
you read the original consequence as being about a *fresh start* specifically —
before anything is queued — that argument is weaker and it is worth saying so.

Second, the reason string is matched by substring in the test. That is brittle
against rewording, and the alternative — a typed state on the contact record —
is a schema change I did not think this earned.

Third, `TestAnUnrelatedOutageDoesNotAgeTheConflict` still sleeps a fixed fifty
milliseconds before cancelling. It fails closed — a loop that never ran leaves
the seeded `conflictSince` in place and the assertion fires — so the risk is a
false failure on a very slow machine, not a false pass. I left it rather than
add a second counter for a test whose subject is one field.

Deliberately left alone: the grace is not configurable, and neither is the
backoff. And the branch name still says deadline.
