### PR TITLE
fix(githubactions): a scale set that merely shares a name is a stranger's, and stays one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,17 @@ by its public and operational effects.
   nothing keeps the row its whole history hangs off. Bindings the
   configuration no longer claims are forgotten on the next start, unless
   they still own a delivery — that trail is kept.
+- **A scale set that merely shares a name is a stranger's, and stays one.**
+  Runpool adopts an existing scale set only when it can show it created that
+  one: either the id matches what it recorded, or an earlier pass wrote down
+  the intention to create that exact name and did not live to record the id.
+  The intention is now written only once the provider has said the name is
+  free, so a refusal leaves nothing behind — before, the refused pass wrote
+  the very record that tells a refusal from a crash, and the next poll adopted
+  the stranger it had just declined, served its owner's jobs on this host and
+  would later have deleted it. Two targets differing only in letter case are
+  refused as the duplicate they are, for the same reason: GitHub logins are
+  case-insensitive, so accepting both would put two bindings on one remote set.
 - **A schema this build cannot account for is refused, not repaired** —
   by reporting as well as by the controller. `status`, a `gc` dry run and
   a `cleanup` or `uninstall` preview apply no migrations, so each says

--- a/internal/app/bindings.go
+++ b/internal/app/bindings.go
@@ -194,23 +194,29 @@ func (s *Controller) ensureScaleSet(ctx context.Context, b *binding) error {
 	// start refuses to adopt it — correctly, because a set that merely
 	// shares a name is a stranger's. The intention is what tells the two
 	// apart.
+	//
+	// It is recorded only once the provider says the name is free, which
+	// is why the write travels as a callback instead of happening here. An
+	// intention written before the lookup is left behind by a pass that is
+	// then refused, and reads on the next pass as proof this instance
+	// created the stranger it had just declined.
 	var intended bool
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 		_, recorded, err := tx.GitHubScaleSet(b.bindingID)
-		if err != nil {
-			return err
-		}
 		intended = recorded
-		if recorded {
-			return nil
-		}
-		return tx.RecordGitHubBindingMetadata(b.bindingID, string(b.ref.Scope),
-			b.ref.CanonicalURL, b.target.RunnerGroup, b.scaleSetName, 0)
+		return err
 	}); err != nil {
 		return err
 	}
+	recordIntent := func() error {
+		return s.store.Tx(ctx, func(tx *store.Tx) error {
+			return tx.RecordGitHubBindingMetadata(b.bindingID, string(b.ref.Scope),
+				b.ref.CanonicalURL, b.target.RunnerGroup, b.scaleSetName, 0)
+		})
+	}
 
-	set, err := b.gh.EnsureScaleSet(ctx, b.target.RunnerGroup, b.scaleSetName, b.scaleSetID, intended)
+	set, err := b.gh.EnsureScaleSet(ctx, b.target.RunnerGroup, b.scaleSetName,
+		b.scaleSetID, intended, recordIntent)
 	if err != nil {
 		return err
 	}

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -25,7 +26,7 @@ type flakyScaleSets struct {
 	calls    atomic.Int32
 }
 
