### PR TITLE
test(contracts): one harness per live suite, run by both gates and by the driver that ships it

### DIFF
--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -80,14 +80,14 @@ jobs:
         run: |
           docker version --format 'engine {{.Server.Version}} api {{.Server.APIVersion}}'
           docker info --format 'cgroup {{.CgroupVersion}} driver {{.CgroupDriver}} rootless {{.SecurityOptions}}'
-      - name: Remove the pull fixture so the pull path is real
-        # TestPullOnMissingImage proves the pull, which it can only do
-        # if the image is genuinely absent first.
-        run: docker rmi busybox:1.36.1-uclibc 2>/dev/null || true
       - name: Run the Docker contracts
-        env:
-          RUNPOOL_DOCKER_CONTRACT: "1"
-        run: go test -count=1 -v ./test/contract/docker/...
+        # The harness the release gate and the SSH driver also run: it
+        # clears the pull fixture and proves it is gone before the suite
+        # starts.
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/docker-contract.test" ./test/contract/docker
+          bash test/contract/docker/remote-harness.sh "$dir"
 
   capsule:
     name: outer capsule, JIT and the egress sandbox
@@ -108,13 +108,10 @@ jobs:
       - name: Build the capsule image from the pinned inputs
         run: docker build -f build/capsule/Dockerfile -t runpool-capsule:dev .
       - name: Run the capsule, egress and budget contracts
-        # The lifecycle drives a real runner with a fake credential —
-        # the runner rejects it and exits, which proves it ran without
-        # needing a provider. The bypass suite proves the capsule has no
-        # route out and that its only egress is the policy.
-        env:
-          RUNPOOL_CAPSULE_CONTRACT: "1"
-        run: go test -count=1 -v -timeout 20m ./test/contract/capsule/...
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/capsule-contract.test" ./test/contract/capsule
+          bash test/contract/capsule/remote-harness.sh "$dir"
       - name: Verify no managed objects were left behind
         # Every object carries ownership labels; a leak here is a
         # cleanup bug that would leak on an operator's host too.
@@ -166,12 +163,14 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Build the durability suite for the container
-        run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/sqlite-contract.test ./test/contract/sqlite
       - name: Run the durability suite on a named volume
         # The state database lives on a named volume in production, so
         # it is tested on one here: WAL behaviour, contention, and
-        # SQLITE_FULL on a capped filesystem.
+        # SQLITE_FULL on a capped filesystem. A run-scoped directory
+        # rather than /tmp, so two runs on one host cannot overwrite each
+        # other's binary mid-test.
         run: |
-          cp test/contract/sqlite/testdata/remote-harness.sh /tmp/
-          bash /tmp/remote-harness.sh /tmp
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/sqlite-contract.test" ./test/contract/sqlite
+          cp test/contract/sqlite/testdata/remote-harness.sh "$dir/"
+          bash "$dir/remote-harness.sh" "$dir"

--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -142,17 +142,19 @@ jobs:
 
       - name: Run the Docker contracts
         env:
-          RUNPOOL_DOCKER_CONTRACT: "1"
           RUNPOOL_CONTRACT_QUALIFY: "1"
         run: |
-          docker image rm -f busybox:1.36.1-uclibc >/dev/null 2>&1 || true
-          go test -count=1 -v ./test/contract/docker/... 2>&1 | tee docker-contract.log
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/docker-contract.test" ./test/contract/docker
+          bash test/contract/docker/remote-harness.sh "$dir" 2>&1 | tee docker-contract.log
 
       - name: Run the capsule, egress and budget contracts
         env:
-          RUNPOOL_CAPSULE_CONTRACT: "1"
           RUNPOOL_CONTRACT_QUALIFY: "1"
-        run: go test -count=1 -v -timeout 30m ./test/contract/capsule/... 2>&1 | tee capsule-contract.log
+        run: |
+          dir=$(mktemp -d)
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$dir/capsule-contract.test" ./test/contract/capsule
+          bash test/contract/capsule/remote-harness.sh "$dir" 2>&1 | tee capsule-contract.log
 
       - name: Run the durability suite on a named volume
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -494,6 +494,12 @@ by its public and operational effects.
 - Every path the documentation names is checked, whether it is written as a
   link or as a command someone will copy, so a rename cannot leave a reference
   that reads as fact.
