### PR TITLE
feat(platform): a lock records every platform qualified, and what a release builds for is a separate list

### DIFF
--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -274,8 +274,18 @@ jobs:
 
           facts = json.load(open("evidence/live/platform-facts.json", encoding="utf-8"))
           reference = json.load(open("build/platform.lock.json", encoding="utf-8"))
-          if reference.get("status") != "frozen":
-              sys.exit("release-qualification reference is not frozen")
+          # The entry for the host that produced these facts. The lock
+          # records one per platform qualified, so a host with none is not
+          # a host that failed the reference -- it is one nobody has run
+          # the suites on, and the record has to say which.
+          arch = facts.get("arch")
+          entries = {e["policy"]["arch"]: e for e in reference["platforms"]}
+          entry = entries.get(arch)
+          if entry is None:
+              sys.exit(f"no release qualification is recorded for {arch}; "
+                       f"this release records {', '.join(sorted(entries))}")
+          if entry.get("status") != "frozen":
+              sys.exit(f"the {arch} release-qualification reference is not frozen")
           checksums = open("evidence/release-artifacts/checksums.txt", encoding="utf-8").read().splitlines()
           e2e_files = glob.glob("evidence/controller-e2e/controller-e2e-*.json")
           if len(e2e_files) != 1:
@@ -295,8 +305,8 @@ jobs:
               "capsule_image": os.environ["CAPSULE_IMAGE"],
               "run": os.environ["RUN_URL"],
               "qualified_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
-              "platform_policy": reference["policy"],
-              "platform_reference": reference["platform"],
+              "platform_policy": entry["policy"],
+              "platform_reference": entry["platform"],
               "platform_observed": facts,
               "standalone_artifacts": checksums,
               "suites": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,18 @@ by its public and operational effects.
   capsule whose job is running and delete the records that clean up after
   it. Cache lane collection already stated that order for the same
   reason.
+- **What a release builds for and what it qualifies are two lists.**
+  `build/platform.lock.json` records one entry per platform whose suites
+  were run and whose host facts were reviewed, so qualifying a second one
+  is an added entry rather than a change to the file that is itself the
+  proof of the gate. A host with no entry fails as not qualified on that
+  platform, naming the ones that are, rather than as an architecture
+  mismatch. `build/images.lock.json` states what a release builds for,
+  which today is more than what has been qualified — and the support
+  matrix says which is which instead of letting one imply the other.
+  Neither the architecture nor the distribution is fixed by the code that
+  reads the record: what it requires is that the selection is stated, and
+  that the platform is one a release can build for.
 - **A session that will not clear says so in the report, not only in the
   log.** The broker holds a crashed predecessor's session until it
   expires by inactivity, and waiting that out is the ordinary shape of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,18 +305,6 @@ by its public and operational effects.
   capsule whose job is running and delete the records that clean up after
   it. Cache lane collection already stated that order for the same
   reason.
-- **What a release builds for and what it qualifies are two lists.**
-  `build/platform.lock.json` records one entry per platform whose suites
-  were run and whose host facts were reviewed, so qualifying a second one
-  is an added entry rather than a change to the file that is itself the
-  proof of the gate. A host with no entry fails as not qualified on that
-  platform, naming the ones that are, rather than as an architecture
-  mismatch. `build/images.lock.json` states what a release builds for,
-  which today is more than what has been qualified — and the support
-  matrix says which is which instead of letting one imply the other.
-  Neither the architecture nor the distribution is fixed by the code that
-  reads the record: what it requires is that the selection is stated, and
-  that the platform is one a release can build for.
 - **A session that will not clear says so in the report, not only in the
   log.** The broker holds a crashed predecessor's session until it
   expires by inactivity, and waiting that out is the ordinary shape of a
@@ -479,6 +467,19 @@ by its public and operational effects.
   command tree**.
 
 ### Release qualification and gates
+
+- **What a release builds for and what it qualifies are two lists.**
+  `build/platform.lock.json` records one entry per platform whose suites
+  were run and whose host facts were reviewed, so qualifying a second one
+  is an added entry rather than a change to the file that is itself the
+  proof of the gate. A host with no entry fails as not qualified on that
+  platform, naming the ones that are, rather than as an architecture
+  mismatch. `build/images.lock.json` states what a release builds for,
+  which today is more than what has been qualified — and the support
+  matrix says which is which instead of letting one imply the other.
+  Neither the architecture nor the distribution is fixed by the code that
+  reads the record: what it requires is that the selection is stated, and
+  that the platform is one a release can build for.
 
 - A release qualifies the exact digest-qualified controller and capsule
   candidates it later promotes; no image is rebuilt after qualification.

--- a/build/images.lock.json
+++ b/build/images.lock.json
@@ -5,10 +5,20 @@
     "it was tested against. The runner and dind pair is versioned together:",
     "the runner's externals tree and the daemon it drives must match.",
     "scripts/verify/image-lock.sh re-resolves each tag and fails when a",
-    "digest has drifted from what is recorded here."
+    "digest has drifted from what is recorded here.",
+    "",
+    "platforms are what a release builds for, which is not what it",
+    "qualifies: build/platform.lock.json records the platforms the suites",
+    "were run on, and neither list promises the other. The digests need no",
+    "per-platform variant because they are index digests already: a build",
+    "targeting one of these resolves that platform's child of the same",
+    "pinned digest."
   ],
   "resolved": "2026-08-15",
-  "platform": "linux/amd64",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
   "images": {
     "runner": {
       "ref": "ghcr.io/actions/actions-runner:2.336.0",

--- a/build/platform.lock.json
+++ b/build/platform.lock.json
@@ -7,20 +7,29 @@
     "The qualification job must compare the observed host with those frozen",
     "facts. It must never derive its expected values from the host under test.",
     "Updating Docker after a freeze requires a new reviewed lock and a complete",
-    "no-skip qualification run; it does not invalidate historical records."
+    "no-skip qualification run; it does not invalidate historical records.",
+    "",
+    "One entry per platform qualified. A platform with no entry is not a",
+    "failure of that platform; it is a platform nobody has run the suites",
+    "on, and the two are reported differently. Adding one is an added",
+    "entry rather than a change to this file's shape."
   ],
-  "schema_version": 1,
-  "status": "pending",
-  "policy": {
-    "os": "debian",
-    "os_version": "13",
-    "os_codename": "trixie",
-    "arch": "amd64",
-    "docker_channel": "stable",
-    "docker_source": "https://download.docker.com/linux/debian",
-    "selection": "latest-stable-at-policy-review",
-    "target_engine": "29.7.2",
-    "reviewed": "2026-08-16",
-    "freeze_point": "before-release-candidate"
-  }
+  "schema_version": 2,
+  "platforms": [
+    {
+      "status": "pending",
+      "policy": {
+        "os": "debian",
+        "os_version": "13",
+        "os_codename": "trixie",
+        "arch": "amd64",
+        "docker_channel": "stable",
+        "docker_source": "https://download.docker.com/linux/debian",
+        "selection": "latest-stable-at-policy-review",
+        "target_engine": "29.7.2",
+        "reviewed": "2026-08-16",
+        "freeze_point": "before-release-candidate"
+      }
+    }
+  ]
 }

--- a/docs/adrs/2026-08-17-multiplatform-locks.md
+++ b/docs/adrs/2026-08-17-multiplatform-locks.md
@@ -99,12 +99,19 @@ is where it actually comes from.
 
 ## What is not
 
-The third decision: the release publishing an index per image. The
-standalone binaries are already cross-built per platform, and the capsule
-image builds for `linux/arm64` — verified, with the Go stage compiling
-rather than reusing a cached layer. What is not done is the publishing
-itself, which needs `buildx` with a push and a different way of reading
-back the digest, and whose only real verification is a release run.
+The third decision: the release publishing an index per image, and the
+standalone binaries per platform. Neither is built. The release workflow
+builds and pushes one image and ships one `linux/amd64` binary; what
+exists per platform is a compile-only gate in `ci.yml`, which builds to
+`/dev/null` and produces no artifact.
+
+What is verified is that it can be done: the capsule image builds for
+`linux/arm64`, with the Go stage compiling rather than reusing a cached
+layer. What is not is the publishing, which needs `buildx` with a push
+and a different way of reading back the digest — `docker image inspect`
+returns nothing after a multi-platform push, and that digest is what is
+injected as the controller's capsule reference. Its only real
+verification is a release run.
 
 Until it lands, a release publishes one platform's image while the lock
 declares two. The support matrix's *built* list is therefore a statement

--- a/docs/adrs/2026-08-17-multiplatform-locks.md
+++ b/docs/adrs/2026-08-17-multiplatform-locks.md
@@ -1,6 +1,7 @@
 # A lock records the platforms that were qualified, not the only one that works
 
-**Status:** accepted; implementation pending
+**Status:** accepted; the lock shape and the reader are built, the
+per-platform publishing is not
 **Date:** 2026-08-17
 
 `build/platform.lock.json` carries a single `policy.arch`, so one lock
@@ -78,3 +79,34 @@ without that evidence. Neither sentence promises the other.
 - Nothing is asserted about a platform that was never run. An
   unqualified platform is unverified, which is neither a promise nor a
   denial.
+
+## What is built
+
+The first, second and fourth decisions above. `platform.lock.json`
+records a list of entries, each with its own policy and its own facts;
+the reader selects by the platform being measured and reports a platform
+with no entry as one nobody has qualified rather than as an architecture
+mismatch. `images.lock.json` declares the platforms a release builds for.
+The support matrix states the two lists separately.
+
+Two things were loosened beyond what this record asked for, on the same
+argument it makes. The distribution was hard-coded next to the
+architecture, so a host on another one could not be recorded either; the
+reader now requires the selection to be *stated* rather than to be a
+particular value. And the operating system is derived from what the
+pinned images publish instead of being written as a rule, because that
+is where it actually comes from.
+
+## What is not
+
+The third decision: the release publishing an index per image. The
+standalone binaries are already cross-built per platform, and the capsule
+image builds for `linux/arm64` — verified, with the Go stage compiling
+rather than reusing a cached layer. What is not done is the publishing
+itself, which needs `buildx` with a push and a different way of reading
+back the digest, and whose only real verification is a release run.
+
+Until it lands, a release publishes one platform's image while the lock
+declares two. The support matrix's *built* list is therefore a statement
+about what the build can produce, not about what the last release
+pushed.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -21,6 +21,6 @@ justified it usually still holds even when the remedy does not.
 | 2026-08-17 | [Capsule image substitution](2026-08-17-capsule-image-substitution.md) — a tier may name its capsule, and the capsule declares its protocol | accepted |
 | 2026-08-17 | [GitHub App credentials](2026-08-17-github-app-credentials.md) — a deployment authenticates as an App, not only as a person | accepted |
 | 2026-08-17 | [Job timeout](2026-08-17-job-timeout.md) — the lease ceiling is a backstop above the provider's own maximum | accepted |
