### PR TITLE
refactor(engine): ExecOK existed only so a test could test it

### DIFF
--- a/internal/engine/docker/exec.go
+++ b/internal/engine/docker/exec.go
@@ -76,13 +76,6 @@ func (c *Client) Exec(ctx context.Context, containerID string, cmd []string) (in
 	return inspect.ExitCode, buf.String(), nil
 }
 
-// ExecOK reports whether a command inside the container exits zero — the
-// readiness-probe shape.
-func (c *Client) ExecOK(ctx context.Context, containerID string, cmd []string) bool {
-	code, _, err := c.Exec(ctx, containerID, cmd)
-	return err == nil && code == 0
-}
-
 // ExecWithInput runs a command inside a running container feeding input
 // on its stdin, and returns its exit code and combined output. It is
 // the credential channel: stdin is the one path into a container that

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -190,11 +190,18 @@ func TestExec(t *testing.T) {
 	if !strings.Contains(out, "from-exec") {
 		t.Errorf("exec output = %q; want the command's stdout", out)
 	}
-	if !c.ExecOK(ctx, id, []string{"true"}) {
-		t.Error("ExecOK on a succeeding command reported failure")
-	}
-	if c.ExecOK(ctx, id, []string{"false"}) {
-		t.Error("ExecOK on a failing command reported success")
+	// Zero and non-zero both come back as codes rather than as errors: a
+	// command that ran and failed is an answer, and only a command that
+	// could not be run is an error.
+	for command, want := range map[string]int{"true": 0, "false": 1} {
+		code, _, err := c.Exec(ctx, id, []string{command})
+		if err != nil {
+			t.Errorf("exec %q: %v", command, err)
+			continue
+		}
+		if code != want {
+			t.Errorf("exec %q exited %d; want %d", command, code, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## What changes

`(*docker.Client).ExecOK` is deleted. Its two contract assertions are rewritten
against `Exec`, where they say something.

## What was found

Nothing in the product called it:

```text
$ grep -rn ExecOK .
test/contract/docker/contract_test.go:193  if !c.ExecOK(ctx, id, []string{"true"})
test/contract/docker/contract_test.go:196  if c.ExecOK(ctx, id, []string{"false"})
internal/engine/docker/exec.go:81          func (c *Client) ExecOK(...)
```

Two lines of code whose only caller was the test asserting that those two lines
work. It was documented as "the readiness-probe shape", and no readiness probe
uses it — the capsule's readiness goes through `Exec` with its exit code, and
the controller's own health is a CLI command.

What the assertions were hiding is worth keeping: `Exec` returns an exit code
rather than an error for a command that ran and failed. Zero and non-zero are
both answers; only a command that could not be run at all is an error. They say
that now, against `Exec`, which is the method the product actually depends on.

## Evidence

```text
$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
$ grep -rn ExecOK .
(no trace)
```

The rewritten assertions run in the live Docker contract, which executes on this
pull request.

## What would notice this regressing

The same contract test, now asserting the exit codes directly: if `Exec` ever
turns a non-zero exit into an error, the `false` case fails.

## Risk, compatibility and operations

`ExecOK` was exported from an internal package with no caller outside its own
test. Nothing else can be affected.

## Changelog

```text
NONE
```

## Notes for your reviewer

This is the last item of the container-engine port's plan. What it removes is
one line of the adapter's surface; what it adds is that the surface no longer
has a method whose reason to exist is the test that tests it.
