### PR TITLE
docs(deployment): Runpool deploys on any Docker host, and a platform is an example rather than a frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,13 @@ by its public and operational effects.
 - The standalone binary and completions are built once before qualification,
   retained by checksum, and published without rebuilding. Releases also carry
   separate controller and capsule SBOMs plus signed provenance attestations.
+- **Runpool deploys on any Docker host that runs Compose.** What a platform has
+  to provide is five things — a container kept running from a digest, a
+  persistent volume, two read-only mounts, the socket, and a redeploy that keeps
+  the volume — and a checklist says how to tell whether one of them does. There
+  is no route in to provide: the controller is headless and its health is a
+  command run inside the container, not an endpoint. Named platforms are
+  examples, not integrations.
 - The status document reports `engine_error` and the preflight names a
   `container engine`, rather than naming the one engine there is. What either
   says about Docker it says in the message, where it is true.

--- a/README.md
+++ b/README.md
@@ -143,12 +143,12 @@ controller: no domain, reverse-proxy route, or public port is required.
 | Platform | Entry point |
 | --- | --- |
 | Docker Compose | [`deploy/compose/compose.yaml`](deploy/compose/compose.yaml) |
-| Dokploy | Deploy the canonical Compose file now; upstream One-Click catalog submission follows the first qualified release |
+| A Compose platform | Deploy the canonical Compose file now; a One-Click catalog entry, where the platform has one, follows the first qualified release |
 
 Read the [deployment guide](docs/deployment.md) before installing. The
 Compose contract reads an operator-managed
 [configuration file](deploy/compose/config.example.yaml); the example selects
-`shared-daemon` for Dokploy-style hosts and illustrates an explicit reserve for
+`shared-daemon` for a host shared with a platform, and illustrates an explicit reserve for
 colocated services. Measure that reserve before deployment. Choose
 `dedicated-daemon` only on an exclusive CI host.
 
@@ -156,7 +156,7 @@ colocated services. Measure that reserve before deployment. Choose
 
 | Guide | Purpose |
 | --- | --- |
-| [Deployment](docs/deployment.md) | Compose, Dokploy, credentials, and lifecycle |
+| [Deployment](docs/deployment.md) | Compose, platforms, credentials, and lifecycle |
 | [Product contract](docs/product-contract.md) | Guarantees, exclusions, and compatibility surfaces |
 | [Architecture](docs/architecture.md) | Components, dependency direction, state, and recovery |
 | [Configuration](docs/reference/configuration.md) | Supported settings and validation rules |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,8 @@ Documentation is organized by the question it answers.
 
 ## Operate Runpool
 
-- [Deployment](deployment.md): Docker Compose and Dokploy deployment
-  surfaces, credentials, upgrades, and removal.
+- [Deployment](deployment.md): the Compose contract, what a platform has to
+  provide, credentials, upgrades, and removal.
 - [Compose configuration example](../deploy/compose/config.example.yaml):
   multi-target file-mode deployment without embedded credentials.
 - [Runbook](runbook.md): startup, pressure response, backup, restore, upgrade,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,17 +12,24 @@ exact image and host platform have passed the gates in
 ## Deployment surface
 
 [`deploy/compose/compose.yaml`](../deploy/compose/compose.yaml) is the canonical
-operator-managed deployment. Platform catalogs derive their template from this
-contract; they are not duplicated here because an unreviewed second copy would
-drift.
+operator-managed deployment, and it is the whole of what Runpool asks a host
+for. Platform catalogs derive their template from this contract; they are not
+duplicated here because an unreviewed second copy would drift.
 