+- Each live suite has one harness, run by the pull-request gate, by the release
+  gate and by the driver that ships it to a host over SSH. The two gates differ
+  only in whether qualification mode is on and whether the output is kept as
+  evidence. The Docker suite's pull fixture is cleared by that harness and the
+  removal is proven, so the test that exists to pull it cannot quietly stop
+  pulling anything.
 - The release-qualification record is one typed document with two ends: the
   job that writes it and the job that reads it back share the type, so a field
   one of them renames is a build failure rather than a publication that

--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -93,7 +93,14 @@ reserved for a script another program invokes as a command, which is why
 
 **A pair of scripts splits by machine.** The driver you run from your own
 machine lives under `scripts/`; the half it ships to the host under test lives
-under `test/`, named `remote-harness.sh`.
+beside its suite under `test/`, named `remote-harness.sh`.
+
+In a gate there is no ship: the runner *is* the host under test, so the workflow
+cross-compiles the suite and runs that same harness directly. That is what keeps
+one suite from having three spellings — the driver's, the pull request's and the
+release's — and it is where anything the suite needs true before it starts
+belongs, such as clearing the image the Docker suite's pull test depends on
+being absent.
 
 Every script carries `#!/usr/bin/env bash`, `set -euo pipefail`, a header saying
 what it proves and why it exists, a `# Usage:` line, and the executable bit. All

--- a/scripts/contracts/capsule.sh
+++ b/scripts/contracts/capsule.sh
@@ -26,11 +26,14 @@ COPYFILE_DISABLE=1 git ls-files -coz --exclude-standard | tar --no-xattrs -czf "
 remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-capsule-contract.XXXXXX')
 remote_dir_q=$(printf '%q' "$remote_dir")
 trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
-scp -q "$out/src.tgz" "$out/capsule-contract.test" "$host":"$remote_dir/"
+# The harness goes with it: the deadline the suite is allowed lives there,
+# so this driver and both CI gates give it the same one.
+scp -q "$out/src.tgz" "$out/capsule-contract.test" \
+  test/contract/capsule/remote-harness.sh "$host":"$remote_dir/"
 # shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
 ssh "$host" "set -e
 mkdir -p '$remote_dir/src'
 tar -xzf '$remote_dir/src.tgz' -C '$remote_dir/src' 2>/dev/null
 cd '$remote_dir/src'
 docker build -q -f build/capsule/Dockerfile -t runpool-capsule:dev . >/dev/null
-RUNPOOL_CAPSULE_CONTRACT=1 '$remote_dir/capsule-contract.test' -test.v -test.count=1"
+bash '$remote_dir/remote-harness.sh' '$remote_dir'"

--- a/scripts/contracts/docker.sh
+++ b/scripts/contracts/docker.sh
@@ -22,9 +22,6 @@ fi
 out=$(mktemp -d)
 trap 'rm -rf "$out"' EXIT
 
-# The pull fixture must match the digest the suite pins.
-pull_fixture='busybox:1.36.1-uclibc@sha256:0872fb3a7632ba9d0ae46a8e832a62b30ce83a6f220b8bb52903d9cf477dabe3'
-
 echo "== cross-compile linux/amd64 (CGO_ENABLED=0) =="
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o "$out/docker-contract.test" ./test/contract/docker
 
@@ -33,19 +30,6 @@ ssh "$host" 'docker version --format "engine {{.Server.Version}} api {{.Server.A
 echo "== release-qualification reference (build/platform.lock.json) =="
 grep -E '"(engine|api|os|os_version|arch|cgroup_driver)"' build/platform.lock.json
 
-# The pull-on-missing-image path only exists while the image is missing:
-# after one run the daemon has it cached and the test passes without
-# exercising a pull. Remove it and verify it is gone — a removal that
-# silently failed turns the pull test into a no-op.
-echo "== clearing the pull fixture so the pull path is real =="
-# shellcheck disable=SC2029 # client-side expansion is intended: the fixture reference is a constant defined above
-ssh "$host" "docker image rm -f '$pull_fixture' >/dev/null 2>&1 || true"
-# shellcheck disable=SC2029 # the fixture is a fixed local constant, intentionally expanded before SSH
-if ssh "$host" "docker image inspect '$pull_fixture' >/dev/null 2>&1"; then
-  echo 'the pull fixture is still present; the pull test would exercise nothing' >&2
-  exit 1
-fi
-
 echo "== contract suite on $host =="
 # The remote directory is run-scoped: a fixed path lets two runs — or
 # two operators — overwrite each other's binaries mid-test. printf %q
