### PR TITLE
fix(engine): a taken volume name is refused, not adopted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,24 @@ by its public and operational effects.
   restriction that could neither be installed into a gateway nor close it
   no longer enters the record either, so the next pass attempts it again
   rather than never trying it again.
+- **A volume that already exists under a capsule's name is refused, not
+  adopted.** Ownership is proven by labels and never by name, and every
+  create behind the engine port reports a taken name so the caller can
+  prove ownership before adopting anything. The daemon's volume create is
+  the exception: it answers a taken name with the volume that is already
+  there, keeping its original labels, and reports no error. So a volume
+  another owner held could be confirmed as a lease's own and mounted as
+  the data root of a privileged daemon. The adapter now inspects first and
+  reports the collision, which is what sends the launcher to the ownership
+  proof it already had.
+- **A capsule that exits before it is ready says so, and says why.** A
+  supervisor writes its terminal state and then exits, so that state is
+  readable for an instant and a poll can miss it — and an exec into a
+  container that is gone always fails, which the wait read as "not yet".
+  A capsule that aborted was therefore polled for the full readiness
+  deadline and reported as a timeout naming nothing actionable. The wait
+  now asks the daemon whether the container is still there, and reports
+  the exit code it left behind.
 
 ### State and operations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,13 @@ while only the exec around it needs a container.
 
 - Keep provider vocabulary inside its adapter. Core packages use neutral,
   opaque identities; the architecture tests enforce dependency direction.
+- A vocabulary that crosses a package boundary is a named type, not a bare
+  string. Several of them here spell the same words — a supervisor protocol
+  state, an execution observation, an attempt state and a container status all
+  have a "running" — and they decide different things. An untyped one compiles
+  when it is confused with another, and the confusions that matter are in the
+  code that rules on whether a job ran. Review checks this; the compiler is
+  what enforces it once the type exists.
 - Keep responsibilities cohesive. Split a package or component when its
   invariants, dependencies, or lifecycle can be tested independently.
 - Comments explain exported contracts, invariants, or non-obvious reasons.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,10 @@ Every external object is created under a durable **resource intent**:
 planned, then creating, then confirmed with its id. A crash anywhere
 leaves an intent whose deterministic name either finds the object or
 proves its absence. Ownership is proven by labels, never by name — a
