### PR TITLE
refactor(docker): ownership is one value, and the labels it writes are pinned

### DIFF
--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -192,7 +192,7 @@ func (m *diskMonitor) measure(ctx context.Context) (disk.Facts, error) {
 	}
 	var managed int64
 	for _, u := range usage {
-		if u.Labels[docker.LabelRole] == cache.RoleCacheLane && u.Size > 0 {
+		if u.Role == cache.RoleCacheLane && u.Size > 0 {
 			managed += u.Size
 		}
 	}

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -24,10 +24,10 @@ func TestMeasureWeighsOnlyThisInstancesLanes(t *testing.T) {
 	h := newHarness(t, 1)
 	h.probe.free = docker.FilesystemFree{FreeBytes: 500, FreeInodes: 90}
 	h.probe.usage = []docker.VolumeUsage{
-		{Name: "lane-a", Size: 100, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
-		{Name: "lane-b", Size: 40, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
-		{Name: "workspace", Size: 9000, Labels: map[string]string{docker.LabelRole: "workspace"}},
-		{Name: "unmeasured", Size: -1, Labels: map[string]string{docker.LabelRole: cache.RoleCacheLane}},
+		{Name: "lane-a", Size: 100, Role: cache.RoleCacheLane},
+		{Name: "lane-b", Size: 40, Role: cache.RoleCacheLane},
+		{Name: "workspace", Size: 9000, Role: "workspace"},
+		{Name: "unmeasured", Size: -1, Role: cache.RoleCacheLane},
 	}
 
 	facts, err := h.srv.disk.measure(t.Context())

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -155,12 +155,8 @@ func (n *networkSandbox) build(ctx context.Context, budget time.Duration) (*caps
 	defer cancel()
 
 	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, docker.NetworkSpec{
-		Name: "runpool-uplink-" + string(n.instanceID)[:8],
-		Labels: map[string]string{
-			docker.LabelManaged:  "true",
-			docker.LabelInstance: string(n.instanceID),
-			docker.LabelRole:     capsule.RoleUplink,
-		},
+		Name:   "runpool-uplink-" + string(n.instanceID)[:8],
+		Labels: docker.Ownership{Instance: n.instanceID, Role: capsule.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uplink network: %w", err)
@@ -623,11 +619,7 @@ func (n *networkSandbox) discoverHostCIDRs(ctx context.Context) ([]string, error
 		Entrypoint:  []string{"/bin/sh", "-c"},
 		Cmd:         []string{"ip -o -4 addr show scope global"},
 		NetworkMode: "host",
-		Labels: map[string]string{
-			docker.LabelManaged:  "true",
-			docker.LabelInstance: string(n.instanceID),
-			docker.LabelRole:     "probe",
-		},
+		Labels:      docker.Ownership{Instance: n.instanceID, Role: "probe"}.Labels(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -97,14 +97,13 @@ func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation 
 	}
 
 	name := VolumeName(lane.ID)
-	labels := map[string]string{
-		docker.LabelManaged:  "true",
-		docker.LabelInstance: string(m.instanceID),
-		docker.LabelRole:     labelRoleValue,
-		LabelProject:         lane.ProjectID,
-		LabelGen:             lane.Generation,
-		LabelLane:            lane.ID,
-	}
+	// The lane's own three go on top of the ownership every managed
+	// object carries: what a lane is warm for is the cache's vocabulary,
+	// not the daemon's.
+	labels := docker.Ownership{Instance: m.instanceID, Role: labelRoleValue}.Labels()
+	labels[LabelProject] = lane.ProjectID
+	labels[LabelGen] = lane.Generation
+	labels[LabelLane] = lane.ID
 	if err := m.volumes.EnsureOwnedVolume(ctx, name, labels); err != nil {
 		// The lane lease must not outlive a volume that cannot be used:
 		// give it back so the job runs uncached and the next acquire can

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -62,7 +62,16 @@ func (f *fakeVolumes) OwnedVolumeUsage(context.Context, assignment.InstanceID) (
 				size = s
 			}
 		}
-		out = append(out, docker.VolumeUsage{Name: name, Labels: labels, Size: size})
+		// Role is lifted out of the labels here because that is what the
+		// adapter does: a fake that reports a volume without the role it
+		// was stamped with is a fake the caller cannot tell apart from a
+		// volume nobody owns.
+		out = append(out, docker.VolumeUsage{
+			Name:   name,
+			Role:   labels["io.runpool.role"],
+			Labels: labels,
+			Size:   size,
+		})
 	}
 	return out, nil
 }
@@ -187,7 +196,7 @@ func TestVolumeNamesAreOpaque(t *testing.T) {
 	if strings.Contains(labels[LabelProject], "acme") {
 		t.Errorf("repository text reached the labels: %q", labels[LabelProject])
 	}
-	if labels[docker.LabelManaged] != "true" || labels[docker.LabelRole] != RoleCacheLane {
+	if labels["io.runpool.managed"] != "true" || labels["io.runpool.role"] != RoleCacheLane {
 		t.Errorf("ownership labels wrong: %v", labels)
 	}
 }

--- a/internal/cache/gc.go
+++ b/internal/cache/gc.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/rhobuild/runpool/internal/platform/docker"
 	"github.com/rhobuild/runpool/internal/store"
 )
 
@@ -78,7 +77,7 @@ func (m *LaneManager) PlanGC(ctx context.Context, opts GCOptions) (GCPlan, error
 	sizes := map[string]int64{} // lane id -> bytes
 	orphaned := map[string]int64{}
 	for _, u := range usage {
-		if u.Labels[docker.LabelRole] != RoleCacheLane {
+		if u.Role != RoleCacheLane {
 			continue
 		}
 		size := u.Size
@@ -111,7 +110,7 @@ func (m *LaneManager) PlanGC(ctx context.Context, opts GCOptions) (GCPlan, error
 		}
 	}
 	for _, u := range usage {
-		if u.Labels[docker.LabelRole] != RoleCacheLane {
+		if u.Role != RoleCacheLane {
 			continue
 		}
 		lane := u.Labels[LabelLane]

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -260,16 +260,15 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	short := docker.ShortID(string(spec.LeaseID))
 	name := func(role string) string { return "runpool-" + role + "-" + short }
 	labels := func(kind, role string) map[string]string {
-		return map[string]string{
-			docker.LabelManaged:  "true",
-			docker.LabelInstance: string(spec.InstanceID),
-			docker.LabelKind:     kind,
-			docker.LabelLease:    string(spec.LeaseID),
-			docker.LabelRole:     role,
-			docker.LabelAttempt:  string(spec.AttemptID),
-			docker.LabelTarget:   string(spec.TargetID),
-			docker.LabelTier:     string(spec.TierID),
-		}
+		return docker.Ownership{
+			Instance: spec.InstanceID,
+			Lease:    spec.LeaseID,
+			Kind:     kind,
+			Role:     role,
+			Attempt:  string(spec.AttemptID),
+			Target:   string(spec.TargetID),
+			Tier:     string(spec.TierID),
+		}.Labels()
 	}
 	resolve := func(kind, objName string) func() (string, error) {
 		return func() (string, error) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -236,12 +236,14 @@ func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
 		Name:     probe,
 		Internal: true,
 		Isolated: true,
-		Labels: map[string]string{
-			docker.LabelManaged:  "true",
-			docker.LabelInstance: "doctor",
-			docker.LabelKind:     "network",
-			docker.LabelRole:     "preflight-probe",
-		},
+		Labels: docker.Ownership{
+			// Not an instance: the preflight runs before one serves, and
+			// the sentinel is what keeps its probe out of any instance's
+			// sweep.
+			Instance: "doctor",
+			Kind:     "network",
+			Role:     "preflight-probe",
+		}.Labels(),
 	})
 	if err != nil {
 		cleanupErr := removeProbeNetwork(ctx, d, probe)

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -330,8 +330,8 @@ func TestIsolatedBridgeProbeLifecycle(t *testing.T) {
 		if !probe.created.Internal || !probe.created.Isolated {
 			t.Fatalf("probe network = %+v; want internal and isolated", probe.created)
 		}
-		if probe.created.Labels[docker.LabelRole] != "preflight-probe" {
-			t.Fatalf("probe role = %q; want preflight-probe", probe.created.Labels[docker.LabelRole])
+		if probe.created.Labels["io.runpool.role"] != "preflight-probe" {
+			t.Fatalf("probe role = %q; want preflight-probe", probe.created.Labels["io.runpool.role"])
 		}
 		if probe.removed != "probe-id" {
 			t.Fatalf("removed %q; want the created network id", probe.removed)

--- a/internal/platform/docker/diskusage.go
+++ b/internal/platform/docker/diskusage.go
@@ -16,7 +16,12 @@ import (
 // VolumeUsage is one owned volume's measured size, as the daemon
 // reports it through the disk-usage endpoint.
 type VolumeUsage struct {
-	Name   string
+	Name string
+	// Role is the ownership role the volume carries, lifted out of the
+	// labels so a caller can ask what a volume is for without knowing
+	// how ownership is written down. Labels stays for the vocabulary
+	// that is the caller's own, such as which lane a cache volume is.
+	Role   string
 	Labels map[string]string
 	// Size in bytes; -1 when the daemon could not compute it.
 	Size int64
@@ -33,14 +38,19 @@ func (c *Client) OwnedVolumeUsage(ctx context.Context, instanceID assignment.Ins
 	}
 	var out []VolumeUsage
 	for _, v := range du.Volumes.Items {
-		if v.Labels[LabelManaged] != "true" || v.Labels[LabelInstance] != string(instanceID) {
+		if v.Labels[labelManaged] != "true" || v.Labels[labelInstance] != string(instanceID) {
 			continue
 		}
 		size := int64(-1)
 		if v.UsageData != nil {
 			size = v.UsageData.Size
 		}
-		out = append(out, VolumeUsage{Name: v.Name, Labels: v.Labels, Size: size})
+		out = append(out, VolumeUsage{
+			Name:   v.Name,
+			Role:   v.Labels[labelRole],
+			Labels: v.Labels,
+			Size:   size,
+		})
 	}
 	return out, nil
 }
@@ -74,12 +84,11 @@ func (c *Client) ProbeFilesystemFree(ctx context.Context, image string, instance
 		// is the supervisor.
 		Entrypoint: []string{"/bin/sh", "-c"},
 		Cmd:        []string{"df -Pk / && df -Pi /"},
-		Labels: map[string]string{
-			LabelManaged:  "true",
-			LabelInstance: string(instanceID),
-			LabelKind:     "container",
-			LabelRole:     "probe",
-		},
+		Labels: Ownership{
+			Instance: instanceID,
+			Kind:     "container",
+			Role:     "probe",
+		}.Labels(),
 	})
 	if err != nil {
 		return FilesystemFree{}, err

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -26,15 +26,61 @@ import (
 // reconcilable through the Docker API alone, so a crashed controller's
 // objects can always be found without trusting its own books.
 const (
-	LabelManaged  = "io.runpool.managed"
-	LabelInstance = "io.runpool.instance"
-	LabelKind     = "io.runpool.kind"
-	LabelLease    = "io.runpool.lease"
-	LabelRole     = "io.runpool.role"
-	LabelAttempt  = "io.runpool.attempt"
-	LabelTarget   = "io.runpool.target"
-	LabelTier     = "io.runpool.tier"
+	labelManaged  = "io.runpool.managed"
+	labelInstance = "io.runpool.instance"
+	labelKind     = "io.runpool.kind"
+	labelLease    = "io.runpool.lease"
+	labelRole     = "io.runpool.role"
+	labelAttempt  = "io.runpool.attempt"
+	labelTarget   = "io.runpool.target"
+	labelTier     = "io.runpool.tier"
 )
+
+// Ownership is what a Runpool instance stamps on everything it creates,
+// and the only thing that proves an object is its to remove. A name is
+// not proof: a foreign object can carry the name a plan expects, and
+// adopting it by name is how a sweep deletes somebody else's work.
+//
+// It is one value rather than a map each caller builds, because the
+// shape is fixed and the six places that built it by hand could each
+// forget a key. What varies is which fields a kind of object has:
+// instance infrastructure carries no lease, and a probe carries neither
+// attempt nor tier. An unset field is left off rather than written
+// empty, so an object states what is true of it and nothing else.
+type Ownership struct {
+	Instance assignment.InstanceID
+	Lease    assignment.LeaseID
+	Kind     string
+	Role     string
+	Attempt  string
+	Target   string
+	Tier     string
+}
+
+// Labels renders the ownership as the labels an object carries. The
+// values are a compatibility surface between releases: a controller
+// sweeps the objects an older one stamped, so a key or a value that
+// changes is a sweep that stops finding them. internal/platform/docker's
+// own test pins them exactly.
+func (o Ownership) Labels() map[string]string {
+	labels := map[string]string{
+		labelManaged:  "true",
+		labelInstance: string(o.Instance),
+	}
+	for key, value := range map[string]string{
+		labelKind:    o.Kind,
+		labelLease:   string(o.Lease),
+		labelRole:    o.Role,
+		labelAttempt: o.Attempt,
+		labelTarget:  o.Target,
+		labelTier:    o.Tier,
+	} {
+		if value != "" {
+			labels[key] = value
+		}
+	}
+	return labels
+}
 
 type Client struct {
 	cli *client.Client
@@ -355,7 +401,7 @@ func (c *Client) resolveOwnedID(ctx context.Context, kind, reference string, ins
 	default:
 		return "", fmt.Errorf("unknown resource kind %q", kind)
 	}
-	if labels[LabelManaged] != "true" || labels[LabelInstance] != string(instanceID) || labels[LabelLease] != string(leaseID) {
+	if labels[labelManaged] != "true" || labels[labelInstance] != string(instanceID) || labels[labelLease] != string(leaseID) {
 		return "", fmt.Errorf("%w: %s %q", ErrForeignResource, kind, reference)
 	}
 	return id, nil
@@ -474,11 +520,11 @@ func (c *Client) ListOwnedContainers(ctx context.Context, instanceID assignment.
 		out = append(out, OwnedContainer{
 			ID:   s.ID,
 			Name: name,
-			Kind: s.Labels[LabelKind],
-			Role: s.Labels[LabelRole],
+			Kind: s.Labels[labelKind],
+			Role: s.Labels[labelRole],
 			// The one conversion: a label is a string until it is read,
 			// and this is where it is read.
-			LeaseID: assignment.LeaseID(s.Labels[LabelLease]),
+			LeaseID: assignment.LeaseID(s.Labels[labelLease]),
 			Running: s.State == container.StateRunning,
 		})
 	}
@@ -487,6 +533,6 @@ func (c *Client) ListOwnedContainers(ctx context.Context, instanceID assignment.
 
 func ownedFilter(instanceID assignment.InstanceID) client.Filters {
 	return client.Filters{}.
-		Add("label", LabelManaged+"=true").
-		Add("label", LabelInstance+"="+string(instanceID))
+		Add("label", labelManaged+"=true").
+		Add("label", labelInstance+"="+string(instanceID))
 }

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -159,7 +159,7 @@ func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID assignment.In
 	}
 	out := make([]OwnedResource, 0, len(nets.Items))
 	for _, n := range nets.Items {
-		out = append(out, OwnedResource{ID: n.ID, LeaseID: assignment.LeaseID(n.Labels[LabelLease]), Role: n.Labels[LabelRole]})
+		out = append(out, OwnedResource{ID: n.ID, LeaseID: assignment.LeaseID(n.Labels[labelLease]), Role: n.Labels[labelRole]})
 	}
 	return out, nil
 }

--- a/internal/platform/docker/ownership_test.go
+++ b/internal/platform/docker/ownership_test.go
@@ -1,0 +1,60 @@
+package docker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestTheLabelsAreExactlyThese: the values are a compatibility surface
+// between releases, and nothing else pins them.
+//
+// A controller sweeps the objects an older controller stamped. It finds
+// them by label, so a key that is renamed or a value that is spelled
+// differently is a sweep that stops finding a whole release's objects —
+// which is a capacity leak and an operator deleting containers by hand.
+// Nothing about that fails at compile time, and no live suite catches it
+// either: both sides of a contract run would use the new spelling and
+// agree.
+//
+// So the exact document is written out here. Changing it is a decision,
+// and this is where it has to be taken.
+func TestTheLabelsAreExactlyThese(t *testing.T) {
+	full := Ownership{
+		Instance: "instance-1",
+		Lease:    "lease-1",
+		Kind:     "container",
+		Role:     "capsule",
+		Attempt:  "attempt-1",
+		Target:   "target-1",
+		Tier:     "tier-1",
+	}
+	const want = `{"io.runpool.attempt":"attempt-1","io.runpool.instance":"instance-1",` +
+		`"io.runpool.kind":"container","io.runpool.lease":"lease-1","io.runpool.managed":"true",` +
+		`"io.runpool.role":"capsule","io.runpool.target":"target-1","io.runpool.tier":"tier-1"}`
+	if got := marshal(t, full.Labels()); got != want {
+		t.Errorf("the labels are\n  %s\nand a release that swept the previous one's objects expects\n  %s",
+			got, want)
+	}
+
+	// Instance infrastructure carries no lease, and that absence is what
+	// InstanceInfrastructure reads to leave it alone. An unset field
+	// written as an empty label would still be absent to a reader, but
+	// it would put a key on the object that says nothing.
+	uplink := Ownership{Instance: "instance-1", Role: "uplink"}
+	const wantUplink = `{"io.runpool.instance":"instance-1","io.runpool.managed":"true",` +
+		`"io.runpool.role":"uplink"}`
+	if got := marshal(t, uplink.Labels()); got != wantUplink {
+		t.Errorf("infrastructure labels are\n  %s\nwant\n  %s", got, wantUplink)
+	}
+}
+
+// marshal renders the labels in key order, which is what makes the
+// comparison exact rather than approximately equal.
+func marshal(t *testing.T, labels map[string]string) string {
+	t.Helper()
+	encoded, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(encoded)
+}

--- a/internal/platform/docker/volume.go
+++ b/internal/platform/docker/volume.go
@@ -58,7 +58,7 @@ func (c *Client) ListOwnedVolumes(ctx context.Context, instanceID assignment.Ins
 	}
 	out := make([]OwnedResource, 0, len(resp.Items))
 	for _, v := range resp.Items {
-		out = append(out, OwnedResource{ID: v.Name, LeaseID: assignment.LeaseID(v.Labels[LabelLease]), Role: v.Labels[LabelRole]})
+		out = append(out, OwnedResource{ID: v.Name, LeaseID: assignment.LeaseID(v.Labels[labelLease]), Role: v.Labels[labelRole]})
 	}
 	return out, nil
 }

--- a/test/contract/capsule/budget_test.go
+++ b/test/contract/capsule/budget_test.go
@@ -39,7 +39,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 
 	uplinkID, err := dock.CreateNetwork(ctx, docker.NetworkSpec{
 		Name:   leaseID + "-uplink",
-		Labels: map[string]string{docker.LabelManaged: "true", docker.LabelInstance: "contract", docker.LabelRole: capsule.RoleUplink},
+		Labels: docker.Ownership{Instance: "contract", Role: capsule.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/test/contract/capsule/bypass_test.go
+++ b/test/contract/capsule/bypass_test.go
@@ -42,7 +42,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	// The uplink stands in for the instance's shared egress network.
 	uplinkID, err := dock.CreateNetwork(ctx, docker.NetworkSpec{
 		Name:   string(string(leaseID) + "-uplink"),
-		Labels: map[string]string{docker.LabelManaged: "true", docker.LabelInstance: "contract", docker.LabelRole: capsule.RoleUplink},
+		Labels: docker.Ownership{Instance: "contract", Role: capsule.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		t.Fatalf("uplink: %v", err)

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -65,11 +65,11 @@ func client(t *testing.T) (*docker.Client, string) {
 
 func labels(instance, lease, kind, role string) map[string]string {
 	return map[string]string{
-		docker.LabelManaged:  "true",
-		docker.LabelInstance: instance,
-		docker.LabelLease:    lease,
-		docker.LabelKind:     kind,
-		docker.LabelRole:     role,
+		"io.runpool.managed":  "true",
+		"io.runpool.instance": instance,
+		"io.runpool.lease":    lease,
+		"io.runpool.kind":     kind,
+		"io.runpool.role":     role,
 	}
 }
 
@@ -629,9 +629,9 @@ func TestEnsureOwnedVolume(t *testing.T) {
 	ctx := t.Context()
 
 	own := map[string]string{
-		docker.LabelManaged:  "true",
-		docker.LabelInstance: instance,
-		docker.LabelRole:     cache.RoleCacheLane,
+		"io.runpool.managed":  "true",
+		"io.runpool.instance": instance,
+		"io.runpool.role":     cache.RoleCacheLane,
 	}
 	name := instance + "-ensure"
 	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
@@ -803,7 +803,7 @@ func TestOwnedVolumeUsage(t *testing.T) {
 	if found.Size < 512*1024 {
 		t.Errorf("size = %d; want at least the 512KiB written", found.Size)
 	}
-	if found.Labels[docker.LabelRole] != cache.RoleCacheLane {
+	if found.Role != cache.RoleCacheLane {
 		t.Errorf("labels did not travel through disk usage: %v", found.Labels)
 	}
 }
@@ -910,8 +910,8 @@ func TestContainerRemovalSparesNamedVolumes(t *testing.T) {
 
 	named := instance + "-keep"
 	if _, err := c.CreateVolume(ctx, named, map[string]string{
-		docker.LabelManaged:  "true",
-		docker.LabelInstance: instance,
+		"io.runpool.managed":  "true",
+		"io.runpool.instance": instance,
 	}); err != nil {
 		t.Fatalf("create named volume: %v", err)
 	}
@@ -922,8 +922,8 @@ func TestContainerRemovalSparesNamedVolumes(t *testing.T) {
 		Image: busybox,
 		Cmd:   []string{"true"},
 		Labels: map[string]string{
-			docker.LabelManaged:  "true",
-			docker.LabelInstance: instance,
+			"io.runpool.managed":  "true",
+			"io.runpool.instance": instance,
 		},
 		Mounts: []docker.Mount{
 			{Volume: named, Target: "/data"},


### PR DESCRIPTION
## What changes

The eight ownership label constants become one `Ownership` value with a
`Labels()` method, and leave the package's exported surface. `VolumeUsage`
carries the role as a field. A test pins the exact label document.

No label changes. That is the point.

## What was found

**Six places built the same fixed-shape map by hand.** `internal/capsule`,
`internal/cache`, two in `internal/app/sandbox`, `internal/doctor` and the
adapter's own disk probe, each writing `docker.LabelManaged: "true"` and its
neighbours. What differs between them is which fields a kind of object has —
instance infrastructure carries no lease, a probe carries neither attempt nor
tier — and that is a value with optional fields, not six literals that each
have to remember eight keys.

**One constant had to stay exported, and it was the wrong reason.**
`internal/app/monitor` and `internal/cache/gc` read the role out of a volume's
labels, so `LabelRole` could not be unexported. `VolumeUsage` carries `Role` as
a field now, both callers ask what a volume is for without knowing how ownership
is written down, and `internal/cache/gc` stops importing the adapter at all.

**Nothing pinned the values, and nothing could have caught them changing.** A
controller finds an older controller's objects by label. A renamed key or a
value spelled differently is a sweep that stops finding a whole release's
objects — a capacity leak, and an operator deleting containers by hand. It fails
at no compile step, and no live contract catches it either: both sides of a
contract run would use the new spelling and agree with each other.

The exact document is written out now, and three ways it can drift were watched
failing:

```text
a renamed key                       -> both cases fail
managed written "1" instead of true -> both cases fail
an unset field stamped anyway       -> the infrastructure case fails
```

**A fake was not reporting what the adapter reports.** `internal/cache`'s fake
volume store returned `VolumeUsage` without the role it had recorded, so once
the readers moved to the field, three GC tests went red — correctly. The fake
lifts the role out of the labels the way the adapter does; a fake that reports a
volume the caller cannot tell from an unowned one is the wrong fake.

## Evidence

```text
$ go test -race -shuffle=on -count=1 ./...
clean

$ go test ./internal/platform/docker/ -run TestTheLabelsAreExactlyThese
ok, and FAIL under each of the three mutations above, in an export

$ grep -rn 'docker.Label[MIKLRAT]' .
(none outside the adapter)

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go tool actionlint
clean
```

The live suites exercise the write sites against a real daemon;
`integration-docker` runs on this pull request because it touches paths in the
filter.

## What would notice this regressing

`TestTheLabelsAreExactlyThese` fails on any change to a key, to the `managed`
value, or to whether an unset field is written. It is a decision to change them
and that test is where the decision has to be taken.

`TestOwnershipQueries` and the ownership half of the Docker contract suite
exercise the labels against a real daemon, which is what proves the stamp and
the filter still agree.

## Risk, compatibility and operations

The labels an object carries are byte-for-byte what they were — verified by the
new test, which was written against the current values rather than derived from
the new code. Objects stamped by any earlier build are found by this one and the
other way round.

`VolumeUsage` gains a field and keeps `Labels`, because the cache's own
vocabulary — which lane, which generation, which project — is still read from
there. No configuration, status API, schema, migration or deployment surface is
touched.

## Changelog

```text
NONE
```

## Notes for your reviewer

This is step two of the container-engine port and the one with the most reach
per line. The label constants were the largest part of the adapter's exported
surface that domain packages depended on; what remains to move is the seam's
types, which is a rename with no behaviour in it.

The doctor's probe stamps `Instance: "doctor"` — a sentinel rather than an
instance id, which is what keeps a preflight probe out of any instance's sweep.
It was that before and still is; the comment now says so where the value is
written.
