### PR TITLE
refactor(engine): the port names the object kind it dispatches on

### DIFF
--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -306,7 +306,7 @@ func (f *fakeProbe) OwnedVolumeUsage(context.Context, assignment.InstanceID) ([]
 type nopVolumes struct{}
 
 func (nopVolumes) EnsureOwnedVolume(context.Context, string, map[string]string) error { return nil }
-func (nopVolumes) OwnedIDByName(_ context.Context, _, name string, _ assignment.InstanceID, _ assignment.LeaseID) (string, error) {
+func (nopVolumes) OwnedIDByName(_ context.Context, _ engine.ObjectKind, name string, _ assignment.InstanceID, _ assignment.LeaseID) (string, error) {
 	return name, nil
 }
 func (nopVolumes) RemoveVolume(context.Context, string) error { return nil }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -53,7 +53,7 @@ type LaneMount struct {
 // measure what this instance's volumes weigh, for the GC planner.
 type laneVolumes interface {
 	EnsureOwnedVolume(ctx context.Context, name string, labels map[string]string) error
-	OwnedIDByName(ctx context.Context, kind, name string,
+	OwnedIDByName(ctx context.Context, kind engine.ObjectKind, name string,
 		instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error)
 	RemoveVolume(ctx context.Context, name string) error
 	OwnedVolumeUsage(ctx context.Context, instanceID assignment.InstanceID) ([]engine.VolumeUsage, error)
@@ -136,7 +136,7 @@ func (m *LaneManager) DeleteLane(ctx context.Context, laneID string) error {
 		return err
 	}
 	name := VolumeName(laneID)
-	if _, err := m.volumes.OwnedIDByName(ctx, "volume", name, m.instanceID, ""); err != nil {
+	if _, err := m.volumes.OwnedIDByName(ctx, engine.KindVolume, name, m.instanceID, ""); err != nil {
 		return fmt.Errorf("lane volume %s: %w", name, err)
 	}
 	return m.volumes.RemoveVolume(ctx, name)

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -35,7 +35,7 @@ func (f *fakeVolumes) EnsureOwnedVolume(_ context.Context, name string, labels m
 	return nil
 }
 
-func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
+func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind engine.ObjectKind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	if f.foreign {
 		return "", engine.ErrForeignResource
 	}

--- a/internal/cache/gc.go
+++ b/internal/cache/gc.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/store"
 )
 
@@ -248,7 +249,7 @@ func (m *LaneManager) RunGC(ctx context.Context, plan GCPlan, actor string) (GCR
 // before them too — but ownership is still proven first, because the
 // volume namespace is shared.
 func (m *LaneManager) removeOrphanVolume(ctx context.Context, name string) error {
-	if _, err := m.volumes.OwnedIDByName(ctx, "volume", name, m.instanceID, ""); err != nil {
+	if _, err := m.volumes.OwnedIDByName(ctx, engine.KindVolume, name, m.instanceID, ""); err != nil {
 		return err
 	}
 	return m.volumes.RemoveVolume(ctx, name)

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -64,9 +64,9 @@ const (
 // Resource kinds and roles stamped on every capsule object, mirrored
 // into the resource intents so reconciliation can find and order them.
 const (
-	KindContainer = "container"
-	KindNetwork   = "network"
-	KindVolume    = "volume"
+	KindContainer = engine.KindContainer
+	KindNetwork   = engine.KindNetwork
+	KindVolume    = engine.KindVolume
 
 	RoleNetwork  = "capsule-net"
 	RoleDindData = "dind-data"
@@ -168,9 +168,14 @@ type ResourceRecorder interface {
 // is ours from an earlier incarnation of this same intent — adopted by
 // proven ownership, never by name — or it is foreign and the launch
 // fails closed.
-func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind, role, name string,
+func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind engine.ObjectKind, role, name string,
 	createFn func() (string, error), resolve func() (string, error)) (string, error) {
-	intentID, err := rec.Plan(kind, role, name)
+	// The kind crosses as a string on purpose: the recorder is the lease
+	// machine, which may not know a container runtime -- cleanup that
+	// depends on one stops working exactly when the runtime is what
+	// failed. It names the same vocabulary in its own type on the far
+	// side, and this is the one place the two meet.
+	intentID, err := rec.Plan(string(kind), role, name)
 	if err != nil {
 		return "", err
 	}
@@ -229,7 +234,7 @@ type capsuleDaemon interface {
 	ContainerStatus(ctx context.Context, id string) (engine.ContainerState, error)
 	Exec(ctx context.Context, containerID string, cmd []string) (int, string, error)
 	ExecWithInput(ctx context.Context, containerID string, cmd []string, input []byte) (int, string, error)
-	OwnedIDByName(ctx context.Context, kind, name string,
+	OwnedIDByName(ctx context.Context, kind engine.ObjectKind, name string,
 		instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error)
 }
 
@@ -294,7 +299,7 @@ func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
 func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (string, error) {
 	short := engine.ShortID(string(spec.LeaseID))
 	name := func(role string) string { return "runpool-" + role + "-" + short }
-	labels := func(kind, role string) map[string]string {
+	labels := func(kind engine.ObjectKind, role string) map[string]string {
 		return engine.Ownership{
 			Instance: spec.InstanceID,
 			Lease:    spec.LeaseID,
@@ -305,7 +310,7 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 			Tier:     string(spec.TierID),
 		}.Labels()
 	}
-	resolve := func(kind, objName string) func() (string, error) {
+	resolve := func(kind engine.ObjectKind, objName string) func() (string, error) {
 		return func() (string, error) {
 			return m.dock.OwnedIDByName(ctx, kind, objName, spec.InstanceID, spec.LeaseID)
 		}
@@ -505,8 +510,8 @@ func protocolVerdict(code int, out string) error {
 // gateway reporting ready. Any failure here fails the launch closed;
 // a capsule is never started with a half-made sandbox.
 func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRecorder, netID string,
-	name func(string) string, labels func(string, string) map[string]string,
-	resolve func(string, string) func() (string, error)) (netip.Addr, string, error) {
+	name func(string) string, labels func(engine.ObjectKind, string) map[string]string,
+	resolve func(engine.ObjectKind, string) func() (string, error)) (netip.Addr, string, error) {
 
 	subnet, err := m.dock.NetworkSubnet(ctx, netID)
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -270,7 +270,7 @@ func checkIsolatedBridge(ctx context.Context, d networkProbeClient, cfg *config.
 			// the sentinel is what keeps its probe out of any instance's
 			// sweep.
 			Instance: "doctor",
-			Kind:     "network",
+			Kind:     engine.KindNetwork,
 			Role:     "preflight-probe",
 		}.Labels(),
 	})

--- a/internal/engine/docker/diskusage.go
+++ b/internal/engine/docker/diskusage.go
@@ -62,7 +62,7 @@ func (c *Client) ProbeFilesystemFree(ctx context.Context, image string, instance
 		Cmd:        []string{"df -Pk / && df -Pi /"},
 		Labels: engine.Ownership{
 			Instance: instanceID,
-			Kind:     "container",
+			Kind:     engine.KindContainer,
 			Role:     "probe",
 		}.Labels(),
 	})

--- a/internal/engine/docker/docker.go
+++ b/internal/engine/docker/docker.go
@@ -258,18 +258,18 @@ func classify(err error) error {
 // create-side conflict it means the conflict was transient, and for
 // recovery it proves the create never took effect. A name match with
 // foreign labels is engine.ErrForeignResource — name equality is not ownership.
-func (c *Client) OwnedIDByName(ctx context.Context, kind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
+func (c *Client) OwnedIDByName(ctx context.Context, kind engine.ObjectKind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	return c.resolveOwnedID(ctx, kind, name, instanceID, leaseID)
 }
 
 // resolveOwnedID accepts either a deterministic name or an immutable daemon
 // id. Creation recovery calls it by name; destructive cleanup calls it by the
 // confirmed id when one was persisted.
-func (c *Client) resolveOwnedID(ctx context.Context, kind, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
+func (c *Client) resolveOwnedID(ctx context.Context, kind engine.ObjectKind, reference string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
 	var id string
 	var labels map[string]string
 	switch kind {
-	case "container":
+	case engine.KindContainer:
 		inspected, err := c.cli.ContainerInspect(ctx, reference, client.ContainerInspectOptions{})
 		if cerrdefs.IsNotFound(err) {
 			return "", nil
@@ -278,7 +278,7 @@ func (c *Client) resolveOwnedID(ctx context.Context, kind, reference string, ins
 			return "", err
 		}
 		id, labels = inspected.Container.ID, inspected.Container.Config.Labels
-	case "network":
+	case engine.KindNetwork:
 		inspected, err := c.cli.NetworkInspect(ctx, reference, client.NetworkInspectOptions{})
 		if cerrdefs.IsNotFound(err) {
 			return "", nil
@@ -287,7 +287,7 @@ func (c *Client) resolveOwnedID(ctx context.Context, kind, reference string, ins
 			return "", err
 		}
 		id, labels = inspected.Network.ID, inspected.Network.Labels
-	case "volume":
+	case engine.KindVolume:
 		inspected, err := c.cli.VolumeInspect(ctx, reference, client.VolumeInspectOptions{})
 		if cerrdefs.IsNotFound(err) {
 			return "", nil

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -35,6 +35,25 @@ const (
 	labelTier     = "io.runpool.tier"
 )
 
+// ObjectKind is the kind of daemon object an ownership stamp describes,
+// and the kind a name is resolved as.
+//
+// It is a named type because it crosses this port in both directions and
+// is dispatched on at the far end: the adapter picks which inspect to
+// call from it, so a value spelled a second time somewhere else is a
+// resolution that silently finds nothing. The store carries the same
+// vocabulary for what it persists, as store.ResourceKind, and the two
+// meet only where an intent is written -- neither is derived from the
+// other, because one is a fact about a running object and the other is a
+// row that outlives it.
+type ObjectKind string
+
+const (
+	KindContainer ObjectKind = "container"
+	KindNetwork   ObjectKind = "network"
+	KindVolume    ObjectKind = "volume"
+)
+
 // Ownership is what a Runpool instance stamps on everything it creates,
 // and the only thing that proves an object is its to remove. A name is
 // not proof: a foreign object can carry the name a plan expects, and
@@ -49,7 +68,7 @@ const (
 type Ownership struct {
 	Instance assignment.InstanceID
 	Lease    assignment.LeaseID
-	Kind     string
+	Kind     ObjectKind
 	Role     string
 	Attempt  string
 	Target   string
@@ -67,7 +86,7 @@ func (o Ownership) Labels() map[string]string {
 		labelInstance: string(o.Instance),
 	}
 	for key, value := range map[string]string{
-		labelKind:    o.Kind,
+		labelKind:    string(o.Kind),
 		labelLease:   string(o.Lease),
 		labelRole:    o.Role,
 		labelAttempt: o.Attempt,
@@ -168,7 +187,7 @@ type ContainerState struct {
 type OwnedContainer struct {
 	ID      string
 	Name    string
-	Kind    string
+	Kind    ObjectKind
 	Role    string
 	LeaseID assignment.LeaseID
 	Running bool
@@ -328,7 +347,7 @@ func OwnershipFrom(labels map[string]string) (Ownership, bool) {
 	return Ownership{
 		Instance: assignment.InstanceID(labels[labelInstance]),
 		Lease:    assignment.LeaseID(labels[labelLease]),
-		Kind:     labels[labelKind],
+		Kind:     ObjectKind(labels[labelKind]),
 		Role:     labels[labelRole],
 		Attempt:  labels[labelAttempt],
 		Target:   labels[labelTarget],

--- a/test/contract/capsule/budget_test.go
+++ b/test/contract/capsule/budget_test.go
@@ -78,7 +78,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+short, "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+short, "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}

--- a/test/contract/capsule/bypass_test.go
+++ b/test/contract/capsule/bypass_test.go
@@ -153,7 +153,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}
@@ -186,7 +186,7 @@ func dumpSandboxDiag(ctx context.Context, t *testing.T, dock *docker.Client,
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, "container", "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Logf("could not resolve gateway for diagnostics: %v", err)
 		return

--- a/test/contract/capsule/contract_test.go
+++ b/test/contract/capsule/contract_test.go
@@ -96,7 +96,7 @@ func (r *memRecorder) cleanup(t *testing.T, dock *docker.Client) {
 	defer r.mu.Unlock()
 	// Containers before the network and volumes that hold them.
 	for _, o := range r.objects {
-		if o.kind == capsule.KindContainer {
+		if o.kind == string(capsule.KindContainer) {
 			if err := dock.RemoveContainer(ctx, o.id); err != nil {
 				t.Errorf("cleanup container %s: %v", o.id, err)
 			}
@@ -104,11 +104,11 @@ func (r *memRecorder) cleanup(t *testing.T, dock *docker.Client) {
 	}
 	for _, o := range r.objects {
 		switch o.kind {
-		case capsule.KindNetwork:
+		case string(capsule.KindNetwork):
 			if err := dock.RemoveNetwork(ctx, o.id); err != nil {
 				t.Errorf("cleanup network %s: %v", o.id, err)
 			}
-		case capsule.KindVolume:
+		case string(capsule.KindVolume):
 			if err := dock.RemoveVolume(ctx, o.id); err != nil {
 				t.Errorf("cleanup volume %s: %v", o.id, err)
 			}

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -468,25 +468,25 @@ func TestOwnedIDByName(t *testing.T) {
 	}
 	t.Cleanup(func() { mustRemoveContainer(t, c, ctx, id) })
 
-	got, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "lease-own")
+	got, err := c.OwnedIDByName(ctx, engine.KindContainer, name, assignment.InstanceID(instance), "lease-own")
 	if err != nil || got != id {
 		t.Errorf("owned resolution = %q, %v; want the created id", got, err)
 	}
 
 	// Same name, different lease: name equality is not ownership.
-	if _, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "someone-else"); !errors.Is(err, engine.ErrForeignResource) {
+	if _, err := c.OwnedIDByName(ctx, engine.KindContainer, name, assignment.InstanceID(instance), "someone-else"); !errors.Is(err, engine.ErrForeignResource) {
 		t.Errorf("foreign resolution = %v; want ErrForeignResource — adopting by name "+
 			"would run work through someone else's object and later delete it", err)
 	}
 	if err := c.RemoveOwnedContainer(ctx, name, assignment.InstanceID(instance), "someone-else"); !errors.Is(err, engine.ErrForeignResource) {
 		t.Fatalf("foreign removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "container", name, assignment.InstanceID(instance), "lease-own"); err != nil || got != id {
+	if got, err := c.OwnedIDByName(ctx, engine.KindContainer, name, assignment.InstanceID(instance), "lease-own"); err != nil || got != id {
 		t.Fatalf("foreign removal changed the owned object: id=%q err=%v", got, err)
 	}
 
 	// Absence is an answer: the create never took effect.
-	if got, err := c.OwnedIDByName(ctx, "container", instance+"-never-existed", assignment.InstanceID(instance), "lease-own"); err != nil || got != "" {
+	if got, err := c.OwnedIDByName(ctx, engine.KindContainer, instance+"-never-existed", assignment.InstanceID(instance), "lease-own"); err != nil || got != "" {
 		t.Errorf("absent resolution = %q, %v; want empty and no error", got, err)
 	}
 }
@@ -515,7 +515,7 @@ func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
 	if err := c.RemoveOwnedNetwork(ctx, networkID, assignment.InstanceID(instance), "different-lease"); !errors.Is(err, engine.ErrForeignResource) {
 		t.Fatalf("foreign network removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "network", networkName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != networkID {
+	if got, err := c.OwnedIDByName(ctx, engine.KindNetwork, networkName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != networkID {
 		t.Fatalf("network changed after refused removal: id=%q err=%v", got, err)
 	}
 
@@ -531,7 +531,7 @@ func TestOwnedRemovalRefusesForeignNetworkAndVolume(t *testing.T) {
 	if err := c.RemoveOwnedVolume(ctx, volumeName, assignment.InstanceID(instance), "different-lease"); !errors.Is(err, engine.ErrForeignResource) {
 		t.Fatalf("foreign volume removal = %v; want ErrForeignResource", err)
 	}
-	if got, err := c.OwnedIDByName(ctx, "volume", volumeName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != volumeName {
+	if got, err := c.OwnedIDByName(ctx, engine.KindVolume, volumeName, assignment.InstanceID(instance), "lease-owner"); err != nil || got != volumeName {
 		t.Fatalf("volume changed after refused removal: id=%q err=%v", got, err)
 	}
 }
@@ -777,11 +777,11 @@ func TestCacheLaneVolumes(t *testing.T) {
 	if err := mgr.DeleteLane(ctx, first.LaneID); err != nil {
 		t.Fatal(err)
 	}
-	gone, err := c.OwnedIDByName(ctx, "volume", first.Volume, assignment.InstanceID(instance), "")
+	gone, err := c.OwnedIDByName(ctx, engine.KindVolume, first.Volume, assignment.InstanceID(instance), "")
 	if err != nil || gone != "" {
 		t.Errorf("evicted volume still resolves: %q, %v", gone, err)
 	}
-	left, err := c.OwnedIDByName(ctx, "volume", other.Volume, assignment.InstanceID(instance), "")
+	left, err := c.OwnedIDByName(ctx, engine.KindVolume, other.Volume, assignment.InstanceID(instance), "")
 	if err != nil || left == "" {
 		t.Errorf("the surviving lane's volume is gone: %q, %v", left, err)
 	}


### PR DESCRIPTION
## What changes

`engine.ObjectKind` names the container/network/volume vocabulary that crosses the
engine port. `Ownership.Kind` and `OwnedContainer.Kind` carry it, the adapter's
resolution switches on its constants, and `internal/capsule`, `internal/cache` and
`internal/doctor` use them instead of literals. Label values are unchanged, so an
object stamped by an older build reads identically.

## What was found

The same vocabulary was spelled four times, and only one of them was typed.

`internal/store` had it right — `ResourceKind` with constants, and `removeObject`
dispatches on them into three separate removal methods. The other three did not:
`internal/capsule` declared untyped constants; `internal/cache` wrote bare `"volume"`
literals *while already importing the package the type belongs in*; and the adapter's
own `resolveOwnedID` switched on a third, independent set of literals.

That switch is what makes this more than tidiness. It picks which inspect to call from
the kind, and its `default` is not an error — an unmatched kind resolves to nothing.
Nothing is a meaningful answer there: on the create side it means the conflict was
transient, and in recovery it means the create never took effect. So a kind spelled
differently anywhere along the chain would not fail loudly. It would quietly assert
that an object which exists does not, and the caller would act on that. It compiled
because three independent spellings happened to agree.

This is the second of these; `engine.ContainerStatus` was the first. `CONTRIBUTING.md`
now carries the rule both come from.

Where it stays a string, and why: `ResourceRecorder.Plan`. Its implementation is the
lease machine, and `narrowDeps` pins `internal/lease` to `{internal/assignment,
internal/store}` for a stated reason — cleanup that depends on a container runtime
stops working exactly when the runtime is what failed. The kind crosses that boundary
opaque and each side names it in its own type. The conversion is one call and carries
the reason.

## Evidence

The compiler is the evidence, and that is also the argument for the change. Typing the
port produced a type error at every call site that had been agreeing by spelling
alone: the capsule's `labels` and `resolve` closures and its gateway helper, the
cache's interface and both its literals, the app's and the cache's fakes, and four
call sites across the contract suites. None was found by reading; every one was found
by building.

```text
hermetic only — this changes no runtime behaviour and no persisted or stamped value,
so there is nothing to observe against a daemon that the type checker does not
already prove. The live suites still exercise the same paths through the constants.
```

## What would notice this regressing

The compiler. A kind that is not one of the three constants no longer type-checks at
any call site, at any of the three places that previously spelled it untyped. That is
the whole of what this buys: the previous arrangement had no check at all.

`TestOwnedIDByName` and the ownership refusals in `test/contract/docker` still hold
the resolution's behaviour, and now pass the constants rather than literals.

## Risk, compatibility and operations

**Trust boundary and ownership: unchanged, and deliberately so.** `Ownership.Labels()`
renders `string(o.Kind)`, so the label values a controller stamps are byte-identical
to what an older build wrote. That matters because the comment on `Ownership` names
those values as a compatibility surface between releases: a controller sweeps objects
an older one stamped. `OwnershipFrom` parses back into the type, so a label written by
any build reads the same.

**Credentials, networking, resource limits: N/A.** This touches no credential path, no
policy, no cgroup or envelope arithmetic, and no container the daemon runs.

**Failure behaviour: strictly narrowed.** The adapter's unmatched-kind branch is
unreachable from typed callers now; it stays as written because the type is an open
string type and the port must still answer a value it has no name for.

**CLI, configuration, status API, schema, migration, deployment, rollback: N/A.** No
flag, key, JSON field, table or deployment artifact changes. `resourceDTO.Kind` in the
status document is built from `store.ResourceKind`, which this does not touch, so the
published shape and its values are unaffected.

**Runbook: N/A.** No operator-visible behaviour changes.

**Not an ADR.** It does not constrain what the code may do later; it implements a rule
`CONTRIBUTING.md` states, which arrived with `engine.ContainerStatus` in #86.

## Changelog

```text
NONE
```

## Notes for your reviewer

The seam at `ResourceRecorder.Plan` is the one place worth a second look: it is a
deliberate untyped crossing, and if the reasoning about `narrowDeps` is wrong then the
right change is to type it and widen the rule, not to leave the conversion where it is.

I left `store.ResourceKind` alone. It is the same vocabulary in the layer that
persists it, and deriving one from the other would put an engine import in the store —
which is a bigger decision than this change, and one I would not make in passing.
