### PR TITLE
test(architecture): the engine SDK is confined to its adapter, and the frozen surfaces do not name it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,9 @@ by its public and operational effects.
 - The standalone binary and completions are built once before qualification,
   retained by checksum, and published without rebuilding. Releases also carry
   separate controller and capsule SBOMs plus signed provenance attestations.
+- The status document reports `engine_error` and the preflight names a
+  `container engine`, rather than naming the one engine there is. What either
+  says about Docker it says in the message, where it is true.
 - Public-repository gates include CodeQL, dependency review, Dependabot,
   vulnerability scanning, SHA-pinned actions, and least-privilege workflow
   permissions.

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -62,7 +62,7 @@ absent state, because the attempt it was asked about cannot exist.
 | `containers` | array | Owned containers: `name`, `role`, `lease_id`, `running` |
 | `networks`, `volumes` | array | Owned objects: `kind`, `role`, `name`, `lease_id`. No `state` — it is recorded per lease, and these are reported from the daemon |
 | `discrepancies` | array or null | Where the books and the daemon disagree; `null` if the daemon could not be asked |
-| `docker_error` | string, optional | Why the daemon could not be asked |
+| `engine_error` | string, optional | Why the daemon could not be asked |
 | `capsule_image_error` | string, optional | Why the shipped capsule image could not be resolved. It concerns only the tiers that name no `capsule_image` of their own: those report what the build ships rather than what a launch would run, while a tier naming its own image reports that one |
 
 Each binding reports what its own loop last managed with its provider:
@@ -148,5 +148,5 @@ as orphans would bury the real findings. What is reported:
 - an owned object carrying neither a lease nor a persistent role.
 
 An unreachable daemon yields `discrepancies: null` and a
