### PR TITLE
fix(app): the launch proves its own gateway carries the policy in force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,19 @@ by its public and operational effects.
   public internet — which is how a capsule reaches a service on the
   host's own public address, an address the runtime deny set withholds
   from facts static validation cannot see.
+- **A capsule runs under the deny set in force, not the one its launch was
+  handed.** A policy change reaches the gateways that exist when it is
+  installed, and a gateway still being created is not one of them — so the
+  launch that creates one proves it carries the current set before its job
+  is authorized to start. Without that, a capsule launched while a network
+  appeared kept the older, more permissive set for the whole life of its
+  job, and no later pass revisited it: the record said the change was in
+  force everywhere, so every pass after compared that set against itself
+  and found nothing to do. In the ordinary case, where nothing moved while
+  the capsule was being built, the check reaches no daemon at all. A
+  restriction that could neither be installed into a gateway nor close it
+  no longer enters the record either, so the next pass attempts it again
+  rather than never trying it again.
 
 ### State and operations
 

--- a/docs/adrs/2026-08-23-the-launch-proves-its-own-gateway.md
+++ b/docs/adrs/2026-08-23-the-launch-proves-its-own-gateway.md
@@ -1,0 +1,112 @@
+# The launch proves its own gateway
+
+**Status:** accepted and implemented
+
+**Date:** 2026-08-23
+
+## Context
+
+A capsule's egress is confined by a gateway container that carries a deny
+set. The controller rediscovers that set periodically and before every
+launch, and installs a change by fanning out to the gateways it can
+enumerate. Once the fan-out returns, it records the new set as the one in
+force.
+
+The record is what the next pass compares against. That comparison asks
+"is any gateway stale?" by comparing the controller's record with the
+controller's record — a comparison that cannot see a gateway. Its
+correctness rests on a claim the bookkeeping cannot support: that the set
+of gateways at the moment of recording is the set that was enumerated.
+
+Launches create gateways concurrently, so the claim is false. A launch
+takes its copy of the sandbox, releases the serialising slot, and then
+spends anywhere up to the capsule preparation budget creating containers
+— which includes pulling an image the daemon may not hold. A policy pass
+running inside that window enumerates the gateways that exist, does not
+find the one being created, records the new set as in force, and returns.
+The gateway then starts carrying the older set.
+
+Nothing revisits it. Every later pass computes the same new set, compares
+it against the recorded new set, finds no change and performs no fan-out
+at all. The capsule keeps the older, more permissive deny set for the
+whole life of its job.
+
+The same record hides a second case. When a restriction cannot be
+installed into a gateway, that gateway is closed; when the close also
+fails, the failure was logged and the new set was recorded anyway. The
+next pass then compares the new set against itself and never attempts the
+restriction again, while the gateway keeps relaying past a deny the
+operator was promised.
+
+## Decision
+
+**The launch that creates a gateway proves that gateway carries the set
+in force, at the one moment it is both enumerable and not yet serving a
+job.** A confirmation step runs after the capsule's preparation completes
+and before the attempt is authorized to start. It compares the sandbox
+the launch was handed against the one in force; when they agree it costs
+two comparisons and reaches no daemon, and when they differ it installs
+the current set into the gateways of that lease and re-reads to confirm
+it was not overtaken. A gateway that cannot be reached, or a lease that
+owns no running gateway, fails the launch — and the launch's own recovery
+removes every resource of the lease, so a stale gateway is torn down
+rather than left denying.
+
+**A restriction that could neither be installed nor closed does not enter
+the books, and the pass reports the failure.** The caller answers it the
+way it already answers a failed enumeration: a launch is refused, and a
+rediscovery closes every gateway to all egress.
+
+**A gateway's first policy is installed through the lock a reload takes.**
+The install that boots a gateway is the one installer with no predecessor
+to read, and every other build states that it needs one instead of
+inferring it from a read that failed.
+
+Two alternatives were measured and rejected.
+
+**Holding the refresh slot across the launch.** This makes the recording
+claim true by preventing gateway creation during a pass, but the slot is
+a single one and the hold would span the entire capsule preparation
+budget — image pulls, readiness waits and the credential exchange. At the
+parallelism this design already reasons about, launches begin failing on
+the wait rather than queueing behind it, because a launch waits on its
+own preparation context. Worse, the periodic rediscovery acquires the
+same slot from a ticker loop, and a ticker drops ticks for a slow
+receiver: to stop a launch crossing a tightening, this stops tightenings
+being discovered.
+
+**Re-asserting the policy on every pass.** Removing the unchanged-set
+early return makes every pass fan out to every gateway. Because a
+rediscovery also runs before every launch, this moves a cost bounded
+per-change to per-launch — one control command per gateway per launch,
+inside the slot every other launch waits for. It also does not close the
+hole: a gateway created after a pass enumerates still misses that pass
+and is corrected only by the next one, which may be after the job has
+finished. It converts a permanent divergence into an intermittent one at
+the highest running cost of the three.
+
+## Consequences
+
+A capsule cannot start under a deny set that is not the one in force. The
+check is free in the ordinary case, where nothing moved while the capsule
+was being built.
+
+A gateway that refuses the policy in force fails its launch rather than
+serving. The attempt returns to the queue and the lease's resources are
+removed, which is the same answer an unprovable sandbox already gets.
+
+A restriction that could neither be installed into a gateway nor close it
+now costs egress for every capsule on the host, on every pass, until the
+gateway is gone. This is deliberate: a gateway relaying past a deny is a
+stronger reason to close everything than not knowing what the deny set
+should be, which already closes everything. Reaching it requires a daemon
+that refuses both an exec and a bounded removal, on which launches and
+teardowns are failing too. The log line names the container and says the
+remedy is the daemon rather than the policy.
+
+**What stays open.** A relaxation that did not reach a gateway leaves
+that capsule confined more tightly than the policy for the life of its
+job, and nothing retries it. That is deliberate — the capsule's work
+continues, and the cost of being too strict is a failed job rather than a
+crossed boundary — but it is a divergence between the record and a
+running gateway, and it is not reported as one.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -25,3 +25,4 @@ justified it usually still holds even when the remedy does not.
 | 2026-08-17 | [Target hosts and scopes](2026-08-17-target-hosts-and-scopes.md) — any host the protocol serves, at any scope it defines | accepted |
 | 2026-08-23 | [The engine port has a name](2026-08-23-the-engine-port-has-a-name.md) — the container engine is a port, and the Moby client is one adapter behind it | accepted and implemented |
 | 2026-08-20 | [The session wait has no deadline](2026-08-20-the-session-wait-has-no-deadline.md) — why giving up costs more than waiting, and what the report says instead | accepted; supersedes one consequence of session conflict |
