### PR TITLE
fix(doctor): the preflight proves the isolated mode took effect, not that the daemon accepted the request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,6 +498,13 @@ by its public and operational effects.
 - The standalone binary and completions are built once before qualification,
   retained by checksum, and published without rebuilding. Releases also carry
   separate controller and capsule SBOMs plus signed provenance attestations.
+- **The preflight proves the isolated bridge took effect, not that the daemon
+  accepted the request.** A daemon that does not recognise the option takes the
+  request and drops it in silence, so a network that creates says nothing; what
+  says something is that the daemon assigned the bridge no host address, which
+  is the address a capsule would otherwise route through. The refusal names the
+  address it found. This is also the first thing that fails when the option is
+  removed from the code: it was possible to delete it and pass every gate.
 - **Runpool deploys on any Docker host that runs Compose.** What a platform has
   to provide is five things — a container kept running from a digest, a
   persistent volume, two read-only mounts, the socket, and a redeploy that keeps

--- a/docs/adrs/2026-08-13-egress-relay.md
+++ b/docs/adrs/2026-08-13-egress-relay.md
@@ -85,6 +85,21 @@ found the same way, by measurement.
 
 ## Consequences
 
+The deny has two halves, and they are dropped by different mechanisms. The
+`internal` flag installs the kernel rules that drop traffic leaving the bridge,
+which covers every destination outside its own subnet. The isolated gateway
+mode leaves the bridge with no host address at all, which covers the
+destinations the first half never sees: traffic to a host-local address is
+delivered without passing the chain that `internal` installs.
+
+Each half is proved by the thing that can see it. The kernel drop is proved by
+the live bypass suite, on a kernel, with a privileged capsule trying to lift
+it. The isolated mode is proved by the preflight, which asks the daemon what it
+assigned the bridge rather than whether it accepted the request — an option key
+a daemon does not recognise is dropped without complaint, so a create tells it
+nothing. The preflight does not prove the kernel drop, and the bypass suite
+does not prove the mode.
+
 - **Kernel-enforced deny.** No route out exists at all; the bypass suite
   asserts unproxied TCP to public addresses fails just as private ones
   do.

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -19,7 +19,10 @@ and what was assumed is already drawn. Live status is in
 
 Runpool requires Docker Engine 28.0 or newer because its restricted network
 profile depends on the `isolated` gateway mode introduced in