-| 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; implementation pending |
+| 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; publishing pending |
 | 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |
 | 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted |

--- a/docs/maintainers/qualification-host.md
+++ b/docs/maintainers/qualification-host.md
@@ -28,15 +28,24 @@ Docker Engine from the official stable channel
 https://download.docker.com/linux/debian
 ```
 
-Architecture is checked against the lock, which records one policy and
-names `amd64` in it. A host of another architecture fails the comparison
-for that reason — not because the suites would fail on it. Recording
-several qualified platforms side by side is the subject of the
-[multiplatform locks decision](../adrs/2026-08-17-multiplatform-locks.md),
-accepted with its implementation pending; until it lands, the lock holds
-exactly one platform and the
-[support matrix](../reference/support-matrix.md) states what has been
-observed and what has not.
+That block describes the entry the lock holds today. It is not a rule:
+the lock records one entry per platform qualified, each with its own
+policy and its own frozen facts, and neither the distribution nor the
+architecture is fixed by the code that reads it. Qualifying a second
+platform is an added entry rather than a change to the file's shape,
+which matters because the file is itself the proof of the gate.
+
+A host with no entry fails as *not qualified on this platform*, naming
+the ones that are — a different answer from a host that was measured and
+differed. What a release builds for is stated separately in
+[`build/images.lock.json`](../../build/images.lock.json), and neither
+list promises the other: see the
+[support matrix](../reference/support-matrix.md).
+
+What the reader still refuses is a platform no release builds for, and a
+reference frozen after the candidate exists. The first would record
+evidence about something nobody can run; the second is evidence that
+could have been written to fit what it was meant to judge.
 
 ## Sizing
 

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -95,6 +95,6 @@ version. Breaking either V1 contract requires an explicit version change.
 
 See the [support matrix](reference/support-matrix.md) for what runs on
 what, and [SUPPORT.md](../SUPPORT.md) for where to ask. The release-reference
-platform is one exact configuration, frozen in `build/platform.lock.json` and
-checked by the contract suite rather than assumed; it does not replace the
-runtime compatibility range.
+platforms are exact configurations, one per platform qualified, frozen in
+`build/platform.lock.json` and checked by the contract suite rather than
+assumed; they do not replace the runtime compatibility range.

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -95,11 +95,19 @@ builds for both.
 one entry per platform whose suites were run and whose host facts were
 reviewed and frozen. It records `amd64` today and nothing else.
 
-So `linux/arm64` is **built and unverified**: a release produces it, and
+So `linux/arm64` is **buildable and unverified**: the build produces it —
+the capsule image and the controller binary both compile for it — and
 nobody has run the suites there. That is a different sentence from
-unsupported, and the gate says which it is — a host with no entry fails
-as *not qualified on this platform*, naming the ones that are, rather
-than as an architecture mismatch.
+unsupported, and the gate says which it is: a host with no entry fails as
+*not qualified on this platform*, naming the ones that are, rather than
+as an architecture mismatch.
+
+**What a release actually publishes today is one platform.** The
+publishing half of that decision is not built: the release workflow
+builds and pushes a single image and ships a single `linux/amd64`
+binary. So *built* here describes what the build can produce, not what
+the last release put in the registry. Do not read it as a promise of an
+arm64 artifact.
 
 The distribution is the same kind of statement. `debian 13 trixie` is
 the reviewed selection in the entry that exists, not a constraint the

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -55,7 +55,7 @@ defines its own expectation.
 
 | | Reference value |
 | --- | --- |
-| OS | Debian 13 (trixie), amd64; exact patch pending host capture |
+| OS | Debian 13 (trixie), amd64 — the selection in the one entry recorded; exact patch pending host capture |
 | Kernel | Pending host capture |
 | Docker Engine | **29.7.2** selected; exact installed package pending capture |
 | Engine API, containerd, runc | Pending host capture |
@@ -83,14 +83,35 @@ does not invalidate earlier release evidence.
 | `public-internet-only` in shared mode | Open capsule egress to host and private networks is incompatible with the coexistence contract |
 | `systemd` or `cgroupfs` driver | Read from the daemon at startup; the parent form is generated for the reported driver and verified live |
 
-**Architecture is qualification evidence, not a design limit.** The gates
-observe `linux/amd64`, which is what the platform lock records and what
-the published images are built for. Nothing in the design restricts an
-architecture: the capsule's base images publish `linux/arm64`, the
-controller is a static Go binary, and the isolation is cgroup v2 and
-kernel netfilter on either. Another architecture is therefore *unverified*
-rather than unsupported — nobody has run the suites there, and this
-document will say so until somebody has.
+**What is built and what is qualified are two lists, and neither promises
+the other.**
+
+*Built* is [`build/images.lock.json`](../../build/images.lock.json):
+`linux/amd64` and `linux/arm64`, which is what the pinned base images
+publish. The controller is a static Go binary and the capsule's Dockerfile
+builds for both.
+
+*Qualified* is [`build/platform.lock.json`](../../build/platform.lock.json),
+one entry per platform whose suites were run and whose host facts were
+reviewed and frozen. It records `amd64` today and nothing else.
+
+So `linux/arm64` is **built and unverified**: a release produces it, and
+nobody has run the suites there. That is a different sentence from
+unsupported, and the gate says which it is — a host with no entry fails
+as *not qualified on this platform*, naming the ones that are, rather
+than as an architecture mismatch.
+
+The distribution is the same kind of statement. `debian 13 trixie` is
+the reviewed selection in the entry that exists, not a constraint the
+reader enforces: a host on another distribution that ran the suites can
+be recorded as its own entry. What no entry can name is a platform no
+release builds for.
+
+Operating system is not on that list. A capsule runs a Linux daemon and
+a Linux runner inside a container, and the isolation is cgroup v2 and
+kernel netfilter; there is no non-Linux variant of the base images to
+build against. That is a design limit, and it is stated as a host
+requirement above rather than as a policy anyone may revise.
 
 The self-hosted release-qualification runner must use GitHub Actions Runner 2.327.1
 or newer so the Node 24 runtime required by the pinned first-party actions is

--- a/internal/app/images.go
+++ b/internal/app/images.go
@@ -17,7 +17,13 @@ import (
 var imageLockJSON []byte
 
 type imageLock struct {
-	Images map[string]struct {
+	// Platforms are what a release builds for. They are not what it
+	// qualifies: build/platform.lock.json records the platforms the
+	// suites were run on, and a release may publish for one nobody has
+	// run. Keeping the two lists apart is what lets either sentence be
+	// said without implying the other.
+	Platforms []string `json:"platforms"`
+	Images    map[string]struct {
 		Ref    string `json:"ref"`
 		Digest string `json:"digest"`
 	} `json:"images"`

--- a/internal/app/images.lock.json
+++ b/internal/app/images.lock.json
@@ -5,10 +5,20 @@
     "it was tested against. The runner and dind pair is versioned together:",
     "the runner's externals tree and the daemon it drives must match.",
     "scripts/verify/image-lock.sh re-resolves each tag and fails when a",
-    "digest has drifted from what is recorded here."
+    "digest has drifted from what is recorded here.",
+    "",
+    "platforms are what a release builds for, which is not what it",
+    "qualifies: build/platform.lock.json records the platforms the suites",
+    "were run on, and neither list promises the other. The digests need no",
+    "per-platform variant because they are index digests already: a build",
+    "targeting one of these resolves that platform's child of the same",
+    "pinned digest."
   ],
   "resolved": "2026-08-15",
-  "platform": "linux/amd64",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
   "images": {
     "runner": {
       "ref": "ghcr.io/actions/actions-runner:2.336.0",

--- a/internal/app/images_lock_test.go
+++ b/internal/app/images_lock_test.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/rhobuild/runpool/internal/platform"
 )
 
 // The embedded lock is what the controller executes; the reviewed lock
@@ -87,4 +90,36 @@ func TestCapsuleImageResolution(t *testing.T) {
 	if _, err := CapsuleImage(func(string) string { return "" }, "ghcr.io/rhobuild/runpool/capsule:v1"); err == nil {
 		t.Fatal("a mutable release capsule reference was accepted")
 	}
+}
+
+// TestTheLockBuildsForEveryPlatformARelease Can: what a release builds
+// for is bounded by what the pinned images publish.
+//
+// The two locks answer different questions — this one what is built,
+// build/platform.lock.json what was qualified — and neither promises the
+// other. What they cannot disagree about is the ceiling: an image the
+// upstream does not publish for a platform cannot be built for it, so a
+// release declaring one would fail at the registry rather than here.
+func TestTheLockBuildsForEveryPlatformAReleaseCan(t *testing.T) {
+	var lock imageLock
+	if err := json.Unmarshal(imageLockJSON, &lock); err != nil {
+		t.Fatalf("parse the image lock: %v", err)
+	}
+	if len(lock.Platforms) == 0 {
+		t.Fatal("the lock declares no platform, so a release builds for nothing it states")
+	}
+	declared := slices.Clone(lock.Platforms)
+	want := slices.Clone(platform.Buildable)
+	slices.Sort(declared)
+	slices.Sort(want)
+	if !slices.Equal(declared, want) {
+		t.Errorf("the lock builds for %v; the pinned images publish %v. A platform in neither "+
+			"list is one a release claims and cannot produce, or one it could produce and "+
+			"does not offer.", declared, want)
+	}
+	// Whole platform strings, operating system included, and compared
+	// against what the images publish rather than against a rule written
+	// here. A capsule runs a Linux daemon and a Linux runner, so there is
+	// no non-Linux variant to build against — and if one were ever
+	// published, that list is where it would show.
 }

--- a/internal/command/platform_summary.go
+++ b/internal/command/platform_summary.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/rhobuild/runpool/internal/platform"
@@ -21,11 +22,16 @@ func releaseQualificationReference() map[string]string {
 	if err != nil {
 		return map[string]string{"error": err.Error()}
 	}
+	// The whole platform, not the architecture alone. A darwin build of
+	// the same architecture would otherwise report a Debian host's facts
+	// two lines below saying it is darwin, and the branch below would
+	// read as a platform check while being an architecture one.
+	here := runtime.GOOS + "/" + runtime.GOARCH
 	qualified, ok := ref.For(runtime.GOARCH)
-	if !ok {
+	if !slices.Contains(platform.Buildable, here) || !ok {
 		return map[string]string{
 			"status":    "not-qualified-here",
-			"arch":      runtime.GOARCH,
+			"platform":  here,
 			"qualified": strings.Join(ref.Arches(), ", "),
 		}
 	}

--- a/internal/command/platform_summary.go
+++ b/internal/command/platform_summary.go
@@ -1,31 +1,53 @@
 package command
 
-import "github.com/rhobuild/runpool/internal/platform"
+import (
+	"runtime"
+	"strings"
 
-// releaseQualificationReference summarizes the exact evidence host reported by
-// `version --json`. Runtime compatibility remains a separate doctor check.
+	"github.com/rhobuild/runpool/internal/platform"
+)
+
+// releaseQualificationReference summarizes the exact evidence host
+// reported by `version --json`. Runtime compatibility remains a separate
+// doctor check.
+//
+// It reports the entry for the architecture this binary is running on,
+// because that is the one an operator reading it is asking about. A
+// build running where nothing was qualified says so and names what was,
+// which is a different answer from a host that was measured and
+// differed.
 func releaseQualificationReference() map[string]string {
 	ref, err := platform.Load()
 	if err != nil {
 		return map[string]string{"error": err.Error()}
 	}
-	if ref.Status != platform.ReferenceStatusFrozen {
+	qualified, ok := ref.For(runtime.GOARCH)
+	if !ok {
 		return map[string]string{
-			"status":         ref.Status,
-			"os":             ref.Policy.OS + " " + ref.Policy.OSVersion,
-			"arch":           ref.Policy.Arch,
-			"docker_channel": ref.Policy.DockerChannel,
-			"selection":      ref.Policy.Selection,
-			"target_engine":  ref.Policy.TargetEngine,
-			"reviewed":       ref.Policy.Reviewed,
+			"status":    "not-qualified-here",
+			"arch":      runtime.GOARCH,
+			"qualified": strings.Join(ref.Arches(), ", "),
+		}
+	}
+	if qualified.Status != platform.ReferenceStatusFrozen {
+		return map[string]string{
+			"status":         qualified.Status,
+			"os":             qualified.Policy.OS + " " + qualified.Policy.OSVersion,
+			"arch":           qualified.Policy.Arch,
+			"docker_channel": qualified.Policy.DockerChannel,
+			"selection":      qualified.Policy.Selection,
+			"target_engine":  qualified.Policy.TargetEngine,
+			"reviewed":       qualified.Policy.Reviewed,
+			"qualified":      strings.Join(ref.Arches(), ", "),
 		}
 	}
 	return map[string]string{
-		"status":   ref.Status,
-		"os":       ref.Platform.OS + " " + ref.Platform.OSVersion,
-		"arch":     ref.Platform.Arch,
-		"engine":   ref.Platform.Engine,
-		"cgroup":   "v" + ref.Platform.CgroupVersion + "/" + ref.Platform.CgroupDriver,
-		"recorded": ref.Recorded,
+		"status":    qualified.Status,
+		"os":        qualified.Platform.OS + " " + qualified.Platform.OSVersion,
+		"arch":      qualified.Platform.Arch,
+		"engine":    qualified.Platform.Engine,
+		"cgroup":    "v" + qualified.Platform.CgroupVersion + "/" + qualified.Platform.CgroupDriver,
+		"recorded":  qualified.Recorded,
+		"qualified": strings.Join(ref.Arches(), ", "),
 	}
 }

--- a/internal/platform/cmd/verify/main.go
+++ b/internal/platform/cmd/verify/main.go
@@ -35,17 +35,31 @@ func main() {
 		fmt.Fprintln(os.Stderr, "verify:", err)
 		os.Exit(1)
 	}
-	if err := reference.RequireFrozen(); err != nil {
+	// The entry for the platform that was measured, not for the platform
+	// this happens to be running on: the facts came from a host, and it
+	// is that host being qualified.
+	//
+	// A platform with no entry is not a host that failed. It is one
+	// nobody has run the suites on, and it says so rather than reporting
+	// an architecture mismatch against whichever entry came first.
+	qualified, ok := reference.For(observed.Arch)
+	if !ok {
+		fmt.Fprintln(os.Stderr, "verify:", reference.NotQualified(observed.Arch))
+		os.Exit(1)
+	}
+	if err := qualified.RequireFrozen(); err != nil {
 		fmt.Fprintln(os.Stderr, "verify:", err)
 		os.Exit(1)
 	}
-	if mismatches := reference.Compare(observed); len(mismatches) != 0 {
-		fmt.Fprintln(os.Stderr, "observed host does not match the release-qualification reference:")
+	if mismatches := qualified.Compare(observed); len(mismatches) != 0 {
+		fmt.Fprintf(os.Stderr, "observed %s host does not match the release-qualification reference:\n",
+			observed.Arch)
 		for _, mismatch := range mismatches {
 			fmt.Fprintln(os.Stderr, " -", mismatch)
 		}
 		os.Exit(1)
 	}
-	fmt.Printf("release-qualification reference matched: %s %s, Docker Engine %s\n",
-		reference.Platform.OS, reference.Platform.OSVersion, reference.Platform.Engine)
+	fmt.Printf("release-qualification reference matched: %s %s %s, Docker Engine %s\n",
+		qualified.Platform.OS, qualified.Platform.OSVersion,
+		qualified.Platform.Arch, qualified.Platform.Engine)
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -207,16 +207,28 @@ func (q Qualified) validate() error {
 	//
 	// What is required is that the choice is stated. A policy missing a
 	// field records a selection nobody can check the host against.
+	// Two of these are rules rather than choices, and stay values. The
+	// channel is what the guide and the lock's own comment require --
+	// evidence from a nightly build is evidence about something no
+	// operator installs -- and the selection names how the target was
+	// picked, which is the sentence the reviewer signed off.
+	if q.Policy.DockerChannel != "stable" {
+		return fmt.Errorf("the %s selection policy takes Docker from the %q channel; release "+
+			"evidence comes from the stable channel an operator installs from", q.Policy.Arch,
+			q.Policy.DockerChannel)
+	}
+	if q.Policy.Selection != "latest-stable-at-policy-review" {
+		return fmt.Errorf("the %s selection policy selects by %q; that string is what a "+
+			"reviewer signed off on, not free text", q.Policy.Arch, q.Policy.Selection)
+	}
 	missing := []string{}
 	for name, value := range map[string]string{
-		"os":             q.Policy.OS,
-		"os_version":     q.Policy.OSVersion,
-		"os_codename":    q.Policy.OSCodename,
-		"docker_channel": q.Policy.DockerChannel,
-		"docker_source":  q.Policy.DockerSource,
-		"selection":      q.Policy.Selection,
-		"target_engine":  q.Policy.TargetEngine,
-		"reviewed":       q.Policy.Reviewed,
+		"os":            q.Policy.OS,
+		"os_version":    q.Policy.OSVersion,
+		"os_codename":   q.Policy.OSCodename,
+		"docker_source": q.Policy.DockerSource,
+		"target_engine": q.Policy.TargetEngine,
+		"reviewed":      q.Policy.Reviewed,
 	} {
 		if value == "" {
 			missing = append(missing, name)
@@ -246,6 +258,26 @@ func (q Qualified) validate() error {
 	default:
 		return fmt.Errorf("platform manifest status %q is unsupported for %s",
 			q.Status, q.Policy.Arch)
+	}
+
+	// The facts have to be the platform the entry claims. Nothing else
+	// relates the two: selection reads the policy and comparison reads
+	// the facts, so an entry labelled one platform and frozen from
+	// another qualifies neither -- the host that ran the suites is told
+	// nobody qualified it, and a host of the claimed platform is told the
+	// reference is something else. That is a wrong qualification rather
+	// than a differently shaped one, and it is what naming a single
+	// architecture used to make unrepresentable.
+	for name, pair := range map[string][2]string{
+		"arch":        {q.Policy.Arch, q.Platform.Arch},
+		"os":          {q.Policy.OS, q.Platform.OS},
+		"os_version":  {q.Policy.OSVersion, q.Platform.OSVersion},
+		"os_codename": {q.Policy.OSCodename, q.Platform.OSCodename},
+	} {
+		if want, got := pair[0], pair[1]; got != "" && got != want {
+			return fmt.Errorf("the %s entry selects %s %q and froze %q; the facts are not from "+
+				"the platform the entry claims", q.Policy.Arch, name, want, got)
+		}
 	}
 
 	missing = nil
@@ -286,7 +318,8 @@ func (q Qualified) validate() error {
 // set of exact host facts has replaced the pending reference.
 func (q Qualified) RequireFrozen() error {
 	if q.Status != ReferenceStatusFrozen {
-		return fmt.Errorf("release-qualification reference is %s; capture and review the installed stable Docker platform before creating a candidate", q.Status)
+		return fmt.Errorf("the %s release-qualification reference is %s; capture and review the "+
+			"installed stable Docker platform before creating a candidate", q.Policy.Arch, q.Status)
 	}
 	return nil
 }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -26,15 +27,85 @@ const (
 //go:embed platform.lock.json
 var manifestJSON []byte
 
-// Reference is the reviewed release-qualification target. A pending reference
-// keeps release gates closed until the operator facts have been captured and
-// frozen in the repository before a candidate tag is created.
+// Buildable are the platforms a release can build for: the intersection
+// of what the pinned upstream images publish. The runner image publishes
+// linux/amd64 and linux/arm64 and nothing else, which is the ceiling;
+// dind publishes more.
+//
+// The operating system is here because the images say so, not because
+// anything in this package decided it. A capsule runs a Linux daemon and
+// a Linux runner inside a container, so there is no non-Linux variant of
+// these images to build against — and if one were ever published, this
+// list is where that would show, rather than in a rule written beside it.
+//
+// It is not the list of qualified platforms. A release may build for a
+// platform nobody has run the suites on, and keeping the two apart is
+// what lets either be said without implying the other.
+var Buildable = []string{"linux/amd64", "linux/arm64"}
+
+// BuildableArches is Buildable's architectures, for the entries in the
+// qualification record, which name a host rather than an image.
+func BuildableArches() []string {
+	out := make([]string, 0, len(Buildable))
+	for _, p := range Buildable {
+		if _, arch, ok := strings.Cut(p, "/"); ok {
+			out = append(out, arch)
+		}
+	}
+	return out
+}
+
+// Reference is the reviewed release-qualification record: one entry per
+// platform that was qualified, each with its own selection policy and,
+// once frozen, its own exact facts.
+//
+// A list rather than one entry because qualification is evidence that
+// the release ran correctly on a host, and there is one host's worth of
+// facts per platform. Shaped as one, the file could not record a second
+// qualification without changing the format that is itself the proof of
+// the gate -- and a gate that refuses a host for not being the one
+// platform its file can express is measuring the file, not the host.
 type Reference struct {
-	SchemaVersion int    `json:"schema_version"`
-	Status        string `json:"status"`
-	Policy        Policy `json:"policy"`
-	Recorded      string `json:"recorded,omitempty"`
-	Platform      Facts  `json:"platform,omitempty"`
+	SchemaVersion int         `json:"schema_version"`
+	Platforms     []Qualified `json:"platforms"`
+}
+
+// Qualified is one platform's selection policy and the facts observed on
+// it. A pending entry keeps release gates closed for that platform until
+// its facts have been captured and reviewed before a candidate tag.
+type Qualified struct {
+	Status   string `json:"status"`
+	Policy   Policy `json:"policy"`
+	Recorded string `json:"recorded,omitempty"`
+	Platform Facts  `json:"platform,omitempty"`
+}
+
+// For returns the entry qualified for an architecture.
+func (r Reference) For(arch string) (Qualified, bool) {
+	for _, q := range r.Platforms {
+		if q.Policy.Arch == arch {
+			return q, true
+		}
+	}
+	return Qualified{}, false
+}
+
+// Arches lists the architectures this release records a qualification
+// for, in the order the file names them. It is what a failure on an
+// unqualified platform says instead of "wrong architecture": the
+// distinction between a host that failed and a host nobody has run.
+func (r Reference) Arches() []string {
+	out := make([]string, 0, len(r.Platforms))
+	for _, q := range r.Platforms {
+		out = append(out, q.Policy.Arch)
+	}
+	return out
+}
+
+// NotQualified is the error a platform with no entry gets.
+func (r Reference) NotQualified(arch string) error {
+	return fmt.Errorf("no release qualification is recorded for %s; this release records %s",
+		arch, strings.Join(r.Arches(), ", "))
 }
 
 // Policy records how the exact target is selected. It is distinct from the
@@ -102,48 +173,101 @@ func MustLoad() Reference {
 }
 
 func (r Reference) validate() error {
-	if r.SchemaVersion != 1 {
+	if r.SchemaVersion != 2 {
 		return fmt.Errorf("platform manifest schema_version %d is unsupported", r.SchemaVersion)
 	}
-	if r.Policy.OS != "debian" || r.Policy.OSVersion != "13" ||
-		r.Policy.OSCodename != "trixie" || r.Policy.Arch != "amd64" ||
-		r.Policy.DockerChannel != "stable" || r.Policy.DockerSource == "" ||
-		r.Policy.Selection != "latest-stable-at-policy-review" || r.Policy.TargetEngine == "" ||
-		r.Policy.Reviewed == "" || r.Policy.FreezePoint != "before-release-candidate" {
-		return fmt.Errorf("platform manifest has an invalid selection policy")
+	if len(r.Platforms) == 0 {
+		return fmt.Errorf("platform manifest records no platform at all")
 	}
-	switch r.Status {
+	seen := map[string]bool{}
+	for _, q := range r.Platforms {
+		if seen[q.Policy.Arch] {
+			return fmt.Errorf("platform manifest records %s twice; which entry qualifies a host "+
+				"would be whichever came first", q.Policy.Arch)
+		}
+		seen[q.Policy.Arch] = true
+		if err := q.validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (q Qualified) validate() error {
+	if !slices.Contains(BuildableArches(), q.Policy.Arch) {
+		return fmt.Errorf("platform manifest qualifies %q, which no release builds for; "+
+			"the pinned images publish %s", q.Policy.Arch, strings.Join(Buildable, ", "))
+	}
+	// Which distribution was selected is a reviewed choice, not a rule.
+	// Naming one here would do to the operating system what naming a
+	// single architecture did to the machine: a host that ran the suites
+	// and passed would be refused for not being the one this file can
+	// express, and the refusal would read as a broken manifest rather
+	// than as an unqualified platform.
+	//
+	// What is required is that the choice is stated. A policy missing a
+	// field records a selection nobody can check the host against.
+	missing := []string{}
+	for name, value := range map[string]string{
+		"os":             q.Policy.OS,
+		"os_version":     q.Policy.OSVersion,
+		"os_codename":    q.Policy.OSCodename,
+		"docker_channel": q.Policy.DockerChannel,
+		"docker_source":  q.Policy.DockerSource,
+		"selection":      q.Policy.Selection,
+		"target_engine":  q.Policy.TargetEngine,
+		"reviewed":       q.Policy.Reviewed,
+	} {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		return fmt.Errorf("the %s selection policy states no %s", q.Policy.Arch,
+			strings.Join(missing, ", "))
+	}
+	// The freeze point is a rule rather than a choice: a lock reviewed
+	// after the candidate exists is a lock the candidate could have been
+	// built against.
+	if q.Policy.FreezePoint != "before-release-candidate" {
+		return fmt.Errorf("the %s selection policy freezes at %q; a reference reviewed after "+
+			"the candidate exists is not evidence about it", q.Policy.Arch, q.Policy.FreezePoint)
+	}
+	switch q.Status {
 	case ReferenceStatusPending:
-		if r.Recorded != "" || r.Platform != (Facts{}) {
-			return fmt.Errorf("pending platform manifest must not contain frozen facts")
+		if q.Recorded != "" || q.Platform != (Facts{}) {
+			return fmt.Errorf("pending platform manifest must not contain frozen facts for %s",
+				q.Policy.Arch)
 		}
 		return nil
 	case ReferenceStatusFrozen:
 		// Continue below and require every exact fact.
 	default:
-		return fmt.Errorf("platform manifest status %q is unsupported", r.Status)
+		return fmt.Errorf("platform manifest status %q is unsupported for %s",
+			q.Status, q.Policy.Arch)
 	}
 
-	missing := []string{}
+	missing = nil
 	for name, value := range map[string]string{
-		"recorded":           r.Recorded,
-		"os":                 r.Platform.OS,
-		"os_version":         r.Platform.OSVersion,
-		"os_codename":        r.Platform.OSCodename,
-		"arch":               r.Platform.Arch,
-		"kernel":             r.Platform.Kernel,
-		"engine":             r.Platform.Engine,
-		"api":                r.Platform.API,
-		"cgroup_version":     r.Platform.CgroupVersion,
-		"cgroup_driver":      r.Platform.CgroupDriver,
-		"storage_driver":     r.Platform.StorageDriver,
-		"backing_filesystem": r.Platform.BackingFilesystem,
-		"containerd":         r.Platform.Containerd,
-		"runc":               r.Platform.Runc,
-		"buildx":             r.Platform.Buildx,
-		"compose":            r.Platform.Compose,
-		"iptables":           r.Platform.IPTables,
-		"nftables":           r.Platform.NFTables,
+		"recorded":           q.Recorded,
+		"os":                 q.Platform.OS,
+		"os_version":         q.Platform.OSVersion,
+		"os_codename":        q.Platform.OSCodename,
+		"arch":               q.Platform.Arch,
+		"kernel":             q.Platform.Kernel,
+		"engine":             q.Platform.Engine,
+		"api":                q.Platform.API,
+		"cgroup_version":     q.Platform.CgroupVersion,
+		"cgroup_driver":      q.Platform.CgroupDriver,
+		"storage_driver":     q.Platform.StorageDriver,
+		"backing_filesystem": q.Platform.BackingFilesystem,
+		"containerd":         q.Platform.Containerd,
+		"runc":               q.Platform.Runc,
+		"buildx":             q.Platform.Buildx,
+		"compose":            q.Platform.Compose,
+		"iptables":           q.Platform.IPTables,
+		"nftables":           q.Platform.NFTables,
 	} {
 		if value == "" {
 			missing = append(missing, name)
@@ -152,7 +276,7 @@ func (r Reference) validate() error {
 	if len(missing) > 0 {
 		return fmt.Errorf("platform manifest is incomplete: %s", strings.Join(missing, ", "))
 	}
-	if r.Platform.Rootless == nil {
+	if q.Platform.Rootless == nil {
 		return fmt.Errorf("platform manifest is incomplete: rootless")
 	}
 	return nil
@@ -160,9 +284,9 @@ func (r Reference) validate() error {
 
 // RequireFrozen rejects release qualification until an independently reviewed
 // set of exact host facts has replaced the pending reference.
-func (r Reference) RequireFrozen() error {
-	if r.Status != ReferenceStatusFrozen {
-		return fmt.Errorf("release-qualification reference is %s; capture and review the installed stable Docker platform before creating a candidate", r.Status)
+func (q Qualified) RequireFrozen() error {
+	if q.Status != ReferenceStatusFrozen {
+		return fmt.Errorf("release-qualification reference is %s; capture and review the installed stable Docker platform before creating a candidate", q.Status)
 	}
 	return nil
 }
@@ -181,9 +305,9 @@ func (m Mismatch) String() string {
 // Compare reports every observed fact that differs from the qualification
 // reference. Missing observations are mismatches because absent evidence
 // cannot qualify a release.
-func (r Reference) Compare(observed Facts) []Mismatch {
-	if r.Status != ReferenceStatusFrozen {
-		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: r.Status}}
+func (q Qualified) Compare(observed Facts) []Mismatch {
+	if q.Status != ReferenceStatusFrozen {
+		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: q.Status}}
 	}
 	var out []Mismatch
 	check := func(property, want, got string) {
@@ -191,24 +315,24 @@ func (r Reference) Compare(observed Facts) []Mismatch {
 			out = append(out, Mismatch{Property: property, Want: want, Got: got})
 		}
 	}
-	check("os", r.Platform.OS, observed.OS)
-	check("os_version", r.Platform.OSVersion, observed.OSVersion)
-	check("os_codename", r.Platform.OSCodename, observed.OSCodename)
-	check("arch", r.Platform.Arch, observed.Arch)
-	check("kernel", r.Platform.Kernel, observed.Kernel)
-	check("engine", r.Platform.Engine, observed.Engine)
-	check("api", r.Platform.API, observed.API)
-	check("cgroup_version", r.Platform.CgroupVersion, observed.CgroupVersion)
-	check("cgroup_driver", r.Platform.CgroupDriver, observed.CgroupDriver)
-	check("storage_driver", r.Platform.StorageDriver, observed.StorageDriver)
-	check("backing_filesystem", r.Platform.BackingFilesystem, observed.BackingFilesystem)
-	check("containerd", r.Platform.Containerd, observed.Containerd)
-	check("runc", r.Platform.Runc, observed.Runc)
-	check("buildx", r.Platform.Buildx, observed.Buildx)
-	check("compose", r.Platform.Compose, observed.Compose)
-	check("iptables", r.Platform.IPTables, observed.IPTables)
-	check("nftables", r.Platform.NFTables, observed.NFTables)
-	if mismatch, ok := compareBoolFact("rootless", r.Platform.Rootless, observed.Rootless); ok {
+	check("os", q.Platform.OS, observed.OS)
+	check("os_version", q.Platform.OSVersion, observed.OSVersion)
+	check("os_codename", q.Platform.OSCodename, observed.OSCodename)
+	check("arch", q.Platform.Arch, observed.Arch)
+	check("kernel", q.Platform.Kernel, observed.Kernel)
+	check("engine", q.Platform.Engine, observed.Engine)
+	check("api", q.Platform.API, observed.API)
+	check("cgroup_version", q.Platform.CgroupVersion, observed.CgroupVersion)
+	check("cgroup_driver", q.Platform.CgroupDriver, observed.CgroupDriver)
+	check("storage_driver", q.Platform.StorageDriver, observed.StorageDriver)
+	check("backing_filesystem", q.Platform.BackingFilesystem, observed.BackingFilesystem)
+	check("containerd", q.Platform.Containerd, observed.Containerd)
+	check("runc", q.Platform.Runc, observed.Runc)
+	check("buildx", q.Platform.Buildx, observed.Buildx)
+	check("compose", q.Platform.Compose, observed.Compose)
+	check("iptables", q.Platform.IPTables, observed.IPTables)
+	check("nftables", q.Platform.NFTables, observed.NFTables)
+	if mismatch, ok := compareBoolFact("rootless", q.Platform.Rootless, observed.Rootless); ok {
 		out = append(out, mismatch)
 	}
 	return out
@@ -216,9 +340,9 @@ func (r Reference) Compare(observed Facts) []Mismatch {
 
 // CompareDockerFacts is the subset of Compare observable through the Docker
 // API. Qualification contracts use it when they need daemon-only evidence.
-func (r Reference) CompareDockerFacts(observed Facts) []Mismatch {
-	if r.Status != ReferenceStatusFrozen {
-		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: r.Status}}
+func (q Qualified) CompareDockerFacts(observed Facts) []Mismatch {
+	if q.Status != ReferenceStatusFrozen {
+		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: q.Status}}
 	}
 	var out []Mismatch
 	check := func(property, want, got string) {
@@ -226,12 +350,12 @@ func (r Reference) CompareDockerFacts(observed Facts) []Mismatch {
 			out = append(out, Mismatch{Property: property, Want: want, Got: got})
 		}
 	}
-	check("engine", r.Platform.Engine, observed.Engine)
-	check("api", r.Platform.API, observed.API)
-	check("arch", r.Platform.Arch, observed.Arch)
-	check("cgroup_version", r.Platform.CgroupVersion, observed.CgroupVersion)
-	check("cgroup_driver", r.Platform.CgroupDriver, observed.CgroupDriver)
-	if mismatch, ok := compareBoolFact("rootless", r.Platform.Rootless, observed.Rootless); ok {
+	check("engine", q.Platform.Engine, observed.Engine)
+	check("api", q.Platform.API, observed.API)
+	check("arch", q.Platform.Arch, observed.Arch)
+	check("cgroup_version", q.Platform.CgroupVersion, observed.CgroupVersion)
+	check("cgroup_driver", q.Platform.CgroupDriver, observed.CgroupDriver)
+	if mismatch, ok := compareBoolFact("rootless", q.Platform.Rootless, observed.Rootless); ok {
 		out = append(out, mismatch)
 	}
 	return out

--- a/internal/platform/platform.lock.json
+++ b/internal/platform/platform.lock.json
@@ -7,20 +7,29 @@
     "The qualification job must compare the observed host with those frozen",
     "facts. It must never derive its expected values from the host under test.",
     "Updating Docker after a freeze requires a new reviewed lock and a complete",
-    "no-skip qualification run; it does not invalidate historical records."
+    "no-skip qualification run; it does not invalidate historical records.",
+    "",
+    "One entry per platform qualified. A platform with no entry is not a",
+    "failure of that platform; it is a platform nobody has run the suites",
+    "on, and the two are reported differently. Adding one is an added",
+    "entry rather than a change to this file's shape."
   ],
-  "schema_version": 1,
-  "status": "pending",
-  "policy": {
-    "os": "debian",
-    "os_version": "13",
-    "os_codename": "trixie",
-    "arch": "amd64",
-    "docker_channel": "stable",
-    "docker_source": "https://download.docker.com/linux/debian",
-    "selection": "latest-stable-at-policy-review",
-    "target_engine": "29.7.2",
-    "reviewed": "2026-08-16",
-    "freeze_point": "before-release-candidate"
-  }
+  "schema_version": 2,
+  "platforms": [
+    {
+      "status": "pending",
+      "policy": {
+        "os": "debian",
+        "os_version": "13",
+        "os_codename": "trixie",
+        "arch": "amd64",
+        "docker_channel": "stable",
+        "docker_source": "https://download.docker.com/linux/debian",
+        "selection": "latest-stable-at-policy-review",
+        "target_engine": "29.7.2",
+        "reviewed": "2026-08-16",
+        "freeze_point": "before-release-candidate"
+      }
+    }
+  ]
 }

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -3,7 +3,6 @@ package platform
 import (
 	"bytes"
 	"os"
-	"slices"
 	"strings"
 	"testing"
 )
@@ -49,25 +48,78 @@ func TestManifestSelectsTheLatestReviewedStableEngine(t *testing.T) {
 // suites on and a host that ran them and differed are different answers,
 // and the file's shape used to make only the second expressible.
 func TestAPlatformWithNoEntryIsNotAFailedOne(t *testing.T) {
-	ref, err := Load()
-	if err != nil {
-		t.Fatal(err)
+	// Two entries this test owns, rather than whatever the lock holds. An
+	// assertion written against the file cannot tell "arm64 was qualified
+	// later" from "selection is broken", and the version of this that
+	// skipped on the first was switched off by the second.
+	amd := frozenQualified()
+	arm := frozenQualified()
+	arm.Policy.Arch, arm.Platform.Arch = "arm64", "arm64"
+	arm.Platform.Kernel = "6.12.0-arm64"
+	ref := Reference{SchemaVersion: 2, Platforms: []Qualified{amd, arm}}
+	if err := ref.validate(); err != nil {
+		t.Fatalf("two platforms did not validate: %v", err)
 	}
-	if _, ok := ref.For("arm64"); ok {
-		t.Skip("arm64 is qualified now, so this says nothing")
+
+	for _, arch := range []string{"amd64", "arm64"} {
+		got, ok := ref.For(arch)
+		if !ok {
+			t.Fatalf("no entry for %s in a record holding %v", arch, ref.Arches())
+		}
+		if got.Policy.Arch != arch {
+			t.Errorf("For(%q) returned the %s entry; a host is then qualified against another "+
+				"platform's facts, which is the failure this record exists to stop",
+				arch, got.Policy.Arch)
+		}
 	}
-	err = ref.NotQualified("arm64")
+	if _, ok := ref.For("riscv64"); ok {
+		t.Error("a platform with no entry was matched to one")
+	}
+
+	err := ref.NotQualified("riscv64")
 	if err == nil {
 		t.Fatal("an unqualified platform produced no error")
 	}
-	if !strings.Contains(err.Error(), "arm64") || !strings.Contains(err.Error(), "amd64") {
-		t.Errorf("the error is %q; it has to name the platform asked about and the ones that "+
-			"are qualified, or it reads as a broken release rather than an unqualified host", err)
+	for _, want := range []string{"riscv64", "amd64", "arm64"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error is %q; it has to name the platform asked about and the ones "+
+				"that are qualified, or it reads as a broken release rather than an "+
+				"unqualified host", err)
+		}
 	}
-	// And the shape can hold one without changing: adding a platform is
-	// adding an entry.
-	if !slices.Contains(BuildableArches(), "arm64") {
-		t.Error("arm64 is not buildable, so a qualification for it could never be recorded")
+}
+
+// TestAnEntryFrozenFromAnotherPlatformIsRefused: selection reads the
+// policy and comparison reads the facts, so an entry labelled one
+// platform and frozen from another qualifies neither.
+//
+// The host that ran the suites is told nobody qualified it, and a host of
+// the claimed platform is told the reference is something else. Naming a
+// single architecture in the reader used to make this unrepresentable,
+// and nothing replaced that when the name came out.
+func TestAnEntryFrozenFromAnotherPlatformIsRefused(t *testing.T) {
+	for name, break_ := range map[string]func(*Qualified){
+		"arch":        func(q *Qualified) { q.Platform.Arch = "arm64" },
+		"os":          func(q *Qualified) { q.Platform.OS = "ubuntu" },
+		"os_version":  func(q *Qualified) { q.Platform.OSVersion = "24.04" },
+		"os_codename": func(q *Qualified) { q.Platform.OSCodename = "noble" },
+	} {
+		q := frozenQualified()
+		break_(&q)
+		if err := q.validate(); err == nil {
+			t.Errorf("an entry whose frozen %s differs from the one it selects validated; "+
+				"the release would claim a platform it never measured", name)
+		}
+	}
+}
+
+// TestTwoEntriesForOnePlatformAreRefused: which one qualified a host
+// would be whichever came first.
+func TestTwoEntriesForOnePlatformAreRefused(t *testing.T) {
+	ref := Reference{SchemaVersion: 2, Platforms: []Qualified{frozenQualified(), frozenQualified()}}
+	if err := ref.validate(); err == nil {
+		t.Error("one platform recorded twice validated, so a host is qualified against " +
+			"whichever entry the file happens to list first")
 	}
 }
 
@@ -86,7 +138,7 @@ func TestManifestRequiresEveryFrozenFact(t *testing.T) {
 		t.Fatal("an incomplete frozen reference validated")
 	}
 
-	missingBoolean := frozenReference()
+	missingBoolean := frozenQualified()
 	missingBoolean.Platform.Rootless = nil
 	if err := missingBoolean.validate(); err == nil {
 		t.Fatal("a frozen reference without the rootless observation validated")
@@ -95,7 +147,7 @@ func TestManifestRequiresEveryFrozenFact(t *testing.T) {
 
 // TestCompareNamesEveryDifference keeps qualification evidence fail-closed.
 func TestCompareNamesEveryDifference(t *testing.T) {
-	ref := frozenReference()
+	ref := frozenQualified()
 
 	if got := ref.Compare(ref.Platform); len(got) != 0 {
 		t.Errorf("the reference platform mismatched itself: %v", got)
@@ -122,7 +174,7 @@ func TestCompareNamesEveryDifference(t *testing.T) {
 }
 
 func TestRuntimeComparisonUsesOnlyDockerFacts(t *testing.T) {
-	ref := frozenReference()
+	ref := frozenQualified()
 	observed := Facts{
 		Engine:        ref.Platform.Engine,
 		API:           ref.Platform.API,
@@ -151,7 +203,7 @@ func testPolicy() Policy {
 	}
 }
 
-func frozenReference() Qualified {
+func frozenQualified() Qualified {
 	return Qualified{
 		Status:   ReferenceStatusFrozen,
 		Policy:   testPolicy(),

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -3,6 +3,8 @@ package platform
 import (
 	"bytes"
 	"os"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -25,26 +27,55 @@ func TestManifestSelectsTheLatestReviewedStableEngine(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ref.Status != ReferenceStatusPending {
-		t.Errorf("status = %q; want pending until the server facts are frozen", ref.Status)
+	amd64, ok := ref.For("amd64")
+	if !ok {
+		t.Fatalf("no entry for amd64; the release records %v", ref.Arches())
 	}
-	if ref.Policy.TargetEngine != "29.7.2" || ref.Policy.DockerChannel != "stable" {
-		t.Errorf("Docker policy = %+v; want stable Engine 29.7.2", ref.Policy)
+	if amd64.Status != ReferenceStatusPending {
+		t.Errorf("status = %q; want pending until the server facts are frozen", amd64.Status)
 	}
-	if err := ref.RequireFrozen(); err == nil {
+	if amd64.Policy.TargetEngine != "29.7.2" || amd64.Policy.DockerChannel != "stable" {
+		t.Errorf("Docker policy = %+v; want stable Engine 29.7.2", amd64.Policy)
+	}
+	if err := amd64.RequireFrozen(); err == nil {
 		t.Fatal("a pending reference was accepted for release qualification")
 	}
-	if got := ref.Compare(Facts{}); len(got) != 1 || got[0].Property != "reference_status" {
+	if got := amd64.Compare(Facts{}); len(got) != 1 || got[0].Property != "reference_status" {
 		t.Fatalf("pending comparison = %v; want a reference_status mismatch", got)
 	}
 }
 
+// TestAPlatformWithNoEntryIsNotAFailedOne: a host nobody has run the
+// suites on and a host that ran them and differed are different answers,
+// and the file's shape used to make only the second expressible.
+func TestAPlatformWithNoEntryIsNotAFailedOne(t *testing.T) {
+	ref, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ref.For("arm64"); ok {
+		t.Skip("arm64 is qualified now, so this says nothing")
+	}
+	err = ref.NotQualified("arm64")
+	if err == nil {
+		t.Fatal("an unqualified platform produced no error")
+	}
+	if !strings.Contains(err.Error(), "arm64") || !strings.Contains(err.Error(), "amd64") {
+		t.Errorf("the error is %q; it has to name the platform asked about and the ones that "+
+			"are qualified, or it reads as a broken release rather than an unqualified host", err)
+	}
+	// And the shape can hold one without changing: adding a platform is
+	// adding an entry.
+	if !slices.Contains(BuildableArches(), "arm64") {
+		t.Error("arm64 is not buildable, so a qualification for it could never be recorded")
+	}
+}
+
 func TestManifestRequiresEveryFrozenFact(t *testing.T) {
-	bad := Reference{
-		SchemaVersion: 1,
-		Status:        ReferenceStatusFrozen,
-		Policy:        testPolicy(),
-		Recorded:      "2026-08-14",
+	bad := Qualified{
+		Status:   ReferenceStatusFrozen,
+		Policy:   testPolicy(),
+		Recorded: "2026-08-14",
 		Platform: Facts{
 			OS: "debian", OSVersion: "13", Arch: "amd64",
 			Engine: "29.7.2", CgroupVersion: "2", CgroupDriver: "systemd",
@@ -120,12 +151,11 @@ func testPolicy() Policy {
 	}
 }
 
-func frozenReference() Reference {
-	return Reference{
-		SchemaVersion: 1,
-		Status:        ReferenceStatusFrozen,
-		Policy:        testPolicy(),
-		Recorded:      "2026-08-14",
+func frozenReference() Qualified {
+	return Qualified{
+		Status:   ReferenceStatusFrozen,
+		Policy:   testPolicy(),
+		Recorded: "2026-08-14",
 		Platform: Facts{
 			OS:                "debian",
 			OSVersion:         "13",
@@ -150,3 +180,77 @@ func frozenReference() Reference {
 }
 
 func boolFact(value bool) *bool { return &value }
+
+// TestTheSelectionPolicyIsAChoiceNotARule: which distribution was
+// selected is reviewed, not validated.
+//
+// Naming one in the validator would do to the operating system what
+// naming a single architecture did to the machine: a host that ran the
+// suites and passed would be refused for not being the one the file can
+// express, and the refusal would read as a broken manifest rather than
+// as an unqualified platform. What has to be true is that the choice is
+// stated, because a policy missing a field records a selection nobody
+// can check a host against.
+func TestTheSelectionPolicyIsAChoiceNotARule(t *testing.T) {
+	elsewhere := testPolicy()
+	elsewhere.OS = "ubuntu"
+	elsewhere.OSVersion = "24.04"
+	elsewhere.OSCodename = "noble"
+	elsewhere.DockerSource = "https://download.docker.com/linux/ubuntu"
+	if err := (Qualified{Status: ReferenceStatusPending, Policy: elsewhere}).validate(); err != nil {
+		t.Errorf("a qualification on another distribution was refused: %v.\n"+
+			"The gate is meant to measure the host, and a host it will not let anyone "+
+			"record is a host it is not measuring.", err)
+	}
+
+	for _, blank := range []func(*Policy){
+		func(p *Policy) { p.OS = "" },
+		func(p *Policy) { p.OSVersion = "" },
+		func(p *Policy) { p.OSCodename = "" },
+		func(p *Policy) { p.DockerChannel = "" },
+		func(p *Policy) { p.DockerSource = "" },
+		func(p *Policy) { p.Selection = "" },
+		func(p *Policy) { p.TargetEngine = "" },
+		func(p *Policy) { p.Reviewed = "" },
+	} {
+		policy := testPolicy()
+		blank(&policy)
+		if err := (Qualified{Status: ReferenceStatusPending, Policy: policy}).validate(); err == nil {
+			t.Errorf("a selection policy missing a field validated: %+v", policy)
+		}
+	}
+
+	// The freeze point stays a rule. A reference reviewed after the
+	// candidate exists is a reference the candidate could have been
+	// built against.
+	late := testPolicy()
+	late.FreezePoint = "after-release-candidate"
+	if err := (Qualified{Status: ReferenceStatusPending, Policy: late}).validate(); err == nil {
+		t.Error("a reference frozen after the candidate validated, so the evidence could have " +
+			"been written to fit what it was meant to judge")
+	}
+}
+
+// TestAnyBuildablePlatformCanBeRecorded: the record has to be able to
+// hold a qualification for every platform a release can produce.
+//
+// Only one is recorded today, so nothing else exercises the entries the
+// file does not yet contain — and a check narrowed back to the one that
+// is there would look correct against this file for as long as it stays
+// the only one.
+func TestAnyBuildablePlatformCanBeRecorded(t *testing.T) {
+	for _, arch := range BuildableArches() {
+		policy := testPolicy()
+		policy.Arch = arch
+		if err := (Qualified{Status: ReferenceStatusPending, Policy: policy}).validate(); err != nil {
+			t.Errorf("a qualification for %s was refused: %v.\nA release builds for it, so a "+
+				"host that ran the suites there has nowhere to be recorded.", arch, err)
+		}
+	}
+	unbuildable := testPolicy()
+	unbuildable.Arch = "riscv64"
+	if err := (Qualified{Status: ReferenceStatusPending, Policy: unbuildable}).validate(); err == nil {
+		t.Error("a qualification was accepted for a platform no release builds for, so the " +
+			"record would claim evidence about something nobody can run")
+	}
+}

--- a/scripts/verify/image-lock.sh
+++ b/scripts/verify/image-lock.sh
@@ -37,10 +37,12 @@ for name in $names; do
     continue
   fi
 
-  # The digest is right; now the platforms behind it. Attestation
-  # manifests carry no architecture and are skipped rather than reported
-  # as a platform nobody asked for.
-  published=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' |
+  # The digest is right; now the platforms behind it. By digest rather
+  # than by tag, so these are the bytes just verified and not whatever
+  # the tag resolves to a moment later. Attestation manifests carry no
+  # architecture and are skipped rather than reported as a platform
+  # nobody asked for.
+  if ! published=$(docker buildx imagetools inspect "${ref%:*}@${want}" --format '{{json .Manifest}}' |
     python3 -c '
 import json, sys
 m = json.load(sys.stdin)
@@ -50,7 +52,11 @@ for d in m.get("manifests", []):
     if p.get("architecture") in (None, "unknown"):
         continue
     out.append(p["os"] + "/" + p["architecture"])
-print(" ".join(sorted(set(out))))')
+print(" ".join(sorted(set(out))))'); then
+    echo "FAIL  $name ($ref): the published platforms could not be read"
+    status=1
+    continue
+  fi
   for platform in $declared; do
     case " $published " in
       *" $platform "*) ;;

--- a/scripts/verify/image-lock.sh
+++ b/scripts/verify/image-lock.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 # Re-resolve every tag in the image lock against its registry and fail if
-# a digest has drifted. The lock is what the controller executes, so
-# drift means the privileged payload changed under a name already
-# reviewed. Needs network and `docker buildx`; the hermetic half — the
-# embedded copy matching the reviewed copy — is a Go test
-# (internal/app/images_lock_test.go) and runs with the ordinary suite.
+# a digest has drifted, and check that every platform the lock says a
+# release builds for is a platform the image actually publishes. The lock
+# is what the controller executes, so drift means the privileged payload
+# changed under a name already reviewed — and a digest bump that quietly
+# drops a platform leaves the declared list and the buildable list
+# agreeing with each other while agreeing with nothing upstream. This is
+# the one check that looks at the registry rather than at another list.
+#
+# Needs network and `docker buildx`; the hermetic half — the embedded
+# copy matching the reviewed copy, and the declared list matching what
+# the code will build — is a Go test (internal/app/images_lock_test.go)
+# and runs with the ordinary suite.
 #
 # Usage: scripts/verify/image-lock.sh
 cd "$(dirname "$0")/../.."
@@ -13,6 +20,7 @@ lock=build/images.lock.json
 status=0
 
 names=$(python3 -c 'import json,sys; print(" ".join(json.load(open(sys.argv[1]))["images"]))' "$lock")
+declared=$(python3 -c 'import json,sys; print(" ".join(json.load(open(sys.argv[1]))["platforms"]))' "$lock")
 for name in $names; do
   ref=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["images"][sys.argv[2]]["ref"])' "$lock" "$name")
   want=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["images"][sys.argv[2]]["digest"])' "$lock" "$name")
@@ -26,6 +34,31 @@ for name in $names; do
   else
     echo "FAIL  $name $ref: lock says $want, registry says $got"
     status=1
+    continue
   fi
+
+  # The digest is right; now the platforms behind it. Attestation
+  # manifests carry no architecture and are skipped rather than reported
+  # as a platform nobody asked for.
+  published=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}' |
+    python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+out = []
+for d in m.get("manifests", []):
+    p = d.get("platform") or {}
+    if p.get("architecture") in (None, "unknown"):
+        continue
+    out.append(p["os"] + "/" + p["architecture"])
+print(" ".join(sorted(set(out))))')
+  for platform in $declared; do
+    case " $published " in
+      *" $platform "*) ;;
+      *)
+        echo "FAIL  $name $ref: the lock builds for $platform and the image publishes $published"
+        status=1
+        ;;
+    esac
+  done
 done
 exit $status

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -110,21 +111,25 @@ func TestDocumentedEngineVersionsMatchTheLock(t *testing.T) {
 		}
 		targets[p.Policy.TargetEngine] = true
 	}
-	if len(targets) != 1 {
-		t.Fatalf("the platforms select %d different engines (%v); a document naming one of them "+
-			"is not stale, and this check cannot tell which", len(targets), targets)
+	// Every selected engine, not one. Two platforms qualified months
+	// apart legitimately pin different ones, and that is what a
+	// per-entry target is for -- so a document naming any of them is
+	// current, and only a version naming none is stale.
+	majors := map[string]bool{}
+	for target := range targets {
+		majors[target[:strings.Index(target, ".")]] = true
 	}
-	var target string
-	for t := range targets {
-		target = t
-	}
-	major := target[:strings.Index(target, ".")]
 
 	out, err := exec.Command("git", "-C", repoPath(), "ls-files", "*.md").Output()
 	if err != nil {
 		t.Fatal(err)
 	}
-	version := regexp.MustCompile(`\b` + regexp.QuoteMeta(major) + `\.\d+\.\d+\b`)
+	alternatives := make([]string, 0, len(majors))
+	for major := range majors {
+		alternatives = append(alternatives, regexp.QuoteMeta(major))
+	}
+	slices.Sort(alternatives)
+	version := regexp.MustCompile(`\b(?:` + strings.Join(alternatives, "|") + `)\.\d+\.\d+\b`)
 	var stale []string
 	for _, file := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 		if strings.HasPrefix(file, "docs/adrs/") {
@@ -135,8 +140,14 @@ func TestDocumentedEngineVersionsMatchTheLock(t *testing.T) {
 			t.Fatal(err)
 		}
 		for _, m := range version.FindAllString(string(body), -1) {
-			if m != target {
-				stale = append(stale, fmt.Sprintf("%s mentions engine %s; the lock names %s", file, m, target))
+			if !targets[m] {
+				selected := make([]string, 0, len(targets))
+				for engine := range targets {
+					selected = append(selected, engine)
+				}
+				slices.Sort(selected)
+				stale = append(stale, fmt.Sprintf("%s mentions engine %s; the lock selects %s",
+					file, m, strings.Join(selected, ", ")))
 			}
 		}
 	}
@@ -376,5 +387,66 @@ func TestNoDocCommentBelongsToAnotherDeclaration(t *testing.T) {
 	}
 	for _, f := range found {
 		t.Error(f)
+	}
+}
+
+// TestEveryReaderOfThePlatformLockKnowsItsShape: the lock is parsed
+// outside Go too, and nothing there fails until a release.
+//
+// The release gate assembles its record with an inline reader. A change
+// to the lock's shape leaves that reader compiling nothing and failing
+// no test — it surfaces the first time somebody freezes an entry and
+// cuts a candidate, and it surfaces as a claim about the reference that
+// is not true of it.
+//
+// This is a text check, which is weaker than running the reader. Running
+// it needs the reader to exist outside the workflow, and that is worth
+// doing; until then this is what stands between a schema change and a
+// release.
+func TestEveryReaderOfThePlatformLockKnowsItsShape(t *testing.T) {
+	raw, err := os.ReadFile(repoPath("build", "platform.lock.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var lock map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &lock); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := lock["platforms"]; !ok {
+		t.Fatal("the lock has no `platforms` key, so this check is about a shape that is gone")
+	}
+
+	out, err := exec.Command("git", "-C", repoPath(), "ls-files",
+		".github/workflows/*.yml", "scripts/*/*.sh", "scripts/*/*.py").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, file := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if file == "" {
+			continue
+		}
+		body, err := os.ReadFile(repoPath(file))
+		if err != nil {
+			t.Fatal(err)
+		}
+		text := string(body)
+		if !strings.Contains(text, "platform.lock.json") {
+			continue
+		}
+		checked++
+		// A reader that only names the file may just be pointing at it in
+		// a comment; one that indexes into it has to know the shape.
+		for _, gone := range []string{`reference["policy"]`, `reference["platform"]`,
+			`reference.get("status")`, `.policy.`, `.platform.arch`} {
+			if strings.Contains(text, gone) {
+				t.Errorf("%s reads the lock as %s, which the file has not had since it "+
+					"became a list of platforms; this fails at release time, saying "+
+					"something untrue about the reference", file, gone)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no file outside Go names the lock, so this proves nothing")
 	}
 }

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -86,16 +86,37 @@ func TestDocumentedEngineVersionsMatchTheLock(t *testing.T) {
 		t.Fatal(err)
 	}
 	var lock struct {
-		Policy struct {
-			TargetEngine string `json:"target_engine"`
-		} `json:"policy"`
+		Platforms []struct {
+			Policy struct {
+				Arch         string `json:"arch"`
+				TargetEngine string `json:"target_engine"`
+			} `json:"policy"`
+		} `json:"platforms"`
 	}
 	if err := json.Unmarshal(raw, &lock); err != nil {
 		t.Fatal(err)
 	}
-	target := lock.Policy.TargetEngine
-	if target == "" {
-		t.Fatal("build/platform.lock.json names no target engine, so this proves nothing")
+	if len(lock.Platforms) == 0 {
+		t.Fatal("build/platform.lock.json names no platform at all, so this proves nothing")
+	}
+	// Every platform's engine, not the first one's. They are selected by
+	// one policy today and need not stay that way, and a page naming a
+	// version no platform selects is the thing this exists to catch.
+	targets := map[string]bool{}
+	for _, p := range lock.Platforms {
+		if p.Policy.TargetEngine == "" {
+			t.Fatalf("the %s entry names no target engine, so this proves nothing about it",
+				p.Policy.Arch)
+		}
+		targets[p.Policy.TargetEngine] = true
+	}
+	if len(targets) != 1 {
+		t.Fatalf("the platforms select %d different engines (%v); a document naming one of them "+
+			"is not stale, and this check cannot tell which", len(targets), targets)
+	}
+	var target string
+	for t := range targets {
+		target = t
 	}
 	major := target[:strings.Index(target, ".")]
 

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -437,8 +437,14 @@ func TestEveryReaderOfThePlatformLockKnowsItsShape(t *testing.T) {
 		checked++
 		// A reader that only names the file may just be pointing at it in
 		// a comment; one that indexes into it has to know the shape.
+		//
+		// The forms below are the top-level ones the old shape had. A
+		// bare path fragment cannot be on this list: an entry's policy is
+		// still reached through `.policy.`, and its facts through
+		// `.platform.`, so a correct reader of the list would be refused
+		// by a check that reads it as the shape that is gone.
 		for _, gone := range []string{`reference["policy"]`, `reference["platform"]`,
-			`reference.get("status")`, `.policy.`, `.platform.arch`} {
+			`reference.get("status")`} {
 			if strings.Contains(text, gone) {
 				t.Errorf("%s reads the lock as %s, which the file has not had since it "+
 					"became a list of platforms; this fails at release time, saying "+

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -528,6 +528,37 @@ func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
 	}
 }
 
+// lockArch translates the daemon's spelling of an architecture into the
+// one the platform lock records. They differ on both platforms a release builds
+// for, and scripts/qualification/platform-facts.sh maps the same pair
+// for the facts the release gate reads.
+func lockArch(daemon string) string {
+	switch daemon {
+	case "x86_64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	}
+	return daemon
+}
+
+// TestTheDaemonSpellingSelectsTheEntry: the entry is selected by the
+// architecture the daemon reports, and the daemon does not spell it the
+// way the lock does.
+//
+// Mapping one architecture and not the other refuses a host that ran the
+// suites for how its daemon writes the name, and it refuses it as a
+// platform nobody qualified -- which is the answer a record of several
+// platforms exists to stop giving.
+func TestTheDaemonSpellingSelectsTheEntry(t *testing.T) {
+	for daemon, want := range map[string]string{"x86_64": "amd64", "aarch64": "arm64"} {
+		if got := lockArch(daemon); got != want {
+			t.Errorf("a daemon reporting %q selects the %q entry; the lock records %q, so the "+
+				"host is told nobody has qualified its platform", daemon, got, want)
+		}
+	}
+}
+
 // TestHostInfo covers the doctor's view of the daemon. Runpool refuses
 // hosts it cannot honour the capsule contract on, and every field here
 // is read from a result struct the migration introduced.
@@ -557,10 +588,7 @@ func TestHostInfo(t *testing.T) {
 	// The expectation comes from the reviewed manifest, never from the host
 	// being evaluated.
 	reference := platform.MustLoad()
-	arch := info.Architecture
-	if arch == "x86_64" {
-		arch = "amd64"
-	}
+	arch := lockArch(info.Architecture)
 	// The entry for the host being measured. A host with none is not a
 	// host that failed the reference; it is one nobody has qualified, and
 	// saying so is what keeps this from reading as a broken release.

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -561,6 +561,13 @@ func TestHostInfo(t *testing.T) {
 	if arch == "x86_64" {
 		arch = "amd64"
 	}
+	// The entry for the host being measured. A host with none is not a
+	// host that failed the reference; it is one nobody has qualified, and
+	// saying so is what keeps this from reading as a broken release.
+	qualified, ok := reference.For(arch)
+	if !ok {
+		t.Fatalf("not the release-qualification reference — %v", reference.NotQualified(arch))
+	}
 	rootless := info.Rootless
 	observed := platform.Facts{
 		Engine:        info.ServerVersion,
@@ -570,14 +577,16 @@ func TestHostInfo(t *testing.T) {
 		CgroupDriver:  info.CgroupDriver,
 		Rootless:      &rootless,
 	}
-	for _, m := range reference.CompareDockerFacts(observed) {
+	for _, m := range qualified.CompareDockerFacts(observed) {
 		t.Errorf("not the release-qualification reference — %s", m)
 	}
-	// OSType and Architecture use the daemon's own spelling, which
-	// differs from the manifest's (x86_64 against amd64), so they are
-	// compared here rather than by mapping one onto the other.
-	if info.OSType != "linux" || info.Architecture != "x86_64" {
-		t.Errorf("platform = %s/%s; the qualification reference is linux/x86_64", info.OSType, info.Architecture)
+	// OSType is compared here rather than through the manifest, which
+	// records no operating-system kind. The architecture is not: it is
+	// what selected the entry above, so comparing it again would compare
+	// a value against itself.
+	if info.OSType != "linux" {
+		t.Errorf("platform = %s/%s; every qualification reference is a Linux host",
+			info.OSType, info.Architecture)
 	}
 	t.Logf("release-qualification reference confirmed: engine %s, api %s, cgroup v%s/%s, rootful",
 		info.ServerVersion, info.APIVersion, info.CgroupVersion, info.CgroupDriver)


### PR DESCRIPTION
## What changes

`build/platform.lock.json` records a list of qualified platforms rather than
one, each with its own selection policy and frozen facts; the reader selects
the entry for the platform being measured and reports one with no entry as
unqualified rather than as an architecture mismatch. `build/images.lock.json`
declares what a release builds for, which is a wider list than what has been
qualified, and the support matrix states the two separately.

This is `2026-08-17-multiplatform-locks`, accepted with its implementation
pending. Three of its four decisions are here. The fourth — the release
publishing an index per image — is not, and the record now says so.

## What was found

**The record could not express a second qualification, and its reader refused
one.** `platform.lock.json` carried a single `policy` object, and
`Reference.validate` required `r.Policy.Arch == "amd64"`. So a host that ran
the suites and passed was refused for not being the platform the file can
express, and it failed as an *invalid manifest* rather than as an unqualified
platform. The maintainer guide stated the consequence plainly: an arm64 host
fails "regardless of how well it runs the suites".

It is a list now. `Reference.For(arch)` selects, `Arches()` and
`NotQualified(arch)` are what a platform with no entry gets, and duplicate
entries are refused because which one qualified a host would otherwise be
whichever came first. `RequireFrozen`, `Compare` and `CompareDockerFacts` move
onto the entry, since they were always about one platform's facts.

`verify -observed` selects on the *observed* facts' architecture, not the
running process's: the facts came from a host, and it is that host being
qualified.

**Two things beyond what the record asked for, on its own argument.** The
distribution was hard-coded beside the architecture —
`Policy.OS != "debian" || OSVersion != "13" || OSCodename != "trixie"` — so a
host on another distribution could not be recorded either, for exactly the
reason the record objects to. The reader now requires the selection to be
*stated* rather than to be a particular value.

And the operating system is derived from what the pinned images publish rather
than written as a rule. A capsule runs a Linux daemon and a Linux runner
inside a container, and the isolation is cgroup v2 and kernel netfilter, so
there is no non-Linux variant of the base images to build against. That makes
it a fact about the images, not a policy — and if one were ever published,
`Buildable` is where it would show. The first draft of the image-lock test had
`os != "linux"` as a rule of its own; it compares whole platform strings
against `Buildable` instead.

**What the reader still refuses**, and why each is a rule rather than a
choice: a platform no release builds for, which would record evidence about
something nobody can run; and a reference frozen after the candidate exists,
which is evidence that could have been written to fit what it was meant to
judge.

**The `platform` key in `images.lock.json` was read by nothing.** It is
`platforms` now and the embedded lock parses it, tied by test to what the
pinned images publish — a platform in one list and not the other is either a
release claiming something it cannot produce or one producing something it
does not offer.

## Evidence

Hermetic, plus one live build. Each mutation was applied alone.

```text
MUTATION 1: the distribution hard-coded again
--- FAIL: TestTheSelectionPolicyIsAChoiceNotARule
    a qualification on another distribution was refused: only debian.
    The gate is meant to measure the host, and a host it will not let
    anyone record is a host it is not measuring.

