### PR TITLE
feat(release): a release publishes every platform it declares

### DIFF
--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -80,18 +80,22 @@ jobs:
           go build -trimpath -ldflags "-X main.version=${VERSION}" -o /tmp/runpool-version ./cmd/runpool
           /tmp/runpool-version version --check-release
           (cd release-artifacts && sha256sum -c checksums.txt)
+          # Every binary in the bundle reports the version and the capsule
+          # reference it was built with -- proven when it was built, on a
+          # runner of its own architecture, which is the only place a
+          # binary can be asked. What this adds is that the bundle
+          # arriving here is the bundle that was built: the checksums
+          # above cover the bytes, and this covers the one it can run.
           chmod +x release-artifacts/runpool-linux-amd64
           release-artifacts/runpool-linux-amd64 version --check-release
-          release-artifacts/runpool-linux-amd64 version --json > /tmp/runpool-release-facts.json
-          python3 - <<'PY'
-          import json, os, sys
-
-          facts = json.load(open("/tmp/runpool-release-facts.json", encoding="utf-8"))
-          if facts.get("version") != os.environ["VERSION"]:
-              sys.exit("standalone candidate has the wrong version")
-          if facts.get("capsule_image") != os.environ["CAPSULE_IMAGE"]:
-              sys.exit("standalone candidate embeds the wrong capsule image")
-          PY
+          facts=$(release-artifacts/runpool-linux-amd64 version --json)
+          echo "$facts"
+          for stamped in "$VERSION" "$CAPSULE_IMAGE"; do
+            case "$facts" in
+              *"$stamped"*) ;;
+              *) echo "the standalone candidate does not report ${stamped}"; exit 1 ;;
+            esac
+          done
 
   hermetic:
     name: hermetic gate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: release
 on:
   push:
     tags: ["v*"]
+  # The candidate chain, run against a throwaway tag. It is the only way
+  # to exercise a multi-platform build and the index it assembles before
+  # a real tag depends on them: the qualification and the publication
+  # below do not run for it.
+  workflow_dispatch:
 
 defaults:
   run:
@@ -25,8 +30,36 @@ env:
   GOTOOLCHAIN: go1.26.6
 
 jobs:
+  version:
+    name: the version this run is for
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.this.outputs.version }}
+      candidate: ${{ steps.this.outputs.candidate }}
+    steps:
+      - name: State the version and the candidate tag
+        # A tag push releases itself; a dispatch is a rehearsal, and the
+        # version it stamps has to be a publishable SemVer string so the
+        # same checks run, while naming itself so nothing mistakes the
+        # images it leaves for a candidate.
+        env:
+          EVENT: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        id: this
+        run: |
+          if [ "$EVENT" = "push" ]; then
+            echo "version=${REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "candidate=candidate-${SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=v0.0.0-dry-run" >> "$GITHUB_OUTPUT"
+            echo "candidate=dry-run-${SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
     name: validate release tag
+    needs: version
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -42,17 +75,23 @@ jobs:
 
       - name: Verify the version stamped into the artifact
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ needs.version.outputs.version }}
         run: |
           go build -trimpath -ldflags "-X main.version=${VERSION}" -o /tmp/runpool-version ./cmd/runpool
           /tmp/runpool-version version --check-release
 
-  candidate:
-    name: build immutable candidates
-    needs: validate
-    runs-on: ubuntu-24.04
+  # One platform per runner, natively. Every base image these build from
+  # is pinned to an index digest that publishes both, so an arm64 runner
+  # resolves the arm64 child of the reviewed digest and nothing is
+  # emulated: the capsule's final stage installs packages, which under
+  # emulation is slow and occasionally wrong, and a binary verified by
+  # running it has to run on the architecture it is for.
+  capsule:
+    name: capsule candidate
+    needs: [validate, version]
+    runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
-    # The one job that writes to a registry before anything has been
+    # The first job that writes to a registry, before anything has been
     # qualified. The protected tag is what authorizes the run; the
     # environment is where that authorization is recorded and can be held
     # for review, the same place the publication gate already lives.