+| 2026-08-23 | [The launch proves its own gateway](2026-08-23-the-launch-proves-its-own-gateway.md) — a capsule cannot start under a deny set that is not the one in force | accepted and implemented |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,6 +183,13 @@ the discovered deny set. This observes networks created by other stacks and
 recreates an idle uplink removed by external cleanup without sharing mutable
 policy slices between concurrent capsules.
 
+The copy is not the guarantee. A policy pass fans a change out to the gateways
+it can enumerate, and a gateway still being created is not among them — so the
+launch that created one proves it carries the set in force before its capsule
+is authorized to start. That check is where a capsule launched across a
+tightening is caught; without it the copy it was handed would confine it for
+the whole life of its job, and no later pass would revisit it.
+
 ## Further reading
 
 - [Threat model](security/threat-model.md) — what is defended and what is accepted

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -160,6 +160,22 @@ classified before it is installed:
 - **discovery failing at all** closes every gateway. An undiscovered
   network is indistinguishable from one that was never there, so a
   policy that cannot be shown to be current is not treated as current.
+- **a restriction that could neither be installed nor closed** stops the
+  pass. The new set is not recorded, so the next pass attempts it again,
+  and the pass reports the failure — which closes every gateway on the
+  host to all egress, on the same rule as a failed discovery. The log
+  line names the container. **The remedy is the daemon holding it, not
+  the policy**: a container that refuses both an exec and a bounded
+  removal is a wedged daemon, and launches and teardowns are failing on
+  it too. Remove the container by hand, or restart the daemon; egress
+  returns on the next pass.
+
+A capsule created while a change is being installed is not left behind.
+The gateway does not exist yet when the pass enumerates, so the launch
+that creates it proves it carries the set in force before the job is
+authorized to start. A gateway that cannot be reached at that point fails
+its launch: the attempt returns to the queue and the lease's resources
+are removed.
 
 The handover is atomic on each half — one kernel restore, one file
 rename — and the window between them is deliberately the stricter of

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -90,6 +90,7 @@ policy remain necessary in either topology.
 | The host cannot be starved by a job | One envelope per lease, split between the capsule and its egress gateway and placed under one parent cgroup: the capsule's aggregate covers runner, daemon and every inner container; the gateway holds the rest of the same tier, because every connection a job opens is work it performs. The doctor refuses a configuration whose full tiers plus reserve exceed the host, and the validator refuses a tier too small to split | Kernel-proven on the reference host: inner OOM charged to the capsule; both containers report one parent cgroup and their limits sum to the tier; a fork storm in the gateway stops at its own ceiling |
 | The host cannot be filled | Disk monitor probes the daemon's filesystem from inside it; admission closes at the soft floor, fails closed at the hard floor, and GC evicts only free lanes | Pressure transitions table-tested; disk-full behaviour live for both SQLite and containers |
 | Egress confinement | Under `public-internet-only`, the host kernel drops anything the capsule addresses beyond its bridge; the gateway relays DNS and HTTP(S) under default-deny, resolving before dialing (rebinding defence) | Live bypass suite: no direct route anywhere, denied addresses refused by name and by address, gateway loss removes egress |
+| A capsule runs under the deny set in force, not the one its launch was handed | A policy change fans out to the gateways that exist; a gateway created during that window is proved by the launch that created it, before its capsule is authorized to start. A gateway that cannot be reached fails the launch, and a restriction that could neither be installed nor closed leaves the record unmoved so the next pass attempts it again | Table-tested: a gateway appearing after a pass enumerated is reloaded by its launch; an unreachable one fails it; an unchanged policy reaches no daemon; an unclosable restriction is retried |
 
 ## Known weakness
 
@@ -133,6 +134,13 @@ These are consequences of the design, not oversights:
   policy, not hardware. On `shared-daemon`, the operator explicitly accepts
   that kernel-level compromise can reach colocated services; use
   `dedicated-daemon` when that impact is unacceptable.
+- **A relaxation that did not reach a gateway is not retried.** When a
+  policy change widens what a capsule may reach and one gateway does not
+  take it, that capsule stays confined more tightly than the policy for
+  the life of its job. The controller records the wider set and moves on:
+  the cost is a job that cannot reach something it was entitled to, not a
+  boundary that was crossed. A restriction that does not land is treated
+  the opposite way, and closes the gateway.
 - **Platform-wide volume prune bypasses Runpool's ownership model.** Docker
   treats an unattached cache lane as unused. On a shared daemon, disable
   unused-volume cleanup and any system prune that includes volumes. Image

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -168,6 +168,15 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return
 	}
