### PR TITLE
ci(workflows): every gate has a deadline, and the toolchain is the one go.mod names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ on:
   # decides a release must be the one every change already passed.
   workflow_call:
 
-# Read-only by default; no job in this workflow needs more.
 defaults:
   run:
     # GitHub's default shell omits pipefail, so a step that pipes into tee
     # reports tee's exit status and a failing suite reads as a pass.
     shell: bash
 
+# Read-only by default; no job in this workflow needs more.
 permissions:
   contents: read
 
@@ -37,6 +37,7 @@ jobs:
     name: dependency review
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Review dependency changes
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
@@ -44,6 +45,7 @@ jobs:
   build:
     name: build and test
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -149,6 +151,7 @@ jobs:
   lint:
     name: workflows, scripts and containers
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -170,7 +173,15 @@ jobs:
         # shellcheck ships with the runner image; the harness scripts
         # run against real hosts, where a quoting bug deletes the wrong
         # thing.
-        run: shellcheck scripts/*/*.sh test/contract/*/testdata/*.sh
+        #
+        # Every script git knows about, rather than a glob. The globs
+        # this replaces were one directory deep and missed
+        # test/drills/remote-drills.sh, which two workflows execute — a
+        # script CI runs and does not lint is the one place a quoting bug
+        # reaches a real host unread. Untracked but unignored files count,
+        # the same set doc-links.sh checks: a script is worth linting from
+        # the moment it exists, not from the moment it is added.
+        run: git ls-files -coz --exclude-standard -- "*.sh" | xargs -0 shellcheck
       - name: Lint the Dockerfiles
         uses: hadolint/hadolint-action@2a66e89f53d0771bb131a7fa31f3136336094aa6 # v3.4.0
         with:
@@ -184,9 +195,9 @@ jobs:
         # Offline by design: in-repo links only, which is what a
         # documentation reorganization breaks silently.
         run: scripts/verify/doc-links.sh
-      - name: Verify the builder images match go.mod
-        # An image tag and a module directive belong to different
-        # updaters, so nothing but this keeps them in step.
+      - name: Verify the builder images and workflows match go.mod
+        # An image tag, a workflow variable and a module directive belong
+        # to different updaters, so nothing but this keeps them in step.
         run: scripts/verify/go-version.sh
       - name: Validate the reference deployment
         run: |
@@ -199,6 +210,7 @@ jobs:
   vulnerabilities:
     name: govulncheck
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -217,6 +229,7 @@ jobs:
   image:
     name: controller image
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,10 +14,18 @@ concurrency:
   group: codeql-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # The exact toolchain, kept equal to go.mod by
+  # scripts/verify/go-version.sh: autobuild compiles the tree, and the
+  # analysis describes whatever compiler it found. No `defaults.run` here
+  # because every step is an action; there is no shell to configure.
+  GOTOOLCHAIN: go1.26.6
+
 jobs:
   analyze:
     name: analyze Go
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -34,10 +34,16 @@ concurrency:
   group: contracts-github-actions
   cancel-in-progress: false
 
+env:
+  # Kept equal to go.mod by scripts/verify/go-version.sh.
+  GOTOOLCHAIN: go1.26.6
+
 jobs:
   contracts:
     name: runner scale set API
     runs-on: ubuntu-24.04
+    # Above the suite's own 40m, plus minting two installation tokens.
+    timeout-minutes: 60
     environment: upstream-contracts
     steps:
       - name: Check out the tree

--- a/.github/workflows/controller-e2e.yml
+++ b/.github/workflows/controller-e2e.yml
@@ -36,6 +36,10 @@ concurrency:
   group: controller-e2e
   cancel-in-progress: false
 
+env:
+  # Kept equal to go.mod by scripts/verify/go-version.sh.
+  GOTOOLCHAIN: go1.26.6
+
 jobs:
   workload:
     name: real assignment, restart, cache and cleanup

--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -56,10 +56,15 @@ concurrency:
   group: integration-docker-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Kept equal to go.mod by scripts/verify/go-version.sh.
+  GOTOOLCHAIN: go1.26.6
+
 jobs:
   daemon:
     name: moby adapter, cache lanes and disk
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -87,6 +92,10 @@ jobs:
   capsule:
     name: outer capsule, JIT and the egress sandbox
     runs-on: ubuntu-24.04
+    # Above the suite's own 20m, plus the capsule image build it does
+    # first: a job deadline under the test's leaves the suite reporting
+    # nothing when it is the thing that hung.
+    timeout-minutes: 40
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -124,6 +133,7 @@ jobs:
   lifecycle:
     name: lifecycle drills
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -146,6 +156,7 @@ jobs:
   sqlite:
     name: sqlite durability
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -37,6 +37,7 @@ jobs:
   validate-ref:
     name: validate release inputs
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Require a protected release tag and immutable images
         env:
@@ -230,6 +231,7 @@ jobs:
     name: release-qualification record
     needs: [hermetic, live, upstream, controller-e2e]
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     outputs:
       commit: ${{ github.sha }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,18 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # The exact toolchain, kept equal to go.mod by
+  # scripts/verify/go-version.sh. This workflow compiles the binary that
+  # ships, so a compiler chosen here and nowhere else would be the one
+  # thing no gate ever exercised.
+  GOTOOLCHAIN: go1.26.6
+
 jobs:
   validate:
     name: validate release tag
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -43,6 +51,12 @@ jobs:
     name: build immutable candidates
     needs: validate
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    # The one job that writes to a registry before anything has been
+    # qualified. The protected tag is what authorizes the run; the
+    # environment is where that authorization is recorded and can be held
+    # for review, the same place the publication gate already lives.
+    environment: release-candidate
     permissions:
       contents: read
       packages: write
@@ -139,6 +153,7 @@ jobs:
     name: attest and publish qualified artifacts
     needs: [candidate, qualify]
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     environment: release
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,12 @@ by its public and operational effects.
 - Public-repository gates include CodeQL, dependency review, Dependabot,
   vulnerability scanning, SHA-pinned actions, and least-privilege workflow
   permissions.
+- Every workflow states the Go toolchain it builds with, held equal to the
+  version `go.mod` declares by the same check that holds the builder images to
+  it, so the binary a release ships is compiled by the toolchain its gates ran.
+  Every job carries a deadline, and every script in the tree is linted.
+- The job that builds the candidate images runs under its own protected
+  environment: it writes to the registry before anything has been qualified.
 - The qualification policy is **pending in `build/platform.lock.json`**.
   Docker Engine 29.7.2 on Debian 13 is selected for the first qualification;
   the exact host facts must be captured, reviewed, and frozen before a release

--- a/docs/maintainers/repository-settings.md
+++ b/docs/maintainers/repository-settings.md
@@ -108,6 +108,12 @@ it.
   tests alone unless somebody dispatches them: Dependabot keeps that update out
   of the grouped batch, CODEOWNERS holds `go.mod`, and the reviewer runs
   `contracts-github-actions` by hand and links the run before merging.
+- Protect `release-candidate` with release-maintainer approval. It gates the
+  one job that writes to the registry before anything has been qualified: the
+  candidate images a release later promotes. The protected `v*` tag is what
+  authorizes the run, and this is where that authorization is recorded and can
+  be held. With a single maintainer, self-review applies here for the reason
+  the rulesets section gives: a bypass taken on every run protects nothing.
 - Protect `release` with required maintainers and the external security review
   approval. Only the final publish job may use it.
 

--- a/scripts/verify/go-version.sh
+++ b/scripts/verify/go-version.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
-# The builder images must name the Go that go.mod declares. Nothing else
-# ties them: an image tag and a module directive are separate ecosystems to
-# every updater, so they drift silently and the drift is invisible in a
-# green build. The binary an image ships would then be compiled by a
-# toolchain no test ever ran, which is the one thing a reproducible build
-# is supposed to rule out.
+# The builder images and the workflows must name the Go that go.mod
+# declares. Nothing else ties them: an image tag, a workflow variable and a
+# module directive are separate ecosystems to every updater, so they drift
+# silently and the drift is invisible in a green build. The binary an image
+# ships would then be compiled by a toolchain no test ever ran, which is the
+# one thing a reproducible build is supposed to rule out.
+#
+# The workflow half is the same argument one step earlier: a gate that
+# resolves its own compiler proves something about a toolchain the release
+# may never use. Every workflow here runs Go, so every workflow states it.
 #
 # Dependabot is configured to propose only patch bumps for the builder, so
 # this is the check behind that policy rather than a substitute for it.
@@ -33,6 +37,27 @@ for dockerfile in build/*/Dockerfile; do
     echo "FAIL  $dockerfile builds with golang:$got, go.mod declares $want"
     status=1
   fi
