### PR TITLE
ci(workflows): one act has one name, and the gate map says what each gate proves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   dependency-review:
-    name: dependency review
+    name: dependency changes
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
@@ -43,7 +43,7 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
   build:
-    name: build and test
+    name: the Go tree, its tests and its generated files
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -65,9 +65,9 @@ jobs:
           if [ -n "$unformatted" ]; then
             echo "not gofmt-clean:"; echo "$unformatted"; exit 1
           fi
-      - name: Vet
+      - name: Vet the packages
         run: go vet ./...
-      - name: Static analysis
+      - name: Run static analysis
         # The check set lives in staticcheck.conf (all checks, with the
         # generated persistence directory subtracting the package-comment
         # rule); a -checks flag here would override those files.
@@ -120,7 +120,7 @@ jobs:
         run: |
           go tool sqlc diff
           go tool sqlc vet
-      - name: Verify generated CLI documentation is current
+      - name: Verify the generated CLI documentation is current
         run: |
           go generate ./internal/command/...
           git diff --exit-code docs/reference/cli
@@ -176,7 +176,7 @@ jobs:
         #
         # Every script git knows about, rather than a glob. The globs
         # this replaces were one directory deep and missed
-        # test/drills/remote-drills.sh, which two workflows execute — a
+        # test/drills/remote-harness.sh, which two workflows execute — a
         # script CI runs and does not lint is the one place a quoting bug
         # reaches a real host unread. Untracked but unignored files
         # count: a script is worth linting from the moment it exists, not
@@ -191,7 +191,7 @@ jobs:
           # base image plus the image lock; pinning apt versions on top
           # of that pins us to a distribution's mirror lifetime.
           ignore: DL3008
-      - name: Validate the reference deployment
+      - name: Verify the reference deployment
         run: |
           mkdir -p /tmp/runpool-ci-credentials
           RUNPOOL_IMAGE=ghcr.io/rhobuild/runpool@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
@@ -200,7 +200,7 @@ jobs:
             docker compose -f deploy/compose/compose.yaml config --quiet
 
   vulnerabilities:
-    name: govulncheck
+    name: known vulnerabilities
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -231,10 +231,10 @@ jobs:
         # Built but not pushed: publishing is a release decision, and a
         # pull request must never be able to publish.
         run: docker build -f build/controller/Dockerfile -t runpool:ci .
-      - name: The runtime layer must carry no shell
+      - name: Verify the runtime layer carries no shell
         run: |
           if docker run --rm --entrypoint sh runpool:ci -c true 2>/dev/null; then
             echo "a shell is reachable in the runtime layer"; exit 1
           fi
-      - name: The image must run
+      - name: Verify the image runs
         run: docker run --rm runpool:ci version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   analyze:
-    name: analyze Go
+    name: security analysis
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -44,9 +44,9 @@ jobs:
         with:
           languages: go
           build-mode: autobuild
-      - name: Build
+      - name: Build the tree for analysis
         uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
-      - name: Analyze
+      - name: Analyze the built tree
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:go

--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Validate the fixture configuration
+      - name: Verify the fixture configuration is complete
         env:
           REPO_URL: ${{ vars.RUNPOOL_CONTRACT_REPO_URL }}
           ORG_URL: ${{ vars.RUNPOOL_CONTRACT_ORG_URL }}
@@ -107,7 +107,7 @@ jobs:
           permission-contents: read
           permission-organization-self-hosted-runners: write
 
-      - name: Upstream contracts
+      - name: Run the upstream contracts
         # The suite creates its own scale sets and removes them through
         # t.Cleanup, including on failure, so a run leaves the fixture
         # as it found it. Release-qualification mode turns every skip into a
@@ -132,7 +132,7 @@ jobs:
           mkdir -p upstream-evidence
           go test -count=1 -v -timeout 40m ./test/contract/githubactions/... 2>&1 | tee upstream-evidence/contract.log
 
-      - name: Redact the evidence before it is kept
+      - name: Refuse credential-bearing evidence
         id: evidence-check
         # The identity evidence records upstream message and job
         # identifiers, which is the point of keeping it. It must not

--- a/.github/workflows/controller-e2e.yml
+++ b/.github/workflows/controller-e2e.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Validate the fixture configuration
+      - name: Verify the fixture configuration is complete
         env:
           ORGANIZATION: ${{ vars.RUNPOOL_E2E_ORGANIZATION }}
           REPOSITORY: ${{ vars.RUNPOOL_E2E_REPOSITORY }}