-func (f *flakyScaleSets) EnsureScaleSet(context.Context, string, string, int, bool) (githubactions.ScaleSet, error) {
+func (f *flakyScaleSets) EnsureScaleSet(context.Context, string, string, int, bool, func() error) (githubactions.ScaleSet, error) {
 	if f.calls.Add(1) <= f.failures {
 		return githubactions.ScaleSet{}, errors.New("provider unreachable")
 	}
@@ -197,7 +198,7 @@ type refusingScaleSets struct {
 	reached func()
 }
 
-func (r *refusingScaleSets) EnsureScaleSet(context.Context, string, string, int, bool) (githubactions.ScaleSet, error) {
+func (r *refusingScaleSets) EnsureScaleSet(context.Context, string, string, int, bool, func() error) (githubactions.ScaleSet, error) {
 	r.calls.Add(1)
 	r.reached()
 	return githubactions.ScaleSet{}, errors.New("provider unreachable")
@@ -324,7 +325,7 @@ func TestACrashBetweenCreatingAndRecordingConverges(t *testing.T) {
 					sets.lastIntended, tc.wantIntended)
 			}
 			if !namedBeforeTheCall {
-				t.Error("the provider was asked to create a name this binding had not written down")
+				t.Error("the callback the controller hands the provider did not write the name down; a crash after the create would leave a set nothing can account for")
 			}
 			if h.bind.scaleSetID != 42 || !h.bind.ensured {
 				t.Errorf("binding did not converge: id=%d ensured=%v", h.bind.scaleSetID, h.bind.ensured)
@@ -353,8 +354,13 @@ type recordingScaleSets struct {
 	duringCall func()
 }
 
-func (r *recordingScaleSets) EnsureScaleSet(_ context.Context, _, _ string, _ int, intended bool) (githubactions.ScaleSet, error) {
+func (r *recordingScaleSets) EnsureScaleSet(_ context.Context, _, _ string, _ int, intended bool, recordIntent func() error) (githubactions.ScaleSet, error) {
 	r.lastIntended = intended
+	// The name is free on this path, so the real adapter records the
+	// intention here, immediately before it creates the set.
+	if err := recordIntent(); err != nil {
+		return githubactions.ScaleSet{}, err
+	}
 	if r.duringCall != nil {
 		r.duringCall()
 	}
@@ -480,5 +486,54 @@ func TestTheDurableBindingKeyDoesNotMoveWithTheURLParser(t *testing.T) {
 	}
 	if sourceBindingKey(base, "runpool-large") == want {
 		t.Error("two scale sets share one binding key")
+	}
+}
+
+// occupiedScaleSets answers the way the provider does when the name is
+// already taken: it adopts only for a caller that can show it created the
+// set, which is what the intention claims.
+type occupiedScaleSets struct {
+	nullProvider
+	adopted int
+}
+
+func (o *occupiedScaleSets) EnsureScaleSet(_ context.Context, _, name string, knownID int, intended bool, _ func() error) (githubactions.ScaleSet, error) {
+	if knownID == 0 && !intended {
+		return githubactions.ScaleSet{}, fmt.Errorf(
+			"scale set %q already exists and this instance has no record of creating it", name)
+	}
+	o.adopted++
+	return githubactions.ScaleSet{ID: 99, Adopted: true}, nil
+}
+
+// TestARefusedNameStaysRefusedOnTheNextPass: a set that merely shares a
+// name is a stranger's, and the refusal has to survive the retry that
+// follows it. The intention exists to tell a set this instance created
+// and failed to write down from one that was simply already there — so an
+// intention written by a pass that was then refused answers that question
+// with its own failure, and the binding adopts the stranger one poll
+// later.
+func TestARefusedNameStaysRefusedOnTheNextPass(t *testing.T) {
+	h := newHarness(t, 1)
+	h.bind.ref = config.TargetRef{
+		Scope: config.ScopeRepository, Owner: "acme", Repository: "app",
+		CanonicalURL: "https://github.com/acme/app",
+	}
+	h.bind.ensured = false
+	h.bind.scaleSetID = 0
+	sets := &occupiedScaleSets{}
+	h.bind.gh = sets
+
+	if err := h.srv.ensureScaleSet(t.Context(), h.bind); err == nil {
+		t.Fatal("the first pass adopted a scale set this instance did not create")
+	}
+	if err := h.srv.ensureScaleSet(t.Context(), h.bind); err == nil {
+		t.Fatal("the second pass adopted it: the refusal was defeated by the intention the refused pass wrote")
+	}
+	if sets.adopted != 0 {
+		t.Errorf("a stranger's scale set was adopted %d times", sets.adopted)
+	}
+	if h.bind.ensured {
+		t.Error("the binding reports itself ensured against a scale set it does not own")
 	}
 }

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -82,7 +82,7 @@ func (f *fakeCapsule) InspectExecution(ctx context.Context, _ capsule.PreparedRu
 // carry methods its test never exercises.
 type nullProvider struct{}
 
-func (nullProvider) EnsureScaleSet(context.Context, string, string, int, bool) (githubactions.ScaleSet, error) {
+func (nullProvider) EnsureScaleSet(context.Context, string, string, int, bool, func() error) (githubactions.ScaleSet, error) {
 	return githubactions.ScaleSet{}, nil
 }
 

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -422,7 +422,7 @@ type runtimeWaiter interface {
 // session keeps its own seam through newSession: the loop's session
 // handling is a subject of its own.
 type provider interface {
-	EnsureScaleSet(ctx context.Context, groupName, name string, knownID int, intended bool) (githubactions.ScaleSet, error)
+	EnsureScaleSet(ctx context.Context, groupName, name string, knownID int, intended bool, recordIntent func() error) (githubactions.ScaleSet, error)
 	GenerateJITConfig(ctx context.Context, scaleSetID int, runnerName, workFolder string) (githubactions.JITConfig, error)
 	RemoveRunner(ctx context.Context, id int) error
 	OpenSession(ctx context.Context, scaleSetID int, owner string) (*githubactions.Session, error)

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -185,10 +185,17 @@ func Validate(c *Config) error {
 		if err != nil {
 			v.errf(path+".url", "%v", err)
 		} else {
-			if targetURLs[ref.CanonicalURL] {
+			// Keyed case-insensitively: GitHub logins and repository
+			// names are, so two targets differing only in case name one
+			// scope. Accepted as distinct they each take a binding key of
+			// their own, and the scale-set name check below is written on
+			// the premise that target URLs are unique — so both would
+			// carry the same default name and collide on one remote set.
+			scope := strings.ToLower(ref.CanonicalURL)
+			if targetURLs[scope] {
 				v.errf(path+".url", "duplicate target %s: bind additional tiers on the existing target instead", ref.CanonicalURL)
 			}
-			targetURLs[ref.CanonicalURL] = true
+			targetURLs[scope] = true
 			// A JIT runner is not bound to the job whose demand message
 			// triggered it — measured live, not assumed — so only a
 			// repository-scoped scale set may mount a repository cache.

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -163,6 +163,18 @@ func TestValidateRules(t *testing.T) {
 			dup.ID = "again"
 			c.Targets = append(c.Targets, dup)
 		}, "targets[1].url"},
+		// GitHub logins and repository names are case-insensitive, so two
+		// targets differing only in case are one scope. Left as duplicates
+		// they each get a binding key of their own, and the scale-set name
+		// check below is written on the premise that target URLs are
+		// unique — so both bindings would carry the same default name and
+		// collide on one remote scale set.
+		"the same target under another case": {func(c *Config) {
+			dup := c.Targets[0]
+			dup.ID = "again"
+			dup.URL = "https://github.com/Acme/App"
+			c.Targets = append(c.Targets, dup)
+		}, "targets[1].url"},
 		"duplicate scale-set name in scope": {func(c *Config) {
 			c.Tiers = append(c.Tiers, Tier{ID: "heavy"})
 			ApplyDefaults(c)

--- a/internal/platform/githubactions/client.go
+++ b/internal/platform/githubactions/client.go
@@ -172,12 +172,18 @@ func (c *Client) RunnerGroupID(ctx context.Context, groupName string) (int, erro
 // exists under the requested name is adopted only when its id matches
 // that record: name equality is not ownership, and adopting a
 // stranger's set would route work through it and later delete it.
-// intended says the caller recorded, before this call, that it was about
-// to create this exact name. It is what separates a set this instance
-// created and failed to write down from a set that was simply already
-// there: without it the first is indistinguishable from the second and
-// the binding can never serve again.
-func (c *Client) EnsureScaleSet(ctx context.Context, groupName, name string, knownID int, intended bool) (ScaleSet, error) {
+// intended says an earlier pass recorded that it was about to create
+// this exact name. It is what separates a set this instance created and
+// failed to write down from a set that was simply already there: without
+// it the first is indistinguishable from the second and the binding can
+// never serve again.
+//
+// recordIntent writes that record, and is called only once the name is
+// known to be free. Recording it any earlier would have a pass that is
+// about to be refused leave behind the very evidence that tells a
+// refusal from a crash, and the next pass would adopt the stranger this
+// one declined.
+func (c *Client) EnsureScaleSet(ctx context.Context, groupName, name string, knownID int, intended bool, recordIntent func() error) (ScaleSet, error) {
 	existing, found, err := c.ScaleSetByName(ctx, groupName, name)
 	if err != nil {
 		return ScaleSet{}, err
@@ -219,6 +225,13 @@ func (c *Client) EnsureScaleSet(ctx context.Context, groupName, name string, kno
 		}
 		existing.Adopted = true
 		return existing, nil
+	}
+	// The name is free, so this is the moment the intention becomes true:
+	// written down before the set exists, and only for a name nothing else
+	// holds. The create below is the step that can be lost, and this is
+	// what makes losing it recoverable.
+	if err := recordIntent(); err != nil {
+		return ScaleSet{}, fmt.Errorf("record the intention to create scale set %q: %w", name, err)
 	}
 	// DisableUpdate is what keeps the runner inside the image it was
 	// built from. Left unset, the scale set tells a runner to upgrade

--- a/test/contract/githubactions/contract_test.go
+++ b/test/contract/githubactions/contract_test.go
@@ -126,9 +126,14 @@ func newWrapper(t *testing.T, configURL, token string) *githubactions.Client {
 // deletion, even when the test fails midway.
 func ensureSet(t *testing.T, gh *githubactions.Client, name string) githubactions.ScaleSet {
 	t.Helper()
-	set, err := gh.EnsureScaleSet(testCtx(t), "", name, 0, false)
+	intent := &intentRecorder{}
+	set, err := gh.EnsureScaleSet(testCtx(t), "", name, 0, false, intent.record)
 	if err != nil {
 		t.Fatalf("ensure scale set %q: %v", name, err)
+	}
+	if intent.calls != 1 {
+		t.Fatalf("the intention was recorded %d times while creating %q; a create that is not"+
+			" written down first cannot be recovered from", intent.calls, name)
 	}
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -162,4 +167,32 @@ func createScaleSet(t *testing.T, c *scaleset.Client, group *scaleset.RunnerGrou
 		t.Fatal("created scale set has no id")
 	}
 	return created
+}
+
+// intentRecorder stands in for the controller.s durable record of the
+// name it is about to create. Which branch calls it is a property only
+// these contracts can observe: the real provider decides whether the name
+// is free, and recording the intention on a path that adopts rather than
+// one that creates is what turns a refusal into an adoption on the pass
+// that follows it.
+type intentRecorder struct{ calls int }
+
+func (r *intentRecorder) record() error {
+	r.calls++
+	return nil
+}
+
+// adoption returns a recorder that fails the test if it is ever called.
+// Adoption is not a create, and an intention recorded on this path is the
+// record that tells a refusal from a crash — written by a pass that had
+// nothing to write down.
+func adoption(t *testing.T) *intentRecorder {
+	t.Helper()
+	r := &intentRecorder{}
+	t.Cleanup(func() {
+		if r.calls != 0 {
+			t.Errorf("adopting an existing scale set recorded the intention to create one, %d times", r.calls)
+		}
+	})
+	return r
 }

--- a/test/contract/githubactions/organization_test.go
+++ b/test/contract/githubactions/organization_test.go
@@ -20,7 +20,7 @@ func TestOrganizationDefaultGroupScaleSet(t *testing.T) {
 
 	// A second ensure adopts only when the caller proves ownership with
 	// the id it recorded; the restart path.
-	again, err := gh.EnsureScaleSet(testCtx(t), "", name, created.ID, false)
+	again, err := gh.EnsureScaleSet(testCtx(t), "", name, created.ID, false, adoption(t).record)
 	if err != nil {
 		t.Fatalf("re-ensure: %v", err)
 	}

--- a/test/contract/githubactions/runnerupdate_test.go
+++ b/test/contract/githubactions/runnerupdate_test.go
@@ -72,7 +72,7 @@ func TestAnAdoptedScaleSetForbidsRunnerSelfUpdate(t *testing.T) {
 			"this test cannot tell adoption from creation")
 	}
 
-	adopted, err := gh.EnsureScaleSet(ctx, "", permissive.Name, permissive.ID, false)
+	adopted, err := gh.EnsureScaleSet(ctx, "", permissive.Name, permissive.ID, false, adoption(t).record)
 	if err != nil {
 		t.Fatalf("adopt scale set %q: %v", permissive.Name, err)
 	}
@@ -129,7 +129,7 @@ func TestAdoptionLeavesACorrectScaleSetAlone(t *testing.T) {
 		}
 	})
 
-	adopted, err := gh.EnsureScaleSet(ctx, "", name, created.ID, false)
+	adopted, err := gh.EnsureScaleSet(ctx, "", name, created.ID, false, adoption(t).record)
 	if err != nil {
 		t.Fatalf("adopt scale set %q: %v", name, err)
 	}


### PR DESCRIPTION
## What changes

The record that says "this instance asked for this name" is written only after the
provider has confirmed the name is free, immediately before the create, instead of
before the provider is asked anything. A pass that is refused now leaves nothing
behind, so the refusal survives every retry. Separately, two targets differing only
in letter case are refused as the duplicate they are.

## What was found

Adoption of an existing scale set requires evidence that this instance created it:
either the recorded id matches, or an earlier pass recorded the intention to create
that exact name and did not live to write the id down. That intention was written
before the lookup.

So the first pass over a name somebody else holds wrote the row, committed it, and
was correctly refused by `EnsureScaleSet` — the refusal message is explicit that the
instance has no record of creating the set. Five seconds later, at `pollBackoff`, the
same binding loop read that row back, concluded the set was its own, skipped the
refusal, and adopted it. `knownID` was still zero, so the id check was skipped too.

From there the binding opens a message session on a scale set whose real owner is
also holding one — the provider allows a single session — serves that owner's queued
jobs on this host, and records the id, which is what would later let `runpool cleanup`
delete it. The doc comment on `EnsureScaleSet` states that name equality is not
ownership. The code did not have that property.

The second commit closes the door that leads there. GitHub logins and repository names
are case-insensitive, but the canonical URL kept the owner and repository segments
verbatim, so two targets naming one account validated as distinct and took a binding
key each. The scale-set name uniqueness check is written on the premise that target
URLs are unique — its own comment says so — so both bindings carried the same default
name in what validation believed were two different scopes, and collided on one remote
set. Which the first commit now refuses rather than adopts.

Rolling the row back when the provider refuses would not have been correct: an
ambiguous create is exactly what the intention exists for, and error classification is
a weaker guarantee than a write that cannot happen on the wrong branch.

## Evidence

Hermetic, plus an assertion the live contracts now carry.

```text
hermetic only — the provider contracts reach protected fixtures and never run on a
pull request, so the assertions added to `ensureSet` and the adoption paths are the
record of what will be observed the next time they are dispatched.
```

- `TestARefusedNameStaysRefusedOnTheNextPass` was watched failing before the fix, on
  the second pass, with the message naming the cause. Re-introducing the pre-lookup
  write as a mutation makes it fail again; it was restored and the package returned to
  green.
- The case-fold case in `TestValidateRules` was watched failing before its fix.
- `gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...` are
  clean across the module.

`TestACrashBetweenCreatingAndRecordingConverges` changed with the code rather than
around it: the property it pinned — the name is written down before the set exists at
the provider — now holds inside the adapter, where a caller cannot get it wrong. Its
fake calls the callback on the create path, so the test proves the callback the
controller supplies is the one that writes the row.

## What would notice this regressing

`TestARefusedNameStaysRefusedOnTheNextPass` fails if a refused pass leaves an
intention behind. `TestACrashBetweenCreatingAndRecordingConverges` still fails if the
name is not written before the create, and still covers the crash the intention exists
for. The case-fold row in `TestValidateRules` fails if the duplicate check stops
folding case.

Which branch calls the callback is a property only the live contracts can observe,
because the adapter's provider client is concrete and faking it would assert the mock.
Those contracts never run on a pull request, so this is the record: `ensureSet` now
asserts the intention was recorded exactly once while creating, and every adoption
path asserts it was not recorded at all — which is the mutation that produced this bug.


## Risk, compatibility and operations

**Trust boundary: this is the fix.** Before it, a binding could take over a scale set
belonging to another organization or another Runpool instance, open a message session
on it while its real owner held one, serve that owner's queued jobs on this host, and
record its id — after which `runpool cleanup` would delete it. That is a cross-tenant
effect reached without any credential the operator did not already hold, which is why
it is the whole of the change rather than a hardening.

**Credentials: unchanged.** No token, App key or JIT path is touched. The refusal
happens after authentication, on what the provider answered.

**Ownership and cleanup: narrowed in the safe direction.** `runpool cleanup` deletes a
scale set only when the recorded id matches; this stops a foreign id ever being
recorded, so the deletion path is reached for fewer sets, never more.

**Failure behaviour: a refusal now persists.** A name held by somebody else is refused
on every pass rather than on the first. An operator who genuinely wants that name must
choose another `scaleSetName` or remove the existing set, which is what the refusal
message already said. The crash the intention exists for is unaffected: it happens
after the create, and the record is written before it.

**Configuration: one previously-accepted document is now refused.** Two targets whose
URLs differ only in letter case validated before and do not now. They named one GitHub
scope, so accepting both produced two bindings racing for one remote scale set. No
canonical URL changes and no binding key changes, so nothing persisted moves.

**Networking, resource limits, status API, schema, migration, deployment, rollback:
N/A.** No policy, envelope, JSON field, table or deployment artifact is touched.

**Runbook: N/A.** The refusal message already names the two remedies.

**Not an ADR.** It restores a property `EnsureScaleSet`'s own doc comment already
claimed — that name equality is not ownership.

## Changelog

```text
Added under "State and operations": a scale set that merely shares a name is a
stranger's, and stays one — including the case-fold half, because two targets
differing only in letter case are one GitHub scope.
```