@@ -53,7 +37,10 @@ echo "== contract suite on $host =="
 remote_dir=$(ssh "$host" 'mktemp -d /tmp/runpool-docker-contract.XXXXXX')
 remote_dir_q=$(printf '%q' "$remote_dir")
 trap 'rm -rf "$out"; ssh "$host" "rm -rf $remote_dir_q" || true' EXIT
-scp -q "$out/docker-contract.test" "$host":"$remote_dir/"
+# The harness goes with it: clearing the pull fixture and proving it gone
+# is the suite's precondition, and both CI gates run the same file rather
+# than a second spelling of it.
+scp -q "$out/docker-contract.test" test/contract/docker/remote-harness.sh "$host":"$remote_dir/"
 qualify_env=""
 if [ -n "${RUNPOOL_CONTRACT_QUALIFY:-}" ]; then
   # No expected version travels from here: the suite embeds the
@@ -61,4 +48,4 @@ if [ -n "${RUNPOOL_CONTRACT_QUALIFY:-}" ]; then
   qualify_env="RUNPOOL_CONTRACT_QUALIFY=1"
 fi
 # shellcheck disable=SC2029 # client-side expansion is intended: remote_dir comes from the remote mktemp above
-ssh "$host" "RUNPOOL_DOCKER_CONTRACT=1 $qualify_env '$remote_dir/docker-contract.test' -test.v -test.count=1"
+ssh "$host" "$qualify_env bash '$remote_dir/remote-harness.sh' '$remote_dir'"

--- a/test/consistency/contracts_test.go
+++ b/test/consistency/contracts_test.go
@@ -1,0 +1,83 @@
+package consistency
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+var shellAssignment = regexp.MustCompile(`(?m)^fixture='([^']+)'`)
+
+// TestTheHarnessClearsTheFixtureTheSuitePulls: the pull path only exists
+// while the image is absent.
+//
+// TestPullOnMissingImage proves that a container creation on an image the
+// daemon does not have pulls it first. After one run the daemon has it
+// cached, so the harness removes it before the suite starts and proves
+// the removal. Remove something else — a stale tag, a digest that moved —
+// and the removal succeeds, the fixture stays cached, and the test passes
+// having exercised nothing.
+//
+// The two live in different languages and neither can see the other.
+func TestTheHarnessClearsTheFixtureTheSuitePulls(t *testing.T) {
+	const harnessPath = "test/contract/docker/remote-harness.sh"
+
+	harness, err := os.ReadFile(repoPath(filepath.FromSlash(harnessPath)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	match := shellAssignment.FindSubmatch(harness)
+	if match == nil {
+		t.Fatalf("%s assigns no fixture, so it clears nothing before the suite runs", harnessPath)
+	}
+	cleared := string(match[1])
+
+	pulled := stringConst(t, filepath.Join("test", "contract", "docker", "contract_test.go"), "missingImage")
+	if cleared != pulled {
+		t.Errorf("%s clears %s; the suite pulls %s, which stays cached and turns "+
+			"TestPullOnMissingImage into a no-op", harnessPath, cleared, pulled)
+	}
+}
+
+// stringConst is the value of a named string constant, read from the
+// declaration rather than matched in the text: a constant is a value the
+// compiler already knows, and the file is Go.
+func stringConst(t *testing.T, file, name string) string {
+	t.Helper()
+	path := repoPath(filepath.FromSlash(file))
+	parsed, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	for _, decl := range parsed.Decls {
+		general, ok := decl.(*ast.GenDecl)
+		if !ok || general.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range general.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+				continue
+			}
+			if value.Names[0].Name != name {
+				continue
+			}
+			literal, ok := value.Values[0].(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				t.Fatalf("%s in %s is not a string literal", name, file)
+			}
+			unquoted, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return unquoted
+		}
+	}
+	t.Fatalf("%s declares no constant %s, so this proves nothing", file, name)
+	return ""
+}