@@ -144,7 +144,7 @@ jobs:
           fi
           echo "safe=true" >> "$GITHUB_OUTPUT"
 
-      - name: Keep controller E2E evidence
+      - name: Keep the controller end-to-end evidence
         if: ${{ always() && steps.evidence-check.outputs.safe == 'true' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -84,7 +84,7 @@ jobs:
         # TestPullOnMissingImage proves the pull, which it can only do
         # if the image is genuinely absent first.
         run: docker rmi busybox:1.36.1-uclibc 2>/dev/null || true
-      - name: Docker contracts
+      - name: Run the Docker contracts
         env:
           RUNPOOL_DOCKER_CONTRACT: "1"
         run: go test -count=1 -v ./test/contract/docker/...
@@ -107,7 +107,7 @@ jobs:
           go-version-file: go.mod
       - name: Build the capsule image from the pinned inputs
         run: docker build -f build/capsule/Dockerfile -t runpool-capsule:dev .
-      - name: Capsule and bypass contracts
+      - name: Run the capsule, egress and budget contracts
         # The lifecycle drives a real runner with a fake credential —
         # the runner rejects it and exits, which proves it ran without
         # needing a provider. The bypass suite proves the capsule has no
@@ -115,7 +115,7 @@ jobs:
         env:
           RUNPOOL_CAPSULE_CONTRACT: "1"
         run: go test -count=1 -v -timeout 20m ./test/contract/capsule/...
-      - name: No capsule objects were left behind
+      - name: Verify no managed objects were left behind
         # Every object carries ownership labels; a leak here is a
         # cleanup bug that would leak on an operator's host too.
         run: |
@@ -143,7 +143,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Install, backup, restore, upgrade, uninstall
+      - name: Run the lifecycle drills
         # The runbook's procedures, executed rather than described:
         # every step asserts its outcome against the real image and a
         # real state volume.
@@ -151,7 +151,7 @@ jobs:
           dir=$(mktemp -d)
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$dir/drill-seed" ./test/drills/seed
           git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$dir/src.tgz" --null -T -
-          bash test/drills/remote-drills.sh "$dir"
+          bash test/drills/remote-harness.sh "$dir"
 
   sqlite:
     name: sqlite durability
@@ -166,9 +166,9 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Build the suite for the container
+      - name: Build the durability suite for the container
         run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/sqlite-contract.test ./test/contract/sqlite
-      - name: Durability on a named volume, with the disk-full case
+      - name: Run the durability suite on a named volume
         # The state database lives on a named volume in production, so
         # it is tested on one here: WAL behaviour, contention, and
         # SQLITE_FULL on a capped filesystem.

--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -72,7 +72,7 @@ jobs:
           name: release-artifacts-candidate
           path: release-artifacts
 
-      - name: Validate SemVer
+      - name: Verify the standalone candidate is the tag it claims
         env:
           CAPSULE_IMAGE: ${{ inputs.capsule_image }}
           VERSION: ${{ github.ref_name }}
@@ -140,7 +140,7 @@ jobs:
           docker pull "$CAPSULE_IMAGE"
           docker tag "$CAPSULE_IMAGE" runpool-capsule:dev
 
-      - name: Docker contracts
+      - name: Run the Docker contracts
         env:
           RUNPOOL_DOCKER_CONTRACT: "1"
           RUNPOOL_CONTRACT_QUALIFY: "1"
@@ -148,27 +148,27 @@ jobs:
           docker image rm -f busybox:1.36.1-uclibc >/dev/null 2>&1 || true
           go test -count=1 -v ./test/contract/docker/... 2>&1 | tee docker-contract.log
 
-      - name: Capsule, egress and budget contracts
+      - name: Run the capsule, egress and budget contracts
         env:
           RUNPOOL_CAPSULE_CONTRACT: "1"
           RUNPOOL_CONTRACT_QUALIFY: "1"
         run: go test -count=1 -v -timeout 30m ./test/contract/capsule/... 2>&1 | tee capsule-contract.log
 
-      - name: SQLite durability
+      - name: Run the durability suite on a named volume
         run: |
           dir=$(mktemp -d)
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/sqlite-contract.test" ./test/contract/sqlite
           cp test/contract/sqlite/testdata/remote-harness.sh "$dir/"
           bash "$dir/remote-harness.sh" "$dir" 2>&1 | tee sqlite-contract.log
 
-      - name: Lifecycle drills
+      - name: Run the lifecycle drills
         run: |
           dir=$(mktemp -d)
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$dir/drill-seed" ./test/drills/seed
           git ls-files -coz --exclude-standard | tar --no-xattrs -czf "$dir/src.tgz" --null -T -
-          bash test/drills/remote-drills.sh "$dir" 2>&1 | tee lifecycle-drills.log
+          bash test/drills/remote-harness.sh "$dir" 2>&1 | tee lifecycle-drills.log
 
-      - name: Verify cleanup
+      - name: Verify no managed objects were left behind
         if: always()
         run: |
           status=0
@@ -190,13 +190,20 @@ jobs:
             docker volume ls --filter label=io.runpool.managed=true
             status=1
           fi
+          exit "$status"
+
+      # Its own step, and always: a leak this host reports must not also
+      # decide whether its registry session is closed. The reference host
+      # outlives the run.
+      - name: Close the registry session
+        if: always()
+        run: |
           if [ -n "${DOCKER_CONFIG:-}" ]; then
             docker --config "$DOCKER_CONFIG" logout ghcr.io >/dev/null 2>&1 || true
             rm -rf -- "$DOCKER_CONFIG"
           fi
-          exit "$status"
 
-      - name: Keep live evidence
+      - name: Keep the live evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -245,19 +252,19 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Download live evidence
+      - name: Download the live evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: live-evidence
           path: evidence/live
 
-      - name: Download upstream evidence
+      - name: Download the upstream evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: upstream-evidence
           path: evidence/upstream
 
-      - name: Download controller E2E evidence
+      - name: Download the controller end-to-end evidence
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: controller-e2e-evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Validate the version stamped into the artifact
+      - name: Verify the version stamped into the artifact
         env:
           VERSION: ${{ github.ref_name }}
         run: |
@@ -178,7 +178,7 @@ jobs:
           name: release-qualification
           path: qualification
 
-      - name: Download the exact standalone artifacts
+      - name: Download the standalone candidates
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-artifacts-candidate
@@ -236,7 +236,7 @@ jobs:
             echo "capsule_reference=$capsule_reference"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Generate controller SBOM
+      - name: Generate the controller SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.promote.outputs.controller_reference }}
@@ -244,7 +244,7 @@ jobs:
           output-file: dist/controller.sbom.spdx.json
           upload-artifact: false
 
