### PR TITLE
fix(doctor): the isolated bridge probe does not refuse a profile that never uses it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -505,6 +505,10 @@ by its public and operational effects.
   is the address a capsule would otherwise route through. The refusal names the
   address it found. This is also the first thing that fails when the option is
   removed from the code: it was possible to delete it and pass every gate.
+  Under `unsafe-open-egress` the probe does not run at all: that profile
+  attaches no capsule to the isolated bridge, so the check reports the
+  unconfined egress rather than refusing the host over a capability nothing
+  would use.
 - **Runpool deploys on any Docker host that runs Compose.** What a platform has
   to provide is five things — a container kept running from a digest, a
   persistent volume, two read-only mounts, the socket, and a redeploy that keeps

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -131,7 +131,7 @@ func Run(ctx context.Context, opts Options) Report {
 		di, np = opts.Docker, opts.Docker
 	}
 	add(checkDaemon(ctx, di))
-	add(checkIsolatedBridge(ctx, np))
+	add(checkIsolatedBridge(ctx, np, opts.Config))
 	for _, res := range checkCgroups(ctx, di, opts.Config) {
 		add(res)
 	}
@@ -221,9 +221,10 @@ type networkProbeClient interface {
 // The probe creates one disposable internal+isolated bridge, labeled as
 // managed so any sweep can recognise it, asks the daemon what it did
 // with it, and removes it. It carries no containers and reserves nothing
-// beyond a subnet for the moment it exists. Failing here is the point: a
-// host that cannot build this network must be refused before it accepts
-// work, not after a job has already been assigned to it.
+// beyond a subnet for the moment it exists. Under the restricted profile
+// failing here is the point: a host that cannot build this network must
+// be refused before it accepts work, not after a job has already been
+// assigned to it.
 //
 // What it asks is whether the bridge got a host address. A create that
 // succeeds proves only that the daemon accepted the request: an option
@@ -239,8 +240,19 @@ type networkProbeClient interface {
 // It does not prove the kernel drops anything. The live bypass suite
 // does that, on a kernel; this proves the mode took effect, on this
 // host, before any work arrives.
-func checkIsolatedBridge(ctx context.Context, d networkProbeClient) Result {
+func checkIsolatedBridge(ctx context.Context, d networkProbeClient, cfg *config.Config) Result {
 	const name = "isolated bridge"
+	// A profile that builds no sandbox never attaches a capsule to this
+	// network, so what the daemon can do with it decides nothing. Probing
+	// anyway would close admission on a supported configuration, and
+	// would repeat a network create on every readiness run for a network
+	// nothing would use.
+	if cfg != nil && cfg.Network.Profile == config.NetworkProfileUnsafeOpen {
+		return Result{name, Warn,
+			"not probed: network.profile is unsafe-open-egress, which builds no sandbox — " +
+				"capsules reach whatever this host reaches, including the LAN and host services",
+			"set network.profile: public-internet-only to confine capsules to the policy relay"}
+	}
 	if d == nil {
 		return Result{name, Fail, "daemon not connected", ""}
 	}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -254,7 +254,7 @@ func TestEngineVersionGuardIsAFloorNotAWindow(t *testing.T) {
 // is an admission gate, so an unusable daemon is a failure rather than a
 // silently skipped check.
 func TestIsolatedBridgeProbeFailsClosedWithoutADaemon(t *testing.T) {
-	res := checkIsolatedBridge(t.Context(), nil)
+	res := checkIsolatedBridge(t.Context(), nil, nil)
 	if res.Status != Fail {
 		t.Errorf("probe without a daemon = %s; want fail", res.Status)
 	}
@@ -323,7 +323,7 @@ func TestTheBridgeProbeAsksWhatTheDaemonDidNotWhatItWasAsked(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			probe := &fakeNetworkProbe{gateways: testCase.gateways}
-			got := checkIsolatedBridge(t.Context(), probe)
+			got := checkIsolatedBridge(t.Context(), probe, nil)
 
 			if got.Status != testCase.want {
 				t.Errorf("status = %v; want %v (%s)", got.Status, testCase.want, got.Detail)
@@ -361,7 +361,7 @@ func (f *fakeNetworkProbe) RemoveNetwork(ctx context.Context, id string) error {
 func TestIsolatedBridgeProbeLifecycle(t *testing.T) {
 	t.Run("create failure", func(t *testing.T) {
 		probe := &fakeNetworkProbe{createErr: errors.New("unsupported")}
-		if got := checkIsolatedBridge(t.Context(), probe); got.Status != Fail {
+		if got := checkIsolatedBridge(t.Context(), probe, nil); got.Status != Fail {
 			t.Fatalf("status = %s; want fail", got.Status)
 		}
 		if probe.removeCalls != 1 {
@@ -372,7 +372,7 @@ func TestIsolatedBridgeProbeLifecycle(t *testing.T) {
 	t.Run("cleanup survives caller cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		probe := &fakeNetworkProbe{cancel: cancel}
-		if got := checkIsolatedBridge(ctx, probe); got.Status != Pass {
+		if got := checkIsolatedBridge(ctx, probe, nil); got.Status != Pass {
 			t.Fatalf("result = %+v; want pass", got)
 		}
 		if probe.removeCalls != 1 {
@@ -394,10 +394,31 @@ func TestIsolatedBridgeProbeLifecycle(t *testing.T) {
 
 	t.Run("cleanup failure closes admission", func(t *testing.T) {
 		probe := &fakeNetworkProbe{removeErr: errors.New("busy")}
-		if got := checkIsolatedBridge(t.Context(), probe); got.Status != Fail {
+		if got := checkIsolatedBridge(t.Context(), probe, nil); got.Status != Fail {
 			t.Fatalf("result = %+v; want fail", got)
 		}
 	})
+}
+
+// TestTheBridgeProbeDoesNotCloseAdmissionOnAProfileThatDoesNotUseIt:
+// unsafe-open-egress builds no sandbox, so the isolated bridge is a
+// capability that profile never asks the daemon for. Refusing a host
+// over it would close admission on a configuration that is deliberate,
+// documented and supported — and the probe is daemon work repeated on
+// every readiness run for a network nothing would attach to.
+func TestTheBridgeProbeDoesNotCloseAdmissionOnAProfileThatDoesNotUseIt(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Network.Profile = config.NetworkProfileUnsafeOpen
+	probe := &fakeNetworkProbe{createErr: errors.New("unsupported")}
+
+	got := checkIsolatedBridge(t.Context(), probe, cfg)
+
+	if got.Status != Warn {
+		t.Errorf("status = %s; want warn — this profile never attaches a capsule to the isolated bridge", got.Status)
+	}
+	if probe.created.Name != "" {
+		t.Errorf("the probe created network %q; a profile that does not use the isolated bridge needs no probe", probe.created.Name)
+	}
 }
 
 // fakeProbe answers as the provider would. It records the group it was

--- a/internal/engine/docker/network.go
+++ b/internal/engine/docker/network.go
@@ -19,10 +19,7 @@ func (c *Client) CreateNetwork(ctx context.Context, spec engine.NetworkSpec) (st
 		Labels:   spec.Labels,
 	}
 	if spec.Isolated {
-		opts.Options = map[string]string{
-			"com.docker.network.bridge.gateway_mode_ipv4": "isolated",
-			"com.docker.network.bridge.gateway_mode_ipv6": "isolated",
-		}
+		opts.Options = isolatedGatewayOptions()
 	}
 	resp, err := c.cli.NetworkCreate(ctx, spec.Name, opts)
 	if err != nil {
@@ -162,4 +159,21 @@ func (c *Client) ListOwnedNetworks(ctx context.Context, instanceID assignment.In
 		out = append(out, engine.OwnedResource{ID: n.ID, LeaseID: own.Lease, Role: own.Role})
 	}
 	return out, nil
+}
+
+// isolatedGatewayOptions asks the bridge driver to assign the network no
+// host address, on both families. The IPv6 half is sent even though
+// capsules deny IPv6: the option is a property of the network the daemon
+// builds, and a daemon with IPv6 enabled would otherwise give the bridge
+// a v6 gateway — a second address a capsule could route through.
+//
+// It is a function so the pair can be asserted. On a v4-only host the
+// v6 key is inert: the daemon assigns no v6 gateway whether it was sent
+// or not, so no observation of a running host there proves the key is
+// still being requested.
+func isolatedGatewayOptions() map[string]string {
+	return map[string]string{
+		"com.docker.network.bridge.gateway_mode_ipv4": "isolated",
+		"com.docker.network.bridge.gateway_mode_ipv6": "isolated",
+	}
 }

--- a/internal/engine/docker/network_test.go
+++ b/internal/engine/docker/network_test.go
@@ -1,0 +1,23 @@
+package docker
+
+import "testing"
+
+// TestIsolatedGatewayOptionsCoverBothFamilies is the only thing that
+// holds the IPv6 half in place. A daemon drops an option key it does not
+// recognise without complaint, and a v4-only host assigns no v6 gateway
+// whether the key was sent or not, so the preflight's observation of a
+// real daemon cannot tell a build that asks for v6 isolation from one
+// that stopped asking.
+func TestIsolatedGatewayOptionsCoverBothFamilies(t *testing.T) {
+	opts := isolatedGatewayOptions()
+	for _, family := range []string{"ipv4", "ipv6"} {
+		key := "com.docker.network.bridge.gateway_mode_" + family
+		if opts[key] != "isolated" {
+			t.Errorf("%s = %q; want %q — the bridge would carry a host address on that family, "+
+				"and a capsule would have a route through it", key, opts[key], "isolated")
+		}
+	}
+	if len(opts) != 2 {
+		t.Errorf("options = %v; want exactly the two gateway modes", opts)
+	}
+}


### PR DESCRIPTION
## What changes

`runpool doctor` no longer creates a probe network or refuses the host over the
isolated bridge when `network.profile` is `unsafe-open-egress`. That profile
attaches no capsule to an isolated bridge, so the check now reports the
unconfined egress as a warning instead — the first place the doctor states out
loud that capsules reach whatever the host reaches. The isolated gateway mode is
also requested on both address families under a named function, so deleting
either key fails a test.

## What was found

The probe was added to prove the daemon honours `gateway_mode: isolated` rather
than inferring it from a version string, and it closes admission when the daemon
assigns the bridge a gateway address. It ran unconditionally. Under
`unsafe-open-egress` that verdict decides nothing: no capsule is attached to an
isolated bridge on that profile, so a daemon which cannot build one is not a
reason to refuse work. The result was that a supported, documented and
deliberately chosen configuration could not start on a daemon whose isolated
mode does not take effect, and that every readiness run created and removed a
network nothing would use.

The engine floor is a separate gate and is unchanged: a daemon below
`platform.MinimumEngineMajor` is refused by the engine check whatever the
profile, so this does not widen the supported engine range and
`docs/reference/support-matrix.md` still holds.

The second commit closes a gap in what the first one relies on. The bridge is
requested as isolated on IPv4 and IPv6, but only IPv4 was held in place by
anything. A daemon drops an unrecognised option key silently, and a host without
IPv6 assigns no v6 gateway whether the key was sent or not — so the preflight
observing a real daemon cannot distinguish a build that asks for v6 isolation
from one that stopped asking. The IPv6 key matters on a daemon with IPv6
enabled, where the bridge would otherwise carry a second address a capsule could
route through.

## Evidence

Hermetic only, and honest: the behaviour is a decision taken from configuration
and from what the daemon reports, and both halves are decidable without one.

- The new doctor test was watched failing before the fix, on both assertions:
  the status was `fail` where the profile requires `warn`, and the probe had
  created `runpool-doctor-161250aa2852` where it must create nothing.
- The IPv6 key was deleted from the source and the new engine test failed on
  both its assertions; restoring it returned the package to green.
- `gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...`
  are clean across the module.

## What would notice a regression

`TestTheBridgeProbeDoesNotCloseAdmissionOnAProfileThatDoesNotUseIt` fails if the
probe runs, or if the verdict closes admission, on a profile that never uses the
bridge. `TestIsolatedGatewayOptionsCoverBothFamilies` fails if either gateway
mode key is dropped or renamed. The existing probe tests still hold the
restricted profile's behaviour unchanged.