--- a/test/contract/capsule/remote-harness.sh
+++ b/test/contract/capsule/remote-harness.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run the outer-capsule, egress and budget contract suite on the host
+# under test.
+#
+# The capsule image is the caller's to prepare, always tagged
+# runpool-capsule:dev: the pull-request gate builds it from the pinned
+# inputs, and the release gate tags the exact candidate it is qualifying.
+# What the caller does not choose is the deadline, which lives here so
+# both gates allow the suite the same time to finish.
+#
+# The lifecycle drives a real runner with a fake credential -- the runner
+# rejects it and exits, which proves it ran without needing a provider.
+# The bypass suite proves the capsule has no route out and that its only
+# egress is the policy.
+#
+# Usage: test/contract/capsule/remote-harness.sh <dir with capsule-contract.test>
+dir=${1:?usage: remote-harness.sh <dir with capsule-contract.test>}
+
+RUNPOOL_CAPSULE_CONTRACT=1 "$dir/capsule-contract.test" -test.v -test.count=1 -test.timeout=30m

--- a/test/contract/docker/remote-harness.sh
+++ b/test/contract/docker/remote-harness.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Run the Docker client contract suite on the host under test.
+#
+# The suite runs on the host rather than inside a container because the
+# contract under test is the daemon API itself, and the resource-envelope
+# check reads cgroup v2 paths. Both gates and the SSH driver run this
+# same file, so the pull fixture is cleared one way rather than three.
+#
+# RUNPOOL_CONTRACT_QUALIFY travels from the caller: in qualification mode
+# the suite additionally requires the exact platform the reviewed lock
+# names. No expected value travels with it — the suite embeds the
+# reference and compares the host against it.
+#
+# Usage: test/contract/docker/remote-harness.sh <dir with docker-contract.test>
+dir=${1:?usage: remote-harness.sh <dir with docker-contract.test>}
+
+# The image TestPullOnMissingImage pulls. Held equal to the suite's own
+# constant by test/consistency: removing something else would leave the
+# fixture cached and the pull path unexercised.
+fixture='busybox:1.36.1-uclibc@sha256:0872fb3a7632ba9d0ae46a8e832a62b30ce83a6f220b8bb52903d9cf477dabe3'
+
+# The pull-on-missing path only exists while the image is missing: after
+# one run the daemon has it cached and the test passes without pulling
+# anything. Prove the removal — one that silently failed turns that test
+# into a no-op, and a no-op reports as a pass.
+docker image rm -f "$fixture" >/dev/null 2>&1 || true
+if docker image inspect "$fixture" >/dev/null 2>&1; then
+  echo 'the pull fixture is still present; the pull test would exercise nothing' >&2
+  exit 1
+fi
+
+RUNPOOL_DOCKER_CONTRACT=1 "$dir/docker-contract.test" -test.v -test.count=1


### PR DESCRIPTION
## What changes

Each live contract suite gets one harness, beside the suite, run by the
pull-request gate, by the release gate and by the SSH driver. The two gates now
run identical commands. A consistency test holds the Docker suite's pull fixture
equal between the harness that clears it and the suite that pulls it.

## What was found

**Every live suite had three spellings, and they had drifted.**

```text
                pull-request gate        release gate             SSH driver
capsule         -timeout 20m             -timeout 30m             (no timeout)
docker fixture  docker rmi <tag>         docker image rm -f <tag> rm -f <digest>, verified
                2>/dev/null || true      >/dev/null 2>&1 || true
sqlite          two steps, /tmp          one step, mktemp         n/a
```

**The copy no gate runs was the only correct one.** `scripts/contracts/docker.sh`
removed the fixture by the digest the suite pins and then proved it gone, with
the reason written down: *"a removal that silently failed turns the pull test
into a no-op."* Both gates removed a bare tag and checked nothing. So
`TestPullOnMissingImage` — which exists to prove that creating a container on an
absent image pulls it — could have been running against a cached image on every
CI run since it was written, passing without pulling anything, and nothing would
have said so.

**The capsule image's source differs between gates on purpose, and its deadline
did not.** The pull-request gate builds the image from the pinned inputs; the
release gate pulls the exact candidate it is qualifying and tags it. Both end at
`runpool-capsule:dev`, so the harness does not build — it runs the suite, and it
owns the deadline, which is one number now rather than 20 minutes on one side
and 30 on the other.