MUTATION 2: the architecture hard-coded to amd64 again
--- FAIL: TestAnyBuildablePlatformCanBeRecorded
    a qualification for arm64 was refused: ... which no release builds
    for. A release builds for it, so a host that ran the suites there has
    nowhere to be recorded.

MUTATION 3: the same platform recorded twice
--- FAIL: TestManifestSelectsTheLatestReviewedStableEngine
    platform manifest records amd64 twice; which entry qualifies a host
    would be whichever came first

MUTATION 4: the image lock declares one platform
--- FAIL: TestTheLockBuildsForEveryPlatformAReleaseCan
    the lock builds for [linux/amd64]; the pinned images publish
    [linux/amd64 linux/arm64]
```

Mutation 2 passed on a first attempt: only `amd64` is recorded, so nothing
exercised an entry for a platform the file does not yet contain, and a check
narrowed back to the one that is there looks correct for as long as it stays
the only one. `TestAnyBuildablePlatformCanBeRecorded` covers every buildable
platform instead.

**Live:** the capsule image builds for `linux/arm64` on a real daemon —
`docker buildx build --platform linux/arm64 -f build/capsule/Dockerfile
--output=type=cacheonly .`, exit 0, with the Go stage compiling for 4.5s
rather than reusing a cached layer. That is the part of per-platform
publishing most likely to fail, and it does not. No image, container, network
or volume was left behind.

The full local gate set mirroring `ci.yml` is green.

## What would notice this regressing

- `TestTheSelectionPolicyIsAChoiceNotARule` — another distribution validates;
  a policy missing any field does not; the freeze point stays a rule.
- `TestAnyBuildablePlatformCanBeRecorded` — every platform a release builds
  for can be recorded, and one it cannot build for cannot.
- `TestAPlatformWithNoEntryIsNotAFailedOne` — the error names the platform
  asked about and the ones that are qualified, so it reads as an unqualified
  host rather than a broken release.
- `TestManifestSelectsTheLatestReviewedStableEngine` — the amd64 entry is
  still pending, still selects stable 29.7.2, and duplicates are refused.
- `TestTheLockBuildsForEveryPlatformAReleaseCan` — the built list is exactly
  what the pinned images publish.
- `TestDocumentedEngineVersionsMatchTheLock` now reads every entry's engine and
  fails if they disagree, because a document naming one of two is not stale and
  the check cannot tell which.

## Risk, compatibility and operations

**Schema.** `platform.lock.json` moves from `schema_version` 1 to 2, and
`images.lock.json`'s `platform` becomes `platforms`. Both are build-time
documents embedded into the binary; neither is operator state and neither
migrates. Nothing is released, so no deployment carries either.

**Behaviour.** No runtime path changes. `doctor`'s compatibility floor is
separate and untouched. What changes is which reference a qualification
compares against and what a failure says.

**`version --json`.** `release_qualification_reference` stays a
`map[string]string`. It reports the entry for the architecture the binary is
running on, and a build running where nothing is qualified reports
`status: not-qualified-here` with the qualified list, rather than the first
entry's values under a different platform's name.

**Operations.** An operator on an unqualified platform now gets a message
naming what is qualified. That is a different sentence from before and a
truthful one; it does not change whether the binary runs, which
`doctor` decides.

**Trust boundary, credentials, networking, resource limits, ownership.** N/A.

**CLI, status API, migration, rollback.** None.

**Decision record.** `2026-08-17-multiplatform-locks` keeps its text and gains
two sections: what is built, and what is not. Its index row reads "accepted;
publishing pending".

## Changelog

```text
### Release and qualification

