### PR TITLE
refactor(command): the maintenance commands hold their daemon through an interface

### DIFF
--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -218,7 +218,25 @@ type ownedPlan struct {
 	volumes    []docker.OwnedResource
 }
 
-func planOwnedResources(ctx context.Context, st *store.Store, dock *docker.Client) (ownedPlan, error) {
+// maintenanceDaemon is the daemon as the maintenance commands need it:
+// enumerate what this instance owns, and remove one object at a time
+// with ownership proven first. Declared here, and narrow, because these
+// are the commands that delete things — what a fake has to be able to
+// say is "this one will not go", and a live daemon cannot be asked to
+// refuse on demand.
+type maintenanceDaemon interface {
+	ListOwnedContainers(context.Context, assignment.InstanceID) ([]docker.OwnedContainer, error)
+	ListOwnedNetworks(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error)
+	ListOwnedVolumes(context.Context, assignment.InstanceID) ([]docker.OwnedResource, error)
+	RemoveOwnedContainer(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
+	RemoveOwnedNetwork(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
+	RemoveOwnedVolume(ctx context.Context, reference string,
+		instanceID assignment.InstanceID, leaseID assignment.LeaseID) error
+}
+
+func planOwnedResources(ctx context.Context, st *store.Store, dock maintenanceDaemon) (ownedPlan, error) {
 	p := ownedPlan{instanceID: string(st.InstanceID())}
 	var err error
 	id := p.instanceID
@@ -295,7 +313,7 @@ func (p ownedPlan) describe(verb string, applying bool) string {
 
 // remove deletes containers first, then the networks and volumes they
 // held open.
-func (p ownedPlan) remove(ctx context.Context, dock *docker.Client) error {
+func (p ownedPlan) remove(ctx context.Context, dock maintenanceDaemon) error {
 	for _, c := range p.containers {
 		if err := dock.RemoveOwnedContainer(ctx, c.ID, assignment.InstanceID(p.instanceID), c.LeaseID); err != nil {
 			return fmt.Errorf("remove container %s: %w", c.Name, err)

--- a/internal/command/maintenance_test.go
+++ b/internal/command/maintenance_test.go
@@ -1,0 +1,112 @@
+package command
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/docker"
+)
+
+// wedgedDaemon removes what it is asked to remove, except the objects
+// named in refuse. The removals are recorded in order, because the order
+// is the invariant: a network or a volume a container still holds open
+// cannot go until the container has.
+type wedgedDaemon struct {
+	maintenanceDaemon
+	refuse  map[string]error
+	removed []string
+}
+
+func (d *wedgedDaemon) remove(kind, reference string) error {
+	if err, ok := d.refuse[reference]; ok {
+		return err
+	}
+	d.removed = append(d.removed, kind+" "+reference)
+	return nil
+}
+
+func (d *wedgedDaemon) RemoveOwnedContainer(_ context.Context, reference string,
+	_ assignment.InstanceID, _ assignment.LeaseID) error {
+	return d.remove("container", reference)
+}
+
+func (d *wedgedDaemon) RemoveOwnedNetwork(_ context.Context, reference string,
+	_ assignment.InstanceID, _ assignment.LeaseID) error {
+	return d.remove("network", reference)
+}
+
+func (d *wedgedDaemon) RemoveOwnedVolume(_ context.Context, reference string,
+	_ assignment.InstanceID, _ assignment.LeaseID) error {
+	return d.remove("volume", reference)
+}
+
+func maintenancePlan() ownedPlan {
+	return ownedPlan{
+		instanceID: "instance-1",
+		containers: []docker.OwnedContainer{{ID: "c1", Name: "runpool-capsule-1"}, {ID: "c2", Name: "runpool-gateway-1"}},
+		networks:   []docker.OwnedResource{{ID: "n1"}},
+		volumes:    []docker.OwnedResource{{ID: "v1"}},
+	}
+}
+
+// TestRemovalStopsAtWhatWillNotGo: a removal that failed is reported,
+// and nothing after it is claimed.
+//
+// The order is the invariant — containers first, then what they held
+// open — and a container that will not die is the case where continuing
+// would report a network removed that the daemon still refuses. A live
+// daemon cannot be asked to wedge a container on demand, so until this
+// path was reachable through a seam nothing exercised it at all.
+func TestRemovalStopsAtWhatWillNotGo(t *testing.T) {
+	wedged := errors.New("device or resource busy")
+
+	for name, testCase := range map[string]struct {
+		refuse      string
+		wantRemoved []string
+		wantErr     string
+	}{
+		"everything goes, containers before what they held open": {
+			wantRemoved: []string{"container c1", "container c2", "network n1", "volume v1"},
+		},
+		"a container that will not die stops the sweep": {
+			refuse:      "c1",
+			wantRemoved: nil,
+			wantErr:     "remove container runpool-capsule-1",
+		},
+		"a network that will not go stops it after the containers": {
+			refuse:      "n1",
+			wantRemoved: []string{"container c1", "container c2"},
+			wantErr:     "remove network n1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			daemon := &wedgedDaemon{}
+			if testCase.refuse != "" {
+				daemon.refuse = map[string]error{testCase.refuse: wedged}
+			}
+			err := maintenancePlan().remove(t.Context(), daemon)
+
+			if testCase.wantErr == "" {
+				if err != nil {
+					t.Fatalf("a plan the daemon accepted failed: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("a removal the daemon refused was reported as done")
+				}
+				if !strings.Contains(err.Error(), testCase.wantErr) {
+					t.Errorf("failed with %q; it has to name what would not go (%q)", err, testCase.wantErr)
+				}
+				if !errors.Is(err, wedged) {
+					t.Error("the daemon's own reason has to survive: it is what an operator acts on")
+				}
+			}
+			if strings.Join(daemon.removed, ", ") != strings.Join(testCase.wantRemoved, ", ") {
+				t.Errorf("removed %v; want %v", daemon.removed, testCase.wantRemoved)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

`planOwnedResources` and `ownedPlan.remove` take a six-method interface declared
in `internal/command` instead of the concrete adapter client. The removal path
gets its first tests.

## What was found

**The path that deletes things had never been exercised.** `cleanup` and
`uninstall` remove every object this instance owns, and `ownedPlan.remove` took
`*docker.Client`. A fake could not be substituted, so the one thing worth saying
to that function — *this object will not go* — could not be said, and no live
daemon can be asked to wedge a container on demand.

**The order is the invariant.** Containers first, then the networks and volumes
they held open. A container that will not die has to stop the sweep: continuing
would report a network removed that the daemon still refuses, and the operator
reading that output would believe the host is clean. Both halves are covered now
— what was removed before the failure, and that nothing after it is claimed.

**The daemon's reason has to survive.** It is what an operator acts on: *device
or resource busy* is a different morning from *no such container*. The test
asserts the wrapped error still unwraps to it.

## Evidence

```text
$ go test ./internal/command/ -run TestRemovalStopsAtWhatWillNotGo -v
--- PASS: everything goes, containers before what they held open
--- PASS: a container that will not die stops the sweep
--- PASS: a network that will not go stops it after the containers

mutations, in an export:
  sweep continues past a refusal  -> FAIL (a container that will not die …)
  the error drops the reason      -> FAIL (a network that will not go …)

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
```

## What would notice this regressing

`TestRemovalStopsAtWhatWillNotGo` fails if the sweep continues past a refusal,
if the order stops being containers-first, or if the daemon's reason stops
surviving into the error a person reads.

The lifecycle drills exercise the same commands against a real daemon, which is
what proves the removals actually happen; what they cannot do is make one fail.

## Risk, compatibility and operations

No behaviour changes. The two functions take an interface the concrete client
already satisfies, and every caller passes the value it passed before.
`openStoreAndDocker` still constructs and returns the concrete client, because
constructing it is the wiring layer's job.

No configuration, status API, schema, migration or deployment surface is
touched.

## Changelog

```text
NONE
```

## Notes for your reviewer

The fake embeds the interface as a nil field, so a method a test did not provide
panics rather than answering. A test that reaches further than it declared says
so instead of passing on a zero value.

This completes the consumer seams for the container-engine port: `internal/app`
and `internal/cache` already declared their own, `internal/capsule` got one last
change, and this is the last package that held the concrete client for anything
but constructing it.
