### PR TITLE
fix(capsule): only a taken name is resolved, and the daemon's answers have names

### DIFF
--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -177,25 +177,38 @@ func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind, role,
 	if err := rec.Creating(intentID); err != nil {
 		return "", err
 	}
-	dockerID, err := createFn()
+	objectID, err := createFn()
 	if err != nil {
-		existing, rerr := resolve()
-		if rerr != nil || existing == "" {
-			if rerr == nil {
-				rerr = err
-			}
-			return "", fmt.Errorf("create %s %s: %w", kind, role, rerr)
+		// Only a taken name is worth resolving, and only then is
+		// adoption an answer rather than a guess. A create that failed
+		// for any other reason -- the daemon gone, the image refused --
+		// says nothing about whether an object exists, and looking one
+		// up anyway reported the failure of the lookup under the name of
+		// the create. The object is not lost either way: the intent is
+		// already durable and in its creating state, so recovery
+		// resolves it by name.
+		if !errors.Is(err, docker.ErrAlreadyExists) {
+			return "", fmt.Errorf("create %s %s: %w", kind, role, err)
 		}
-		dockerID = existing
+		existing, rerr := resolve()
+		if rerr != nil {
+			return "", fmt.Errorf("resolving the %s %s that already exists: %w", kind, role, rerr)
+		}
+		if existing == "" {
+			// The name was taken when the create ran and free when the
+			// lookup ran, so nothing is there to adopt.
+			return "", fmt.Errorf("create %s %s: %w", kind, role, err)
+		}
+		objectID = existing
 	}
-	if err := rec.Confirm(intentID, dockerID); err != nil {
+	if err := rec.Confirm(intentID, objectID); err != nil {
 		// The object exists and the intent still names it in its
 		// creating state: recovery resolves it by name. Nothing is
 		// removed here, because losing the object is worse than
 		// re-finding it.
 		return "", fmt.Errorf("confirming %s %s: %w", kind, role, err)
 	}
-	return dockerID, nil
+	return objectID, nil
 }
 
 // Launcher builds capsules. It holds no per-capsule state: everything a

--- a/internal/capsule/create_test.go
+++ b/internal/capsule/create_test.go
@@ -1,0 +1,125 @@
+package capsule
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// recorder is the intent saga, remembering what it was told. Every
+// object is planned before it exists and confirmed after, so a crash
+// anywhere leaves an intent whose name either finds the object or
+// proves its absence.
+type recorder struct {
+	planned   []string
+	creating  int
+	confirmed map[assignment.ResourceIntentID]string
+}
+
+func (r *recorder) Plan(kind, role, name string) (assignment.ResourceIntentID, error) {
+	r.planned = append(r.planned, kind+"/"+role+"/"+name)
+	return assignment.ResourceIntentID(len(r.planned)), nil
+}
+
+func (r *recorder) Creating(assignment.ResourceIntentID) error { r.creating++; return nil }
+
+func (r *recorder) Confirm(id assignment.ResourceIntentID, objectID string) error {
+	if r.confirmed == nil {
+		r.confirmed = map[assignment.ResourceIntentID]string{}
+	}
+	r.confirmed[id] = objectID
+	return nil
+}
+
+// TestOnlyATakenNameIsResolved: a create that failed for any other
+// reason says nothing about whether an object exists.
+//
+// Looking one up anyway had two costs. The failure it reported was the
+// lookup's, under the name of the create — so a daemon that had gone
+// away was reported as "create network …: <an inspect error>". And an
+// object adopted after an unknown failure is adopted on a guess, which
+// is the one thing this saga exists not to do: nothing is lost by
+// refusing, because the intent is already durable and in its creating
+// state, and recovery resolves it by name.
+func TestOnlyATakenNameIsResolved(t *testing.T) {
+	taken := fmt.Errorf("create: %w", docker.ErrAlreadyExists)
+	gone := errors.New("Cannot connect to the Docker daemon")
+
+	for name, testCase := range map[string]struct {
+		createErr error
+		existing  string
+		resolved  bool
+		want      string
+	}{
+		"a taken name is resolved and adopted": {
+			createErr: taken, existing: "object-1", resolved: true,
+		},
+		"a taken name with nothing behind it fails": {
+			createErr: taken, resolved: true, want: "already exists",
+		},
+		"an unreachable daemon is not resolved": {
+			createErr: gone, resolved: false, want: "Cannot connect",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := &recorder{}
+			asked := false
+			id, err := (&Launcher{}).create(t.Context(), rec, "network", "capsule-net", "runpool-net-1",
+				func() (string, error) { return "", testCase.createErr },
+				func() (string, error) { asked = true; return testCase.existing, nil })
+
+			if asked != testCase.resolved {
+				t.Errorf("the name was looked up = %v; want %v", asked, testCase.resolved)
+			}
+			if testCase.want == "" {
+				if err != nil {
+					t.Fatalf("adopting the existing object failed: %v", err)
+				}
+				if id != testCase.existing {
+					t.Errorf("adopted %q; the object that exists is %q", id, testCase.existing)
+				}
+				if rec.confirmed[1] != testCase.existing {
+					t.Error("the intent was not confirmed with the object that was adopted")
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("a create that failed returned %q", id)
+			}
+			if !strings.Contains(err.Error(), testCase.want) {
+				t.Errorf("failed with %q; the reason has to carry %q", err, testCase.want)
+			}
+		})
+	}
+}
+
+// TestTheIntentIsDurableBeforeTheObjectExists: planned, then creating,
+// then the effect. A crash between any two of those leaves an intent
+// whose deterministic name either finds the object or proves it absent,
+// which is what makes a leaked object impossible rather than unlikely.
+func TestTheIntentIsDurableBeforeTheObjectExists(t *testing.T) {
+	rec := &recorder{}
+	created := false
+	if _, err := (&Launcher{}).create(t.Context(), rec, "volume", "dind-data", "runpool-dind-1",
+		func() (string, error) {
+			if len(rec.planned) != 1 || rec.creating != 1 {
+				t.Error("the object was created before its intent was durable")
+			}
+			created = true
+			return "volume-1", nil
+		},
+		func() (string, error) { t.Error("a successful create was looked up"); return "", nil },
+	); err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("nothing was created")
+	}
+	if rec.confirmed[1] != "volume-1" {
+		t.Error("the intent was not confirmed with what was created")
+	}
+}

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -2,11 +2,12 @@ package capsule
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"strings"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/platform/docker"
 )
 
