### PR TITLE
docs(maintainers): the release needs write access to the packages it publishes

### DIFF
--- a/docs/maintainers/repository-settings.md
+++ b/docs/maintainers/repository-settings.md
@@ -108,6 +108,18 @@ it.
   tests alone unless somebody dispatches them: Dependabot keeps that update out
   of the grouped batch, CODEOWNERS holds `go.mod`, and the reviewer runs
   `contracts-github-actions` by hand and links the run before merging.
+- Link the `runpool` and `runpool/capsule` container packages to this
+  repository with the Write role, from each package's own Actions access
+  settings. A package created outside a workflow — by a person pushing from a
+  laptop — carries no repository link, and this repository's `GITHUB_TOKEN`
+  cannot write to it: the release builds the image and then fails at its first
+  push with `denied: permission_denied: write_package`. There is no API for the
+  grant and none for reading it back: the packages API reports a repository only
+  for a package a workflow published, so the only confirmation that the grant
+  took is a push that succeeds. Dispatching `release.yml` by hand is that push,
+  and it stops before qualifying or publishing anything.
+- Make both packages public before the first release. The repository is public;
+  a release whose images nobody can pull is not one.
 - Protect `release-candidate` with release-maintainer approval. It gates the
   one job that writes to the registry before anything has been qualified: the
   candidate images a release later promotes. The protected `v*` tag is what


### PR DESCRIPTION
## What changes

Two lines in the maintainer baseline: link both container packages to this
repository with the Write role, and make them public before the first release.

## What was found

A rehearsal of the release path — the first time it has ever run — failed at its
first push, after building the image:

```text
capsule candidate (linux/arm64, ubuntu-24.04-arm)
  denied: permission_denied: write_package
```

Both packages exist and neither is linked to this repository:

```text
name             visibility   repository    versions   created
runpool          private      NOT LINKED    12         2026-08-17
runpool/capsule  private      NOT LINKED    10         2026-08-17
```

They were created by someone pushing from a laptop during development. A package
created outside a workflow carries no repository link, and without it this
repository's `GITHUB_TOKEN` has no write access to it, whatever the job's
`permissions:` block says.

**None of this is new.** The release workflow could never have pushed, in any
version of it. The only reason it had not failed before is that it had never
run: there has never been a release, and until this week there was no way to
exercise the path without cutting a tag.

Both are also private while the repository is public — a release whose images
nobody can pull.

Neither is settable through an API. They are switches on each package's own
settings page, which is why they belong in the baseline a maintainer applies
alongside the rulesets and the environments, rather than in a workflow.

## Evidence

```text
$ gh api /orgs/rhobuild/packages/container/runpool
{"repository":"NOT LINKED","versions":12,"visibility":"private"}
$ gh api /orgs/rhobuild/packages/container/runpool%2Fcapsule
{"repository":"NOT LINKED","versions":10,"visibility":"private"}
```

Documentation only; the consistency suite covers the paths it names.

## What would notice this regressing

Nothing automated, and nothing can: the state lives in GitHub's package
settings, not in this tree. What noticed it is the rehearsal, which is now the
thing that runs before a tag rather than after one.

## Risk, compatibility and operations

No code. The two settings it describes are the maintainer's to apply, and until
they are, any release run fails at its first push having built the images.

## Changelog

```text
NONE
```

## Notes for your reviewer

The rehearsal that found this is `workflow_dispatch` on `release.yml`. It is
worth running again once the packages are linked — it stopped at the first push,
so everything past it is still unexercised: the index assembly, the controller
build against the capsule index, the per-platform binaries and the artifact
bundle.