-[Engine 28](https://docs.docker.com/engine/release-notes/28/). The
+[Engine 28](https://docs.docker.com/engine/release-notes/28/). The version is
+the floor, not the proof: the preflight builds one such bridge and checks the
+daemon assigned it no host address, because a daemon that does not recognise
+the option accepts the request and drops it in silence. The
 controller negotiates a mutually supported Engine API version; it does not
 require the host daemon to equal the release-qualification patch and it does
 not reject a newer major solely for being newer.

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -202,10 +202,11 @@ func checkDaemon(ctx context.Context, d daemonInfo) Result {
 	return Result{"container engine", Pass, detail, ""}
 }
 
-// networkProbeClient is the two calls the bridge probe needs, named so
+// networkProbeClient is the three calls the bridge probe needs, named so
 // the probe cannot reach the rest of a daemon client.
 type networkProbeClient interface {
 	CreateNetwork(context.Context, engine.NetworkSpec) (string, error)
+	NetworkGateways(ctx context.Context, id string) ([]string, error)
 	RemoveNetwork(context.Context, string) error
 }
 
@@ -218,11 +219,26 @@ type networkProbeClient interface {
 // refuse the network a capsule needs.
 //
 // The probe creates one disposable internal+isolated bridge, labeled as
-// managed so any sweep can recognise it, and removes it immediately. It
-// carries no containers and reserves nothing beyond a subnet for the
-// moment it exists. Failing here is the point: a host that cannot build
-// this network must be refused before it accepts work, not after a job
-// has already been assigned to it.
+// managed so any sweep can recognise it, asks the daemon what it did
+// with it, and removes it. It carries no containers and reserves nothing
+// beyond a subnet for the moment it exists. Failing here is the point: a
+// host that cannot build this network must be refused before it accepts
+// work, not after a job has already been assigned to it.
+//
+// What it asks is whether the bridge got a host address. A create that
+// succeeds proves only that the daemon accepted the request: an option
+// key it does not recognise is dropped without complaint, so a build
+// that renamed the option, or never had it, answers a create exactly
+// like one that honours it. Under the isolated mode the daemon assigns
+// no gateway, which is the whole point -- the address a capsule would
+// route through is the address that does not exist. That is a decision
+// the daemon took, and it is the half of the deny that the capsule's
+// own bypass suite cannot see: traffic to a host-local address is
+// delivered without ever passing the chain that internal installs.
+//
+// It does not prove the kernel drops anything. The live bypass suite
+// does that, on a kernel; this proves the mode took effect, on this
+// host, before any work arrives.
 func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
 	const name = "isolated bridge"
 	if d == nil {
@@ -257,12 +273,28 @@ func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
 			"the restricted network profile needs the Engine 28 isolated gateway mode; " +
 				"use a daemon that provides it, or accept unsafe-open-egress deliberately"}
 	}
+	// Before the removal, and its failure must not skip it: readiness runs
+	// on an interval, and a host that leaks one network per run runs out
+	// of address pools.
+	gateways, inspectErr := d.NetworkGateways(ctx, id)
 	if err := removeProbeNetwork(ctx, d, id); err != nil {
 		return Result{name, Fail,
 			"created, but the probe network could not be removed: " + err.Error(),
 			"remove " + probe + " manually"}
 	}
-	return Result{name, Pass, "internal isolated bridge created and removed", ""}
+	if inspectErr != nil {
+		return Result{name, Fail, "the probe network could not be inspected: " + inspectErr.Error(),
+			"check the socket mount and daemon health"}
+	}
+	if len(gateways) > 0 {
+		return Result{name, Fail,
+			"the daemon accepted an internal isolated bridge but assigned it a gateway address (" +
+				strings.Join(gateways, ", ") + "); the isolated gateway mode did not take effect",
+			"this daemon ignores com.docker.network.bridge.gateway_mode_ipv4=isolated, so a capsule " +
+				"would have a route to the host; use a stock Engine 28 or newer daemon, or choose " +
+				"network.profile: unsafe-open-egress deliberately"}
+	}
+	return Result{name, Pass, "internal isolated bridge created with no gateway address, and removed", ""}
 }
 
 func removeProbeNetwork(ctx context.Context, d networkProbeClient, id string) error {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -287,6 +287,60 @@ type fakeNetworkProbe struct {
 	removed      string
 	removeCalls  int
 	removeCtxErr error
+	// gateways is what the daemon assigned the probe network. Under the
+	// isolated mode it assigns none, so a non-empty answer is a daemon
+	// that took the request and ignored it.
+	gateways   []string
+	inspectErr error
+}
+
+// TestTheBridgeProbeAsksWhatTheDaemonDidNotWhatItWasAsked: a create that
+// succeeds proves the request was accepted, not that it was honoured.
+//
+// An option key the daemon does not recognise is dropped without
+// complaint, so a build that renamed the option, or never had it,
+// answers a create exactly like one that honours it. What differs is
+// what the daemon then did: under the isolated mode it assigns the
+// bridge no gateway, and the address a capsule would route through is
+// the address that does not exist.
+//
+// The probe network is removed either way. Readiness runs on an
+// interval, and a host that leaks one network per failing run runs out
+// of address pools.
+func TestTheBridgeProbeAsksWhatTheDaemonDidNotWhatItWasAsked(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		gateways []string
+		want     Status
+		detail   string
+	}{
+		"no gateway is the mode taking effect": {
+			want: Pass, detail: "no gateway address",
+		},
+		"a gateway is a daemon that took the request and ignored it": {
+			gateways: []string{"172.19.0.1"},
+			want:     Fail, detail: "172.19.0.1",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			probe := &fakeNetworkProbe{gateways: testCase.gateways}
+			got := checkIsolatedBridge(t.Context(), probe)
+
+			if got.Status != testCase.want {
+				t.Errorf("status = %v; want %v (%s)", got.Status, testCase.want, got.Detail)
+			}
+			if !strings.Contains(got.Detail, testCase.detail) {
+				t.Errorf("detail = %q; it has to name %q", got.Detail, testCase.detail)
+			}
+			if probe.removeCalls != 1 {
+				t.Errorf("the probe network was removed %d times; a host that leaks one per "+
+					"readiness run runs out of address pools", probe.removeCalls)
+			}
+		})
+	}
+}
+
+func (f *fakeNetworkProbe) NetworkGateways(context.Context, string) ([]string, error) {
+	return f.gateways, f.inspectErr
 }
 
 func (f *fakeNetworkProbe) CreateNetwork(_ context.Context, spec engine.NetworkSpec) (string, error) {

--- a/internal/engine/docker/network.go
+++ b/internal/engine/docker/network.go
@@ -90,6 +90,27 @@ func (c *Client) EnsureOwnedNetwork(ctx context.Context, spec engine.NetworkSpec
 	return inspected.Network.ID, nil
 }
 
+// NetworkGateways is every host address the daemon assigned to a
+// network, which for an isolated bridge is none.
+//
+// It reports what the daemon did rather than what it was asked for: the
+// options an inspect echoes back are the ones that were sent, honoured
+// or not, so reading them proves only that the request was made. A
+// gateway address is a decision the daemon took.
+func (c *Client) NetworkGateways(ctx context.Context, id string) ([]string, error) {
+	inspected, err := c.cli.NetworkInspect(ctx, id, client.NetworkInspectOptions{})
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, cfg := range inspected.Network.IPAM.Config {
+		if cfg.Gateway.IsValid() {
+			out = append(out, cfg.Gateway.String())
+		}
+	}
+	return out, nil
+}
+
 // NetworkSubnet returns a network's IPv4 subnet as assigned by IPAM.
 func (c *Client) NetworkSubnet(ctx context.Context, id string) (string, error) {
 	inspected, err := c.cli.NetworkInspect(ctx, id, client.NetworkInspectOptions{})


### PR DESCRIPTION
## What changes

`checkIsolatedBridge` asks the daemon what it assigned the probe network and
fails if it assigned a host address. One extra inspect, no container, no image.
The egress record states the deny's two halves and how each is proved.

## What was found

**Deleting the two option strings failed no gate at all** — not the preflight,
and not the live bypass suite either.

**The preflight could not catch it.** Its comment argues that a version string
is a claim and must be probed, and then accepts a `create` as a claim in exactly
the same way. Moby's bridge driver parses options with a switch that has no
default branch: an option *key* it does not recognise is dropped without
complaint. So a backport, a patched build, or a future major that renames the
option answers a create exactly like a daemon that honours it — which is the
case the comment invoked.

**The bypass suite could not catch it either.** It names seven direct
destinations. Six are outside the capsule bridge's own subnet, and those are
dropped by `internal` alone — the rules it installs hang off FORWARD. The
seventh is host-local, and host-local traffic is delivered through INPUT, which
those rules never see; the probe dials port 80 where nothing listens, so a
refused connection reads as blocked either way. The suite stays green on a
capsule that has gained a default route and reach to every address on the host.
Its own header comment names the isolated mode as the thing under test.

**The daemon does differ, in one field.** Under `gateway_mode_ipv4=isolated`
IPAM assigns no gateway, and the address a capsule would route through is the
address that does not exist. Measured against Engine 29.6.1:

```text
internal + gateway_mode_ipv4=isolated   subnet 172.22.0.0/16  gateway [invalid IP]
internal alone                          subnet 172.23.0.0/16  gateway [172.23.0.1]
```

The daemon also refuses `isolated` without `internal`, so that one observation
covers both halves of the request.

**End to end, against a real daemon**, with the option strings deleted:

```text
before: pass isolated bridge  internal isolated bridge created with no gateway address, and removed
after:  fail isolated bridge  the daemon accepted an internal isolated bridge but assigned it a
                              gateway address (172.22.0.1); the isolated gateway mode did not take effect
        → this daemon ignores com.docker.network.bridge.gateway_mode_ipv4=isolated, so a capsule
          would have a route to the host; use a stock Engine 28 or newer daemon, or choose
          network.profile: unsafe-open-egress deliberately
```

Naming the address it found is what lets an operator tell "your daemon ignored
the option" from "your IPAM is unusual".

## Evidence

```text
$ runpool doctor            # local Engine 29.6.1, real daemon
pass isolated bridge  internal isolated bridge created with no gateway address, and removed

$ runpool doctor            # same, with the two option strings deleted in an export
fail isolated bridge  ... assigned it a gateway address (172.22.0.1) ...

$ go test ./internal/doctor/ -run TestTheBridgeProbe -v
--- PASS: no gateway is the mode taking effect
--- PASS: a gateway is a daemon that took the request and ignored it

$ gofmt -l . && go vet ./... && go tool staticcheck ./... && go test -race -shuffle=on ./...
clean
```

Two repository gates caught a defect while this was being written: the comment
for the new method was inserted between `NetworkSubnet`'s comment and
`NetworkSubnet`, and both `staticcheck` and
`TestNoDocCommentBelongsToAnotherDeclaration` named it.

## What would notice this regressing

The option strings now have a gate for the first time. Deleting them fails
`runpool doctor` on any real host, which fails the `lifecycle drills` job — its
harness greps the doctor's output for a line beginning `fail` — on a pull
request, because that workflow's path filter already covers `internal/engine/**`.
It also fails `controller-e2e`, since serve runs the preflight before accepting
work.

Hermetically, `TestTheBridgeProbeAsksWhatTheDaemonDidNotWhatItWasAsked` covers
both outcomes and asserts the probe network is removed either way.

What this does not prove is that the kernel drops anything. The live bypass
suite does that, on a kernel, with a privileged capsule trying to lift it.
Neither substitutes for the other, and the egress record now says so.

## Risk, compatibility and operations

One extra `NetworkInspect` on the unix socket per preflight — one round trip,
milliseconds, against a create-and-remove pair that rewrites iptables rules and
costs a hundred times that. No image, no container, no pull: the preflight stays
image-free, which is what lets it run identically from `runpool doctor`,
`runpool healthcheck --mode=readiness` and serve. Readiness has a 15-second
budget and is meant to be polled; this does not move it.

The inspect happens before the removal and its failure does not skip the
removal. Readiness runs on an interval, and a host that leaks one network per
failing run runs out of address pools.

A daemon older than Engine 28 already fails the version floor; it now also fails
this check, correctly, and both are printed.

Not addressed, and pre-existing: the check fails admission regardless of
`network.profile`, so a host that deliberately chose `unsafe-open-egress` is
refused for a capability it never uses. Degrading to a warning in that case is a
small follow-up, not part of this.

## Changelog

```text
- **The preflight proves the isolated bridge took effect, not that the daemon
  accepted the request.** A daemon that does not recognise the option takes the
  request and drops it in silence, so a network that creates says nothing; what
  says something is that the daemon assigned the bridge no host address, which
  is the address a capsule would otherwise route through. The refusal names the
  address it found. This is also the first thing that fails when the option is
  removed from the code: it was possible to delete it and pass every gate.
```

## Notes for your reviewer

The option considered and rejected was attaching a throwaway container to the
probe network and asserting it cannot reach the host. Its strongest assertion
collapses into this one — on a correctly isolated network there is no host
address to dial, so what a container can actually report is "I have no default
route", which is the same fact read expensively. It would also need an image the
preflight does not have and cannot get at two of its three entry points, and it
would break the lifecycle drill, which runs the doctor on a host that has never
built the capsule image.

On IPv6: on a v4-only host there is no v6 IPAM entry, so deleting only the
`_ipv6` string is not caught. That is one sentence in the check's comment rather
than machinery.