@@ -17,7 +18,7 @@ func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntim
 	state, err := m.dock.ContainerStatus(ctx, string(prepared.RuntimeID))
 	switch {
 	case err == nil:
-	case docker.IsNotFound(err):
+	case errors.Is(err, docker.ErrNotFound):
 		return assignment.ObservedAbsent, nil
 	default:
 		return assignment.ObservedUnavailable, err

--- a/internal/platform/docker/docker.go
+++ b/internal/platform/docker/docker.go
@@ -233,7 +233,7 @@ func (c *Client) CreateContainer(ctx context.Context, spec ContainerSpec) (strin
 		id, err = create()
 	}
 	if err != nil {
-		return "", fmt.Errorf("create container %s: %w", spec.Name, err)
+		return "", fmt.Errorf("create container %s: %w", spec.Name, classify(err))
 	}
 	return id, nil
 }
@@ -344,10 +344,44 @@ func ignoreNotFound(err error) error {
 	return err
 }
 
-// IsNotFound reports whether err means the daemon has no such object.
-// Callers that must distinguish absence from unreachability — execution
-// inspection, most of all — depend on this being a typed check.
-func IsNotFound(err error) bool { return cerrdefs.IsNotFound(err) }
+// The daemon's answers, in Runpool's vocabulary. A caller that has to
+// act differently on one of these gets a sentinel to test for; a caller
+// that only reports the failure gets the daemon's own text, which says
+// more than a category would.
+//
+// There are three because three call sites branch. A category nothing
+// branches on is a category that will be wrong the first time somebody
+// relies on it, since nothing exercises the mapping.
+var (
+	// ErrNotFound is absence, which is different from unreachability:
+	// an execution that cannot be found ended, and one that cannot be
+	// asked about is undecided.
+	ErrNotFound = errors.New("the daemon has no such object")
+	// ErrAlreadyExists is the name being taken. Recovery resolves it by
+	// proving ownership; anything else that fails a create is a failure
+	// to create.
+	ErrAlreadyExists = errors.New("an object of that name already exists")
+	// ErrUnavailable is the daemon not answering at all.
+	ErrUnavailable = errors.New("the daemon could not be reached")
+)
+
+// classify names what a daemon error means, keeping the daemon's own
+// text: the sentinel is for branching and the text is for reading. An
+// error it has no name for is returned as it came, because inventing a
+// category for it would be a claim this package cannot make.
+func classify(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case cerrdefs.IsNotFound(err):
+		return fmt.Errorf("%w: %w", ErrNotFound, err)
+	case cerrdefs.IsAlreadyExists(err), cerrdefs.IsConflict(err):
+		return fmt.Errorf("%w: %w", ErrAlreadyExists, err)
+	case cerrdefs.IsUnavailable(err), client.IsErrConnectionFailed(err):
+		return fmt.Errorf("%w: %w", ErrUnavailable, err)
+	}
+	return err
+}
 
 // ErrForeignResource reports an object that carries the expected name
 // but not this owner's labels. Adopting it would mean running work