-`docker_error`, never an empty list — a report that compared nothing
+`engine_error`, never an empty list — a report that compared nothing
 must not look like a clean one.

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -197,7 +197,7 @@ func runStatus(streams IO, asJSON bool, buildCapsule string) error {
 	}
 	fmt.Fprintf(streams.Out, "\nowned networks (%d), volumes (%d)\n", len(obs.networks), len(obs.volumes))
 	if obs.err != nil {
-		fmt.Fprintf(streams.Out, "\ndocker: %v — the books could not be compared with the daemon\n", obs.err)
+		fmt.Fprintf(streams.Out, "\nengine: %v — the books could not be compared with the daemon\n", obs.err)
 		return nil
 	}
 

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -62,10 +62,10 @@ type statusDoc struct {
 	Volumes       []resourceDTO  `json:"volumes"`
 	// Discrepancies is the books-versus-daemon comparison across every
 	// observed object kind. It is null only when the daemon could not
-	// be asked, which docker_error then explains: an unreadable daemon
+	// be asked, which engine_error then explains: an unreadable daemon
 	// must not report as a clean one.
 	Discrepancies []string `json:"discrepancies"`
-	DockerError   string   `json:"docker_error,omitempty"`
+	EngineError   string   `json:"engine_error,omitempty"`
 	// CapsuleImageError explains a capsule image this command could not
 	// resolve. It is about the shipped default only: a tier naming its
 	// own capsule_image reports that one, and a launch would run it. The
@@ -252,7 +252,7 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: v.Role, Name: v.ID, LeaseID: string(v.LeaseID)})
 	}
 	if obs.err != nil {
-		doc.DockerError = obs.err.Error()
+		doc.EngineError = obs.err.Error()
 	} else {
 		doc.Discrepancies = discrepancies(snap.Leases, obs)
 	}

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -129,8 +129,8 @@ func TestStatusDiscrepanciesCoverEveryKind(t *testing.T) {
 	if doc.Discrepancies != nil {
 		t.Errorf("discrepancies = %v with an unreachable daemon; want null (not compared)", doc.Discrepancies)
 	}
-	if doc.DockerError == "" {
-		t.Error("an unreachable daemon must be reported in docker_error")
+	if doc.EngineError == "" {
+		t.Error("an unreachable daemon must be reported in engine_error")
 	}
 }
 
@@ -320,7 +320,7 @@ func TestBothStatusAnswersShareOneEnvelope(t *testing.T) {
 // emitted every one of its other fields as a zero value. Two of those
 // are actively misleading rather than merely noisy: `discrepancies:
 // null` is defined by this API as "the daemon could not be asked", and
-// `docker_error` being absent then says it could. A reader diagnosing a
+// `engine_error` being absent then says it could. A reader diagnosing a
 // fresh install would be told the daemon is unreachable and given no
 // reason why.
 func TestThePreServeAnswerCarriesOnlyItsOwnFields(t *testing.T) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -181,24 +181,24 @@ func checkPlatform() Result {
 // precisely the verdicts that stop a host from serving.
 func checkDaemon(ctx context.Context, d daemonInfo) Result {
 	if d == nil {
-		return Result{"docker daemon", Fail, "not connected",
+		return Result{"container engine", Fail, "not connected",
 			"mount the daemon socket at /var/run/docker.sock"}
 	}
 	info, err := d.Info(ctx)
 	if err != nil {
-		return Result{"docker daemon", Fail, err.Error(), "check the socket mount and daemon health"}
+		return Result{"container engine", Fail, err.Error(), "check the socket mount and daemon health"}
 	}
 	if info.Rootless {
-		return Result{"docker daemon", Fail, "rootless mode (engine " + info.ServerVersion + ")",
+		return Result{"container engine", Fail, "rootless mode (engine " + info.ServerVersion + ")",
 			"V1 requires rootful Docker: privileged dind and cgroup limits differ under rootless"}
 	}
 	major := majorVersion(info.ServerVersion)
 	detail := fmt.Sprintf("engine %s, api %s, %s", info.ServerVersion, info.APIVersion, info.Architecture)
 	if major < platform.MinimumEngineMajor {
-		return Result{"docker daemon", Fail, detail,
+		return Result{"container engine", Fail, detail,
 			fmt.Sprintf("upgrade to Docker Engine %d or newer", platform.MinimumEngineMajor)}
 	}
-	return Result{"docker daemon", Pass, detail, ""}
+	return Result{"container engine", Pass, detail, ""}
 }
 
 // networkProbeClient is the two calls the bridge probe needs, named so

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -722,7 +722,7 @@ func TestDoctorRunsWithoutADaemon(t *testing.T) {
 	for _, r := range report.Results {
 		named = append(named, r.Name)
 	}
-	for _, want := range []string{"docker daemon", "isolated bridge"} {
+	for _, want := range []string{"container engine", "isolated bridge"} {
 		if !slices.Contains(named, want) {
 			t.Errorf("no %q result in %v; the check never ran", want, named)
 		}

--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -20,7 +20,18 @@ const (
 	// upstream is the provider SDK itself; only the adapter and its
 	// contract suite may see it.
 	upstream = "github.com/actions/scaleset"
+	// engineAdapter is the Moby adapter, and engineSDKs are the modules
+	// only it may see.
+	engineAdapter = module + "/internal/platform/docker"
 )
+
+// engineSDKs are the container-engine libraries. Their types describe a
+// daemon's API, and a domain package holding one is a domain package
+// that has learned which daemon it is talking to.
+var engineSDKs = []string{
+	"github.com/moby/",
+	"github.com/containerd/errdefs",
+}
 
 // corePackages are the provider-neutral packages. None of them may
 // depend on the GitHub Actions adapter or the upstream SDK, directly or
@@ -194,6 +205,34 @@ func TestGeneratedPersistenceStaysInsideTheStore(t *testing.T) {
 		for _, imported := range imports {
 			if imported == generated {
 				t.Errorf("%s imports %s; generated persistence is internal to the store package", importer, generated)
+			}
+		}
+	}
+}
+
+// TestTheEngineSDKStaysInsideItsAdapter: the decision is written down
+// and nothing enforced it.
+//
+// The Docker API client ADR says it plainly -- keep all daemon
+// operations behind internal/platform/docker; no domain package imports
+// Moby types -- and the tree obeys it. What was missing is the thing
+// that keeps obeying it: the architecture rules here covered the
+// provider SDK and said nothing about the engine's, so the first import
+// that crossed the line would have compiled, passed, and moved the
+// boundary by one convenient edit.
+func TestTheEngineSDKStaysInsideItsAdapter(t *testing.T) {
+	for importer, imports := range importGraph(t) {
+		if importer == engineAdapter {
+			continue
+		}
+		for _, imported := range imports {
+			for _, sdk := range engineSDKs {
+				if !strings.HasPrefix(imported, sdk) {
+					continue
+				}
+				t.Errorf("%s imports %s; only %s may see a container engine's own types, "+
+					"and what leaves it is Runpool's vocabulary rather than a daemon's",
+					importer, imported, engineAdapter)
 			}
 		}
 	}


### PR DESCRIPTION
## What changes

An architecture rule confining `github.com/moby/…` and
`github.com/containerd/errdefs` to `internal/platform/docker`, and two renames
in surfaces that freeze at the first release: `docker_error` becomes
`engine_error` in the `status --json` document, and the preflight's `docker
daemon` check becomes `container engine`.

## What was found

**The decision was written down and nothing enforced it.**
`docs/adrs/2026-08-12-docker-api-client.md` states it: *"Keep all daemon
operations behind `internal/platform/docker`; no domain package imports Moby
types."* The tree obeys it — exactly one package imports the SDK today:

```text
$ go list -f '{{.ImportPath}} {{join .Imports " "}}' github.com/rhobuild/runpool/... \
    | grep -E 'github.com/(moby|containerd)' | awk '{print $1}' | sort -u
github.com/rhobuild/runpool/internal/platform/docker
```

But `test/architecture` covered only the *provider* SDK. The first import that
crossed this line would have compiled, passed every gate, and moved the boundary
by one convenient edit — the way a dependency is always lost. Watched failing
against a real import of each family:

```text
internal/cache imports github.com/moby/moby/client; only internal/platform/docker may see …
internal/disk imports github.com/containerd/errdefs; only internal/platform/docker may see …
```

**Two names outlive this change, and only until the release.** `status --json`
is a versioned document — `docs/reference/status-api.md` gives it its own
`api_version` — and it carried `docker_error`. The preflight reported a check
named `docker daemon`. Both are free to change today and neither is afterwards:
that is when the contract freezes and when an operator's report starts parsing
it.

They are `engine_error` and `container engine` now. What either has to say about
Docker it says in the message, where it is true: the remediation still names the
socket to mount, and the SDK's own text still reads *"Cannot connect to the
Docker daemon"*, which is honest — it is the engine that failed talking.

**Both surfaces had tests asserting the old names.** That is how the rename was
checked rather than assumed:

```text
internal/command/statusdto_test.go:132: doc.DockerError undefined
internal/doctor/doctor_test.go:727: no "docker daemon" result in [platform host topology
  container engine isolated bridge cgroups state directory capacity physical capacity]
```

## Evidence

```text
$ go test ./test/architecture/ -run TestTheEngineSDKStaysInsideItsAdapter
ok   (and FAIL against an injected import of each SDK family, in an export)

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean

$ grep -rn 'docker_error|DockerError|"docker daemon"' .
(none)
```

Hermetic only. Nothing here changes behaviour; the two renames change two
strings the tests already pinned.

## What would notice this regressing

`TestTheEngineSDKStaysInsideItsAdapter` fails on any package outside the adapter
importing a container-engine SDK, by direct import rather than by the closure,
so it names the edge somebody added.

The two renamed surfaces keep the tests that caught the rename:
`statusdto_test.go` asserts an unreachable daemon is reported in the field, and
`doctor_test.go` asserts the check runs by name.

## Risk, compatibility and operations

`status --json` is a versioned surface and this renames one optional field in
it. Nothing has been released, so nothing consumes it yet — which is the whole
argument for doing it now rather than after. The `api_version` stays `v1`
because there is no released `v1` to break.

The preflight's check name appears in `runpool doctor` output and in its JSON.
That surface is not versioned in the product contract, and the generated CLI
reference does not name individual checks, so nothing else moved.

No configuration, schema, migration or deployment surface is touched.

## Changelog

```text
- The status document reports `engine_error` and the preflight names a
  `container engine`, rather than naming the one engine there is. What either
  says about Docker it says in the message, where it is true.
```

## Notes for your reviewer

This is the first step of the container-engine port, and deliberately the part
that has to come first: the rule enters while the tree already satisfies it, so
it protects the steps that follow rather than arriving after them; and the
renames happen while they are still free.

Nothing moves package yet. `internal/platform/docker` keeps its path, and the
seam's own types still leave it under a `docker.` name — that is the next step,
and it is a rename with no behaviour in it.