+done
+
+for workflow in .github/workflows/*.yml; do
+  # Every pin in the file, not the first: a workflow may state one and a
+  # job below it another, and the one that disagrees is the drift this
+  # exists to find. A trailing comment is tolerated so a pin that is
+  # there does not report as absent.
+  pinned=$(sed -n 's/^ *GOTOOLCHAIN: *go\([0-9][^ #]*\).*$/\1/p' "$workflow")
+  if [ -z "$pinned" ]; then
+    echo "FAIL  $workflow pins no GOTOOLCHAIN, so its steps may resolve another compiler"
+    status=1
+    continue
+  fi
+  for got in $pinned; do
+    if [ "$got" = "$want" ]; then
+      echo "ok    $workflow GOTOOLCHAIN go$got"
+    else
+      echo "FAIL  $workflow pins GOTOOLCHAIN go$got, go.mod declares $want"
+      status=1
+    fi
+  done
 done
 
 exit $status


### PR DESCRIPTION
## What changes

Every job in every workflow now has a deadline, every workflow states the Go
toolchain and is held to the one `go.mod` declares, the shell lint covers every
tracked script instead of two one-deep globs, and the job that pushes candidate
images to the registry runs under its own environment.

No behaviour of the product changes. What changes is what the gates guarantee
about the artifact they pass.

## What was found

**Five of seven workflows pinned no `GOTOOLCHAIN`**, and `release.yml` — which
compiles the binary a release ships — was one of them. `actions/setup-go` reads
`go-version-file: go.mod`, so the installed toolchain is right today; nothing
stopped Go from resolving a different one at build time, and nothing compared
any workflow with `go.mod`. `scripts/verify/go-version.sh` already held the
builder images to the module directive for exactly this reason — an image tag
and a module directive belong to different updaters — and the workflow variable
is a third such ecosystem. `codeql.yml` is included because `autobuild`
compiles the tree, so the analysis describes whichever compiler it found; it
gets no `defaults.run` because every step there is an action.

**Twenty of twenty-two jobs had no `timeout-minutes`**, including the four that
drive a real daemon. A hung job holds a runner and reports nothing. The
suite-level `-timeout` values that partly covered this live inside the process
that would be hung, which is why the two jobs whose deadline is derived from
one say so in a comment: the capsule job at 40m sits above its suite's 20m plus
the image build it does first, and the upstream contracts job at 60m above its
suite's 40m plus two token mints. The rest are generous bounds well above
observed durations (the longest job on this branch ran 4m34s). Jobs that call a
reusable workflow take no deadline — GitHub does not accept one there — so
those deadlines live on the called jobs, all of which now have them.

**The shell lint matched `scripts/*/*.sh test/contract/*/testdata/*.sh`**, one
directory deep. Comparing that against `git ls-files '*.sh'` returns exactly one
file: `test/drills/remote-drills.sh`, which `integration-docker.yml` and
`qualify-release.yml` both execute against a real host. A script CI runs and
does not lint is the one place a quoting bug reaches a host unread. Asking git
for tracked scripts also means a script added at any depth is linted the day it
lands, rather than the day someone remembers the glob.

**`release.yml`'s `candidate` job was the only registry writer with no
environment.** The protected `v*` tag is what authorizes the run and that does
not change; the environment is where the authorization is recorded and can be
held, which is what the publication gate already does one job later.

## Evidence

Hermetic only — every gate this touches runs on a pull request, and the two new
guards were watched failing before the fix.

```text
$ scripts/verify/go-version.sh          # before pinning the five
ok    build/capsule/Dockerfile golang:1.26.6
ok    build/controller/Dockerfile golang:1.26.6
ok    .github/workflows/ci.yml GOTOOLCHAIN go1.26.6
FAIL  .github/workflows/codeql.yml pins no GOTOOLCHAIN, so its steps may resolve another compiler
FAIL  .github/workflows/contracts-github-actions.yml pins no GOTOOLCHAIN, ...
FAIL  .github/workflows/controller-e2e.yml pins no GOTOOLCHAIN, ...
FAIL  .github/workflows/integration-docker.yml pins no GOTOOLCHAIN, ...
ok    .github/workflows/qualify-release.yml GOTOOLCHAIN go1.26.6
FAIL  .github/workflows/release.yml pins no GOTOOLCHAIN, ...
exit=1

$ comm -13 <(ls scripts/*/*.sh test/contract/*/testdata/*.sh | sort) <(git ls-files '*.sh' | sort)
test/drills/remote-drills.sh

$ git ls-files -z '*.sh' | xargs -0 shellcheck   # all twelve, after widening
exit=0

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on -count=1 ./...
clean

$ go tool actionlint && scripts/verify/doc-links.sh
exit=0; all relative documentation links resolve
```

## What would notice this regressing

`scripts/verify/go-version.sh`, run by the `lint` job, fails if any workflow
drops its `GOTOOLCHAIN` or names a version `go.mod` does not. The same job's
shell lint now fails on any tracked script at any depth. Nothing enforces that
a job carries `timeout-minutes` — GitHub has no such setting and this repository
has no workflow-shape test to hang it on; a new job without one would pass. If
that becomes a pattern, the check belongs beside the others in
`test/consistency`.

## Risk, compatibility and operations

No trust boundary, credential, ownership, cleanup, networking or resource-limit
behaviour changes. No CLI, configuration, status API, schema or migration
surface is touched.

One operational effect: `release.yml`'s `candidate` job now names the
`release-candidate` environment. GitHub creates a referenced environment on
first use with no protection rules, so a release run behaves exactly as before
until a maintainer configures it; `docs/maintainers/repository-settings.md` says
to protect it with release-maintainer approval, alongside the three environments
already listed. Note the ordering that follows from it: with protection
configured, a release pauses before building candidates rather than after.

Deadlines are ceilings, not budgets — every value sits well above the observed
duration of the job it bounds, so a slow-but-healthy run is not cut short. The
failure mode a deadline introduces is a cancelled job on a genuinely stuck run,
which is the intent.

No decision is constrained here that would need an ADR: the toolchain check
extends the policy `docs/adrs/2026-08-12-docker-api-client.md` already states
about pinning, and the rest is gate hygiene.

## Changelog

```text
- Every workflow states the Go toolchain it builds with, held equal to the
  version `go.mod` declares by the same check that holds the builder images to
  it, so the binary a release ships is compiled by the toolchain its gates ran.
  Every job carries a deadline, and every script in the tree is linted.
- The job that builds the candidate images runs under its own protected
  environment: it writes to the registry before anything has been qualified.
```

## Notes for your reviewer

The `release-candidate` environment is the one judgement call here rather than a
mechanical fix. The argument against it is that the protected tag already
authorizes the run and a second gate on throwaway `candidate-<sha>` references
buys little; the argument for it is that it is the only job holding
`packages: write` with nothing recording the deployment, and an unconfigured
environment costs nothing until someone decides otherwise.

Left alone deliberately: `codeql.yml` still has no `defaults.run` block, because
it has no `run:` step to configure.