-name collision is refused rather than adopted. Destructive recovery repeats
+name collision is refused rather than adopted. One create needs the adapter
+to make that true: the daemon answers a taken volume name with the volume
+that is already there and no error, so the adapter inspects first and
+reports the collision the rest of the port is built on. Destructive recovery repeats
 that proof immediately before removal, using the expected instance and lease;
 a stale intent cannot delete a foreign object that later reused its name.
 

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -606,12 +606,29 @@ func stateVerdict(want string, code int, out string, execErr error) (done bool, 
 
 // awaitState polls a supervisor-family container until it reports the
 // wanted state or one it can no longer leave.
+//
+// An exec into a container that is no longer running always fails, and a
+// supervisor writes its terminal state and then exits — so that state is
+// readable for an instant and a poll can miss it. Treated as "not yet",
+// every such failure spends the whole deadline and reports a timeout
+// naming nothing an operator can act on, which is the outcome
+// stateVerdict exists to prevent for a container that stays up. Asking
+// the daemon whether the container is still there is what covers the one
+// that does not.
 func (m *Launcher) awaitState(ctx context.Context, containerID, want string) error {
 	deadline := time.Now().Add(readyTimeout)
 	for {
 		code, out, err := m.dock.Exec(ctx, containerID, []string{supervisorPath, "state"})
 		if done, verdict := stateVerdict(want, code, out, err); done {
 			return verdict
+		}
+		if err != nil {
+			// Best effort: a daemon that cannot answer this leaves the
+			// poll exactly where it was, which is the deadline below.
+			if state, serr := m.dock.ContainerStatus(ctx, containerID); serr == nil && state.Status != "running" {
+				return fmt.Errorf("container %s exited %d before reaching %q",
+					engine.ShortID(containerID), state.ExitCode, want)
+			}
 		}
 		if time.Now().After(deadline) {
 			return fmt.Errorf("container %s did not reach %q within %s", engine.ShortID(containerID), want, readyTimeout)

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -625,7 +625,7 @@ func (m *Launcher) awaitState(ctx context.Context, containerID, want string) err
 		if err != nil {
 			// Best effort: a daemon that cannot answer this leaves the
 			// poll exactly where it was, which is the deadline below.
-			if state, serr := m.dock.ContainerStatus(ctx, containerID); serr == nil && state.Status != "running" {
+			if state, serr := m.dock.ContainerStatus(ctx, containerID); serr == nil && state.Status != engine.StatusRunning {
 				return fmt.Errorf("container %s exited %d before reaching %q",
 					engine.ShortID(containerID), state.ExitCode, want)
 			}

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -98,18 +98,18 @@ func classifySupervisorState(state string) (assignment.ExecutionObservation, err
 // only time an exec can succeed.
 func classifyContainerState(runtimeID string, state engine.ContainerState) (obs assignment.ExecutionObservation, askSupervisor bool, err error) {
 	switch state.Status {
-	case "created":
+	case engine.StatusCreated:
 		// The daemon's own word, not the capsule's: this container has
 		// never been started, so nothing inside it has run to say
 		// otherwise.
 		return assignment.ObservedNeverStarted, false, nil
-	case "exited", "dead":
+	case engine.StatusExited, engine.StatusDead:
 		// A stopped capsule cannot be asked anything: exec needs a running
 		// container and the control surface is tmpfs. The exit code is the
 		// only account it left, which is why the supervisor reserves one
 		// for "the runner never started".
 		return ClassifyExit(state.ExitCode), false, nil
-	case "running", "paused", "restarting":
+	case engine.StatusRunning, engine.StatusPaused, engine.StatusRestarting:
 		return assignment.ObservedUnavailable, true, nil
 	default:
 		return assignment.ObservedUnavailable, false,

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -2,8 +2,10 @@ package capsule
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/capsule/protocol"
@@ -219,5 +221,38 @@ func TestTheDaemonsAccountIsNotTheCapsulesOwn(t *testing.T) {
 		t.Errorf("the daemon's account and the capsule's are both %q; nothing downstream can "+
 			"weigh one against the other, and the one the workload can write is the one that "+
 			"would win", daemon)
+	}
+}
+
+// TestAwaitStateStopsWhenTheContainerHasExited: the terminal states above
+// are only readable while the container is up, and a supervisor writes
+// one and then exits. That leaves the state file readable for an instant,
+// which a half-second poll can miss.
+//
+// An exec into a container that is gone always fails, and a failed exec
+// is "keep asking" — so a supervisor that aborted was polled for the
+// whole readiness deadline and then reported as a timeout. On a
+// misconfigured host that is ninety seconds per launch, and the operator
+// is told the container did not reach a state rather than that it exited
+// and with what code.
+func TestAwaitStateStopsWhenTheContainerHasExited(t *testing.T) {
+	d := &fakeDaemon{
+		exec: func(string, []string) (int, string, error) {
+			return 0, "", errors.New("container is not running")
+		},
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: "exited", ExitCode: SupervisorAbortedExitCode}, nil
+		},
+	}
+	start := time.Now()
+	err := (&Launcher{dock: d}).awaitState(t.Context(), "capsule-1", protocol.StateWaiting)
+	if err == nil {
+		t.Fatal("a container that had already exited was reported as still becoming ready")
+	}
+	if !strings.Contains(err.Error(), strconv.Itoa(SupervisorAbortedExitCode)) {
+		t.Errorf("error = %q; it has to name the exit code, which is the whole of what the container left behind", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("the wait took %s; a container the daemon says is gone is not polled to the deadline", elapsed)
 	}
 }

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -79,19 +79,19 @@ func TestClassifySupervisorExitSeparatesAbortFromExit(t *testing.T) {
 // container cannot be asked.
 func TestClassifyContainerStateNeverAsksAStoppedCapsule(t *testing.T) {
 	for _, tc := range []struct {
-		status        string
+		status        engine.ContainerStatus
 		exit          int
 		want          assignment.ExecutionObservation
 		askSupervisor bool
 	}{
-		{"created", 0, assignment.ObservedNeverStarted, false},
-		{"running", 0, assignment.ObservedUnavailable, true},
-		{"paused", 0, assignment.ObservedUnavailable, true},
-		{"restarting", 0, assignment.ObservedUnavailable, true},
-		{"exited", 0, assignment.ObservedExited, false},
-		{"exited", 1, assignment.ObservedExited, false},
-		{"exited", SupervisorAbortedExitCode, assignment.ObservedCreated, false},
-		{"dead", SupervisorAbortedExitCode, assignment.ObservedCreated, false},
+		{engine.StatusCreated, 0, assignment.ObservedNeverStarted, false},
+		{engine.StatusRunning, 0, assignment.ObservedUnavailable, true},
+		{engine.StatusPaused, 0, assignment.ObservedUnavailable, true},
+		{engine.StatusRestarting, 0, assignment.ObservedUnavailable, true},
+		{engine.StatusExited, 0, assignment.ObservedExited, false},
+		{engine.StatusExited, 1, assignment.ObservedExited, false},
+		{engine.StatusExited, SupervisorAbortedExitCode, assignment.ObservedCreated, false},
+		{engine.StatusDead, SupervisorAbortedExitCode, assignment.ObservedCreated, false},
 	} {
 		got, ask, err := classifyContainerState("c1", engine.ContainerState{Status: tc.status, ExitCode: tc.exit})
 		if err != nil {
@@ -203,7 +203,7 @@ func TestOnlyWaitingProvesTheRunnerNeverStarted(t *testing.T) {
 // against another needs to be able to tell them apart, and one value
 // for both makes that impossible.
 func TestTheDaemonsAccountIsNotTheCapsulesOwn(t *testing.T) {
-	daemon, _, err := classifyContainerState("c1", engine.ContainerState{Status: "created"})
+	daemon, _, err := classifyContainerState("c1", engine.ContainerState{Status: engine.StatusCreated})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestAwaitStateStopsWhenTheContainerHasExited(t *testing.T) {
 			return 0, "", errors.New("container is not running")
 		},
 		status: func(string) (engine.ContainerState, error) {
-			return engine.ContainerState{Status: "exited", ExitCode: SupervisorAbortedExitCode}, nil
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: SupervisorAbortedExitCode}, nil
 		},
 	}
 	start := time.Now()

--- a/internal/engine/docker/docker.go
+++ b/internal/engine/docker/docker.go
@@ -362,7 +362,7 @@ func (c *Client) ContainerStatus(ctx context.Context, id string) (engine.Contain
 		return engine.ContainerState{}, fmt.Errorf("container %s reports no state", id)
 	}
 	return engine.ContainerState{
-		Status:   string(inspected.Container.State.Status),
+		Status:   engine.ContainerStatus(inspected.Container.State.Status),
 		ExitCode: inspected.Container.State.ExitCode,
 	}, nil
 }

--- a/internal/engine/docker/volume.go
+++ b/internal/engine/docker/volume.go
@@ -13,7 +13,26 @@ import (
 
 // CreateVolume creates a named, labeled volume — an ephemeral capsule
 // volume (dind data), removed with its lease.
+//
+// It inspects before creating, because the daemon's volume create is the
+// one create behind this port that does not refuse a taken name: it
+// returns the volume that is already there, keeping its original labels,
+// and reports no error. Every other create here reports a collision, and
+// the callers are built on that report — a taken name is what sends them
+// to prove ownership before adopting anything. Without this, a volume
+// another owner holds is confirmed as the lease's own and mounted as the
+// data root of a privileged daemon.
+//
+// What it does not close is the instant between the two calls. A volume
+// created there is still adopted silently, which is why ownership is
+// proven by the caller rather than inferred from this call succeeding.
 func (c *Client) CreateVolume(ctx context.Context, name string, labels map[string]string) (string, error) {
+	switch _, err := c.cli.VolumeInspect(ctx, name, client.VolumeInspectOptions{}); {
+	case err == nil:
+		return "", fmt.Errorf("%w: volume %q", engine.ErrAlreadyExists, name)
+	case !cerrdefs.IsNotFound(err):
+		return "", classify(err)
+	}
 	created, err := c.cli.VolumeCreate(ctx, client.VolumeCreateOptions{Name: name, Labels: labels})
 	if err != nil {
 		return "", classify(err)

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -129,13 +129,38 @@ type ContainerSpec struct {
 	CgroupParent string
 }
 
+// ContainerStatus is the daemon's own word for where a container is in
+// its lifecycle.
+//
+// It is a named type because three other vocabularies in this tree spell
+// some of the same words and mean different things by them: a supervisor
+// protocol state, an execution observation and an attempt state each have
+// a "running". The one that arrives from outside this process is the one
+// that must not be mistaken for the others, and it is the one that used
+// to be a bare string.
+//
+// The set below is not closed. A daemon may answer with something this
+// build has no name for, and the reader that decides whether a job may
+// have run treats an unknown status as proving nothing rather than as
+// impossible.
+type ContainerStatus string
+
+const (
+	StatusCreated    ContainerStatus = "created"
+	StatusRunning    ContainerStatus = "running"
+	StatusPaused     ContainerStatus = "paused"
+	StatusRestarting ContainerStatus = "restarting"
+	StatusExited     ContainerStatus = "exited"
+	StatusDead       ContainerStatus = "dead"
+)
+
 // ContainerState is what the daemon can still say about a container after
 // it has stopped. ExitCode is carried alongside Status because a stopped
 // container's own filesystem is no longer reachable — no exec, and its
 // tmpfs control surface is gone — so the exit code is the only account of
 // itself a capsule can leave behind.
 type ContainerState struct {
-	Status   string
+	Status   ContainerStatus
 	ExitCode int
 }
 

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -663,6 +663,39 @@ func TestEnsureOwnedVolume(t *testing.T) {
 	}
 }
 
+// TestCreateVolumeRefusesATakenName is the other half, and the one the
+// capsule depends on. The daemon's volume create is the only create
+// behind this port that answers a taken name with the volume that is
+// already there and no error, so a launcher built on collisions being
+// reported would adopt a stranger's volume and mount it as the data root
+// of a privileged daemon. The adapter is what makes the daemon's answer
+// match the port's contract.
+func TestCreateVolumeRefusesATakenName(t *testing.T) {
+	c, instance := client(t)
+	ctx := t.Context()
+
+	name := instance + "-taken"
+	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
+	if _, err := c.CreateVolume(ctx, name, map[string]string{"someone": "else"}); err != nil {
+		t.Fatalf("seeding the volume that is already there: %v", err)
+	}
+
+	own := map[string]string{
+		"io.runpool.managed":  "true",
+		"io.runpool.instance": instance,
+		"io.runpool.role":     "dind-data",
+	}
+	_, err := c.CreateVolume(ctx, name, own)
+	if !errors.Is(err, engine.ErrAlreadyExists) {
+		t.Fatalf("creating over an existing volume = %v; want ErrAlreadyExists", err)
+	}
+	// And the volume that was there is untouched: the labels are still
+	// its owner's, so nothing read this as an adoption.
+	if _, err := c.CreateVolume(ctx, name, own); !errors.Is(err, engine.ErrAlreadyExists) {
+		t.Fatalf("the second create = %v; want the same refusal", err)
+	}
+}
+
 // TestCacheLaneVolumes is the live cache contract, end to end through
 // the real manager and store against the real daemon: warm data left by
 // one job is what the next job of the same lane mounts; another


### PR DESCRIPTION
## What changes

The engine adapter inspects before creating a volume, so a name that is already
taken produces the collision the port's contract promises. And a capsule or
gateway that exits before reaching a state is no longer polled to the readiness
deadline: the wait asks the daemon whether the container is still there and
reports the exit code it left behind.

## What was found

**The volume.** Ownership is proven by labels and never by name — `docs/architecture.md`
states it, and the launcher is built on it: a create that reports a taken name is
what sends it to `OwnedIDByName`, which returns nothing for an object this lease does
not own, and the launch fails.

The daemon's volume create never reports one. Verified in the vendored source
(`moby@v28.5.2/volume/service/store.go`): when the name exists it returns that volume
with its original labels and a bare `nil` error, under an upstream `TODO` noting the
labels are inconsistent. So for the dind data volume the proof was never reached, and
a volume another owner held would have been confirmed as the lease's own and mounted
at `/var/lib/docker` inside a privileged container — the data root of the job's own
daemon.

The codebase already knew this. `EnsureOwnedVolume`, one function below in the same
file, says exactly this about the same call and inspects first — but only cache lanes
go through it. The capsule path used the unguarded create.

The teardown side was already correct, which made the consequence worse rather than
better: removal returns `ErrForeignResource`, the intent never clears, finalisation
refuses, and the lease is quarantined permanently while holding its admission credit
and retrying a removal that can never succeed.

**The wait.** `stateVerdict` treats an exec error as "keep polling", and an exec into a
container that is no longer running always fails. A supervisor writes its terminal
state and then exits, so that state is readable for an instant and the half-second
poll can miss it. The result is exactly the outcome the verdict's own comment says it
exists to prevent — the mechanism only covered a container that keeps running after
reaching a terminal state, which the supervisor never does. On a misconfigured host,
every launch on the tier burned ninety seconds and produced a message naming nothing
an operator could act on.

## Evidence

- `TestAwaitStateStopsWhenTheContainerHasExited` was watched failing under the
  mutation that removes the status check. It failed in **90.25s** with
  `container capsule-1 did not reach "waiting" within 1m30s` — which is both the
  assertion and the cost the fix removes, measured.
- The launcher's fail-closed half needed no new test: `TestOnlyATakenNameIsResolved`
  already proves that a taken name with nothing owned behind it fails rather than
  adopts. What was missing was that volumes never reported a taken name, and that is
  the adapter.
- `gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...` are
  clean across the module.

```text
--- FAIL: TestAwaitStateStopsWhenTheContainerHasExited (90.25s)
    container capsule-1 did not reach "waiting" within 1m30s
    the wait took 1m30.245720375s

The volume half is hermetic only — the daemon's silent adoption is the behaviour
under test, so faking it would assert the mock. Its contract never runs on a pull
request.
```

The adapter change itself is proved live, because the daemon's silent adoption is the
behaviour under test and faking it would assert the mock. `TestCreateVolumeRefusesATakenName`
seeds a volume with foreign labels and requires `ErrAlreadyExists`, then requires the
same refusal a second time — so a create that quietly adopted would fail on the first
assertion and one that adopted-then-owned would fail on the second. Those contracts do
not run on a pull request.

## What would notice this regressing

`TestCreateVolumeRefusesATakenName` fails if the inspect is dropped.
`TestAwaitStateStopsWhenTheContainerHasExited` fails — and takes ninety seconds doing
it — if the status check is dropped. `TestOnlyATakenNameIsResolved` still holds the
launcher's side.


## Risk, compatibility and operations

**Trust boundary: the volume half is the fix.** A volume another owner held could be
confirmed as a lease's own and mounted at `/var/lib/docker` inside a privileged
container — the data root of the job's own daemon, so its contents were readable and
writable by the job. Ownership is now proven before the name is reused, which is what
`docs/architecture.md` already claimed for every object.

**Ownership and cleanup: the failure it removes was a permanent one.** The teardown
side was already correct, so a foreign volume produced `ErrForeignResource` on removal,
an intent that never cleared, a finalisation that refused, and a lease quarantined
forever while holding its admission credit. Refusing at creation is what stops the
lease being created at all.

**Failure behaviour: a launch fails sooner and says more.** A capsule or gateway that
exits before reaching a state is reported with its exit code instead of a
ninety-second timeout. Nothing that previously succeeded now fails: the wait only
stops early on a container the daemon says is no longer running, and a daemon that
cannot answer leaves the poll where it was.

**Resource limits: N/A, but the wait's cost drops.** On a misconfigured host each
launch on the tier burned the full readiness deadline.

**Credentials, networking, status API, schema, migration, deployment, rollback: N/A.**

**Runbook: N/A.** The new message names the container and its exit code, which is more
than the timeout it replaces.

**Not an ADR.** Both halves restore properties already stated — ownership proven by
labels, and a terminal state ending the poll.

**Typing:** the third commit adds `engine.ContainerStatus` and the rule behind it to
`CONTRIBUTING.md`. It changes no value: the status strings are the daemon's own and
are unchanged.

## Changelog

```text
Added under "Isolation and egress": a volume that already exists under a capsule's
name is refused, not adopted; and a capsule that exits before it is ready says so,
and says why. The container-status type has no changelog entry — no observable
behaviour or persisted value changes.
```