**Neither suite reads anything relative to its working directory**, checked
before moving them, which is why both can run as prebuilt binaries the way the
sqlite and lifecycle suites already did. In a gate there is no ship: the runner
is the host under test, so the workflow cross-compiles and runs the harness
directly.

## Evidence

The point of the change, measured — the two gates' commands for all four suites,
diffed:

```text
=== Run the Docker contracts
   +RUNPOOL_CONTRACT_QUALIFY: "1"
   -bash test/contract/docker/remote-harness.sh "$dir"
   +bash test/contract/docker/remote-harness.sh "$dir" 2>&1 | tee docker-contract.log
=== Run the capsule, egress and budget contracts
   +RUNPOOL_CONTRACT_QUALIFY: "1"
   -bash test/contract/capsule/remote-harness.sh "$dir"
   +bash test/contract/capsule/remote-harness.sh "$dir" 2>&1 | tee capsule-contract.log
=== Run the durability suite on a named volume
   -bash "$dir/remote-harness.sh" "$dir"
   +bash "$dir/remote-harness.sh" "$dir" 2>&1 | tee sqlite-contract.log
=== Run the lifecycle drills
   -bash test/drills/remote-harness.sh "$dir"
   +bash test/drills/remote-harness.sh "$dir" 2>&1 | tee lifecycle-drills.log
```

Two differences, both meant: qualification mode, and whether the output is kept
as evidence.

The fixture check, watched failing both ways it can break, in an export:

```text
harness clears a digest the suite does not pull
  -> test/contract/docker/remote-harness.sh clears …@sha256:1111…; the suite pulls
     …@sha256:0872…, which stays cached and turns TestPullOnMissingImage into a no-op
harness clears nothing
  -> test/contract/docker/remote-harness.sh assigns no fixture, so it clears nothing
     before the suite runs

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
$ go tool actionlint && git ls-files -coz --exclude-standard -- "*.sh" | xargs -0 shellcheck
exit=0
```

The live suites themselves cannot run on a pull request without a daemon; the
four `integration-docker` jobs are what exercise these harnesses, and they run
on this pull request because it touches paths in their filter.

## What would notice this regressing

`TestTheHarnessClearsTheFixtureTheSuitePulls` fails if the harness clears
something the suite does not pull, or stops clearing anything. It reads the Go
constant from its declaration rather than matching text, so renaming the
constant fails loudly instead of silently matching nothing.

The harness itself is what notices the removal failing: it inspects the fixture
after removing it and exits non-zero if it is still there. That check existed
only in the SSH driver before, which no gate runs.

Nothing checks that a fifth suite added later gets a harness rather than an
inline command. That is a convention in `docs/maintainers/ci.md`, not a gate.

## Risk, compatibility and operations

The suites now run as prebuilt binaries rather than through `go test ./...`.
Neither reads anything relative to its working directory — verified before the
move — and this is the form the sqlite and lifecycle suites already used. The
observable difference is that `go test`'s package-level output framing is
replaced by the binary's own, which is the same `-test.v` stream.

The Docker suite's fixture is now removed by its pinned digest rather than by a
bare tag, and the run fails if the image survives. On a host where the removal
genuinely cannot happen, that turns a silent pass into a visible failure, which
is the intent.

The capsule suite's deadline is 30 minutes on both gates, up from 20 on the
pull-request side. The job deadline above it is 40 minutes and unchanged.

No product code, CLI, configuration, status API, schema or migration surface is
touched.

## Changelog

```text
- Each live suite has one harness, run by the pull-request gate, by the release
  gate and by the driver that ships it to a host over SSH. The two gates differ
  only in whether qualification mode is on and whether the output is kept as
  evidence. The Docker suite's pull fixture is cleared by that harness and the
  removal is proven, so the test that exists to pull it cannot quietly stop
  pulling anything.
```

## Notes for your reviewer

The `integration-docker` jobs are the ones to read the run of: they exercise
every harness this changes. The release gate's copies cannot be exercised
outside a qualification run, which is exactly why they had drifted unnoticed.

Left alone: the sqlite harness still lives under `testdata/`, where `go build`
ignores it and `.dockerignore` excludes it. The precedent is established and the
two new harnesses sit beside their suites instead, which is where the naming
rule points; moving the sqlite one is a rename for symmetry alone and would
touch the driver, both gates and the harness's own usage line.
