### PR TITLE
refactor(capsule): the capsule holds its daemon through an interface it declares

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,14 @@ deliberately thin here and proved elsewhere.
 `internal/capsule` and the socket-facing half of `internal/gateway` are
 thin translations of an external API. A unit test there asserts the mock,
 so they are proved by the suites that run against a real daemon and a real
-provider instead:
+provider instead.
+
+The exception is what a live daemon cannot be asked for. It cannot be told
+to be unreachable, to answer with something nobody has a name for, or to
+refuse a name that is taken — and those answers decide whether an attempt
+is settled or held for a person. `internal/capsule` holds the daemon
+through an interface it declares itself, so those refusals can be asked
+for and are covered hermetically. What still needs a daemon:
 
 | Code | Proved by |
 | --- | --- |

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -211,11 +211,33 @@ func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind, role,
 	return objectID, nil
 }
 
+// capsuleDaemon is the daemon as a capsule needs it, declared here
+// rather than by the adapter: what this package may know is the eleven
+// operations a capsule is built from, and a seam is what lets the
+// refusals be asked for. A live daemon cannot be told to be absent, to
+// be unreachable, or to refuse a container that is already running, and
+// those are the answers that decide whether an attempt is settled or
+// held for a person.
+type capsuleDaemon interface {
+	CreateNetwork(context.Context, docker.NetworkSpec) (string, error)
+	CreateVolume(ctx context.Context, name string, labels map[string]string) (string, error)
+	CreateContainer(context.Context, docker.ContainerSpec) (string, error)
+	StartContainer(ctx context.Context, id string) error
+	ConnectNetwork(ctx context.Context, networkID, containerID string) error
+	NetworkSubnet(ctx context.Context, id string) (string, error)
+	ContainerIPOn(ctx context.Context, containerID, networkID string) (ip, subnet string, err error)
+	ContainerStatus(ctx context.Context, id string) (docker.ContainerState, error)
+	Exec(ctx context.Context, containerID string, cmd []string) (int, string, error)
+	ExecWithInput(ctx context.Context, containerID string, cmd []string, input []byte) (int, string, error)
+	OwnedIDByName(ctx context.Context, kind, name string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error)
+}
+
 // Launcher builds capsules. It holds no per-capsule state: everything a
 // launch needs arrives in its Spec, and everything it creates is
 // recorded through the caller's ResourceRecorder.
 type Launcher struct {
-	dock *docker.Client
+	dock capsuleDaemon
 	// gatewayImage is what every egress gateway runs, whatever a tier
 	// configured for its jobs. It belongs to the launcher rather than to
 	// a Spec because it is not a per-launch decision: the gateway is the
@@ -226,7 +248,7 @@ type Launcher struct {
 	gatewayImage string
 }
 
-func NewLauncher(d *docker.Client, gatewayImage string) *Launcher {
+func NewLauncher(d capsuleDaemon, gatewayImage string) *Launcher {
 	return &Launcher{dock: d, gatewayImage: gatewayImage}
 }
 

--- a/internal/capsule/daemon_test.go
+++ b/internal/capsule/daemon_test.go
@@ -1,0 +1,25 @@
+package capsule
+
+import (
+	"context"
+
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// fakeDaemon answers the one or two calls a test cares about. The
+// embedded interface is nil on purpose: a method this fake was not given
+// panics rather than returning a zero value, so a test that reaches
+// further than it declared says so instead of passing on a lie.
+type fakeDaemon struct {
+	capsuleDaemon
+	status func(id string) (docker.ContainerState, error)
+	exec   func(id string, cmd []string) (int, string, error)
+}
+
+func (f *fakeDaemon) ContainerStatus(_ context.Context, id string) (docker.ContainerState, error) {
+	return f.status(id)
+}
+
+func (f *fakeDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
+	return f.exec(id, cmd)
+}

--- a/internal/capsule/inspect_test.go
+++ b/internal/capsule/inspect_test.go
@@ -1,0 +1,63 @@
+package capsule
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// TestAnUndecidableExecutionIsHeldRatherThanSettled: absence ends an
+// attempt and unreachability does not, and everything the daemon has no
+// name for is unreachability.
+//
+// The distinction decides whether work is settled or held for a person,
+// and it is the one a classification can quietly narrow: give the daemon
+// three named answers and it is tempting to let the unnamed ones fall
+// somewhere convenient. They fall to undecided, which is the only answer
+// that cannot lose a job — and no live daemon can be asked to produce
+// them, which is why this reaches it through a seam.
+func TestAnUndecidableExecutionIsHeldRatherThanSettled(t *testing.T) {
+	prepared := PreparedRuntime{RuntimeID: assignment.RuntimeID("runtime-1")}
+
+	for name, testCase := range map[string]struct {
+		err     error
+		want    assignment.ExecutionObservation
+		reports bool
+	}{
+		"a container that is gone ended": {
+			err:  fmt.Errorf("inspect: %w", docker.ErrNotFound),
+			want: assignment.ObservedAbsent,
+		},
+		"a daemon that cannot be reached decides nothing": {
+			err:     fmt.Errorf("inspect: %w", docker.ErrUnavailable),
+			want:    assignment.ObservedUnavailable,
+			reports: true,
+		},
+		"an answer with no name decides nothing either": {
+			err:     errors.New("i/o timeout"),
+			want:    assignment.ObservedUnavailable,
+			reports: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			launcher := &Launcher{dock: &fakeDaemon{
+				status: func(string) (docker.ContainerState, error) {
+					return docker.ContainerState{}, testCase.err
+				},
+			}}
+			got, err := launcher.InspectExecution(t.Context(), prepared)
+			if got != testCase.want {
+				t.Errorf("observed %q; want %q", got, testCase.want)
+			}
+			if testCase.reports && err == nil {
+				t.Error("an undecided observation must carry the reason it is undecided")
+			}
+			if !testCase.reports && err != nil {
+				t.Errorf("a decided observation carried an error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

`capsule.Launcher` holds an eleven-method interface it declares itself instead
of the concrete adapter client. Three hermetic tests cover the observation the
daemon's errors decide. The contribution guide's coverage claim is corrected.

## What was found

**The answer that cannot be checked is the one that loses jobs.** An execution
the daemon cannot be asked about is undecided, and an undecided attempt is held
for a person rather than settled — that is the product contract. Everything the
daemon has no name for has to land there.

Naming three of the daemon's answers last week made that a live question: give
the daemon named categories and the unnamed ones start falling somewhere
convenient. Nothing could have caught it. `InspectExecution` reaches the daemon
through the concrete client, and no live daemon can be told to be unreachable,
or to answer with something nobody has a name for.

It reaches an interface now, and the three cases are asked for directly:

```text
a container that is gone ended              -> absent
a daemon that cannot be reached decides nothing -> unavailable, with the reason
an answer with no name decides nothing either   -> unavailable, with the reason

mutation, in an export — default narrowed to absence:
  observed "absent"; want "unavailable"   (twice)
```

That second failure is an attempt settled as ended when nothing knows it ended.

**The interface is declared by the consumer, not the adapter.** What this
package may know is the eleven operations a capsule is built from — create a
network, a volume, a container; start it; attach it; ask its address, its subnet
and its state; exec, exec with input; resolve an owned name. The adapter's
concrete client satisfies it structurally and nothing about it changed.

**The fake refuses what it was not given.** It embeds the interface as a nil
field, so a method a test did not provide panics rather than returning a zero
value — a test that reaches further than it declared says so instead of passing
on a lie.

## Evidence

```text
$ go test ./internal/capsule/ -run TestAnUndecidable -v
--- PASS: a container that is gone ended
--- PASS: a daemon that cannot be reached decides nothing
--- PASS: an answer with no name decides nothing either

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
```

A repository test caught a defect in this change while it was being made: the
interface was inserted between `Launcher`'s doc comment and `Launcher`, so that
comment documented the interface. `TestNoDocCommentBelongsToAnotherDeclaration`
named it with the line number.

## What would notice this regressing

`TestAnUndecidableExecutionIsHeldRatherThanSettled` fails if absence stops
ending an attempt, or if anything unnamed stops being undecided. It is the guard
on the classification added last week, which had none.

The live capsule contract still exercises the mechanics — the create, the exec,
the credential channel — against a real daemon, which is what an interface
cannot prove.

## Risk, compatibility and operations

No behaviour changes. `NewLauncher` takes an interface the concrete client
already satisfies; every caller passes the same value it passed before.

No configuration, status API, schema, migration or deployment surface is
touched.

## Changelog

```text
NONE
```

## Notes for your reviewer

`CONTRIBUTING.md` said this package's daemon-facing half is proved live. That
stays true of the mechanics and is now false of the refusals, so it says which
is which — a live daemon cannot be told to be absent, unreachable, or to refuse
a name that is taken, and those are the answers that decide whether work is
settled or held.

`internal/command` still holds the concrete client. Its destructive path,
`ownedPlan.remove`, is the other place a refusal cannot be asked for today; that
is the next step and a separate change.