+	// The gateway exists and is ready now, so this is the first moment
+	// the policy it carries can be checked against the one in force --
+	// and the last moment before the capsule is authorized to start, so
+	// it is the only one at which a stale gateway is still free.
+	if err := s.netSandbox.confirmLaunch(prepCtx, lease.ID, sandbox); err != nil {
+		log.Error("the capsule's gateway does not carry the egress policy in force", "error", err)
+		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
+		return
+	}
 	// Recorded after the preparation exists — evidence names what
 	// happened, never what was about to be attempted.
 	if err := s.leases.RecordEvidence(ctx, lease.ID, store.EvidenceRuntimePrepared); err != nil {

--- a/internal/app/sandbox.go
+++ b/internal/app/sandbox.go
@@ -336,6 +336,69 @@ func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error
 	return n.state.snapshot(), nil
 }
 
+// confirmLaunch proves the gateway this launch created carries the set in
+// force, before the capsule it fronts is authorized to start.
+//
+// A policy pass fans a change out to the gateways it can enumerate. One
+// still being created is not among them, and it should not be: it is not
+// relaying anything yet. What the pass cannot do is come back for it once
+// it starts, because the record it leaves behind reports the new set as in
+// force, and every later pass compares that set against itself and finds
+// nothing to do. Without this, a capsule launched across a tightening
+// keeps the older, more permissive set for the whole life of its job.
+//
+// The launch is what closes that gap, at the one moment its gateway is
+// both enumerable and not yet serving work. It costs two comparisons in
+// the ordinary case, where the policy did not move while the capsule was
+// being built, and reaches the daemon only when it did.
+func (n *networkSandbox) confirmLaunch(ctx context.Context, leaseID assignment.LeaseID, launched *capsule.Sandbox) error {
+	if n == nil || launched == nil {
+		return nil
+	}
+	inForce := n.state.snapshot()
+	if sameSandbox(launched, inForce) {
+		return nil
+	}
+	containers, err := n.ownedContainers(ctx)
+	if err != nil {
+		return fmt.Errorf("enumerate gateways: %w", err)
+	}
+	payload, err := json.Marshal(egress.Policy{Allow: inForce.Allow, Deny: inForce.Deny})
+	if err != nil {
+		return err
+	}
+	var confirmed int
+	for _, c := range containers {
+		if c.Role != capsule.RoleGateway || c.LeaseID != leaseID || !c.Running {
+			continue
+		}
+		if err := n.reloadGateway(ctx, c, payload); err != nil {
+			return fmt.Errorf("install the policy in force into gateway %s: %w", engine.ShortID(c.ID), err)
+		}
+		confirmed++
+	}
+	if confirmed == 0 {
+		// Nothing to install the policy into means nothing proves this
+		// capsule's egress is confined, which is the same answer as a
+		// gateway that refused it.
+		return fmt.Errorf("lease %s owns no running gateway to confirm the egress policy against", leaseID)
+	}
+	// A pass that moved the set while this ran leaves the gateway one
+	// generation behind. A capsule must not start under a set that was
+	// current a moment ago, and the pass that moved it could not have
+	// reached this gateway either.
+	if after := n.state.snapshot(); !sameSandbox(inForce, after) {
+		return fmt.Errorf("the egress policy moved while the gateway was being confirmed")
+	}
+	return nil
+}
+
+// sameSandbox reports whether two sandboxes confine a capsule the same
+// way: the same deny set, reached through the same uplink.
+func sameSandbox(a, b *capsule.Sandbox) bool {
+	return ClassifyPolicy(a.Deny, b.Deny) == PolicyUnchanged && a.UplinkNetworkID == b.UplinkNetworkID
+}
+
 func (n *networkSandbox) refresh(ctx context.Context) error {
 	select {
 	case n.state.refreshing <- struct{}{}:
@@ -407,31 +470,54 @@ func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox)
 		// landed nowhere would never be attempted again.
 		return fmt.Errorf("enumerate gateways: %w", err)
 	}