-      - name: Generate capsule SBOM
+      - name: Generate the capsule SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.promote.outputs.capsule_reference }}
@@ -252,19 +252,19 @@ jobs:
           output-file: dist/capsule.sbom.spdx.json
           upload-artifact: false
 
-      - name: Attest standalone artifacts
+      - name: Attest the standalone artifacts
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: dist/checksums.txt
 
-      - name: Attest controller provenance
+      - name: Attest the controller provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.promote.outputs.controller_name }}
           subject-digest: ${{ steps.promote.outputs.controller_digest }}
           push-to-registry: true
 
-      - name: Attest controller SBOM
+      - name: Attest the controller SBOM
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.promote.outputs.controller_name }}
@@ -272,14 +272,14 @@ jobs:
           sbom-path: dist/controller.sbom.spdx.json
           push-to-registry: true
 
-      - name: Attest capsule provenance
+      - name: Attest the capsule provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.promote.outputs.capsule_name }}
           subject-digest: ${{ steps.promote.outputs.capsule_digest }}
           push-to-registry: true
 
-      - name: Attest capsule SBOM
+      - name: Attest the capsule SBOM
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-name: ${{ steps.promote.outputs.capsule_name }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ Documentation is organized by the question it answers.
   selection and, once frozen, exact facts required by qualification.
 - [`build/images.lock.json`](../build/images.lock.json): digest-pinned capsule
   inputs.
+- [Continuous integration](maintainers/ci.md): what each gate proves, where it
+  runs, and the names the workflows use.
 - [Repository settings](maintainers/repository-settings.md): GitHub rulesets,
   environments, Actions permissions, and security features required before
   public launch.

--- a/docs/adrs/2026-08-11-session-conflict.md
+++ b/docs/adrs/2026-08-11-session-conflict.md
@@ -1,6 +1,7 @@
 # A crashed controller's broker session must be waited out
 
-**Status:** accepted
+**Status:** accepted; its retry deadline superseded by
+[the session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md)
 **Date:** 2026-08-11
 
 ## Context

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -9,13 +9,13 @@ justified it usually still holds even when the remedy does not.
 | --- | --- | --- |
 | 2026-08-11 | [SQLite driver](2026-08-11-sqlite-driver.md) — modernc, pinned and tested on a Linux named volume | accepted |
 | 2026-08-11 | [Session conflict](2026-08-11-session-conflict.md) — one session per scale set, and what a conflict means | accepted; its retry deadline superseded |
-| 2026-08-11 | [Shared network namespace](2026-08-11-shared-network-namespace.md) — the runner joins dind rather than attaching itself | accepted |
-| 2026-08-11 | [Advertised capacity](2026-08-11-advertised-capacity.md) — capacity is a total, not a delta | accepted |
+| 2026-08-11 | [Shared network namespace](2026-08-11-shared-network-namespace.md) — the runner joins dind rather than attaching itself | accepted; implementation evolved to a single capsule container |
+| 2026-08-11 | [Advertised capacity](2026-08-11-advertised-capacity.md) — capacity is a total, not a delta | accepted; allocation refined by admission credits |
 | 2026-08-11 | [Capacity floor](2026-08-11-capacity-floor.md) — every binding floored at one | superseded by admission credits |
 | 2026-08-11 | [Repository cache scope](2026-08-11-repository-cache-scope.md) — persistent lanes only where identity binds | accepted |
 | 2026-08-11 | [Plain L3 routing is rejected](2026-08-11-network-sandbox-proxy.md) — why an in-bridge gateway cannot forward, and the one path the host's rule leaves open | accepted, implemented by the egress relay |
 | 2026-08-12 | [Docker API client](2026-08-12-docker-api-client.md) — versioned Moby modules behind a live-tested adapter | accepted |
-| 2026-08-13 | [Egress is a relay, not a route](2026-08-13-egress-relay.md) — what the host's own `--internal` rule forces, and what it gives | accepted |
+| 2026-08-13 | [Egress is a relay, not a route](2026-08-13-egress-relay.md) — what the host's own `--internal` rule forces, and what it gives | accepted and implemented; release qualification pending |
 | 2026-08-13 | [Admission credits](2026-08-13-admission-credits.md) — tier parallelism is shared credit with a rotating discovery credit | accepted |
 | 2026-08-14 | [Scheduling and swap semantics](2026-08-14-scheduling-and-swap.md) — optional global parallelism and provider-neutral resource units | accepted |
 | 2026-08-17 | [Capsule image substitution](2026-08-17-capsule-image-substitution.md) — a tier may name its capsule, and the capsule declares its protocol | accepted |
@@ -23,4 +23,4 @@ justified it usually still holds even when the remedy does not.
 | 2026-08-17 | [Job timeout](2026-08-17-job-timeout.md) — the lease ceiling is a backstop above the provider's own maximum | accepted |
 | 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; publishing pending |
 | 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |
-| 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted |
+| 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted; supersedes one consequence of session conflict |

--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -1,0 +1,108 @@
+# Continuous integration
+
+What each gate proves, where it runs, and the names the workflows use.
+[Repository settings](repository-settings.md) holds the half that lives in
+GitHub rather than in this tree.
+
+## The gates
+
+Every gate is a job. A gate that needs a real Docker daemon says so, because
+that is what decides whether it can run on a pull request at all.
+
+| Workflow | Job | Proves | Runs on |
+| --- | --- | --- | --- |
+| `ci` | `dependency changes` | No dependency change brings a known-vulnerable or unreviewed module | Hosted, pull requests only |
+| `ci` | `the Go tree, its tests and its generated files` | Formatting, vet, static analysis, the raced suite with its coverage floor, the generated persistence layer and CLI reference are current, the module is tidy, the release binaries cross-build, the configuration examples validate, and the locked image digests have not drifted | Hosted; the digest check needs the network |
+| `ci` | `workflows, scripts and containers` | Workflows, shell scripts and Dockerfiles lint, and the reference deployment resolves | Hosted; needs a daemon for hadolint and `compose config` |
+| `ci` | `known vulnerabilities` | No package in the build has a known vulnerability | Hosted |
+| `ci` | `controller image` | The controller image builds, its runtime layer carries no shell, and it runs | Hosted; needs a daemon |
+| `codeql` | `security analysis` | Static security analysis of the built tree | Hosted |
+| `integration-docker` | `moby adapter, cache lanes and disk` | The Docker adapter, cache lanes and disk pressure against a real daemon | Hosted daemon; path-filtered, plus nightly |
+| `integration-docker` | `outer capsule, JIT and the egress sandbox` | A real capsule, its credential channel and the egress sandbox, leaving no managed object behind | Hosted daemon |
+| `integration-docker` | `lifecycle drills` | Install, backup, restore, upgrade and uninstall, end to end | Hosted daemon |
+| `integration-docker` | `sqlite durability` | Durability on a named volume, including the disk-full case, across kills | Hosted daemon |
+| `contracts-github-actions` | `runner scale set API` | The provider adapter against the real scale-set API | Protected `upstream-contracts`; weekly, and during qualification |
+| `controller-e2e` | `real assignment, restart, cache and cleanup` | The exact controller and capsule candidates running real assignments | Self-hosted, protected `release-qualification` |
+| `qualify-release` | `validate release inputs` | The ref is a protected tag, the images are digest-qualified, and the standalone candidate is the tag it claims | Hosted |
+| `qualify-release` | `live contracts on the reference host` | Every live suite, without skips, on the reference host | Self-hosted, protected |
+| `qualify-release` | `release-qualification record` | The evidence supports the claim the record makes | Hosted |
+| `release` | `build immutable candidates` | The candidate images and standalone artifacts exist by digest and checksum | Hosted, protected `release-candidate` |
+| `release` | `attest and publish qualified artifacts` | The record covers this build, the artifacts match their checksums, and the promoted digests are the qualified ones | Hosted, protected `release` |
+
+`qualify-release` also calls `ci`, `contracts-github-actions` and
+`controller-e2e` rather than restating them: two definitions of one gate drift,
+and the one that decides a release must be the one every change already passed.
+
+Checks that are not gates in a Go file live beside the code they check.
+`test/consistency` holds the ones that tie together values in different
+ecosystems — a documented path and the file it names, a workflow's toolchain and
+`go.mod` — and `test/architecture` holds the import rules. They run inside the
+suite, which is why neither has a step of its own.
+
+## Required checks
+
+Six job names are required status checks on `main`:
+
+```text
+the Go tree, its tests and its generated files
+workflows, scripts and containers
+known vulnerabilities
+security analysis
+dependency changes
+controller image
+```
+
+GitHub matches a required check by its name, and the branch requires strict
+status checks with `enforce_admins` on, so a renamed job leaves a required
+check that never reports and nobody — including an administrator — can merge
+until the setting is edited.
+
+Renaming one is three operations in one sitting, in this order: push the rename
+and let the run report the new name, replace the old context with the new one in
+a single write to the branch protection, then merge. The API takes a context
+that has never reported, so the requirement is switched rather than removed, and
+the branch is never without it. What the window costs is that any other open
+pull request, still carrying the old name, cannot merge until it picks up the
+rename.
+
+## Names
+
+**A job is named for the subject its gate guards**, not for the tool that
+inspects it and not for one of the acts it performs. The name is what a reader
+sees in the checks list, next to five others, so it has to say which part of the
+tree just passed. A job id is an identifier rather than a label: it is short,
+it appears in `needs:`, and it does not have to match the name.
+
+**A step is named as an imperative, in Sentence case, with its article, for the
+one act it performs.** `Verify the module is tidy`, not `Module tidy check`;
+`Verify the image runs`, not `The image must run`. A check uses `Verify` unless
+the tool's own word is the act, as in `Lint the workflows`.
+
+**One act has one name.** The capsule suite, the lifecycle drills and the
+durability suite each run in two workflows, and the names have to match; where
+they drifted, the pull request that ran them side by side is what found it. A
+step that does two things gets two names, which is why closing the registry
+session is its own step rather than a clause inside a cleanup check.
+
+**A script is named for its subject, under a directory named for its verb or
+its domain**: `scripts/verify/coverage.sh`, `scripts/contracts/docker.sh`. Two
+levels, always — `test/consistency` globs `scripts/*/*.sh`, and a script at the
+top level leaves that check without anything saying so. An imperative name is
+reserved for a script another program invokes as a command, which is why
+`scripts/qualification/start-jit-runner.sh` keeps its verb.
+
+**A pair of scripts splits by machine.** The driver you run from your own
+machine lives under `scripts/`; the half it ships to the host under test lives
+under `test/`, named `remote-harness.sh`.
+
+Every script carries `#!/usr/bin/env bash`, `set -euo pipefail`, a header saying
+what it proves and why it exists, a `# Usage:` line, and the executable bit. All
+of them are shellchecked, at any depth, tracked or not.
+
+## Shell, and what is not shell
+
+A script is shell when its job is to run other programs: `ssh`, `tar`, `docker`,
+`uname`. It is a Go test or a Go command when its job is to read a file and
+decide something — those get parsed with the parser for the format, and they get
+tests of their own. The repository does not add a second language toolchain for
+this: nothing here is written in Python.

--- a/scripts/drills/lifecycle.sh
+++ b/scripts/drills/lifecycle.sh
@@ -29,6 +29,6 @@ COPYFILE_DISABLE=1 git ls-files -coz --exclude-standard | tar --no-xattrs -czf "
 remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-drills.XXXXXX')
 remote_dir_q=$(printf '%q' "$remote_dir")
 trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
-scp -q "$out/src.tgz" "$out/drill-seed" test/drills/remote-drills.sh "$host":"$remote_dir/"
+scp -q "$out/src.tgz" "$out/drill-seed" test/drills/remote-harness.sh "$host":"$remote_dir/"
 # shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
-ssh "$host" "bash '$remote_dir/remote-drills.sh' '$remote_dir'"
+ssh "$host" "bash '$remote_dir/remote-harness.sh' '$remote_dir'"

--- a/test/drills/remote-harness.sh
+++ b/test/drills/remote-harness.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 # step. Everything it creates is named after this run and removed at
 # the end, success or failure.
 #
-# Usage: remote-drills.sh <dir>
-dir=${1:?usage: remote-drills.sh <dir with src.tgz and drill-seed>}
+# Usage: remote-harness.sh <dir>
+dir=${1:?usage: remote-harness.sh <dir with src.tgz and drill-seed>}
 run_id=$(basename "$dir" | tr -dc 'a-zA-Z0-9' | tail -c 8)
 vol="runpool-drill-state-$run_id"
 img="runpool:drill-$run_id"


### PR DESCRIPTION
## What changes

Thirty-seven step names and four job names move to one shape each. Two steps that
were doing more than their name said are split or renamed.
`test/drills/remote-drills.sh` becomes `remote-harness.sh`. A new
`docs/maintainers/ci.md` records what each gate proves, where it runs, and the
naming rules. Four ADR index rows and one ADR record are aligned with each other.

The four renamed jobs are required status checks, so the branch protection's
contexts were switched to match. That is described below.

## What was found

**Three registers were in use for step names.** Imperative (`Build the
controller image`), assertion (`The image must run`, `No capsule objects were
left behind`), and bare noun phrase (`Docker contracts`, `SQLite durability`).
`codeql.yml` had the only two bare verbs in the tree, `Build` and `Analyze`. The
`Keep …` and `Verify …` families dropped their article halfway through.

**The names that mattered are the ones that drifted while naming one act.** The
capsule suite, the lifecycle drills and the durability suite each run in both
`integration-docker` and `qualify-release`, under different names in each:

```text
Capsule and bypass contracts              Capsule, egress and budget contracts
Install, backup, restore, upgrade, …      Lifecycle drills
Build the suite … / Durability on a …     SQLite durability
No capsule objects were left behind       Verify cleanup
```

A reader comparing the pull-request gate with the release gate could not see
they were the same suite. They match now, which is what will make the
divergence in their *bodies* — different timeouts, two spellings of the same
fixture removal — visible when that is fixed.

**Two names were not describing what ran.** `Verify cleanup` in
`qualify-release` also logged out of the registry and removed the isolated
`DOCKER_CONFIG` — work `controller-e2e` names honestly as `Close the registry
session`. It is two steps now. The logout keeps `if: always()`, so it still runs
when the leak check fails: a leak this host reports must not decide whether its
registry session is closed, and the reference host outlives the run. `Validate
SemVer` also verified the artifact checksums, the embedded capsule image and the
binary's own reported facts.

**Four job names did not survive the rule they were being written into.** A job
is named for the subject its gate guards. Against that:

| was | is | why it moved |
| --- | --- | --- |
| `build and test` | `the Go tree, its tests and its generated files` | it named two of the eleven acts it runs: formatting, vet, static analysis, the raced suite and its coverage floor, two generated-file parity checks, module tidiness, the cross-builds, the configuration examples, and the image-digest drift check |
| `govulncheck` | `known vulnerabilities` | named the tool, while its own step already said `Scan for known vulnerabilities` |
| `analyze Go` | `security analysis` | named the action rather than what it guards |
| `dependency review` | `dependency changes` | the same |

`workflows, scripts and containers` and `controller image` already named their
subject and are unchanged. The set now reads as six subjects rather than two
subjects, two actions, one tool and one pair of verbs.

**The quantity was checked too, and is right.** The five `ci` jobs split by
runner need and by wall clock, not by taste: `known vulnerabilities` costs 28s in
parallel and would add that to the critical path of a 4m49s job if folded in;
`workflows, scripts and containers` and `controller image` need a daemon. The
four `integration-docker` jobs are correctly *not* required, because the
workflow is path-filtered and a documentation-only change never creates those
checks.

**`test/drills/remote-drills.sh` said "drills" twice**, and it is the second
half of a pair whose other half is already `remote-harness.sh` in the SQLite
contract. All six references moved with it, and the documentation check added
last week is what would have caught any that did not.

**Statuses were written in one place and read in another.** Four ADR index rows
said `accepted` where the record itself said `accepted; allocation refined by
admission credits`, `accepted; implementation evolved to a single capsule
container`, `accepted and implemented; release qualification pending`, and
`accepted; supersedes one consequence of session conflict`. One drifted the
other way: the index knew the session-conflict retry deadline was superseded and
the record did not say so. Both directions are the same error.

## Evidence

```text
$ go tool actionlint
exit=0

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean

$ git ls-files -coz --exclude-standard -- "*.sh" | xargs -0 shellcheck
exit=0

checks reporting on this branch, under the new names: 11 pass
merge state: CLEAN
```

The branch protection change, in order, with the before state captured first:

```text
1. rename pushed; the run reports the six new contexts
2. PATCH …/protection/required_status_checks   (the sub-resource, not a PUT of
   the whole object: a full replace does not carry required_signatures)
3. re-read and diff against the snapshot

everything but the checks: unchanged
  strict, enforce_admins, reviews, signatures, conversations,
  force_pushes, deletions, linear history, restrictions
count before: 6   count after: 6
```

One effect was not asked for and is worth naming: GitHub resolves `app_id` for a
context it has not stored before, so the five new ones came back pinned to the
GitHub Actions app while the one unchanged name stayed at "any app". A required
context any GitHub App may report can be satisfied by a third party reporting a
same-named check, so the sixth was pinned as well rather than loosening the
five. All six now require the check to come from GitHub Actions.

## What would notice this regressing

Nothing checks the shape of a step name, and nothing should: it is prose, and a
rule that machine-checks prose costs more than it returns. What is checked is
the part that broke silently before — `TestEveryPathTheDocumentationNamesResolves`
fails if a rename leaves a documented path behind, which is what made the
`remote-harness.sh` rename safe to do at all.

A job rename is caught by the branch itself: the required context stops
reporting and no pull request merges, including for an administrator. That is
the mechanism `docs/maintainers/ci.md` documents.

The ADR statuses have no check. They are two sentences in two files, and the
index is short enough to read.

## Risk, compatibility and operations

Branch protection on `main` was edited: six required contexts replaced by name,
and all six pinned to the GitHub Actions app. Nothing else in the protection
changed — verified by diffing the full object against a snapshot taken before
the write. The window in which the old contexts were required while this branch
reported the new ones affected only this pull request, the single one open.

No job id, trigger, permission, environment or concurrency group changes. One
behavioural change: the registry logout in `qualify-release`'s live job is its
own step. It ran unconditionally before, inside a step that always ran, and it
runs unconditionally now, in a step that always runs. What differs is that a
leak check failure no longer shares a step with it, so both outcomes are visible
separately.

No product code, CLI, configuration, status API, schema or migration surface is
touched.

## Changelog

```text
NONE
```

## Notes for your reviewer

`docs/maintainers/ci.md` is the piece worth reading closely: the gate table, the
required-check procedure, the naming rules, and the line between shell and Go —
a script is shell when its job is to run other programs, and a Go test when its
job is to read a file and decide something.

The `integration-docker` job names are left alone. They already name their
subjects, and they are not required checks, so nothing about them was blocking.