-The Dokploy One-Click template follows the
-[official contribution workflow](https://dokploy.github.io/templates/): fork
-`Dokploy/templates`, add `blueprints/runpool`, open a pull request, test its
-automatically generated preview and Base64 import, and let the upstream merge
-become the catalog authority. Do not submit a mutable development image. The
-blueprint is created from an immutable release candidate or release and updated
-through an upstream pull request whenever the deployment contract changes.
+What a platform has to provide is short, and it is the same list everywhere:
+
+- a way to run one container from a digest-qualified image and keep it running;
+- a persistent named volume for the state directory;
+- two read-only bind mounts, for the configuration and the credential
+  directory;
+- the Docker socket, which is what the controller drives;
+- a redeploy that keeps the volume.
+
+What it does not have to provide is a route in. The controller is headless and
+its health is a command the platform runs inside the container —
+`runpool healthcheck --mode=liveness` — not an endpoint it polls. There is no
+port to publish and no HTTP surface to expose, which is why there is none to
+protect.
 
 ## Choose the host topology
 
@@ -32,14 +39,21 @@ topology is therefore explicit rather than inferred:
 
 | Topology | Use it when | Contract |
 | --- | --- | --- |
-| `shared-daemon` | Dokploy and application services already use this Engine | Private, trusted CI only; restricted egress; explicit host reserve; no platform-wide volume prune |
+| `shared-daemon` | The platform and other application services already use this Engine | Private, trusted CI only; restricted egress; explicit host reserve; no platform-wide volume prune |
 | `dedicated-daemon` | The Engine is exclusive to Runpool | Smaller compromise blast radius and the recommended security posture; still not a hostile-code sandbox |
 
 `shared-daemon` lets the operator run and observe the controller and ephemeral
 capsules through the same Docker control plane. It does not make Docker
-multi-tenant: controller, daemon or kernel compromise can affect Dokploy and
-every colocated service. Use it only when that impact is an accepted risk for
-the workflows being admitted.
+multi-tenant: controller, daemon or kernel compromise can affect the platform
+and every colocated service. Use it only when that impact is an accepted risk
+for the workflows being admitted.
+
+`dedicated-daemon` means an Engine on the host that is Runpool's alone. It does
+not mean giving Runpool a privileged daemon of its own inside a container
+beside the platform's. That arrangement reads like isolation and is not one: the
+container needs the privileges that make it equivalent to the host's daemon, it
+doubles what a qualification has to measure, and the capsule's own inner daemon
+already provides the per-job separation this would be reaching for.
 
 Runpool labels its controller-visible objects with `io.runpool.*` ownership
 and correlation fields. Cleanup re-inspects instance and lease ownership
@@ -48,7 +62,7 @@ never issues daemon-wide prune.
 
 ### Shared-daemon cleanup policy
 
-Disable Dokploy jobs or maintenance actions that run any of the following
+Disable platform jobs or maintenance actions that run any of the following
 against the shared Engine:
 
 - `docker volume prune`;
@@ -133,10 +147,11 @@ same authority as mounting those files individually while allowing targets to
 be added without changing the deployment manifest.
 
 The default Compose source paths are
-`../files/runpool/config.yaml` and `../files/runpool/credentials`. Dokploy
-preserves `../files` across deployments, unlike files from a repository clone.
-Other Compose operators set `RUNPOOL_CONFIG_PATH` and
-`RUNPOOL_CREDENTIALS_PATH` to explicit existing sources. Both bind mounts use
+`../files/runpool/config.yaml` and `../files/runpool/credentials`, because a
+platform that keeps a directory across deployments usually keeps that one —
+Dokploy does. Operators elsewhere set `RUNPOOL_CONFIG_PATH` and
+`RUNPOOL_CREDENTIALS_PATH` to explicit existing sources, and should: a default
+that suits one platform is not a recommendation. Both bind mounts use
 `create_host_path: false`, so a typo fails startup instead of silently creating
 an empty directory.
 
@@ -228,45 +243,93 @@ admission, inspect the dry-run plan, and confirm the instance identifier so the
 controller can remove only the resources its state proves it owns. Delete the
 platform service and state volume only after the uninstall completes.
 
+## Platforms
+
+Runpool does not integrate with a deployment platform and does not need to. A
+platform that provides the five things above can run it, and the ones below are
+named because operators ask, not because any of them is part of the design.
+
+| Platform | Status |
+| --- | --- |
+| Compose on a Docker host | The canonical contract; every gate is answered here |
+| [Dokploy](https://dokploy.com) | Compose-native, and the catalog path below is written for it |
+| [Temps](https://temps.sh) | Compose-native; its Compose support is confirmed by its authors |
+| [Coolify](https://coolify.io) | Compose-native |
+
+None of them is *verified* in the sense the [support
+matrix](reference/support-matrix.md) uses that word. Verified means somebody ran
+the checklist below on that platform and recorded what happened, and that has
+not been done for any of them yet.
+
+### The platform checklist
+
+What this proves is not that Runpool works — the gates prove that. It is that
+the platform does not break it. Eight things, in order:
+
+1. The state volume survives a redeploy: `runpool status` reports the same
+   instance and the same leases before and after.
+2. The mounted socket passes a complete `runpool doctor`, including the
+   internal isolated bridge — a platform managing its own networks is the thing
+   most likely to interfere with that one.
+3. Configuration and credentials arrive read-only and at mode `0600`, and the
+   platform copies neither into a log nor into an environment variable.
+4. The platform's health display is wired to `runpool healthcheck` and reflects
+   both `liveness` and `readiness`, rather than a TCP port that does not exist.
+5. The platform's stop grace period exceeds the controller's shutdown budget, so
+   a stop does not kill the controller mid-drain.
+6. A redeploy with a live capsule adopts it rather than re-running its job.
+7. The platform's own cleanup — prunes, maintenance jobs — leaves Runpool's
+   volumes alone: sentinels created outside Runpool are still there afterwards,
+   verified by id.
+8. The platform's logs and `exec` reach the controller, which is how an image
+   with no shell is operated.
+
+A platform that fails one of these is not unsupported. It is a platform with one
+thing to configure, and the checklist says which.
+
 ## Catalog publication
 
-The Dokploy catalog is maintained upstream, not copied into this repository. A
-release maintainer derives the blueprint from the released, digest-qualified
-Compose contract and reviews the generated preview. Catalog updates are release
-work: a mutable development image or unreleased schema must never be published
-as a One-Click service.
+A catalog entry is one platform's distribution of the contract above, not a
+second implementation of it. It is maintained upstream, not copied into this
+repository: a release maintainer derives the blueprint from the released,
+digest-qualified Compose contract and reviews the generated preview. Catalog
+updates are release work — a mutable development image or unreleased schema must
+never be published as a One-Click service.
 
-## Dokploy without a catalog entry
+Dokploy's is the
+[official contribution workflow](https://dokploy.github.io/templates/): fork
+`Dokploy/templates`, add `blueprints/runpool`, open a pull request, test its
+automatically generated preview and Base64 import, and let the upstream merge
+become the catalog authority.
 
-The public One-Click catalog is not a prerequisite for deployment. Until the
-first qualified release is accepted upstream, use this procedure:
+## Deploying through a platform
 
-1. In the Dokploy organization that owns the server, create project `runpool`,
-   environment `production`, and a Docker Compose service named `runpool`.
+A catalog entry is not a prerequisite. Every platform that runs Compose takes
+the same seven steps; the words in brackets are Dokploy's names for them.
+
+1. Create a project and a Compose service named `runpool` [project,
+   environment, Docker Compose service].
 2. Use the canonical
-   [`deploy/compose/compose.yaml`](../deploy/compose/compose.yaml) as the Compose
-   definition. It creates only the `controller` service inside the `runpool`
-   Compose project.
-3. Through **Advanced → Mounts**, create the configuration and credential files
-   under Dokploy's persistent `../files` area:
-   `../files/runpool/config.yaml`,
-   `../files/runpool/credentials/<credential-id>`. Copy the configuration
+   [`deploy/compose/compose.yaml`](../deploy/compose/compose.yaml) as the
+   Compose definition. It creates only the `controller` service.
+3. Create the configuration and credential files in whatever directory the
+   platform preserves across deployments [Advanced → Mounts, under `../files`]:
+   one `config.yaml`, and one file per credential. Copy the configuration
    example, then replace target names and capacity with reviewed values.
 4. Put exactly one token in each credential file, terminate it with an optional
    newline, and set every credential file to mode `0600`. Never put a token in
-   the configuration, Compose definition, or Dokploy environment editor.
-5. Set only `RUNPOOL_IMAGE` in the environment editor, using the complete
-   released `@sha256:` reference. Set `RUNPOOL_CONFIG_PATH` or
-   `RUNPOOL_CREDENTIALS_PATH` only when deliberately using non-default source
-   paths.
-6. Render the Compose model and verify that it contains no token values,
-   published ports, domains, or reverse-proxy labels. Validate the mounted
-   document with `runpool config effective` before starting `serve`.
+   the configuration, the Compose definition, or the platform's environment
+   editor.
+5. Set only `RUNPOOL_IMAGE` in the environment, using the complete released
+   `@sha256:` reference. Set `RUNPOOL_CONFIG_PATH` or `RUNPOOL_CREDENTIALS_PATH`
+   only when the persisted directory is not the default one.
+6. Render the Compose model and verify it contains no token values, published
+   ports, domains, or reverse-proxy labels. Validate the mounted document with
+   `runpool config effective` before starting `serve`.
 7. Deploy, wait for the healthcheck, and run `runpool doctor` and
    `runpool status`. Admit ordinary work only after a private fixture workflow
    succeeds for every target.
 
 The controller is headless: do not attach a domain or expose a port. This keeps
-the source of truth in Runpool while following Dokploy's normal Compose path;
-the later catalog blueprint is distribution metadata in the upstream template
-repository, not a second deployment implementation here.
+the source of truth in Runpool while following the platform's normal Compose
+path.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -36,7 +36,7 @@ tier — and `status --json` exposes the same under `host_topology` and
 `scheduling`. On a `shared-daemon` host:
 
 - keep the configured CPU, memory, swap and free-disk reserve above the
-  measured peak of Dokploy and colocated applications;
+  measured peak of the platform and colocated applications;
 - set `scheduling.parallelism` when the host budget must hold across every
   target and tier, rather than letting each tier fill independently;
 - do not run `docker volume prune`, `docker system prune --volumes`, or a

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -60,7 +60,8 @@ not a silent standing grant to whoever holds the name.
 
 Runpool requires an explicit host topology:
 
-- **`shared-daemon`** is the Dokploy and single-server coexistence contract.
+- **`shared-daemon`** is the single-server coexistence contract, for a host
+  whose Engine a deployment platform is already using.
   It is supported only for private workflows the operator already authorizes
   on that host. Runpool withholds an explicit CPU, memory and free-disk reserve,
   requires restricted egress, isolates organization targets in an explicit


### PR DESCRIPTION
## What changes

`docs/deployment.md` is reframed around the Compose contract rather than around
one platform, gains the list of what a platform has to provide and a checklist
for telling whether one does, and states two things it did not: that there is no
route in to provide, and what a dedicated daemon is not.

Documentation only.

## What was found

**The page was written around one platform.** Its topology table named it, its
cleanup policy named it, its default mount paths exist because that platform
preserves that directory, and a third of the page was a procedure for it — 24
mentions, in a document about a product that integrates with none.

What Runpool actually asks a host for is five things: a container kept running
from a digest-qualified image, a persistent named volume, two read-only bind
mounts, the Docker socket, and a redeploy that keeps the volume. That is the
frame now, and platforms are examples under it with an honest status: none is
*verified*, because verified means somebody ran the checklist and recorded what
happened.

**The checklist was the missing piece.** It does not re-prove Runpool — the
gates do that. It proves the platform does not break it, and every item is
something a platform plausibly gets wrong:

- the state volume survives a redeploy;
- the socket passes a complete `runpool doctor`, including the internal
  isolated bridge, which is the check a platform managing its own networks is
  most likely to interfere with;
- credentials arrive read-only at `0600` and are copied into no log or
  environment variable;
- the health display is wired to `runpool healthcheck` rather than to a TCP
  port that does not exist;
- the stop grace period outlasts the shutdown budget;
- a redeploy with a live capsule adopts it rather than re-running its job;
- the platform's own prune leaves Runpool's volumes alone, verified by id;
- logs and `exec` reach an image with no shell.

**Two things were true and unsaid.** A platform needs no route in: the
controller is headless and its health is a command run inside the container, so
there is no endpoint to expose — which is why there is none to protect. And
`dedicated-daemon` means an Engine on the host that is Runpool's alone; it does
not mean a privileged daemon of its own inside a container beside the platform's.
That arrangement reads like isolation and is not one — the container needs the
privileges that make it equivalent to the host's daemon, it doubles what a
qualification has to measure, and the capsule's own inner daemon already provides
the per-job separation it reaches for.

## Evidence

```text
mentions of one platform in the deployment page: 24 -> 6, each an example

$ go test -count=1 ./...            # documentation paths and links
clean
```

`TestEveryPathTheDocumentationNamesResolves` covers every path this page names.

## What would notice this regressing

The documentation check fails on any path this page names that stops existing.
Nothing checks that a platform stays an example rather than becoming the frame;
that is prose, and the checklist is what keeps the distinction useful — a
platform is verified when somebody runs it, and unverified until then.

## Risk, compatibility and operations

No code. The default Compose source paths are unchanged; what changed is that
the page now says *why* they are the defaults, and that operators elsewhere
should set the two variables explicitly rather than inherit a default that suits
one platform.

The topology guidance is unchanged in substance. What is added is what
`dedicated-daemon` excludes, which was implied and never stated.

## Changelog

```text
- **Runpool deploys on any Docker host that runs Compose.** What a platform has
  to provide is five things — a container kept running from a digest, a
  persistent volume, two read-only mounts, the socket, and a redeploy that keeps
  the volume — and a checklist says how to tell whether one of them does. There
  is no route in to provide: the controller is headless and its health is a
  command run inside the container, not an endpoint. Named platforms are
  examples, not integrations.
```

## Notes for your reviewer

The platform table lists Compose, Dokploy, Temps and Coolify. Temps is there
because its Compose support is confirmed by its authors; that is the whole of
what is claimed for it, and running the checklist on a disposable server is what
would change its status.

The catalog section keeps Dokploy's contribution workflow, because it is that
platform's process and it is accurate. What changed is that it now sits under a
heading saying a catalog entry is one platform's distribution of the contract,
not a second implementation of it.