@@ -60,9 +99,192 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push this platform's capsule
+        env:
+          NAME: ghcr.io/${{ github.repository }}/capsule
+          PLATFORM: ${{ matrix.platform }}
+          CANDIDATE: ${{ needs.version.outputs.candidate }}
+        run: |
+          arch=${PLATFORM#*/}
+          docker build -f build/capsule/Dockerfile -t "${NAME}:${CANDIDATE}-${arch}" .
+          docker push "${NAME}:${CANDIDATE}-${arch}"
+          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' \
+            "${NAME}:${CANDIDATE}-${arch}")
+          case "$reference" in
+            *@sha256:*) ;;
+            *) echo "registry returned no immutable capsule digest"; exit 1 ;;
+          esac
+          # The digest travels as a file rather than a job output: a
+          # matrix leg's outputs overwrite its siblings', and which of
+          # them survived would decide what the index holds.
+          mkdir -p digests
+          printf '%s' "${reference#*@}" > "digests/${arch}"
+
+      - name: Keep this platform's digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: capsule-digest-${{ strategy.job-index }}
+          path: digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  capsule-index:
+    name: capsule index
+    needs: [capsule, version]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: release-candidate
+    permissions:
+      contents: read
+      packages: write
     outputs:
-      capsule_image: ${{ steps.capsule.outputs.reference }}
-      controller_image: ${{ steps.controller.outputs.reference }}
+      reference: ${{ steps.index.outputs.reference }}
+    steps:
+      - name: Download the per-platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: capsule-digest-*
+          merge-multiple: true
+          path: digests
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Assemble the capsule index
+        id: index
+        env:
+          NAME: ghcr.io/${{ github.repository }}/capsule
+          CANDIDATE: ${{ needs.version.outputs.candidate }}
+        run: |
+          set --
+          for file in digests/*; do
+            set -- "$@" "${NAME}@$(cat "$file")"
+          done
+          [ "$#" -gt 0 ] || { echo "no platform digest to index"; exit 1; }
+          # A manifest list assembled from the bytes each runner pushed.
+          # The controller embeds this one reference: the daemon resolves
+          # the matching child at pull time, so one exact digest is
+          # correct for every architecture.
+          docker buildx imagetools create --tag "${NAME}:${CANDIDATE}" "$@"
+          digest=$(docker buildx imagetools inspect "${NAME}:${CANDIDATE}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          case "$digest" in
+            sha256:*) ;;
+            *) echo "the registry returned no index digest"; exit 1 ;;
+          esac
+          # The index has to hold every platform that was pushed into it.
+          # The digest files are named for the architecture each runner
+          # built, so the set that was assembled is compared with the set
+          # the registry now serves rather than with a list written here:
+          # a leg that failed to upload, or a create that silently took
+          # fewer arguments, is an index missing a platform nobody asked
+          # about again until an operator pulls one.
+          built=$(basename -a digests/* | sort | tr '\n' ' ')
+          # One line, so no indentation of this file leaks into the
+          # template's own output. Attestation manifests carry no real
+          # architecture and are skipped rather than counted as a
+          # platform nobody asked for.
+          template='{{range .Manifest.Manifests}}{{if .Platform}}{{if ne .Platform.Architecture "unknown"}}{{.Platform.Architecture}} {{end}}{{end}}{{end}}'
+          published=$(docker buildx imagetools inspect "${NAME}@${digest}" --format "$template" \
+            | tr ' ' '\n' | grep -v '^$' | sort | tr '\n' ' ')
+          if [ "$built" != "$published" ]; then
+            echo "the index serves [$published]; this run built [$built]"
+            exit 1
+          fi
+          echo "reference=${NAME}@${digest}" >> "$GITHUB_OUTPUT"
+
+  controller:
+    name: controller candidate
+    needs: [capsule-index, version]
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 60
+    environment: release-candidate
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Authenticate to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build and push this platform's controller
+        env:
+          CAPSULE_IMAGE: ${{ needs.capsule-index.outputs.reference }}
+          NAME: ghcr.io/${{ github.repository }}
+          PLATFORM: ${{ matrix.platform }}
+          CANDIDATE: ${{ needs.version.outputs.candidate }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          arch=${PLATFORM#*/}
+          docker build -f build/controller/Dockerfile \
+            --build-arg "VERSION=${VERSION}" \
+            --build-arg "CAPSULE_IMAGE=${CAPSULE_IMAGE}" \
+            -t "${NAME}:${CANDIDATE}-${arch}" .
+          docker push "${NAME}:${CANDIDATE}-${arch}"
+          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' \
+            "${NAME}:${CANDIDATE}-${arch}")
+          case "$reference" in
+            *@sha256:*) ;;
+            *) echo "registry returned no immutable controller digest"; exit 1 ;;
+          esac
+          mkdir -p digests
+          printf '%s' "${reference#*@}" > "digests/${arch}"
+
+      - name: Keep this platform's digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: controller-digest-${{ strategy.job-index }}
+          path: digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  artifacts:
+    name: standalone candidates
+    needs: [capsule-index, version]
+    runs-on: ${{ matrix.runs-on }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runs-on: ubuntu-24.04
+          - platform: linux/arm64
+            runs-on: ubuntu-24.04-arm
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -74,60 +296,139 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Build this platform's standalone binary
+        # Built and then run on the architecture it is for. A binary
+        # whose own report is only ever read on another architecture is
+        # a binary nothing has executed.
+        env:
+          CAPSULE_IMAGE: ${{ needs.capsule-index.outputs.reference }}
+          PLATFORM: ${{ matrix.platform }}
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          arch=${PLATFORM#*/}
+          mkdir -p release-artifacts
+          GOOS=linux GOARCH="$arch" CGO_ENABLED=0 go build -trimpath \
+            -ldflags "-s -w -X main.version=${VERSION} -X main.capsuleImage=${CAPSULE_IMAGE}" \
+            -o "release-artifacts/runpool-linux-${arch}" ./cmd/runpool
+          "release-artifacts/runpool-linux-${arch}" version --check-release
+          facts=$("release-artifacts/runpool-linux-${arch}" version --json)
+          echo "$facts"
+          # What the linker stamped, read back out of the binary that
+          # will ship. A -X that silently did nothing leaves the default
+          # capsule reference, which is a mutable tag: the release would
+          # carry a controller that resolves its capsule at run time
+          # instead of running the one that was qualified.
+          for stamped in "$VERSION" "$CAPSULE_IMAGE"; do
+            case "$facts" in
+              *"$stamped"*) ;;
+              *) echo "the ${arch} binary does not report ${stamped}"; exit 1 ;;
+            esac
+          done
+          (cd release-artifacts && sha256sum "runpool-linux-${arch}" > "checksums-${arch}.txt")
+
+      - name: Keep this platform's standalone candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: standalone-${{ strategy.job-index }}
+          path: release-artifacts/*
+          retention-days: 1
+          if-no-files-found: error
+
+  candidate:
+    name: build immutable candidates
+    needs: [capsule-index, controller, artifacts, version]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: release-candidate
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      capsule_image: ${{ needs.capsule-index.outputs.reference }}
+      controller_image: ${{ steps.index.outputs.reference }}
+    steps:
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Download the per-platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: controller-digest-*
+          merge-multiple: true
+          path: digests
+
+      - name: Download the per-platform standalone candidates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: standalone-*
+          merge-multiple: true
+          path: release-artifacts
+
       - name: Authenticate to GHCR
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-      - name: Build and push the capsule candidate
-        id: capsule
+      - name: Assemble the controller index
+        id: index
         env:
-          IMAGE: ghcr.io/${{ github.repository }}/capsule:candidate-${{ github.sha }}
+          NAME: ghcr.io/${{ github.repository }}
+          CANDIDATE: ${{ needs.version.outputs.candidate }}
         run: |
-          docker build -f build/capsule/Dockerfile -t "$IMAGE" .
-          docker push "$IMAGE"
-          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE")
-          case "$reference" in
-            *@sha256:*) ;;
-            *) echo "registry returned no immutable capsule digest"; exit 1 ;;
+          set --
+          for file in digests/*; do
+            set -- "$@" "${NAME}@$(cat "$file")"
+          done
+          [ "$#" -gt 0 ] || { echo "no platform digest to index"; exit 1; }
+          docker buildx imagetools create --tag "${NAME}:${CANDIDATE}" "$@"
+          digest=$(docker buildx imagetools inspect "${NAME}:${CANDIDATE}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          case "$digest" in
+            sha256:*) ;;
+            *) echo "the registry returned no index digest"; exit 1 ;;
           esac
-          echo "reference=$reference" >> "$GITHUB_OUTPUT"
+          # The index has to hold every platform that was pushed into it.
+          # The digest files are named for the architecture each runner
+          # built, so the set that was assembled is compared with the set
+          # the registry now serves rather than with a list written here:
+          # a leg that failed to upload, or a create that silently took
+          # fewer arguments, is an index missing a platform nobody asked
+          # about again until an operator pulls one.
+          built=$(basename -a digests/* | sort | tr '\n' ' ')
+          # One line, so no indentation of this file leaks into the
+          # template's own output. Attestation manifests carry no real
+          # architecture and are skipped rather than counted as a
+          # platform nobody asked for.
+          template='{{range .Manifest.Manifests}}{{if .Platform}}{{if ne .Platform.Architecture "unknown"}}{{.Platform.Architecture}} {{end}}{{end}}{{end}}'
+          published=$(docker buildx imagetools inspect "${NAME}@${digest}" --format "$template" \
+            | tr ' ' '\n' | grep -v '^$' | sort | tr '\n' ' ')
+          if [ "$built" != "$published" ]; then
+            echo "the index serves [$published]; this run built [$built]"
+            exit 1
+          fi
+          echo "reference=${NAME}@${digest}" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push the controller candidate
-        id: controller
-        env:
-          CAPSULE_IMAGE: ${{ steps.capsule.outputs.reference }}
-          IMAGE: ghcr.io/${{ github.repository }}:candidate-${{ github.sha }}
-          VERSION: ${{ github.ref_name }}
+      - name: Complete the standalone release artifacts
+        # The completions are the same bytes on every platform, so they
+        # are generated once here rather than per runner, and the
+        # checksums each runner produced are joined into the one file the
+        # publication verifies against.
         run: |
-          docker build -f build/controller/Dockerfile \
-            --build-arg "VERSION=${VERSION}" \
-            --build-arg "CAPSULE_IMAGE=${CAPSULE_IMAGE}" \
-            -t "$IMAGE" .
-          docker push "$IMAGE"
-          reference=$(docker image inspect --format '{{index .RepoDigests 0}}' "$IMAGE")
-          case "$reference" in
-            *@sha256:*) ;;
-            *) echo "registry returned no immutable controller digest"; exit 1 ;;
-          esac
-          echo "reference=$reference" >> "$GITHUB_OUTPUT"
-
-      - name: Build the standalone release artifacts
-        env:
-          CAPSULE_IMAGE: ${{ steps.capsule.outputs.reference }}
-          VERSION: ${{ github.ref_name }}
-        run: |
-          mkdir -p release-artifacts
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath \
-            -ldflags "-s -w -X main.version=${VERSION} -X main.capsuleImage=${CAPSULE_IMAGE}" \
-            -o release-artifacts/runpool-linux-amd64 ./cmd/runpool
           go generate ./internal/command/...
           git diff --exit-code docs/reference/cli
           tar -C dist/completions -czf release-artifacts/runpool-completions.tar.gz .
-          (cd release-artifacts && sha256sum runpool-linux-amd64 runpool-completions.tar.gz > checksums.txt)
-          release-artifacts/runpool-linux-amd64 version --check-release
-          release-artifacts/runpool-linux-amd64 version --json
-          (cd release-artifacts && sha256sum -c checksums.txt)
+          cd release-artifacts
+          sha256sum runpool-completions.tar.gz > checksums.txt
+          cat checksums-*.txt >> checksums.txt
+          rm -f checksums-*.txt
+          sha256sum -c checksums.txt
 
       - name: Keep the immutable release artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -140,6 +441,7 @@ jobs:
   qualify:
     name: qualify the exact commit and candidates
     needs: candidate
+    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: read
@@ -151,7 +453,8 @@ jobs:
 
   publish:
     name: attest and publish qualified artifacts
-    needs: [candidate, qualify]
+    needs: [candidate, qualify, version]
+    if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     environment: release
@@ -208,22 +511,27 @@ jobs:
           CAPSULE_NAME: ghcr.io/${{ github.repository }}/capsule
           CONTROLLER_CANDIDATE: ${{ needs.candidate.outputs.controller_image }}
           CONTROLLER_NAME: ghcr.io/${{ github.repository }}
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ needs.version.outputs.version }}
         run: |
           set -euo pipefail
+          # A manifest copy inside the registry, not a pull and a retag:
+          # pulling an index brings down the runner's own platform, and
+          # pushing that back under the release tag would publish one
+          # child of what was qualified. Copying the index preserves its
+          # digest by construction, which is what the check below reads
+          # back.
           promote() {
             candidate=$1
             name=$2
-            docker pull "$candidate" >&2
-            docker tag "$candidate" "${name}:${VERSION}"
-            docker push "${name}:${VERSION}" >&2
-            docker pull "${name}:${VERSION}" >&2
-            reference="${name}@${candidate#*@}"
-            docker image inspect --format '{{range .RepoDigests}}{{println .}}{{end}}' "${name}:${VERSION}" | grep -Fxq "$reference" || {
+            digest=${candidate#*@}
+            docker buildx imagetools create --tag "${name}:${VERSION}" "$candidate" >&2
+            promoted=$(docker buildx imagetools inspect "${name}:${VERSION}" \
+              --format '{{json .Manifest.Digest}}' | tr -d '"')
+            if [ "$promoted" != "$digest" ]; then
               echo "promoted digest differs from the qualified candidate"
               exit 1
-            }
-            printf '%s' "$reference"
+            fi
+            printf '%s' "${name}@${digest}"
           }
           controller_reference=$(promote "$CONTROLLER_CANDIDATE" "$CONTROLLER_NAME")
           capsule_reference=$(promote "$CAPSULE_CANDIDATE" "$CAPSULE_NAME")
@@ -292,6 +600,7 @@ jobs:
         with:
           files: |
             dist/runpool-linux-amd64
+            dist/runpool-linux-arm64
             dist/runpool-completions.tar.gz
             dist/checksums.txt
             dist/controller.sbom.spdx.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,16 @@ by its public and operational effects.
   reads the record: what it requires is that the selection is stated, and
   that the platform is one a release can build for.
 
+- **A release publishes every platform it declares.** Each is built on a runner
+  of its own architecture, so nothing is emulated and each standalone binary is
+  verified by running it where it will run. The images are published as an index
+  assembled from those builds, and the assembly fails if the index serves fewer
+  platforms than the run produced. The controller embeds one capsule reference,
+  the index digest, which is correct for either architecture because the daemon
+  resolves the matching child at pull time. Promotion copies that index inside
+  the registry rather than pulling and retagging, which would publish one
+  platform of what was qualified.
+
 - A release qualifies the exact digest-qualified controller and capsule
   candidates it later promotes; no image is rebuilt after qualification.
 - Platform qualification compares every locked host fact and fails when a

--- a/docs/adrs/2026-08-17-multiplatform-locks.md
+++ b/docs/adrs/2026-08-17-multiplatform-locks.md
@@ -1,7 +1,6 @@
 # A lock records the platforms that were qualified, not the only one that works
 
-**Status:** accepted; the lock shape and the reader are built, the
-per-platform publishing is not
+**Status:** accepted and implemented
 **Date:** 2026-08-17
 
 `build/platform.lock.json` carries a single `policy.arch`, so one lock
@@ -82,38 +81,39 @@ without that evidence. Neither sentence promises the other.
 
 ## What is built
 
-The first, second and fourth decisions above. `platform.lock.json`
-records a list of entries, each with its own policy and its own facts;
-the reader selects by the platform being measured and reports a platform
-with no entry as one nobody has qualified rather than as an architecture
-mismatch. `images.lock.json` declares the platforms a release builds for.
-The support matrix states the two lists separately.
+All four decisions. `platform.lock.json` records a list of entries, each
+with its own policy and its own facts; the reader selects by the platform
+being measured and reports a platform with no entry as one nobody has
+qualified rather than as an architecture mismatch. `images.lock.json`
+declares the platforms a release builds for, and the release builds and
+publishes exactly those. The support matrix states the built list and the
+qualified list separately.
 
 Two things were loosened beyond what this record asked for, on the same
 argument it makes. The distribution was hard-coded next to the
 architecture, so a host on another one could not be recorded either; the
 reader now requires the selection to be *stated* rather than to be a
 particular value. And the operating system is derived from what the
-pinned images publish instead of being written as a rule, because that
-is where it actually comes from.
+pinned images publish instead of being written as a rule, because that is
+where it actually comes from.
 
-## What is not
+## The route the publishing took, which is not the one this record expected
 
-The third decision: the release publishing an index per image, and the
-standalone binaries per platform. Neither is built. The release workflow
-builds and pushes one image and ships one `linux/amd64` binary; what
-exists per platform is a compile-only gate in `ci.yml`, which builds to
-`/dev/null` and produces no artifact.
+This record anticipated `buildx` with a multi-platform push, and named
+the obstacle: `docker image inspect` returns nothing after one, and that
+digest is what is injected as the controller's capsule reference.
 
-What is verified is that it can be done: the capsule image builds for
-`linux/arm64`, with the Go stage compiling rather than reusing a cached
-layer. What is not is the publishing, which needs `buildx` with a push
-and a different way of reading back the digest — `docker image inspect`
-returns nothing after a multi-platform push, and that digest is what is
-injected as the controller's capsule reference. Its only real
-verification is a release run.
+That obstacle was avoided rather than solved. Every base image these
+build from is pinned to an index digest that publishes both platforms, so
+each platform is built on a runner of its own architecture, resolving the
+matching child of the same reviewed digest. `docker image inspect` then
+answers normally, because the image was built and pushed locally. The
+index is assembled afterwards from the digests the runners pushed, and
+its own digest is read back from the registry.
 
-Until it lands, a release publishes one platform's image while the lock
-declares two. The support matrix's *built* list is therefore a statement
-about what the build can produce, not about what the last release
-pushed.
+Two consequences follow. Nothing is emulated, which matters because the
+capsule's final stage installs packages, and because a standalone binary
+is verified by running it — on the architecture it is for. And the
+promotion is a manifest copy inside the registry rather than a pull and a
+retag: pulling an index brings down one child, and pushing that back
+under the release tag would publish one platform of what was qualified.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -21,6 +21,6 @@ justified it usually still holds even when the remedy does not.
 | 2026-08-17 | [Capsule image substitution](2026-08-17-capsule-image-substitution.md) — a tier may name its capsule, and the capsule declares its protocol | accepted |
 | 2026-08-17 | [GitHub App credentials](2026-08-17-github-app-credentials.md) — a deployment authenticates as an App, not only as a person | accepted |
 | 2026-08-17 | [Job timeout](2026-08-17-job-timeout.md) — the lease ceiling is a backstop above the provider's own maximum | accepted |
-| 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted; publishing pending |
+| 2026-08-17 | [Multiplatform locks](2026-08-17-multiplatform-locks.md) — a lock records the platforms qualified, not the only one that works | accepted and implemented |
 | 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |
 | 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted; supersedes one consequence of session conflict |

--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -26,7 +26,8 @@ that is what decides whether it can run on a pull request at all.
 | `qualify-release` | `validate release inputs` | The ref is a protected tag, the images are digest-qualified, and the standalone candidate is the tag it claims | Hosted |
 | `qualify-release` | `live contracts on the reference host` | Every live suite, without skips, on the reference host | Self-hosted, protected |
 | `qualify-release` | `release-qualification record` | The evidence supports the claim the record makes | Hosted |
-| `release` | `build immutable candidates` | The candidate images and standalone artifacts exist by digest and checksum | Hosted, protected `release-candidate` |
+| `release` | `capsule candidate`, `controller candidate`, `standalone candidates` | Each platform built on a runner of its own architecture, pushed by digest | Hosted, one leg per platform, protected `release-candidate` |
+| `release` | `capsule index`, `build immutable candidates` | The index serves every platform the run built, and the standalone artifacts exist by checksum | Hosted, protected `release-candidate` |
 | `release` | `attest and publish qualified artifacts` | The record covers this build, the artifacts match their checksums, and the promoted digests are the qualified ones | Hosted, protected `release` |
 
 `qualify-release` also calls `ci`, `contracts-github-actions` and
@@ -111,5 +112,13 @@ of them are shellchecked, at any depth, tracked or not.
 A script is shell when its job is to run other programs: `ssh`, `tar`, `docker`,
 `uname`. It is a Go test or a Go command when its job is to read a file and
 decide something — those get parsed with the parser for the format, and they get
-tests of their own. The repository does not add a second language toolchain for
-this: nothing here is written in Python.
+tests of their own.
+
+Two scripts still call `python3`, both to read JSON a shell cannot:
+`scripts/verify/image-lock.sh` and `scripts/qualification/start-jit-runner.sh`.
+They are what is left of a second toolchain the contribution guide says this
+repository does not add, and the way out of the first one is to lift the image
+lock into a package both the controller and a gate can import, the way the
+platform lock already is. Where a Go template can answer instead, it does:
+`docker buildx imagetools inspect --format` prints the platforms an index
+serves, so the release verifies its own indexes without parsing anything.

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -102,12 +102,12 @@ unsupported, and the gate says which it is: a host with no entry fails as
 *not qualified on this platform*, naming the ones that are, rather than
 as an architecture mismatch.
 
-**What a release actually publishes today is one platform.** The
-publishing half of that decision is not built: the release workflow
-builds and pushes a single image and ships a single `linux/amd64`
-binary. So *built* here describes what the build can produce, not what
-the last release put in the registry. Do not read it as a promise of an
-arm64 artifact.
+A release publishes an index per image covering both, and a standalone
+binary per platform. Each platform is built on a runner of its own
+architecture and the index is assembled from the digests they pushed, so
+one immutable reference is correct for either: the daemon resolves the
+matching child at pull time. The index assembly fails if it serves fewer
+platforms than the run built.
 
 The distribution is the same kind of statement. `debian 13 trixie` is
 the reviewed selection in the entry that exists, not a constraint the

--- a/test/consistency/contracts_test.go
+++ b/test/consistency/contracts_test.go
@@ -1,6 +1,7 @@
 package consistency
 
 import (
+	"encoding/json"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -80,4 +81,14 @@ func stringConst(t *testing.T, file, name string) string {
 	}
 	t.Fatalf("%s declares no constant %s, so this proves nothing", file, name)
 	return ""
+}
+
+// readRepoJSON decodes one of the repository's own JSON documents.
+func readRepoJSON(t *testing.T, file string, into any) error {
+	t.Helper()
+	body, err := os.ReadFile(repoPath(filepath.FromSlash(file)))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(body, into)
 }

--- a/test/consistency/release_test.go
+++ b/test/consistency/release_test.go
@@ -1,0 +1,53 @@
+package consistency
+
+import (
+	"os"
+	"slices"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTheReleaseBuildsEveryPlatformTheLockDeclares: the lock says what a
+// release builds for, and the release workflow is what builds it.
+//
+// Nothing else relates the two. `build/images.lock.json` declares the
+// platforms, `internal/app` embeds that declaration, and a Go test holds
+// it equal to the platforms the pinned base images publish — but the
+// workflow that produces the artifacts reads none of it. A lock
+// declaring two platforms beside a release that pushes one is a claim
+// with nothing behind it, and the first reader to notice is an operator
+// pulling an image for an architecture that was never published.
+func TestTheReleaseBuildsEveryPlatformTheLockDeclares(t *testing.T) {
+	var lock struct {
+		Platforms []string `json:"platforms"`
+	}
+	if err := readRepoJSON(t, "build/images.lock.json", &lock); err != nil {
+		t.Fatal(err)
+	}
+	if len(lock.Platforms) == 0 {
+		t.Fatal("the image lock declares no platform, so this proves nothing")
+	}
+
+	body, err := os.ReadFile(repoPath(".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow yaml.Node
+	if err := yaml.Unmarshal(body, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	built := valuesOf(&workflow, "platform")
+	slices.Sort(built)
+	built = slices.Compact(built)
+	declared := slices.Clone(lock.Platforms)
+	slices.Sort(declared)
+
+	if !slices.Equal(built, declared) {
+		t.Errorf("the release builds for %s; the lock declares %s. A platform in one list "+
+			"and not the other is one a release claims and does not produce, or one it "+
+			"produces and does not offer.",
+			strings.Join(built, ", "), strings.Join(declared, ", "))
+	}
+}


### PR DESCRIPTION
## What changes

The release builds each declared platform on a runner of its own architecture,
publishes an index per image assembled from those builds, ships a standalone
binary per platform, and promotes by copying the index rather than pulling and
retagging. A dispatch trigger runs the same chain against a throwaway tag with
the qualification and the publication skipped.

This is the last unbuilt decision of
[the multiplatform-locks record](docs/adrs/2026-08-17-multiplatform-locks.md).

## What was found

**The lock declared two platforms and the release pushed one.** Nothing related
the two: `build/images.lock.json` declares them, `internal/app` embeds the
declaration, a Go test holds it equal to what the pinned base images publish —
and the workflow that produces the artifacts read none of it. The new
`TestTheReleaseBuildsEveryPlatformTheLockDeclares` closes that link and was
watched failing first:

```text
the release builds for ; the lock declares linux/amd64, linux/arm64
```

**The Dockerfiles need no change.** The record anticipated `--platform=$BUILDPLATFORM`
and `TARGETARCH`, which is what one buildx invocation needs to avoid emulating.
Building each platform on its own runner makes that unnecessary — but only if
every pinned base is an index. Checked, all four are:

```text
golang:1.26.6-alpine          index: 386, amd64, arm, arm64, ppc64le, riscv64, s390x
distroless/static-debian12    index: amd64, arm, arm64, ppc64le, s390x
docker:29.7.2-dind            index: amd64, arm, arm64
actions-runner:2.336.0        index: amd64, arm64
```

So an arm64 runner resolves the arm64 child of the same reviewed digest.

**The record's obstacle was avoided, not solved.** It named one: `docker image
inspect` returns nothing after a multi-platform push, and that digest is what
the controller embeds. Built natively, the image is local and inspect answers
normally; the index is assembled afterwards from the digests the runners pushed,
with `docker buildx imagetools create`. Each assembly then reads back what the
registry serves and fails if the index holds fewer platforms than the run built
— a leg that failed to upload, or a create that silently took fewer arguments,
is otherwise an index missing a platform nobody notices until an operator pulls
one.

**Promotion would have published one child of what was qualified.** `docker pull`
of an index brings down the runner's own platform; the old `pull` + `tag` +
`push` would then have put a single-platform image under the release tag. It is
a manifest copy inside the registry now, which preserves the digest by
construction.

**Two things were wrong beyond the missing platform**, both found by reading the
consumers rather than the producer:

- the draft release attached `dist/runpool-linux-amd64` and nothing else, so an
  arm64 binary would have been built, checksummed, qualified and never
  published — with `fail_on_unmatched_files: true` staying quiet, because the
  pattern it was given did match;
- the facts a binary reports, its version and the capsule reference the linker
  stamped, were read back from the amd64 binary alone. A `-X` that silently did
  nothing leaves the default capsule reference, which is a *mutable tag*: the
  release would carry a controller resolving its capsule at run time instead of
  running the one that was qualified. Each binary is now read on the runner that
  built it, which is the only place a binary can be asked.

That last check was the final `python3` heredoc in any workflow.

## Evidence

```text
$ go test ./test/consistency/ -run TestTheReleaseBuildsEveryPlatformTheLockDeclares
before: FAIL — the release builds for ; the lock declares linux/amd64, linux/arm64
after:  ok

$ docker buildx imagetools inspect <each pinned base> --format '{{range .Manifest.Manifests}}…'
all four are indexes covering linux/arm64

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
$ go tool actionlint && git ls-files -coz --exclude-standard -- "*.sh" | xargs -0 shellcheck
exit=0
$ grep -c python3 .github/workflows/*.yml
none
```

**The release path itself is not exercised by this pull request, and cannot be.**
A `workflow_dispatch` trigger only accepts a workflow that exists on the default
branch, so the dry-run can first run after this merges. That ordering is the
one thing I would not have chosen: it means the restructure lands unexercised
and the dry-run is the immediate next step, not a gate on this change.

## What would notice this regressing

`TestTheReleaseBuildsEveryPlatformTheLockDeclares` fails if the release stops
building a platform the lock declares, or builds one it does not. It reads the
matrix, so adding a platform to the lock without adding a runner fails
hermetically.

Each index assembly compares what the registry serves against the digests it was
given, so a dropped platform fails the release rather than the operator who
pulls it. Each binary's stamped version and capsule reference are read back out
of the binary on the architecture that can run it.

What nothing catches: a platform added to the matrix without a runner label that
exists. `runs-on: ubuntu-24.04-arm` is a GitHub-hosted label; a typo there is a
job that never starts, which the dispatch rehearsal would show and no hermetic
check can.

## Risk, compatibility and operations

The candidate stage is five jobs where it was one: two matrix legs for the
capsule, an index, two legs each for the controller and the binaries, and a
merge. Wall clock grows by roughly one image build, since the controller cannot
start until the capsule index exists — its build argument is that index digest.

`ubuntu-24.04-arm` is a GitHub-hosted runner, free for public repositories. This
repository is public.

A dispatch run pushes to GHCR under `dry-run-<sha>` tags and does not clean them
up: GHCR's package API refuses App installation tokens for deletion, which is
the same constraint `docs/maintainers/repository-settings.md` already records
for the end-to-end fixture. Removing them needs a classic token with
`delete:packages`.

No product code, CLI, configuration, status API, schema or migration surface is
touched. The controller still embeds exactly one capsule reference; it is now an
index digest, which is correct for either architecture because the daemon
resolves the matching child at pull time.

## Changelog

```text
- **A release publishes every platform it declares.** Each is built on a runner
  of its own architecture, so nothing is emulated and each standalone binary is
  verified by running it where it will run. The images are published as an index
  assembled from those builds, and the assembly fails if the index serves fewer
  platforms than the run produced. The controller embeds one capsule reference,
  the index digest, which is correct for either architecture because the daemon
  resolves the matching child at pull time. Promotion copies that index inside
  the registry rather than pulling and retagging, which would publish one
  platform of what was qualified.
```

## Notes for your reviewer

The per-platform digests travel between jobs as uploaded files rather than job
outputs. A matrix leg's outputs overwrite its siblings', so which leg survived
would decide what the index holds — the failure would be an index with one
platform and a green run.

`docs/maintainers/ci.md` gained an honest paragraph it was missing: two scripts
still call `python3` to read JSON a shell cannot, and the way out of the first is
to lift the image lock into a package both the controller and a gate can import,
the way the platform lock already is.