@@ -464,7 +498,10 @@ type ContainerState struct {
 func (c *Client) ContainerStatus(ctx context.Context, id string) (ContainerState, error) {
 	inspected, err := c.cli.ContainerInspect(ctx, id, client.ContainerInspectOptions{})
 	if err != nil {
-		return ContainerState{}, err
+		// Classified because the answer decides an attempt's fate: a
+		// container that is gone ended, and one the daemon cannot be
+		// asked about is undecided and goes to a person.
+		return ContainerState{}, classify(err)
 	}
 	if inspected.Container.State == nil {
 		return ContainerState{}, fmt.Errorf("container %s reports no state", id)

--- a/internal/platform/docker/network.go
+++ b/internal/platform/docker/network.go
@@ -37,7 +37,7 @@ func (c *Client) CreateNetwork(ctx context.Context, spec NetworkSpec) (string, e
 	}
 	resp, err := c.cli.NetworkCreate(ctx, spec.Name, opts)
 	if err != nil {
-		return "", err
+		return "", classify(err)
 	}
 	return resp.ID, nil
 }

--- a/internal/platform/docker/volume.go
+++ b/internal/platform/docker/volume.go
@@ -15,7 +15,7 @@ import (
 func (c *Client) CreateVolume(ctx context.Context, name string, labels map[string]string) (string, error) {
 	created, err := c.cli.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name, Labels: labels})
 	if err != nil {
-		return "", err
+		return "", classify(err)
 	}
 	return created.Volume.Name, nil
 }

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -893,7 +893,7 @@ func mustRemoveContainer(t *testing.T, c *docker.Client, ctx context.Context, id
 	// Absence is verified, not assumed: a removal the daemon accepted
 	// but did not complete leaves a privileged leftover this suite
 	// exists to notice.
-	if _, err := c.ContainerStatus(cctx, id); !docker.IsNotFound(err) {
+	if _, err := c.ContainerStatus(cctx, id); !errors.Is(err, docker.ErrNotFound) {
 		t.Errorf("cleanup: container %s still exists after removal (status error: %v)", id, err)
 	}
 }


### PR DESCRIPTION
## What changes

Three error sentinels on the daemon adapter — absence, a name already taken, an
unreachable daemon — applied at the four calls whose callers branch. The capsule
launcher resolves a name only when the create says it is taken.
`internal/capsule` gets its first hermetic tests.

## What was found

**A failed create was always followed by a lookup, and the wrong failure was
reported.** `Launcher.create` called `resolve()` on any create error. When the
daemon is gone, both calls fail, and the message reads:

```text
create network capsule-net: <an inspect error>
```

— the create's name over the lookup's failure. Its own comment already described
the narrower contract: *"When the create call reports a name conflict, resolve
settles it."* The code was broader than the sentence.

**The deeper cost is not the message.** An object adopted after an *unknown*
failure is adopted on a guess. The product contract refuses exactly that
elsewhere — "where evidence cannot decide what happened, the attempt is held for
a person instead of being guessed at" — and the intent saga is built so it never
has to: the intent is durable and in its `creating` state before the effect is
attempted, so an object created by a call that then failed is found by recovery,
by its deterministic name, with ownership proven. Refusing to adopt inline loses
nothing and stops one guess.

**Three sentinels, and only three.** Absence, a taken name, unreachable — the
three that a call site branches on. `containerd/errdefs` offers eighteen
predicates; a category nothing branches on is a category that is wrong the first
time somebody relies on it, because nothing ever exercised the mapping. Each
sentinel wraps the daemon's own text rather than replacing it: the sentinel is
for branching, the text is for reading. An error with no name is passed through
as it came, because inventing a category for it would be a claim the adapter
cannot make.

**`internal/capsule` had no hermetic tests at all.** The contribution guide lists
it under "mechanics are covered live". But the create saga takes its effect and
its lookup as functions, so what it does with a failure can be asked without a
daemon. It now is: both branches, and that the intent is durable before anything
exists.

## Evidence

```text
$ go test ./internal/capsule/ -run TestOnlyATakenNameIsResolved -v
--- PASS: a taken name is resolved and adopted
--- PASS: a taken name with nothing behind it fails
--- PASS: an unreachable daemon is not resolved

mutation, in an export — restore the old "resolve on any error":
    create_test.go:76: the name was looked up = true; want false

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
```

The live Docker contract exercises the classified boundaries against a real
daemon; `integration-docker` runs on this pull request.

## What would notice this regressing

`TestOnlyATakenNameIsResolved` fails if the launcher looks up a name after a
failure that was not a conflict, or stops adopting one after a conflict.
`TestTheIntentIsDurableBeforeTheObjectExists` fails if the effect is attempted
before the intent is recorded.

The live suite's cleanup assertion tests absence through the sentinel now, so a
classification that stopped mapping not-found would fail there rather than
silently reporting a removed container as still present.

What nothing hermetic covers yet: the error switch in `InspectExecution`, where
an *unmapped* error must still fall through to `ObservedUnavailable` — an
attempt held for a person rather than settled. It reaches the daemon through the
concrete client, so it stays a live-only path until `internal/capsule` holds it
through an interface, which is the next step.

## Risk, compatibility and operations

One behavioural change, and it is the point: a create that fails for a reason
other than a taken name no longer adopts an object it finds. The case this
narrows is a create that failed ambiguously — a timeout after the daemon acted —
where the launch now fails instead of adopting. The object is not leaked: the
durable intent names it and recovery resolves it by name, with ownership proven,
which is the path a crash between the two calls already took.

`docker.IsNotFound` is replaced by `errors.Is(err, docker.ErrNotFound)`, which
is the same test through a sentinel rather than a function. No configuration,
status API, schema, migration or deployment surface is touched.

## Changelog

```text
NONE
```

## Notes for your reviewer

The classification is applied at four calls, not at every daemon call: container
inspection, and the three creates. Wrapping everywhere would have named
categories no caller reads, which is the thing this deliberately avoids —
`ErrPermissionDenied` in particular exists in the SDK and is not here, because
nothing acts differently on it and a sentinel that nothing tests is a mapping
nothing checks.