-	// Recorded only now: the set has reached every gateway that could be
-	// named, so this is what is in force rather than what was intended.
-	// The refresh slot is held across both, so no launch can observe the
-	// window between them.
-	n.state.replace(next)
-	if len(failed) == 0 {
-		return nil
-	}
-	if !change.restricts() {
-		// A relaxation that did not land leaves the capsule with the
-		// stricter policy it started under. Its work continues.
-		n.log.Warn("some gateways kept the previous, stricter policy",
-			"gateways", len(failed), "change", change.String())
-		return nil
-	}
-	// A restriction that did not land leaves a capsule able to reach
-	// something the policy now denies. Close those gateways.
-	n.log.Error("a restriction could not be installed; closing the affected gateways",
-		"gateways", len(failed))
-	eachGateway(failed, func(id string) {
-		if err := n.closeGateway(ctx, id); err != nil {
-			n.log.Error("a gateway could not be closed and may still relay a denied address",
-				"container", id, "error", err)
+	if len(failed) > 0 {
+		if !change.restricts() {
+			// A relaxation that did not land leaves the capsule with the
+			// stricter policy it started under. Its work continues.
+			n.log.Warn("some gateways kept the previous, stricter policy",
+				"gateways", len(failed), "change", change.String())
+		} else {
+			// A restriction that did not land leaves a capsule able to
+			// reach something the policy now denies. Close those
+			// gateways.
+			n.log.Error("a restriction could not be installed; closing the affected gateways",
+				"gateways", len(failed))
+			var mu sync.Mutex
+			var open []string
+			eachGateway(failed, func(id string) {
+				if err := n.closeGateway(ctx, id); err != nil {
+					n.log.Error("a gateway could not be closed and may still relay a denied address; "+
+						"the remedy is the daemon holding it, not the policy",
+						"container", id, "error", err)
+					mu.Lock()
+					open = append(open, id)
+					mu.Unlock()
+				}
+			})
+			if len(open) > 0 {
+				// The books do not move. A restriction that neither
+				// reached a gateway nor removed it is not in force, and
+				// recording it would have the next pass compare the new
+				// set against itself, report it unchanged, and never
+				// attempt it again -- the same reason an enumeration
+				// failure leaves the snapshot alone. The caller closes
+				// every gateway on this host, which is what a set that
+				// cannot be shown to be current costs everywhere else
+				// here: a gateway relaying past a deny the operator was
+				// promised is a stronger reason for that than not
+				// knowing what the deny set should be.
+				return fmt.Errorf("a restriction could not be installed and the gateway could not be closed: %s",
+					strings.Join(open, ", "))
+			}
 		}
-	})
+	}
+	// Recorded only now: the set is in force in every gateway that was
+	// relaying, either because it was installed there or because that
+	// gateway is gone. A gateway created while this ran is not covered
+	// by this record and is not meant to be -- the launch that creates
+	// one confirms it against this snapshot before its capsule is
+	// authorized to start.
+	n.state.replace(next)
 	return nil
 }
 
@@ -496,20 +582,36 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 		if c.Role != capsule.RoleGateway || !c.Running {
 			return
 		}
-		code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
-			return n.daemon.ExecWithInput(ctx, c.ID,
-				[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
-		})
-		if err != nil || code != 0 {
+		if err := n.reloadGateway(ctx, c, payload); err != nil {
 			mu.Lock()
 			failed = append(failed, c.ID)
 			mu.Unlock()
-			n.log.Error("gateway policy reload failed", "container", c.Name, "exit", code, "error", err, "output", out)
+			n.log.Error("gateway policy reload failed", "container", c.Name, "error", err)
 			return
 		}
 		n.log.Info("gateway policy reloaded", "container", c.Name)
 	})
 	return failed, nil