- **What a release builds for and what it qualifies are two lists.**
  `build/platform.lock.json` records one entry per platform whose suites
  were run and whose host facts were reviewed, so qualifying a second one
  is an added entry rather than a change to the file that is itself the
  proof of the gate. A host with no entry fails as not qualified on that
  platform, naming the ones that are, rather than as an architecture
  mismatch. `build/images.lock.json` states what a release builds for,
  which today is more than what has been qualified — and the support
  matrix says which is which instead of letting one imply the other.
  Neither the architecture nor the distribution is fixed by the code that
  reads the record: what it requires is that the selection is stated, and
  that the platform is one a release can build for.
```

## Notes for your reviewer

What is deliberately not here is the record's third decision: the release
publishing an index per image, and the standalone binaries per platform. The
binaries are already cross-built by an existing gate. The image half needs
`buildx` with a push and a different way of reading the digest back —
`docker image inspect` returns nothing for a multi-platform push — and its
only real verification is a release run. I would rather it landed with that
evidence than be reviewed on the strength of my reading it correctly.

The consequence, stated in the record and in the matrix: until it lands, a
release publishes one platform's image while the lock declares two, so the
*built* list describes what the build can produce rather than what the last
release pushed.

The thing I would look at first is whether loosening the distribution is
right. The argument for is the record's own: a validator naming one value
measures the file rather than the host. The argument against is that the pin
was how a reviewed selection stayed reviewed — and what replaces it is that
the fields must be present, which is weaker. If you want the selection
constrained, the place is a check that the entry matches the maintainer guide,
not a literal in the reader.