+}
+
+// reloadGateway installs one policy into one gateway. It is spelled once
+// because two callers reach it for different reasons -- a pass fanning a
+// change out to every gateway that was relaying, and a launch proving the
+// gateway it just created carries the set in force -- and a reload that
+// judged its exit code differently on those two paths would be two
+// answers to the same question.
+func (n *networkSandbox) reloadGateway(ctx context.Context, c engine.OwnedContainer, payload []byte) error {
+	code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
+		return n.daemon.ExecWithInput(ctx, c.ID,
+			[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
+	})
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return fmt.Errorf("gateway-reload exited %d: %s", code, out)
+	}
+	return nil
 }
 
 // gatewayControlTimeout bounds one gateway control operation — an exec

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -103,6 +103,14 @@ type fakeSandboxDaemon struct {
 	// refuse names the containers whose exec fails, which is how a
 	// gateway that will not take a new policy is expressed.
 	refuse map[string]bool
+	// removeErr names the containers the daemon will not remove, which is
+	// how a gateway that can neither be reloaded nor closed is expressed.
+	removeErr map[string]error
+	// onList runs inside the enumeration, after the answer to this call
+	// has been taken. Appending there is how a gateway appears between a
+	// pass listing them and that pass finishing, which is the moment a
+	// launch creates one.
+	onList func(*fakeSandboxDaemon)
 	// delay is how long each gateway control command takes, which is
 	// what makes a serial pass distinguishable from a concurrent one.
 	delay time.Duration
@@ -128,8 +136,11 @@ type fakeSandboxDaemon struct {
 	// holds the lock before any gateway has been reached.
 	listDeadline time.Time
 	listBounded  bool
-	reloaded     []string
-	removed      []string
+	// lists counts enumerations, which is what separates a confirmation
+	// that had nothing to do from one that reached the daemon.
+	lists    int
+	reloaded []string
+	removed  []string
 	// events is what the daemon was asked to do, in order, as
 	// "<verb>:<container>". Two sorted sets cannot say that the
 	// revocation came before the removal, and per-gateway order is
@@ -220,11 +231,16 @@ func (f *fakeSandboxDaemon) RunTask(ctx context.Context, _ engine.ContainerSpec)
 func (f *fakeSandboxDaemon) ListOwnedContainers(ctx context.Context, _ assignment.InstanceID) ([]engine.OwnedContainer, error) {
 	f.mu.Lock()
 	f.listDeadline, f.listBounded = ctx.Deadline()
+	f.lists++
+	answer := slices.Clone(f.containers)
+	if f.onList != nil {
+		f.onList(f)
+	}
 	f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
-	return f.containers, nil
+	return answer, nil
 }
 func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
 	f.serve()
@@ -250,6 +266,9 @@ func (f *fakeSandboxDaemon) RemoveContainer(ctx context.Context, id string) erro
 	f.mu.Unlock()
 	f.serve()
 	f.note(&f.events, "remove:"+id)
+	if err := f.removeErr[id]; err != nil {
+		return err
+	}
 	f.note(&f.removed, id)
 	return nil
 }
@@ -810,5 +829,183 @@ func TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency(t *testing.T) {
 	if len(daemon.events) != 0 || len(daemon.removed) != 0 {
 		t.Errorf("a stopped rediscovery reached the daemon: %v, removed %v",
 			daemon.events, daemon.removed)
+	}
+}
+
+// tighter returns the deny set of s with one more range in it.
+func tighter(s *capsule.Sandbox) *capsule.Sandbox {
+	next := *s
+	next.Deny = append(slices.Clone(s.Deny), "192.168.0.0/16")
+	return &next
+}
+
+func sandboxFixture() *capsule.Sandbox {
+	return &capsule.Sandbox{
+		UplinkNetworkID: "uplink-1",
+		UplinkSubnet:    "172.30.0.0/24",
+		Deny:            []string{"10.0.0.0/8"},
+	}
+}
+
+// TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy: a pass
+// fans a change out to the gateways it can enumerate, and one still being
+// created is not among them. Nothing comes back for it afterwards either,
+// because the pass records the new set as in force and every later pass
+// compares that set against itself. The launch that created the gateway
+// is what closes the gap, before its capsule is authorized to start.
+func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T) {
+	daemon := &fakeSandboxDaemon{
+		refuse: map[string]bool{},
+		containers: []engine.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
+		},
+	}
+	// The launch's gateway appears just after the pass has listed, which
+	// is the whole of the window this closes.
+	daemon.onList = func(f *fakeSandboxDaemon) {
+		f.containers = append(f.containers, engine.OwnedContainer{
+			ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"})
+		f.onList = nil
+	}
+	n := newTestSandbox(t, daemon, sandboxFixture())
+	launched := n.state.snapshot()
+
+	if err := n.applyPolicy(t.Context(), tighter(launched)); err != nil {
+		t.Fatalf("applyPolicy: %v", err)
+	}
+	if got := daemon.reloads(); len(got) != 1 || got[0] != "gw-1" {
+		t.Fatalf("the pass reloaded %v; a gateway it never named cannot be among them", got)
+	}
+
+	if err := n.confirmLaunch(t.Context(), "lse-late", launched); err != nil {
+		t.Fatalf("confirmLaunch: %v", err)
+	}
+	if got := daemon.reloads(); !slices.Contains(got, "gw-late") {
+		t.Errorf("reloaded %v; the launch must install the set in force into the gateway it created", got)
+	}
+}
+
+// TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon: the ordinary
+// case is that nothing moved while the capsule was being built, and it
+// has to stay free. Re-asserting the policy on every launch instead would
+// cost one exec per gateway per launch, which is the cost the fan-out is
+// bounded to avoid.
+func TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon(t *testing.T) {
+	daemon := &fakeSandboxDaemon{
+		refuse: map[string]bool{},
+		containers: []engine.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
+		},
+	}
+	n := newTestSandbox(t, daemon, sandboxFixture())
+
+	if err := n.confirmLaunch(t.Context(), "lse-1", n.state.snapshot()); err != nil {
+		t.Fatalf("confirmLaunch: %v", err)
+	}
+	if got := daemon.reloads(); len(got) != 0 {
+		t.Errorf("reloaded %v; a launch whose policy did not move reaches no gateway", got)
+	}
+	if daemon.lists != 0 {
+		t.Errorf("the daemon was enumerated %d times; a launch whose policy did not move does not ask",
+			daemon.lists)
+	}
+}
+
+// TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch: an unprovable
+// policy refuses a launch everywhere else in this file, and a gateway that
+// will not take the set in force is exactly that. The teardown belongs to
+// the launch's own recovery, which removes every resource of the lease --
+// so this must not remove anything itself.
+func TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch(t *testing.T) {
+	launched := sandboxFixture()
+	for name, tc := range map[string]struct {
+		containers []engine.OwnedContainer
+		refuse     map[string]bool
+	}{
+		"the gateway refuses the policy in force": {
+			containers: []engine.OwnedContainer{
+				{ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"},
+			},
+			refuse: map[string]bool{"gw-late": true},
+		},
+		"the lease owns no running gateway": {
+			containers: []engine.OwnedContainer{
+				{ID: "gw-other", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-other"},
+			},
+			refuse: map[string]bool{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			daemon := &fakeSandboxDaemon{refuse: tc.refuse, containers: tc.containers}
+			n := newTestSandbox(t, daemon, tighter(launched))
+
+			if err := n.confirmLaunch(t.Context(), "lse-late", launched); err == nil {
+				t.Fatal("the launch was confirmed against a policy no gateway of its own carries")
+			}
+			if got := daemon.removes(); len(got) != 0 {
+				t.Errorf("removed %v; the launch's own recovery owns the teardown", got)
+			}
+		})
+	}
+}
+
+// TestAConfirmationThatWasOvertakenFailsTheLaunch: a pass that moved the
+// set while the confirmation ran leaves the gateway one generation behind,
+// and could not have reached it either. A capsule must not start under a
+// set that was current a moment ago.
+func TestAConfirmationThatWasOvertakenFailsTheLaunch(t *testing.T) {
+	launched := sandboxFixture()
+	daemon := &fakeSandboxDaemon{
+		refuse: map[string]bool{},
+		containers: []engine.OwnedContainer{
+			{ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"},
+		},
+	}
+	n := newTestSandbox(t, daemon, tighter(launched))
+	daemon.onList = func(f *fakeSandboxDaemon) {
+		f.onList = nil
+		moved := *launched
+		moved.Deny = []string{"10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"}
+		n.state.replace(&moved)
+	}
+
+	if err := n.confirmLaunch(t.Context(), "lse-late", launched); err == nil {
+		t.Fatal("the launch was confirmed against a set that had already been superseded")
+	}
+}
+
+// TestARestrictionThatCouldNotBeClosedIsRetried: a restriction that
+// reached no gateway and could not close it either is not in force. The
+// books must not move, for the same reason an enumeration failure leaves
+// them alone -- recorded, the next pass compares the new set against
+// itself and never attempts it again, while a gateway keeps relaying past
+// a deny the operator was promised.
+func TestARestrictionThatCouldNotBeClosedIsRetried(t *testing.T) {
+	daemon := &fakeSandboxDaemon{
+		refuse:    map[string]bool{"gw-bad": true},
+		removeErr: map[string]error{"gw-bad": errors.New("container is wedged")},
+		containers: []engine.OwnedContainer{
+			{ID: "gw-bad", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-bad"},
+		},
+	}
+	n := newTestSandbox(t, daemon, sandboxFixture())
+	tightened := tighter(sandboxFixture())
+
+	if err := n.applyPolicy(t.Context(), tightened); err == nil {
+		t.Fatal("a restriction that reached no gateway and closed none reported success")
+	}
+	if got := n.state.snapshot().Deny; len(got) != 1 {
+		t.Fatalf("the books record %v as in force; it is in no gateway", got)
+	}
+
+	// The daemon recovers, and the pass that follows must see the change
+	// again rather than compare the new set against itself.
+	daemon.refuse = map[string]bool{}
+	daemon.removeErr = nil
+	if err := n.applyPolicy(t.Context(), tightened); err != nil {
+		t.Fatalf("the retry failed: %v", err)
+	}
+	if got := n.state.snapshot().Deny; len(got) != 2 {
+		t.Errorf("the books record %v after a retry that reached the gateway", got)
 	}
 }

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/rhobuild/runpool/internal/capsule/protocol"
 	"github.com/rhobuild/runpool/internal/egress"
-	"github.com/rhobuild/runpool/internal/platform/atomicfile"
 )
 
 // Config is what the gateway needs to start. The caller supplies the
@@ -69,15 +68,19 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("interfaces: %w", err)
 	}
-	if err := ApplyFirewall(policy, legs); err != nil {
+	// The kernel and the file go under the lock a reload takes, and in the
+	// order a reload uses. Applied outside it, a reload arriving while this
+	// gateway boots either failed on a file that did not exist yet, or
+	// completed and was then clobbered by the write that followed it --
+	// leaving the kernel on one policy and the relay's own check on
+	// another. Blocking on the lock, it now waits for this install and
+	// then finds a policy in force.
+	if err := installPolicy(cfg.ControlDir, func(egress.Policy, bool) (egress.Policy, error) {
+		return policy, nil
+	}); err != nil {
 		return fmt.Errorf("ruleset: %w", err)
 	}
-	// The policy in force lives in a file from here on, so a reload
-	// exec and this process agree on one source.
 	path := PolicyPath(cfg.ControlDir)
-	if err := atomicfile.Replace(path, []byte(cfg.Policy), 0o600, -1, -1); err != nil {
-		return fmt.Errorf("policy file: %w", err)
-	}
 	store := &PolicyStore{Path: path}
 	if _, err := store.Current(); err != nil {
 		return fmt.Errorf("policy: %w", err)

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -159,7 +159,10 @@ func Reload(controlDir string, r io.Reader) error {
 	if err := json.Unmarshal(payload, &incoming); err != nil {
 		return err
 	}
-	return installPolicy(controlDir, func(current egress.Policy) (egress.Policy, error) {
+	return installPolicy(controlDir, func(current egress.Policy, inForce bool) (egress.Policy, error) {
+		if !inForce {
+			return egress.Policy{}, errNoPolicyInForce
+		}
 		next := egress.Policy{
 			InternalSubnet: current.InternalSubnet,
 			UplinkSubnet:   current.UplinkSubnet,
@@ -186,7 +189,10 @@ func Reload(controlDir string, r io.Reader) error {
 // "narrower", it is merely older, and a subnet that appeared since is
 // reachable under it.
 func DenyAll(controlDir string) error {
-	return installPolicy(controlDir, func(current egress.Policy) (egress.Policy, error) {
+	return installPolicy(controlDir, func(current egress.Policy, inForce bool) (egress.Policy, error) {
+		if !inForce {
+			return egress.Policy{}, errNoPolicyInForce
+		}
 		return egress.Policy{
 			InternalSubnet: current.InternalSubnet,
 			UplinkSubnet:   current.UplinkSubnet,
@@ -204,7 +210,7 @@ func DenyAll(controlDir string) error {
 // The two legs always come from the policy in force. Which networks a
 // gateway bridges is a fact of its own creation, not something a later
 // discovery pass may redefine.
-func installPolicy(controlDir string, build func(current egress.Policy) (egress.Policy, error)) error {
+func installPolicy(controlDir string, build func(current egress.Policy, inForce bool) (egress.Policy, error)) error {
 	return installPolicyWith(controlDir, build, applyToKernel)
 }
 
@@ -226,7 +232,7 @@ func applyToKernel(next egress.Policy) error {
 }
 
 func installPolicyWith(controlDir string,
-	build func(current egress.Policy) (egress.Policy, error),
+	build func(current egress.Policy, inForce bool) (egress.Policy, error),
 	apply func(next egress.Policy) error) error {
 
 	// The two callers reach this from separate `docker exec` processes
@@ -256,15 +262,23 @@ func installPolicyWith(controlDir string,
 	defer syscall.Flock(int(lock.Fd()), syscall.LOCK_UN)
 
 	path := PolicyPath(controlDir)
-	inForce, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("no policy in force: %w", err)
-	}
+	// An absent file is not an error here. A gateway installs its first
+	// policy through this same lock, so that one installer has no
+	// predecessor to read -- and every other build says so itself rather
+	// than inferring it from a read that failed.
 	var current egress.Policy
-	if err := json.Unmarshal(inForce, &current); err != nil {
-		return err
+	inForce := true
+	switch encoded, err := os.ReadFile(path); {
+	case os.IsNotExist(err):
+		inForce = false
+	case err != nil:
+		return fmt.Errorf("read the policy in force: %w", err)
+	default:
+		if err := json.Unmarshal(encoded, &current); err != nil {
+			return err
+		}
 	}
-	next, err := build(current)
+	next, err := build(current, inForce)
 	if err != nil {
 		return err
 	}
@@ -277,3 +291,8 @@ func installPolicyWith(controlDir string,
 	}
 	return atomicfile.Replace(path, encoded, 0o600, -1, -1)
 }
+
+// errNoPolicyInForce is what a build returns when it needs a predecessor
+// and there is none. Only a gateway's first install is entitled to that,
+// and it is the one build that does not ask.
+var errNoPolicyInForce = errors.New("no policy in force")

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -189,14 +190,14 @@ func TestAConcurrentInstallLeavesAPolicyInForce(t *testing.T) {
 	// ever touched.
 	noKernel := func(egress.Policy) error { return nil }
 	reload := func() error {
-		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+		return installPolicyWith(dir, func(current egress.Policy, _ bool) (egress.Policy, error) {
 			next := current
 			next.Deny = []string{"10.0.0.0/8", "192.168.0.0/16"}
 			return next, next.Validate()
 		}, noKernel)
 	}
 	denyAll := func() error {
-		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+		return installPolicyWith(dir, func(current egress.Policy, _ bool) (egress.Policy, error) {
 			next := current
 			next.Allow, next.Deny = nil, []string{"0.0.0.0/0"}
 			return next, nil
@@ -299,7 +300,7 @@ func TestConcurrentInstallsAreSerialized(t *testing.T) {
 	// to hold shut.
 	var inside, peak atomic.Int32
 	install := func() error {
-		return installPolicyWith(dir, func(current egress.Policy) (egress.Policy, error) {
+		return installPolicyWith(dir, func(current egress.Policy, _ bool) (egress.Policy, error) {
 			n := inside.Add(1)
 			for {
 				seen := peak.Load()
@@ -475,5 +476,57 @@ func TestAnEqualLengthInstallIsNotMissed(t *testing.T) {
 	if s.Generation() == baseline {
 		t.Error("the generation did not move on the second install; the pooled transport " +
 			"keeps every connection the previous policy authorised")
+	}
+}
+
+// TestOnlyAFirstInstallMayFindNoPolicyInForce: a gateway installs the
+// policy it boots with through the same lock a reload takes, so exactly
+// one installer has no predecessor to read. Every other build says it
+// needs one rather than inferring it from a read that failed — an
+// inference that would let a reload seed a gateway whose legs nothing has
+// identified, and whose kernel carries no ruleset at all.
+//
+// The lock file is what says the boot install went through that path.
+// Written outside it, a reload arriving during the boot either failed on
+// a file that did not exist yet or was clobbered by the write that
+// followed it, leaving the kernel on one policy and the relay's own check
+// on another.
+func TestOnlyAFirstInstallMayFindNoPolicyInForce(t *testing.T) {
+	dir := t.TempDir()
+
+	// Both refuse, and both say why. Refusing is not the property at
+	// risk -- an empty predecessor leaves no legs, so the kernel step
+	// would refuse either way -- it is that the operator is told the
+	// gateway has no policy in force rather than being handed a
+	// validation failure about subnets nobody wrote.
+	if err := Reload(dir, strings.NewReader(`{"allow":[],"deny":["10.0.0.0/8"]}`)); !errors.Is(err, errNoPolicyInForce) {
+		t.Errorf("reload with no policy in force = %v; want %v", err, errNoPolicyInForce)
+	}
+	if err := DenyAll(dir); !errors.Is(err, errNoPolicyInForce) {
+		t.Errorf("emergency close with no policy in force = %v; want %v", err, errNoPolicyInForce)
+	}
+	if _, err := os.Stat(PolicyPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("a refused install left a policy behind: %v", err)
+	}
+
+	first := egress.Policy{
+		InternalSubnet: "172.31.0.0/24",
+		UplinkSubnet:   "172.31.1.0/24",
+		Deny:           []string{"10.0.0.0/8"},
+	}
+	err := installPolicyWith(dir, func(_ egress.Policy, inForce bool) (egress.Policy, error) {
+		if inForce {
+			t.Error("the first install found a policy in force")
+		}
+		return first, nil
+	}, func(egress.Policy) error { return nil })
+	if err != nil {
+		t.Fatalf("the first install failed: %v", err)
+	}
+	if _, err := (&PolicyStore{Path: PolicyPath(dir)}).Current(); err != nil {
+		t.Fatalf("no policy in force after the first install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, policyLockFile)); err != nil {
+		t.Errorf("the first install did not take the lock a reload takes: %v", err)
 	}
 }


### PR DESCRIPTION
## What changes

A launch confirms that the gateway it created carries the egress policy in force,
after preparation completes and before the attempt is authorized to start. A
restriction that could neither be installed into a gateway nor close it no longer
enters the record. And a gateway's first policy is installed through the same lock
a reload takes, in the same order.

## What was found

A policy change installs by fanning out to the gateways the controller can
enumerate, then records the new set as in force. That record is what the next pass
compares against — so the question "is any gateway stale?" is answered by comparing
the controller's record against the controller's record. It cannot see a gateway.
Its correctness rested on a claim the bookkeeping cannot support: that the set of
gateways at the moment of recording is the set that was enumerated.

Launches create gateways concurrently, so the claim is false. `forLaunch` releases
the serialising slot inside `refresh`, so the snapshot it returns is held by nothing
while the launch builds containers — which includes an image pull when the daemon
lacks it. A pass running in that window does not name the gateway being created,
records the change as in force, and returns. The gateway then starts carrying the
older set.

Nothing revisits it, and that is what made it permanent rather than transient:
`applyPolicy` returns early on an unchanged set, so every later pass compares the
recorded set against itself and performs no fan-out at all. The capsule keeps the
older, more permissive deny set for the whole life of its job. On a shared daemon —
the topology that requires this profile — that is a capsule reaching another
tenant's network it was meant to be denied.

The same record hid a second case. A restriction that could not be installed into a
gateway closes it; when the close also failed, the failure was logged and the new
set was recorded anyway. The next pass then compared the new set against itself and
never attempted the restriction again.

Two alternatives were measured before this one was written, and both were rejected:

- **Holding the refresh slot across the launch** makes the recording claim true, but
  the slot is a single one and the hold would span the whole capsule preparation
  budget. The periodic rediscovery acquires the same slot from a ticker loop, and a
  ticker drops ticks for a slow receiver — so to stop a launch crossing a tightening,
  it stops tightenings being discovered.
- **Re-asserting the policy on every pass** moves a cost bounded per-change to
  per-launch, because a rediscovery already runs before every launch. It also does
  not close the hole: a gateway created after a pass enumerates still misses it and
  is corrected only by the next one, possibly after the job has finished.

`docs/adrs/2026-08-23-the-launch-proves-its-own-gateway.md` records the decision and
the arithmetic that rejected each alternative.

## Evidence

Hermetic. Every assertion below was watched failing under the mutation named.

```text
hermetic only — the mutations are the observation. Each row below was run with the
named line broken, the test was seen to fail, and the line was restored.
```

| Test | Mutation that kills it |
| --- | --- |
| `TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy` | the confirmation does nothing |
| `TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon` | the unchanged-set short-circuit is removed — which is the rejected alternative's shape |
| `TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch` | a lease with no running gateway counts as confirmed |
| `TestAConfirmationThatWasOvertakenFailsTheLaunch` | the post-reload re-read is dropped |
| `TestARestrictionThatCouldNotBeClosedIsRetried` | the record moves before the close loop |
| `TestOnlyAFirstInstallMayFindNoPolicyInForce` | the absent-predecessor guard is removed from the other builds |

The fake gained two capabilities it lacked, both of which the defect needed: a hook
that makes a gateway appear after an enumeration has been answered, and a removal
that can fail. Neither was expressible before, which is why no test covered this.

One assertion was rewritten rather than kept: the first-install guard was watched
*surviving* its mutation, because an absent predecessor carries no legs and the
kernel step refuses anyway. What the guard actually buys is the message, so the test
asserts the message.

`gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...` are
clean across the module.

## What would notice this regressing

The table above. `TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon` is worth
naming separately: it exists to stop this design drifting into the alternative that
was rejected, by failing the moment a launch starts reaching the daemon when nothing
moved.

## Risk, compatibility and operations

A restriction that could neither be installed nor closed now closes every gateway on
the host, on every pass, until that container is gone. Reaching it takes a daemon
refusing both an exec and a bounded removal, on which launches and teardowns are
already failing. The log line names the container and says the remedy is the daemon
rather than the policy; `docs/runbook.md` carries the procedure.

`docs/security/threat-model.md` records the newly closed case, and states the residue
that stays open: a *relaxation* that did not reach a gateway leaves that capsule
confined more tightly than the policy for the life of its job, and nothing retries it.


Beyond the operator-visible change above:

**Trust boundary: this is the fix.** A capsule launched across a policy tightening
kept the older, more permissive deny set for the life of its job, and no later pass
revisited it. On `shared-daemon` — the topology that requires this profile — that is a
capsule reaching another tenant's network it was meant to be denied.

**Networking: the fail-closed rule is extended, not weakened.** A gateway that cannot
be reached at confirmation fails its launch, and the launch's own recovery removes
every resource of the lease. A restriction that could neither be installed nor closed
now leaves the record unmoved and reports, which the callers already answer by
refusing a launch or closing every gateway — the same answer a failed discovery
already gets.

**Resource limits and throughput: measured, and the reason the alternatives lost.**
The confirmation costs two slice comparisons and no daemon call when nothing moved
while the capsule was being built. Holding the refresh slot across a launch was
rejected on arithmetic against the 15-minute preparation budget and the rediscovery
ticker; re-asserting on every pass was rejected because a rediscovery already runs
before every launch, making it one control command per gateway per launch.

**Credentials, status API, schema, migration, rollback: N/A.** No credential path, JSON
field, table or persisted value is touched.

**Deployment: N/A.** No compose or artifact change.

**ADR:** `docs/adrs/2026-08-23-the-launch-proves-its-own-gateway.md`, new with this
change. It records where the policy invariant is established and the arithmetic that
rejected each alternative. `docs/architecture.md`, `docs/security/threat-model.md` and
`docs/runbook.md` move with it.

## Changelog

```text
Added under "Isolation and egress": a capsule runs under the deny set in force, not
the one its launch was handed — including that a restriction which could neither be
installed nor closed no longer enters the record.
```
