### PR TITLE
fix(lease): the proof that a workload never began outlives the pass that took it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ by its public and operational effects.
   answer is available — and an authorization that could not be written at
   all says so, so an assignment nothing ever started is still simply
   served again.
+  That proof outlives the pass that took it. Cleanup can fail against a
+  wedged daemon, and the retry is a different pass with nothing measured:
+  it either measured nothing or found the capsule a measurement would
+  have come from already gone, which is the one this cleanup is removing.
+  What a serving establishes is kept with its lease, so the retry reads it
+  back rather than settling a job that never ran as one that did. A later
+  measurement that does establish something still wins, because the
+  accounts arrive in order — the daemon's, then the capsule's own, then
+  the provider's.
 - Under the restricted network profile a capsule has **no route out**.
   Its only egress is a per-capsule gateway that resolves and connects
   on its behalf under a default-deny policy, which is also the DNS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,6 +93,14 @@ while only the exec around it needs a container.
   when it is confused with another, and the confusions that matter are in the
   code that rules on whether a job ran. Review checks this; the compiler is
   what enforces it once the type exists.
+- A closed vocabulary starts at a non-empty value, because a state always
+  exists: an attempt has one, a lease has one, a resource kind has one. The
+  exception is a vocabulary that describes a measurement rather than a state,
+  because a measurement can simply not have been taken — and then that member
+  is named, equals the zero value so an unassigned variable is already correct,
+  and joins the totality list so nothing decides for it by omission. Either way
+  the empty literal appears once, in the constant that defines it, and never at
+  a call site. An optional string is not a vocabulary and needs no constant.
 - Keep responsibilities cohesive. Split a package or component when its
   invariants, dependencies, or lifecycle can be tested independently.
 - Comments explain exported contracts, invariants, or non-obvious reasons.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,14 @@ carries no provider identifier at all. Keeping the two apart is what
 stops a cleanup state being read as an execution outcome, which is how
 a job that never ran gets settled as if it had.
 
+It does carry one measurement: what its own serving established about
+whether the workload began. That is not lease state and is never read as
+any — the disposition still rules on the attempt, from evidence and
+from a proof. It is kept because cleanup can fail and be retried, and
+the pass that measured the proof is then not the pass that disposes of
+the attempt; a retry arrives having measured nothing, and would settle a
+job that never ran.
+
 An attempt whose work provably never began returns to the servable queue
 and is served again, so it holds one lease per serving: at most one live
 at a time, and the released ones are the record of what it cost. The

--- a/internal/app/durability_test.go
+++ b/internal/app/durability_test.go
@@ -27,7 +27,7 @@ func TestLateRedeliveryDoesNotRecreateWork(t *testing.T) {
 	lease, attemptID := leaseFor(t, h, "probe-job")
 	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
 	h.recordEvidence(lease.ID, store.EvidenceExitObserved)
-	if err := h.srv.leases.Finalize(t.Context(), lease.ID, ""); err != nil {
+	if err := h.srv.leases.Finalize(t.Context(), lease.ID, assignment.NoObservation); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -1021,8 +1022,88 @@ func TestEveryObservationHasAStartFailureReport(t *testing.T) {
 				"outcome; it is the clearest answer there is")
 		}
 	}
-	if report, unproven := startFailureReport("something-nobody-declared"); report != "" || !unproven {
-		t.Errorf("an observation this package does not know reported %q, unproven=%v; "+
-			"want no report and no claim", report, unproven)
+	// A value this package does not know makes no claim about what it
+	// means -- and still says so, because the caller logs the report as
+	// the message. An empty one is an operator page with nothing to
+	// filter, alert or search on.
+	report, unproven := startFailureReport("something-nobody-declared")
+	if !unproven {
+		t.Error("an observation this package does not know was reported as an established outcome")
+	}
+	if !strings.Contains(report, "does not declare") {
+		t.Errorf("an undeclared observation reported %q; it has to say that it is undeclared "+
+			"rather than name a meaning, and it has to say something", report)
+	}
+}
+
+// TestAProofSurvivesThePeriodicPass is the reachable sequence, driven
+// through the real recovery and the real periodic pass.
+//
+// A capsule reports that the runner never owned the job, so the attempt
+// must return to the queue even though the capsule had already reported
+// itself up. Removal then fails against a wedged daemon and the lease
+// parks in quarantine. The periodic pass that picks it up carries no
+// observation at all — it holds no daemon inventory — so without the
+// serving's own record it disposes of the attempt on evidence alone and
+// settles a job that never ran. Nothing serves that workload again, and
+// the books say it started.
+func TestAProofSurvivesThePeriodicPass(t *testing.T) {
+	h := newHarness(t, 1)
+	remover := &faultyRemover{}
+	h.useRemover(remover)
+	if err := h.deliver(demand("job-proof", "app", 81)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attempt := leaseFor(t, h, "job-proof")
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		// The capsule reported itself up and the attempt is running:
+		// this is what a settled disposition would rule on.
+		if err := tx.RecordEvidence(attempt, store.EvidenceRunningObserved); err != nil {
+			return err
+		}
+		if err := tx.Advance(attempt, store.AttemptLeased, store.AttemptStarting); err != nil {
+			return err
+		}
+		if err := tx.Advance(attempt, store.AttemptStarting, store.AttemptRunning); err != nil {
+			return err
+		}
+		id, err := tx.PlanResource(lease.ID, store.ResourceContainer, "runner", "runpool-runner-proof")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "proof-1")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The pass that measured the proof cannot finish.
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID,
+		assignment.ObservedCreated); err == nil {
+		t.Fatal("recovery with a wedged daemon succeeded")
+	}
+	if got := reloadLease(t, h, lease.ID); got.StartObservation != assignment.ObservedCreated {
+		t.Fatalf("the serving recorded %q; the proof has to outlive the pass that took it",
+			got.StartObservation)
+	}
+
+	// The daemon heals and the backoff elapses.
+	remover.healed = true
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		intents, err := tx.Resources(lease.ID)
+		if err != nil {
+			return err
+		}
+		return tx.RecordResourceError(intents[0].ID, errors.New("previous failure"), time.Now().Add(-time.Second))
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h.srv.retryStranded(t.Context())
+
+	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
+		t.Errorf("lease = %s after the periodic pass; want released", got.State)
+	}
+	if got := attemptState(t, h, attempt); got.State != store.AttemptReady {
+		t.Errorf("attempt = %s; want ready — the capsule proved the runner never owned this job", got.State)
 	}
 }

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -411,7 +411,7 @@ func TestPeriodicReconcileConvergesQuarantine(t *testing.T) {
 	// The removal fails: the lease parks in quarantine with backoff
 	// booked on the intent, and the attempt stays leased — unresolved,
 	// visible, waiting.
-	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err == nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, assignment.NoObservation); err == nil {
 		t.Fatal("recoverCapsuleFailure with a wedged daemon succeeded")
 	}
 	if got := reloadLease(t, h, lease.ID); got.State != store.LeaseQuarantined {

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -1107,3 +1107,118 @@ func TestAProofSurvivesThePeriodicPass(t *testing.T) {
 		t.Errorf("attempt = %s; want ready — the capsule proved the runner never owned this job", got.State)
 	}
 }
+
+// TestAbandonmentKeepsWhatThisServingMeasured: past the drain window the
+// lease is left as it is for the successor to recover, and that is
+// right -- but what this pass measured is not left with it unless it is
+// written down. Nothing re-takes it: the successor's pass only inspects
+// a runtime while the evidence is still start_authorized, and an
+// ambiguous start reaches here past that. Discarded, the capsule's proof
+// that the runner never owned the job is gone and the successor settles
+// the attempt as one that ran.
+func TestAbandonmentKeepsWhatThisServingMeasured(t *testing.T) {
+	h := newHarness(t, 1)
+	remover := &countingRemover{}
+	h.useRemover(remover)
+	if err := h.deliver(demand("job-drained", "app", 91)); err != nil {
+		t.Fatal(err)
+	}
+	lease, _ := leaseFor(t, h, "job-drained")
+	before := reloadLease(t, h, lease.ID).State
+
+	h.srv.abandoning.Store(true)
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID,
+		assignment.ObservedCreated); err != nil {
+		t.Fatalf("abandoned recovery reported an error: %v", err)
+	}
+	if got := reloadLease(t, h, lease.ID).StartObservation; got != assignment.ObservedCreated {
+		t.Errorf("the serving recorded %q past the drain window; nothing else will ever take that measurement", got)
+	}
+	// And the branch still does what it exists for.
+	if got := reloadLease(t, h, lease.ID).State; got != before {
+		t.Errorf("lease moved from %s to %s; abandonment leaves it as it is", before, got)
+	}
+	if n := remover.calls.Load(); n != 0 {
+		t.Errorf("abandonment removed %d objects; it must dismantle nothing", n)
+	}
+}
+
+// TestTheProviderOverrulesTheCapsuleAcrossARetry: the capsule's account
+// of never having handed the job over is produced inside the machine
+// running that job, and the provider's answer replaces it. That exchange
+// happens after the recorded proof is read back, which is the whole
+// reason the read is placed where it is: on a retry the capsule is gone
+// and only the record carries its account, so a readback that ran later
+// -- or a write that ran earlier -- would leave the provider with
+// nothing to overrule and requeue a job it says was handed over.
+func TestTheProviderOverrulesTheCapsuleAcrossARetry(t *testing.T) {
+	h := newHarness(t, 1)
+	remover := &faultyRemover{}
+	h.useRemover(remover)
+	reg := &fakeRegistry{removeErr: errors.New("provider unreachable")}
+	h.bind.gh = reg
+	if err := h.deliver(demand("job-overruled", "app", 92)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attempt := leaseFor(t, h, "job-overruled")
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		if err := tx.RecordGitHubRunnerID(attempt, 4242); err != nil {
+			return err
+		}
+		if err := tx.RecordEvidence(attempt, store.EvidenceRunningObserved); err != nil {
+			return err
+		}
+		if err := tx.Advance(attempt, store.AttemptLeased, store.AttemptStarting); err != nil {
+			return err
+		}
+		if err := tx.Advance(attempt, store.AttemptStarting, store.AttemptRunning); err != nil {
+			return err
+		}
+		id, err := tx.PlanResource(lease.ID, store.ResourceContainer, "runner", "runpool-runner-overruled")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(id, "overruled-1")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The capsule says the runner never owned the job. The provider
+	// cannot be reached this pass, and removal fails, so the lease parks.
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID,
+		assignment.ObservedCreated); err == nil {
+		t.Fatal("recovery with a wedged daemon succeeded")
+	}
+	if got := reloadLease(t, h, lease.ID).StartObservation; got != assignment.ObservedCreated {
+		t.Fatalf("the serving recorded %q; the capsule's account is what the provider has to overrule", got)
+	}
+
+	// The retry measures nothing of its own -- the capsule is being
+	// removed -- and the provider now says it still holds the runner. This
+	// pass fails too, so what it learned has to be written down here or it
+	// is gone: the overrule reaches the disposition as a parameter only on
+	// a pass that completes.
+	reg.removeErr = githubactions.ErrJobStillRunning
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID,
+		assignment.NoObservation); err == nil {
+		t.Fatal("the second pass succeeded against a wedged daemon")
+	}
+	if got := reloadLease(t, h, lease.ID).StartObservation; got != assignment.ObservedRunning {
+		t.Fatalf("the serving recorded %q after the provider overruled the capsule; the record has to be "+
+			"written after that exchange, not before it", got)
+	}
+
+	// A third pass, with nothing measured and the provider unreachable
+	// again: the disposition comes from the record alone.
+	remover.healed = true
+	reg.removeErr = errors.New("provider unreachable")
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID,
+		assignment.NoObservation); err != nil {
+		t.Fatalf("the third pass failed: %v", err)
+	}
+	got := attemptState(t, h, attempt)
+	if got.State != store.AttemptSettled || got.Resolution != assignment.ResolutionStartedObserved {
+		t.Errorf("attempt = %s/%s; the party that assigned the work says it was handed over, "+
+			"so it is not returned to the queue", got.State, got.Resolution)
+	}
+}

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -266,7 +266,7 @@ func (s *Controller) adopt(b *binding, lease store.Lease, runnerContainer string
 		defer endRecovery()
 		if err != nil {
 			s.log.Error("adopted capsule wait failed", "lease", lease.ID, "error", err)
-			if err := s.recoverCapsuleFailure(done, b, lease.ID, ""); err != nil {
+			if err := s.recoverCapsuleFailure(done, b, lease.ID, assignment.NoObservation); err != nil {
 				s.log.Error("adopted capsule could not be resolved; reconciliation will retry",
 					"lease", lease.ID, "error", err)
 			}
@@ -587,7 +587,7 @@ func (s *Controller) resolveStranded(ctx context.Context, lease store.Lease, ret
 	}
 	*retried++
 	b := s.byBinding[lease.BindingID] // may be nil if the target was removed
-	if err := s.recoverCapsuleFailure(ctx, b, lease.ID, ""); err != nil {
+	if err := s.recoverCapsuleFailure(ctx, b, lease.ID, assignment.NoObservation); err != nil {
 		s.log.Warn("stranded lease still unresolved",
 			"lease", lease.ID, "state", string(lease.State), "error", err)
 		return

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -113,7 +113,7 @@ func TestCapsuleFailureRecoverySurvivesAMissingBinding(t *testing.T) {
 			t.Fatalf("recoverCapsuleFailure panicked with a missing binding: %v", r)
 		}
 	}()
-	if err := h.srv.recoverCapsuleFailure(t.Context(), nil, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), nil, lease.ID, assignment.NoObservation); err != nil {
 		t.Fatalf("recoverCapsuleFailure with a missing binding: %v", err)
 	}
 }

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -106,7 +106,7 @@ func TestReassignmentOfASettledJobIsServable(t *testing.T) {
 	lease, attemptID := leaseFor(t, h, "job-reassigned")
 	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
 	h.recordEvidence(lease.ID, store.EvidenceExitObserved)
-	if err := h.srv.leases.Finalize(t.Context(), lease.ID, ""); err != nil {
+	if err := h.srv.leases.Finalize(t.Context(), lease.ID, assignment.NoObservation); err != nil {
 		t.Fatal(err)
 	}
 	if got := len(h.ready()); got != 0 {

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -402,6 +402,13 @@ func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leas
 		log.Error("failure transition failed", "error", err)
 		return err
 	}
+	// A retry of this recovery arrives with nothing measured, because the
+	// pass that measured it is the one that failed. Reading it back here
+	// rather than at the disposition puts it in front of the provider
+	// question below, which is the one thing entitled to overrule it.
+	if !startObs.Establishes() && was.StartObservation.Establishes() {
+		startObs = was.StartObservation
+	}
 
 	// The runner id lives in the adapter's metadata for the attempt this
 	// lease serves; a binding of another provider has none, and zero
@@ -461,6 +468,15 @@ func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leas
 		}
 	}
 
+	// Before the first destructive step, and after every refinement above
+	// that can overrule it. A recovery that cannot record what it saw must
+	// not destroy the thing it saw: the lease stays cleaning, holding its
+	// credit and its objects, and the periodic pass runs the whole
+	// recovery again with the capsule still there.
+	if err := s.leases.RecordStartObservation(ctx, leaseID, startObs); err != nil {
+		log.Error("cannot record what this serving measured; nothing is removed", "error", err)
+		return err
+	}
 	if err := s.leases.RemoveResources(ctx, leaseID); err != nil {
 		log.Error("failure cleanup failed; lease quarantined", "error", err)
 		s.leases.Quarantine(leaseID)
@@ -499,8 +515,18 @@ func startFailureReport(obs assignment.ExecutionObservation) (report string, unp
 		// Decided before this is reached, and named here so the totality
 		// check is about every observation rather than the leftovers.
 		return "the runtime outlived the start that reported an error", false
+	case assignment.NoObservation:
+		// Distinct from the pair above it: those were asked and could not
+		// answer, this was never asked. Both need an operator, and only
+		// one of them says the runtime was reached.
+		return "no observation was taken of this start; the assignment needs an operator", true
 	}
-	return "", true
+	// A value this build does not declare. Naming what it means would be
+	// inventing one, and that is the mistake this function exists to stop.
+	// Saying nothing is a different mistake: the caller logs this as the
+	// message, so an empty one pages an operator with a line that has no
+	// message to filter, alert or search on.
+	return "the start failed carrying an observation this build does not declare", true
 }
 
 // remainingCeiling is what is left of a lease's tier ceiling.

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -53,9 +53,11 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	defer s.wg.Done()
 	attemptID := lease.AttemptID
 	// startObs carries the classification of an ambiguous start into the
-	// finalizing transaction. It lives in memory because it is taken
-	// before cleanup destroys the container that proves it; after a
-	// crash, recovery re-takes the same observation from the daemon.
+	// finalizing transaction. Recovery does not re-take it: the pass that
+	// inspects a runtime only does so while the evidence is still
+	// start_authorized, and an ambiguous start reaches here past that. So
+	// it is recorded with the lease on the way into cleanup, and a retry
+	// reads it back rather than measuring again.
 	var startObs assignment.ExecutionObservation
 	// The scheduler claims the lease before this goroutine is started, so
 	// the claim is unbroken from the moment the lease row exists. Claiming
@@ -393,6 +395,14 @@ func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leas
 	// already past this point runs to completion: its transitions are
 	// durable, and the successor resumes whatever it left.
 	if s.abandoning.Load() {
+		// The lease is left as it is, but what this pass measured is not:
+		// nothing re-takes it, and the successor arrives with an evidence
+		// state past the one that would make it inspect. Recording is a
+		// column rather than a state, so it leaves the successor a lease
+		// to recover exactly as this branch intends.
+		if err := s.leases.RecordStartObservation(ctx, leaseID, startObs); err != nil {
+			log.Error("cannot record what this serving measured before abandoning it", "error", err)
+		}
 		log.Warn("drain window elapsed; the lease is left as it is for the next start to recover")
 		return nil
 	}

--- a/internal/app/shutdown_test.go
+++ b/internal/app/shutdown_test.go
@@ -124,7 +124,7 @@ func TestDrainExpiryAbandonsRecovery(t *testing.T) {
 	before := reloadLease(t, h, lease.ID).State
 
 	h.srv.abandoning.Store(true)
-	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, assignment.NoObservation); err != nil {
 		t.Fatalf("abandoned recovery reported an error: %v", err)
 	}
 	if got := reloadLease(t, h, lease.ID).State; got != before {
@@ -137,7 +137,7 @@ func TestDrainExpiryAbandonsRecovery(t *testing.T) {
 	// The mutation half: the same call without the abandonment is the
 	// destructive path, so the assertions above are proven able to fail.
 	h.srv.abandoning.Store(false)
-	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, ""); err != nil {
+	if err := h.srv.recoverCapsuleFailure(t.Context(), h.bind, lease.ID, assignment.NoObservation); err != nil {
 		t.Fatalf("live recovery failed: %v", err)
 	}
 	if got := reloadLease(t, h, lease.ID).State; got == before {

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -161,6 +161,17 @@ type WorkloadLifecycleEvent struct {
 type ExecutionObservation string
 
 const (
+	// NoObservation means this pass took no observation at all: nothing
+	// asked the daemon or the capsule, so nothing is established and
+	// nothing is contradicted. It does not carry the Observed prefix
+	// because the six values that do each name what an observer saw, and
+	// this names that there was no observer.
+	//
+	// It is the zero value, and it is what a cleanup retry arrives with:
+	// the pass that measured is the pass that failed. What that pass
+	// recorded on the lease is what a retry reads back, because this
+	// value is not evidence against it.
+	NoObservation ExecutionObservation = ""
 	// ObservedCreated means the supervisor still holds the runner
 	// unstarted. It is the capsule's own account of itself, reached
 	// either by asking it or by reading the status it reserved for
@@ -183,7 +194,31 @@ const (
 	ObservedUnavailable ExecutionObservation = "unavailable"
 )
 
-// AllExecutionObservations is every observation that exists.
+// Establishes reports whether this observation says anything about
+// whether the workload began.
+//
+// Three do not, and they are the ones a retry produces: NoObservation
+// because that pass measured nothing, ObservedAbsent because the capsule
+// a measurement would have come from is the one the cleanup being
+// retried has already removed, and ObservedUnavailable because the
+// runtime could not be made to answer. None of them is evidence against
+// a measurement an earlier pass took, which is why what a serving
+// measures is kept rather than carried only by the goroutine that took
+// it.
+func (o ExecutionObservation) Establishes() bool {
+	switch o {
+	case ObservedCreated, ObservedNeverStarted, ObservedRunning, ObservedExited:
+		return true
+	default:
+		return false
+	}
+}
+
+// AllExecutionObservations is every value of this vocabulary, which is
+// one more than the observations: NoObservation is a value and not an
+// observation, and a switch that leaves it out decides for it by
+// omission -- in the one function whose contract is that nothing is
+// decided by omission.
 //
 // Anything deciding what to do with one has to decide for all of them,
 // and a switch says nothing when a value is added: it falls into
@@ -191,6 +226,7 @@ const (
 // value added here without a home elsewhere is what a totality check
 // has to fail on.
 var AllExecutionObservations = []ExecutionObservation{
+	NoObservation,
 	ObservedCreated,
 	ObservedNeverStarted,
 	ObservedRunning,

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -145,6 +145,9 @@ func (m *Manager) FinishCleaning(ctx context.Context, lease store.Lease, obs ass
 			return err
 		}
 	}
+	if err := m.RecordStartObservation(ctx, lease.ID, obs); err != nil {
+		return err
+	}
 	if err := m.RemoveResources(ctx, lease.ID); err != nil {
 		return err
 	}
@@ -214,7 +217,8 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), "cleanup_completed"); err != nil {
 		return err
 	}
-	return m.applyDisposition(tx, attempt, lease.ID, startObs, dispositionFor(attempt, startObs))
+	d, effective := dispositionFor(lease, attempt, startObs)
+	return m.applyDisposition(tx, attempt, lease.ID, effective, d)
 }
 
 // disposition is what the books must record about an attempt whose
@@ -280,7 +284,8 @@ func servedByThisLease(state store.AttemptState) bool {
 	return false
 }
 
-// dispositionFor decides what one ended serving means for its attempt.
+// dispositionFor decides what one ended serving means for its attempt,
+// and reports the observation it decided on.
 // The precedence is stated here, once, in the order these cases are
 // written — but the cases are exhaustive over a value, so adding one
 // cannot silently reorder the others the way inserting a switch case
@@ -294,7 +299,26 @@ func servedByThisLease(state store.AttemptState) bool {
 // exit code it reserves for exactly that. ObservedNeverStarted is the
 // daemon's: a container it has never started. They differ in who is
 // saying it and not in what it proves, so both requeue.
-func dispositionFor(attempt store.Attempt, obs assignment.ExecutionObservation) disposition {
+//
+// A proof also outranks a later pass that measured nothing. Cleanup can
+// fail and be retried, and the retry re-enters this with no observation
+// or with absent — neither of which establishes anything, and the second
+// only because the capsule the measurement would have come from is the
+// one this cleanup is removing. Reading back what the serving recorded
+// is what keeps the proof from being spent by the pass that took it. A
+// later measurement that does establish something still wins, because
+// the accounts arrive in order: the daemon's, then the capsule's own,
+// then the provider's.
+func dispositionFor(lease store.Lease, attempt store.Attempt,
+	obs assignment.ExecutionObservation) (disposition, assignment.ExecutionObservation) {
+
+	if !obs.Establishes() && lease.StartObservation.Establishes() {
+		obs = lease.StartObservation
+	}
+	return dispositionOf(attempt, obs), obs
+}
+
+func dispositionOf(attempt store.Attempt, obs assignment.ExecutionObservation) disposition {
 	switch {
 	case !servedByThisLease(attempt.State):
 		return dispositionNone
@@ -397,7 +421,8 @@ func (m *Manager) requeueOrReview(tx *store.Tx, attemptID assignment.AttemptID, 
 // disposeAttempt once carried their own switches and drifted apart.
 func (m *Manager) DisposeStranded(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) {
 	m.withAttemptOfLease(ctx, lease.ID, func(tx *store.Tx, attempt store.Attempt) error {
-		return m.applyDisposition(tx, attempt, lease.ID, obs, dispositionFor(attempt, obs))
+		d, effective := dispositionFor(lease, attempt, obs)
+		return m.applyDisposition(tx, attempt, lease.ID, effective, d)
 	})
 }
 
@@ -438,6 +463,29 @@ func (m *Manager) Quarantine(leaseID assignment.LeaseID) {
 		m.log.Error("cannot quarantine the lease; it stays in its current state",
 			"lease", leaseID, "error", err)
 	}
+}
+
+// RecordStartObservation keeps what this serving measured about whether
+// the workload began, so a cleanup that has to be retried does not lose
+// it. Only a measurement that establishes something is written: the
+// values a retry produces establish nothing, and writing one would spend
+// the proof the pass before it recorded.
+//
+// It runs on a context detached from the caller's for the same reason
+// evidence does: the answer is about work that has already happened, and
+// a cancelled recovery that has seen something must still be able to say
+// so.
+func (m *Manager) RecordStartObservation(ctx context.Context, leaseID assignment.LeaseID,
+	obs assignment.ExecutionObservation) error {
+
+	if !obs.Establishes() {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	return m.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.RecordLeaseStartObservation(leaseID, obs)
+	})
 }
 
 // RemoveResources drives every one of a lease's intents to absent, in

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -102,7 +102,10 @@ func (m *Manager) Release(ctx context.Context, leaseID assignment.LeaseID, from 
 		m.Quarantine(leaseID)
 		return err
 	}
-	return m.Finalize(ctx, leaseID, "")
+	// The ordinary ending takes no observation: the disposition rules on
+	// evidence, and a serving that ended cleanly recorded nothing to read
+	// back.
+	return m.Finalize(ctx, leaseID, assignment.NoObservation)
 }
 
 // ToCleaning moves a lease into cleaning from wherever a crash or a

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 	"time"
 
@@ -755,5 +756,43 @@ func TestOnlyAMeasurementIsRecorded(t *testing.T) {
 				t.Errorf("the serving recorded %q; want %q", got, want)
 			}
 		})
+	}
+}
+
+// TestTheColumnRefusesAnEmptyMeasurement: the storage represents a
+// serving that recorded nothing as NULL, and the empty string is not a
+// second way to spell it. Two representations of one state is what a
+// reader of the table would have to know about and nothing would tell
+// them, so the column refuses one of them outright -- below the Go guard
+// rather than beside it, because a guard that can be removed is not what
+// keeps a table honest.
+func TestTheColumnRefusesAnEmptyMeasurement(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	err := f.m.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.RecordLeaseStartObservation(f.lease.ID, "")
+	})
+	if err == nil {
+		t.Fatal("the column accepted an empty measurement; NULL and the empty string now both mean nothing")
+	}
+	if !strings.Contains(err.Error(), "CHECK") {
+		t.Errorf("the write failed with %v; the column's own constraint is what has to refuse it", err)
+	}
+}
+
+// TestTheColumnRefusesAnEmptyRuntimeName: a lease that has registered no
+// runtime has no name, and the lookup that answers "which attempt ran as
+// this runtime" searches by that value. An empty name stored here would
+// be a name a caller could ask for, matching a lease that registered
+// nothing -- so the column refuses it and the absence is NULL.
+func TestTheColumnRefusesAnEmptyRuntimeName(t *testing.T) {
+	f := newFixture(t, nopRemover{})
+	err := f.m.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.SetLeaseRuntimeName(f.lease.ID, "")
+	})
+	if err == nil {
+		t.Fatal("the column accepted an empty runtime name; a lookup for one would match a lease that registered nothing")
+	}
+	if !strings.Contains(err.Error(), "CHECK") {
+		t.Errorf("the write failed with %v; the column's own constraint is what has to refuse it", err)
 	}
 }

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -514,33 +514,59 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 	for name, tc := range map[string]struct {
 		state    store.AttemptState
 		evidence store.Evidence
-		obs      assignment.ExecutionObservation
-		want     disposition
+		// stored is what the serving recorded when it measured, which a
+		// retry of its cleanup has to read back: the pass that measured is
+		// the one that failed, and it arrives here having measured nothing.
+		stored assignment.ExecutionObservation
+		obs    assignment.ExecutionObservation
+		want   disposition
 	}{
 		"proven inert outranks a running observation": {
-			store.AttemptRunning, store.EvidenceRunningObserved, assignment.ObservedCreated, dispositionRequeue},
+			store.AttemptRunning, store.EvidenceRunningObserved, "", assignment.ObservedCreated, dispositionRequeue},
+		// The three below are the retry of the row above: its cleanup
+		// failed, so the pass that measured the proof is not the pass that
+		// disposes of the attempt. What the retry carries establishes
+		// nothing -- it either measured nothing or found the capsule this
+		// cleanup is removing already gone -- and without the recorded
+		// proof each of them settles a job that never ran.
+		"a recorded proof outranks a retry that found nothing": {
+			store.AttemptRunning, store.EvidenceRunningObserved,
+			assignment.ObservedCreated, assignment.ObservedAbsent, dispositionRequeue},
+		"a recorded proof outranks a retry that measured nothing": {
+			store.AttemptRunning, store.EvidenceRunningObserved,
+			assignment.ObservedCreated, "", dispositionRequeue},
+		// And a later measurement that does establish something still
+		// wins: the provider is asked again on the retry, and it is the
+		// one account entitled to overrule the capsule.
+		"a later establishing measurement outranks the recorded proof": {
+			store.AttemptRunning, store.EvidenceRunningObserved,
+			assignment.ObservedCreated, assignment.ObservedRunning, dispositionSettleStarted},
 		"an observed exit settles as completed": {
-			store.AttemptRunning, store.EvidenceExitObserved, "", dispositionSettleCompleted},
+			store.AttemptRunning, store.EvidenceExitObserved, "", "", dispositionSettleCompleted},
+		// Nothing measured and nothing recorded: the tier ceiling, where
+		// the capsule is destroyed while the runner is still working. That
+		// job really did run.
 		"a running observation settles as started": {
-			store.AttemptRunning, store.EvidenceRunningObserved, "", dispositionSettleStarted},
+			store.AttemptRunning, store.EvidenceRunningObserved, "", "", dispositionSettleStarted},
 		"nothing prepared returns to the queue": {
-			store.AttemptLeased, store.EvidenceNotStarted, "", dispositionRequeue},
+			store.AttemptLeased, store.EvidenceNotStarted, "", "", dispositionRequeue},
 		"a running runtime settles as started": {
-			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.ObservedRunning, dispositionSettleStarted},
+			store.AttemptStarting, store.EvidenceStartAuthorized, "", assignment.ObservedRunning, dispositionSettleStarted},
 		"an unprovable start is held": {
-			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.ObservedAbsent, dispositionReview},
+			store.AttemptStarting, store.EvidenceStartAuthorized, "", assignment.ObservedAbsent, dispositionReview},
 		"an attempt an operator returned to the queue is left alone": {
-			store.AttemptReady, store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptReady, store.EvidenceNotStarted, "", "", dispositionNone},
 		"a superseded attempt is left alone": {
-			store.AttemptSuperseded, store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptSuperseded, store.EvidenceNotStarted, "", "", dispositionNone},
 		"a held attempt is left alone": {
-			store.AttemptManualReview, store.EvidenceNotStarted, "", dispositionNone},
+			store.AttemptManualReview, store.EvidenceNotStarted, "", "", dispositionNone},
 		"a settled attempt is left alone": {
-			store.AttemptSettled, store.EvidenceExitObserved, "", dispositionNone},
+			store.AttemptSettled, store.EvidenceExitObserved, "", "", dispositionNone},
 	} {
 		t.Run(name, func(t *testing.T) {
 			attempt := store.Attempt{State: tc.state, Evidence: tc.evidence}
-			if got := dispositionFor(attempt, tc.obs); got != tc.want {
+			lease := store.Lease{StartObservation: tc.stored}
+			if got, _ := dispositionFor(lease, attempt, tc.obs); got != tc.want {
 				t.Errorf("dispositionFor(%s, %s, %s) = %d; want %d",
 					tc.state, tc.evidence, tc.obs, got, tc.want)
 			}
@@ -646,5 +672,88 @@ func TestAnAttemptReturnedToTheQueueDoesNotPinItsLease(t *testing.T) {
 	}
 	if got := f.attemptState().State; got != store.AttemptReady {
 		t.Errorf("attempt = %s; want it left where the operator put it", got)
+	}
+}
+
+// TestARecordedProofSurvivesAFailedCleanup is the sequence the record
+// exists for.
+//
+// A capsule reports that the runner never owned the job, so the
+// attempt must return to the queue even though the capsule had already
+// reported itself up. Cleanup then fails against a wedged daemon and the
+// lease is quarantined -- the documented retry path. The pass that
+// measured the proof is therefore not the pass that disposes of the
+// attempt, and the retry arrives having measured nothing: absent,
+// because the capsule a measurement would have come from is the one this
+// cleanup is removing.
+//
+// Without the record the retry settles the attempt as one that ran, and
+// the workload is never served again while the books say it started.
+func TestARecordedProofSurvivesAFailedCleanup(t *testing.T) {
+	remover := &wedgedRemover{}
+	f := newFixture(t, remover)
+	f.driveTo(store.LeaseDraining)
+	f.advanceAttemptTo(store.AttemptRunning)
+	f.tx(func(tx *store.Tx) error {
+		if err := tx.RecordEvidence(f.lease.AttemptID, store.EvidenceRunningObserved); err != nil {
+			return err
+		}
+		id, err := tx.PlanResource(f.lease.ID, store.ResourceContainer, "runner", "runpool-runner-proof")
+		if err != nil {
+			return err
+		}
+		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "proof-1")
+	})
+
+	// The pass that measured the proof cannot finish: the daemon is wedged.
+	if err := f.m.FinishCleaning(t.Context(), f.reload(), assignment.ObservedCreated); err == nil {
+		t.Fatal("cleanup against a wedged daemon reported success")
+	}
+	if got := f.reload().StartObservation; got != assignment.ObservedCreated {
+		t.Fatalf("the serving recorded %q; the proof has to outlive the pass that took it", got)
+	}
+
+	// The daemon heals and the retry runs, having measured nothing.
+	remover.healed = true
+	if err := f.m.FinishCleaning(t.Context(), f.reload(), assignment.ObservedAbsent); err != nil {
+		t.Fatalf("the retry failed: %v", err)
+	}
+	got := f.attemptState()
+	if got.State != store.AttemptReady {
+		t.Errorf("attempt = %s; want ready — the capsule proved the runner never owned this job", got.State)
+	}
+	if got.Resolution != "" {
+		t.Errorf("attempt resolution = %q; a job that never ran is not settled", got.Resolution)
+	}
+}
+
+// TestOnlyAMeasurementIsRecorded holds the predicate in Go and the
+// column's own constraint to one rule. They are two statements of it in
+// different languages, and both directions of drift are a real failure:
+// a value that establishes nothing written over a proof spends it, and a
+// value that does establish something refused by the database aborts a
+// recovery in the middle and pins a lease that should have released.
+func TestOnlyAMeasurementIsRecorded(t *testing.T) {
+	// The list is every value of the vocabulary, NoObservation included,
+	// so this covers the value a retry arrives with as well as the
+	// measurements.
+	for _, obs := range assignment.AllExecutionObservations {
+		name := string(obs)
+		if obs == assignment.NoObservation {
+			name = "nothing measured"
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newFixture(t, nopRemover{})
+			if err := f.m.RecordStartObservation(t.Context(), f.lease.ID, obs); err != nil {
+				t.Fatalf("recording %q: %v", obs, err)
+			}
+			want := obs
+			if !obs.Establishes() {
+				want = ""
+			}
+			if got := f.reload().StartObservation; got != want {
+				t.Errorf("the serving recorded %q; want %q", got, want)
+			}
+		})
 	}
 }

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -750,7 +750,7 @@ func TestOnlyAMeasurementIsRecorded(t *testing.T) {
 			}
 			want := obs
 			if !obs.Establishes() {
-				want = ""
+				want = assignment.NoObservation
 			}
 			if got := f.reload().StartObservation; got != want {
 				t.Errorf("the serving recorded %q; want %q", got, want)

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -203,13 +203,13 @@ func TestFinalizeDisposesByEvidence(t *testing.T) {
 		wantState      store.AttemptState
 		wantResolution string
 	}{
-		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, "", false, store.AttemptSettled, assignment.ResolutionCompletedObserved},
-		{"running observed", store.EvidenceRunningObserved, store.LeaseCleaning, "", false, store.AttemptSettled, assignment.ResolutionStartedObserved},
-		{"nothing was prepared", store.EvidenceNotStarted, store.LeaseCleaning, "", false, store.AttemptReady, ""},
-		{"prepared but never authorized", store.EvidenceRuntimePrepared, store.LeaseCleaning, "", false, store.AttemptReady, ""},
+		{"exit observed", store.EvidenceExitObserved, store.LeaseCleaning, assignment.NoObservation, false, store.AttemptSettled, assignment.ResolutionCompletedObserved},
+		{"running observed", store.EvidenceRunningObserved, store.LeaseCleaning, assignment.NoObservation, false, store.AttemptSettled, assignment.ResolutionStartedObserved},
+		{"nothing was prepared", store.EvidenceNotStarted, store.LeaseCleaning, assignment.NoObservation, false, store.AttemptReady, ""},
+		{"prepared but never authorized", store.EvidenceRuntimePrepared, store.LeaseCleaning, assignment.NoObservation, false, store.AttemptReady, ""},
 		{"authorized and unprovable", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedAbsent, false, store.AttemptManualReview, ""},
 		{"authorized and proven inert", store.EvidenceStartAuthorized, store.LeaseCleaning, assignment.ObservedCreated, false, store.AttemptReady, ""},
-		{"lease not yet cleaning", store.EvidenceNotStarted, store.LeaseQuarantined, "", true, store.AttemptLeased, ""},
+		{"lease not yet cleaning", store.EvidenceNotStarted, store.LeaseQuarantined, assignment.NoObservation, true, store.AttemptLeased, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -254,7 +254,7 @@ func TestFinalizeIsAtomic(t *testing.T) {
 		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "leftover")
 	})
 
-	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err == nil {
+	if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.NoObservation); err == nil {
 		t.Fatal("finalizing with a surviving resource record succeeded")
 	}
 	if got := f.reload(); got.State != store.LeaseCleaning {
@@ -352,7 +352,7 @@ func TestReleaseQuarantinesOnAWedgedDaemon(t *testing.T) {
 	if _, err := f.m.ToCleaning(t.Context(), f.lease.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.m.FinishCleaning(t.Context(), f.reload(), ""); err != nil {
+	if err := f.m.FinishCleaning(t.Context(), f.reload(), assignment.NoObservation); err != nil {
 		t.Fatal(err)
 	}
 	if got := f.reload(); got.State != store.LeaseReleased {
@@ -414,7 +414,7 @@ func TestTheExhaustedBudgetHoldsTheAttemptForReview(t *testing.T) {
 	// retriable evidence, and the attempt returns to ready.
 	for serving := 1; ; serving++ {
 		f.driveTo(store.LeaseCleaning)
-		if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+		if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.NoObservation); err != nil {
 			t.Fatalf("finalize serving %d: %v", serving, err)
 		}
 		var attempt store.Attempt
@@ -492,7 +492,7 @@ func TestAHeldAttemptDoesNotPinItsLease(t *testing.T) {
 		return tx.HoldForReview(id, store.ReviewReasonIncompatibleCapsule)
 	})
 
-	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+	if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.NoObservation); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}
 	if got := f.reload().State; got != store.LeaseReleased {
@@ -522,7 +522,7 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 		want   disposition
 	}{
 		"proven inert outranks a running observation": {
-			store.AttemptRunning, store.EvidenceRunningObserved, "", assignment.ObservedCreated, dispositionRequeue},
+			store.AttemptRunning, store.EvidenceRunningObserved, assignment.NoObservation, assignment.ObservedCreated, dispositionRequeue},
 		// The three below are the retry of the row above: its cleanup
 		// failed, so the pass that measured the proof is not the pass that
 		// disposes of the attempt. What the retry carries establishes
@@ -534,7 +534,7 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 			assignment.ObservedCreated, assignment.ObservedAbsent, dispositionRequeue},
 		"a recorded proof outranks a retry that measured nothing": {
 			store.AttemptRunning, store.EvidenceRunningObserved,
-			assignment.ObservedCreated, "", dispositionRequeue},
+			assignment.ObservedCreated, assignment.NoObservation, dispositionRequeue},
 		// And a later measurement that does establish something still
 		// wins: the provider is asked again on the retry, and it is the
 		// one account entitled to overrule the capsule.
@@ -542,26 +542,26 @@ func TestBothDispositionPathsAgree(t *testing.T) {
 			store.AttemptRunning, store.EvidenceRunningObserved,
 			assignment.ObservedCreated, assignment.ObservedRunning, dispositionSettleStarted},
 		"an observed exit settles as completed": {
-			store.AttemptRunning, store.EvidenceExitObserved, "", "", dispositionSettleCompleted},
+			store.AttemptRunning, store.EvidenceExitObserved, assignment.NoObservation, assignment.NoObservation, dispositionSettleCompleted},
 		// Nothing measured and nothing recorded: the tier ceiling, where
 		// the capsule is destroyed while the runner is still working. That
 		// job really did run.
 		"a running observation settles as started": {
-			store.AttemptRunning, store.EvidenceRunningObserved, "", "", dispositionSettleStarted},
+			store.AttemptRunning, store.EvidenceRunningObserved, assignment.NoObservation, assignment.NoObservation, dispositionSettleStarted},
 		"nothing prepared returns to the queue": {
-			store.AttemptLeased, store.EvidenceNotStarted, "", "", dispositionRequeue},
+			store.AttemptLeased, store.EvidenceNotStarted, assignment.NoObservation, assignment.NoObservation, dispositionRequeue},
 		"a running runtime settles as started": {
-			store.AttemptStarting, store.EvidenceStartAuthorized, "", assignment.ObservedRunning, dispositionSettleStarted},
+			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.NoObservation, assignment.ObservedRunning, dispositionSettleStarted},
 		"an unprovable start is held": {
-			store.AttemptStarting, store.EvidenceStartAuthorized, "", assignment.ObservedAbsent, dispositionReview},
+			store.AttemptStarting, store.EvidenceStartAuthorized, assignment.NoObservation, assignment.ObservedAbsent, dispositionReview},
 		"an attempt an operator returned to the queue is left alone": {
-			store.AttemptReady, store.EvidenceNotStarted, "", "", dispositionNone},
+			store.AttemptReady, store.EvidenceNotStarted, assignment.NoObservation, assignment.NoObservation, dispositionNone},
 		"a superseded attempt is left alone": {
-			store.AttemptSuperseded, store.EvidenceNotStarted, "", "", dispositionNone},
+			store.AttemptSuperseded, store.EvidenceNotStarted, assignment.NoObservation, assignment.NoObservation, dispositionNone},
 		"a held attempt is left alone": {
-			store.AttemptManualReview, store.EvidenceNotStarted, "", "", dispositionNone},
+			store.AttemptManualReview, store.EvidenceNotStarted, assignment.NoObservation, assignment.NoObservation, dispositionNone},
 		"a settled attempt is left alone": {
-			store.AttemptSettled, store.EvidenceExitObserved, "", "", dispositionNone},
+			store.AttemptSettled, store.EvidenceExitObserved, assignment.NoObservation, assignment.NoObservation, dispositionNone},
 	} {
 		t.Run(name, func(t *testing.T) {
 			attempt := store.Attempt{State: tc.state, Evidence: tc.evidence}
@@ -637,7 +637,7 @@ func TestEveryServingStateCanBeDisposedOf(t *testing.T) {
 
 			// Retriable evidence is the disposition that reaches the
 			// requeue from every one of these states.
-			if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+			if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.NoObservation); err != nil {
 				t.Fatalf("Finalize from %s: %v", state, err)
 			}
 			if got := f.reload().State; got != store.LeaseReleased {
@@ -664,7 +664,7 @@ func TestAnAttemptReturnedToTheQueueDoesNotPinItsLease(t *testing.T) {
 		return tx.ResolveReviewToReady(id, "resolved", "operator")
 	})
 
-	if err := f.m.Finalize(t.Context(), f.lease.ID, ""); err != nil {
+	if err := f.m.Finalize(t.Context(), f.lease.ID, assignment.NoObservation); err != nil {
 		t.Fatalf("Finalize: %v", err)
 	}
 	if got := f.reload().State; got != store.LeaseReleased {

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -97,8 +97,15 @@ type Lease struct {
 	TierID      assignment.TierID
 	State       LeaseState
 	RuntimeName assignment.RuntimeName
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	// StartObservation is what this serving measured about whether the
+	// workload began, kept because the measurement outlives the goroutine
+	// that took it. A cleanup that has to be retried re-enters the
+	// finalizing transaction with nothing in hand, and an attempt whose
+	// capsule proved the runner never owned the job would otherwise settle
+	// there as one that ran. Empty means this serving established nothing.
+	StartObservation assignment.ExecutionObservation
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
 }
 
 // ResourceKind is the Docker object type of an owned capsule resource;

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -79,6 +79,22 @@ func (t *Tx) SetLeaseRuntimeName(id assignment.LeaseID, runtimeName assignment.R
 		runtimeName, id))
 }
 
+// RecordLeaseStartObservation keeps what this serving measured about
+// whether the workload began.
+//
+// It is written on the way into the cleanup that ends a serving, after
+// every refinement that can overrule the measurement and before the
+// first destructive step -- so a retry of that cleanup reads back the
+// answer the pass that failed had already reached. The write is
+// unconditional because a later establishing measurement is a better one:
+// the capsule's own account of itself arrives after the daemon's, and the
+// provider's after that.
+func (t *Tx) RecordLeaseStartObservation(id assignment.LeaseID, obs assignment.ExecutionObservation) error {
+	return t.mustAffect(t.tx.Exec(
+		`UPDATE capsule_leases SET start_observation = ?, updated_at = unixepoch() WHERE id = ?`,
+		obs, id))
+}
+
 func (t *Tx) LeaseByID(id assignment.LeaseID) (Lease, error) {
 	l, err := t.scanLease(t.tx.QueryRow(selectLease+`WHERE id = ?`, id))
 	if errors.Is(err, sql.ErrNoRows) {
@@ -305,7 +321,7 @@ func (t *Tx) PurgeLease(id assignment.LeaseID) error {
 	return nil
 }
 
-const selectLease = `SELECT id, binding_id, attempt_id, tier_id, state, runtime_name, created_at, updated_at FROM capsule_leases `
+const selectLease = `SELECT id, binding_id, attempt_id, tier_id, state, runtime_name, start_observation, created_at, updated_at FROM capsule_leases `
 
 type rowScanner interface{ Scan(...any) error }
 
@@ -313,7 +329,7 @@ func (t *Tx) scanLease(r rowScanner) (Lease, error) {
 	var l Lease
 	var created, updated int64
 	err := r.Scan(&l.ID, &l.BindingID, &l.AttemptID, &l.TierID, &l.State,
-		&l.RuntimeName, &created, &updated)
+		&l.RuntimeName, &l.StartObservation, &created, &updated)
 	l.CreatedAt = time.Unix(created, 0).UTC()
 	l.UpdatedAt = time.Unix(updated, 0).UTC()
 	return l, err

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -328,8 +328,17 @@ type rowScanner interface{ Scan(...any) error }
 func (t *Tx) scanLease(r rowScanner) (Lease, error) {
 	var l Lease
 	var created, updated int64
+	// NULL is an absence: a serving that recorded nothing, a runtime that
+	// never registered. NullString renders both as the empty string, which
+	// is each type's own zero -- NoObservation by name for the measurement,
+	// and for the runtime a name no lookup will answer for. The storage
+	// represents the absence and the domain's zero value means it; this is
+	// the one line where they meet.
+	var observed, runtime sql.NullString
 	err := r.Scan(&l.ID, &l.BindingID, &l.AttemptID, &l.TierID, &l.State,
-		&l.RuntimeName, &l.StartObservation, &created, &updated)
+		&runtime, &observed, &created, &updated)
+	l.RuntimeName = assignment.RuntimeName(runtime.String)
+	l.StartObservation = assignment.ExecutionObservation(observed.String)
 	l.CreatedAt = time.Unix(created, 0).UTC()
 	l.UpdatedAt = time.Unix(updated, 0).UTC()
 	return l, err

--- a/internal/store/migrations/000001_initial.up.sql
+++ b/internal/store/migrations/000001_initial.up.sql
@@ -147,16 +147,23 @@ CREATE TABLE capsule_leases (
 	-- The name the runtime registered under. Lifecycle events correlate
 	-- by workload key; this is the cross-check that says a runner is
 	-- executing the workload it was provisioned for.
-	runtime_name  TEXT NOT NULL DEFAULT '',
+	--
+	-- NULL until a runtime registers, because the lookup below is by this
+	-- value: an empty one stored here would be a name a caller could ask
+	-- for and match a lease that never registered anything.
+	runtime_name  TEXT CHECK (runtime_name IS NULL OR length(runtime_name) > 0),
 	-- What this serving measured about whether the workload began. The
 	-- proof outranks the evidence -- an attempt whose capsule reports the
 	-- runner never owned the job returns to the queue even though the
 	-- capsule reported itself up -- and a cleanup that has to be retried
 	-- would otherwise carry no proof into the retry and settle the
 	-- attempt as one that ran. Only a value that establishes something is
-	-- recorded; absent and unavailable establish nothing and stay NoObservation ('').
-	start_observation TEXT NOT NULL DEFAULT '' CHECK (start_observation IN (
-		'', 'created', 'never_started', 'running', 'exited')),
+	-- recorded. NULL is a serving that recorded nothing, which is what a
+	-- lease is born with: absent and unavailable establish nothing, so
+	-- they are never written, and the empty string is refused outright --
+	-- one representation of nothing, not two.
+	start_observation TEXT CHECK (start_observation IS NULL OR start_observation IN (
+		'created', 'never_started', 'running', 'exited')),
 	created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
 	updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
 );

--- a/internal/store/migrations/000001_initial.up.sql
+++ b/internal/store/migrations/000001_initial.up.sql
@@ -148,6 +148,15 @@ CREATE TABLE capsule_leases (
 	-- by workload key; this is the cross-check that says a runner is
 	-- executing the workload it was provisioned for.
 	runtime_name  TEXT NOT NULL DEFAULT '',
+	-- What this serving measured about whether the workload began. The
+	-- proof outranks the evidence -- an attempt whose capsule reports the
+	-- runner never owned the job returns to the queue even though the
+	-- capsule reported itself up -- and a cleanup that has to be retried
+	-- would otherwise carry no proof into the retry and settle the
+	-- attempt as one that ran. Only a value that establishes something is
+	-- recorded; absent and unavailable establish nothing and stay NoObservation ('').
+	start_observation TEXT NOT NULL DEFAULT '' CHECK (start_observation IN (
+		'', 'created', 'never_started', 'running', 'exited')),
 	created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
 	updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
 );

--- a/internal/store/schema/current.sql
+++ b/internal/store/schema/current.sql
@@ -93,16 +93,23 @@ CREATE TABLE capsule_leases (
 	-- The name the runtime registered under. Lifecycle events correlate
 	-- by workload key; this is the cross-check that says a runner is
 	-- executing the workload it was provisioned for.
-	runtime_name  TEXT NOT NULL DEFAULT '',
+	--
+	-- NULL until a runtime registers, because the lookup below is by this
+	-- value: an empty one stored here would be a name a caller could ask
+	-- for and match a lease that never registered anything.
+	runtime_name  TEXT CHECK (runtime_name IS NULL OR length(runtime_name) > 0),
 	-- What this serving measured about whether the workload began. The
 	-- proof outranks the evidence -- an attempt whose capsule reports the
 	-- runner never owned the job returns to the queue even though the
 	-- capsule reported itself up -- and a cleanup that has to be retried
 	-- would otherwise carry no proof into the retry and settle the
 	-- attempt as one that ran. Only a value that establishes something is
-	-- recorded; absent and unavailable establish nothing and stay NoObservation ('').
-	start_observation TEXT NOT NULL DEFAULT '' CHECK (start_observation IN (
-		'', 'created', 'never_started', 'running', 'exited')),
+	-- recorded. NULL is a serving that recorded nothing, which is what a
+	-- lease is born with: absent and unavailable establish nothing, so
+	-- they are never written, and the empty string is refused outright --
+	-- one representation of nothing, not two.
+	start_observation TEXT CHECK (start_observation IS NULL OR start_observation IN (
+		'created', 'never_started', 'running', 'exited')),
 	created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
 	updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
 );

--- a/internal/store/schema/current.sql
+++ b/internal/store/schema/current.sql
@@ -94,6 +94,15 @@ CREATE TABLE capsule_leases (
 	-- by workload key; this is the cross-check that says a runner is
 	-- executing the workload it was provisioned for.
 	runtime_name  TEXT NOT NULL DEFAULT '',
+	-- What this serving measured about whether the workload began. The
+	-- proof outranks the evidence -- an attempt whose capsule reports the
+	-- runner never owned the job returns to the queue even though the
+	-- capsule reported itself up -- and a cleanup that has to be retried
+	-- would otherwise carry no proof into the retry and settle the
+	-- attempt as one that ran. Only a value that establishes something is
+	-- recorded; absent and unavailable establish nothing and stay NoObservation ('').
+	start_observation TEXT NOT NULL DEFAULT '' CHECK (start_observation IN (
+		'', 'created', 'never_started', 'running', 'exited')),
 	created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
 	updated_at    INTEGER NOT NULL DEFAULT (unixepoch())
 );

--- a/internal/store/sqlitedb/models.go
+++ b/internal/store/sqlitedb/models.go
@@ -69,14 +69,15 @@ type CacheProject struct {
 }
 
 type CapsuleLease struct {
-	ID          string
-	BindingID   int64
-	AttemptID   string
-	TierID      string
-	State       string
-	RuntimeName string
-	CreatedAt   int64
-	UpdatedAt   int64
+	ID               string
+	BindingID        int64
+	AttemptID        string
+	TierID           string
+	State            string
+	RuntimeName      string
+	StartObservation string
+	CreatedAt        int64
+	UpdatedAt        int64
 }
 
 type GithubActionsAttemptMetadatum struct {

--- a/internal/store/sqlitedb/models.go
+++ b/internal/store/sqlitedb/models.go
@@ -74,8 +74,8 @@ type CapsuleLease struct {
 	AttemptID        string
 	TierID           string
 	State            string
-	RuntimeName      string
-	StartObservation string
+	RuntimeName      sql.NullString
+	StartObservation sql.NullString
 	CreatedAt        int64
 	UpdatedAt        int64
 }


### PR DESCRIPTION
## What changes

What a serving establishes about whether its workload began is kept with its lease, so
a cleanup that has to be retried does not lose it. `dispositionFor` reads it back when
the pass disposing of the attempt measured nothing itself. The vocabulary's zero value
gains a name, `assignment.NoObservation`, and joins the totality list — which forces
`startFailureReport` to have a case for it. An observation this build does not declare
now reports that, instead of reporting nothing.

## What was found

`dispositionFor` puts the proof first: a capsule reporting that the runner never owned
the job returns the attempt to the queue, outranking evidence that says only that the
capsule reported itself up. Its comment explains why — `running_observed` is written
when the capsule reports readiness, never when a runner is seen owning a job.

That proof arrived as a parameter and was never made durable, so both recovery paths
lost it. `resolveStranded` passes no observation at all: it holds no daemon inventory.
`resolveInterrupted` defaults to `ObservedAbsent` and only refines it by inspecting the
container when the evidence is `start_authorized` — and the motivating case is already
past that, at `running_observed`. Either way the switch falls through to the running
observation and settles the attempt as one that ran.

The sequence is ordinary. A supervisor exits with the code reserved for the runner
never owning the job; the controller sets the proof and logs that the attempt returns
to the queue. Resource removal then fails against a wedged container, so the lease is
quarantined — the documented retry path. The next periodic pass, or the next start,
re-enters the finalizing transaction with nothing in hand and settles the attempt
`settled / started_observed`. **The workload is never served again and the books record
that it started.** That is the "never silently lost" half of the product's central
claim.

Two things I got wrong first, and what corrected them:

The obvious fix — persist it and fall back when the parameter is empty — is not
sufficient, because a retry does not pass an empty value. It passes `ObservedAbsent`,
which is a default rather than a measurement. The rule is that a recorded proof
outranks a later pass that established nothing, not that the parameter wins unless
empty.

And the write does not belong at the transition into cleaning, which is where it
naturally reads. The deregistration block that follows can replace the capsule's
account with the provider's — the provider saying the job *was* handed over. Writing
before it, with a fall-back-when-empty rule, would have restored the stale proof on the
retry and requeued a job that ran. That is the same defect inverted, and it is worse.

Where a constant was chosen: the write is unconditional, guarded only by whether the
observation establishes anything. There is no never-downgrade clause, because a value
is only ever written on the way into the cleanup that ends a serving — every path that
produces one returns immediately after, and the one branch that continues does not
write. A test pins that invariant rather than a rule compensating for its absence.

This is one commit rather than three because the parts do not stand alone. The column
needs the name for `''` to be the persisted form of a value rather than a sentinel for
absence; naming it forces the totality case; and that case is what exposed the empty
report. A commit between any two of them is a state worth objecting to.

Why not a nullable column: `NULL` means no value, and after naming, "nothing was
measured" *is* a value with a doc comment, a place in the totality list and a case in
the report. `NULL` would be a fourth state — "we do not know whether anything was
measured" — that nothing can produce and nothing could act on. It would also cost
`sql.NullString` at every read, or a mapping that gives one domain value two
representations, and it would put this column inside SQL's three-valued logic for no
gain. The schema does use `NULL`, deliberately, for timestamps that have not happened
and for a lane that is not leased: absence with no name in the domain. This is not that.

## Evidence

Hermetic. Every assertion was watched failing under the mutation named.

| Test | Mutation that kills it |
| --- | --- |
| `TestBothDispositionPathsAgree`, two new rows | the merge is removed from `dispositionFor` |
| `TestBothDispositionPathsAgree`, third new row | the recorded proof wins unconditionally |
| `TestARecordedProofSurvivesAFailedCleanup` | the write is removed from `FinishCleaning` |
| `TestAProofSurvivesThePeriodicPass` | the write is removed from the recovery path |
| `TestOnlyAMeasurementIsRecorded` | the predicate guard is removed — the column's own CHECK then refuses, loudly |
| `TestEveryObservationHasAStartFailureReport` | the case for `NoObservation` is removed, or the undeclared report returns nothing |
| `TestAbandonmentKeepsWhatThisServingMeasured` | the write before the abandonment return is removed |
| `TestTheProviderOverrulesTheCapsuleAcrossARetry` | the readback moves after the provider question, or the write moves before it |

```text
--- FAIL: TestOnlyAMeasurementIsRecorded/absent
    recording "absent": constraint failed: CHECK constraint failed: start_observation IN (

--- FAIL: TestEveryObservationHasAStartFailureReport
    observation "" has no report, so a failed start carrying it is logged as an
    outcome nobody could establish and paged on
```

The first is the predicate in Go and the constraint in SQL holding each other: they are
two statements of one rule, and neither can drift in silence. The second is the
totality list doing what it exists for.

## What would notice this regressing

The table above. `TestOnlyAMeasurementIsRecorded` derives its domain from
`AllExecutionObservations` rather than restating it, so a value added to the vocabulary
is covered without anyone remembering to add a row.

What would not notice: `DisposeStranded` keeps a hole one size smaller. If its
transaction fails and no earlier path recorded anything, the next pass re-derives
`ObservedAbsent` and settles from evidence exactly as before. Closing it needs a durable
write on a path the code documents as unreachable, and I would not add one until
something shows it reachable.

## Risk, compatibility and operations

**Trust boundary: N/A.** No credential, policy, network or privileged surface is
touched.

**Correctness: this is the fix.** It closes a path by which a job that provably never
ran was recorded as having run and never served again.

**Schema: the baseline migration changes.** Pre-release, so it is still mutable and this
is the sanctioned way. The consequence is real and immediate for developers: the schema
fingerprint changes, so **every existing state directory is refused on the next start**
with the "different migrations" error, naming the two ways out. That is the designed
behaviour of a mutable baseline, and `internal/store/fingerprint_test.go` is what says
so. There are no tags and no deployments, so nothing else is affected.

**Migration and rollback:** forward-only after the first release, unchanged by this. The
generated model, the schema snapshot and `sqlc diff`/`sqlc vet` are all regenerated and
in parity.

**Status API: unchanged.** `resourceDTO` and the lease reporting shape do not carry this
column; nothing in the published document moves.

**Failure behaviour: a recovery that cannot record what it measured now removes
nothing.** The lease stays cleaning, holding its credit and its objects, and the
periodic pass runs the whole recovery again with the capsule still there. This costs
nothing in practice — the failure means the local store is unreachable, and the removal
path writes intents through the same store — and the principle is that a recovery which
cannot record what it saw must not destroy the thing it saw.

**CLI, configuration, deployment, networking, resource limits: N/A.**

**Runbook: N/A.** No new operator-visible failure. The one message that changes is an
improvement: a failed start carrying an observation this build does not declare now
says so rather than logging an empty message, which in structured logging is a page
nobody can filter, alert or search on.

**Not an ADR.** It restores a property `dispositionFor` already stated and could not
keep.

## Changelog

```text
Extended the "An assignment is requeued only on proof that no runner ever started"
bullet under "Isolation and egress": that proof now outlives the pass that took it,
so a cleanup retried against a wedged daemon no longer settles a job that never ran.
```

## Notes for your reviewer

The two rows in `TestBothDispositionPathsAgree` that were already there are unchanged,
including `{running_observed, nothing measured, settleStarted}`. I had it down as the
bug and it is not: it is the tier ceiling, where the capsule is destroyed while the
runner is still working, and that job really did run. It now carries a comment saying
so, because it is the row a reader is most likely to "fix".

The naming of `NoObservation` deliberately breaks the `Observed` prefix. The six values
that carry it each name what an observer saw; this one names that there was no
observer. `ObservedNothing` and `ObservedNone` both read as "looked and found none",
which is `ObservedAbsent`.


---

A review of this branch found two things in it, both now fixed and both carried by the
last commit.

**A proof measured past the drain window was discarded.** The abandonment early return
sits above every write, and nothing re-takes the measurement: the successor's pass
inspects a runtime only while the evidence is still `start_authorized`, and an
ambiguous start reaches that point past it. So the branch's own claim — that what a
serving establishes is kept with its lease — had an exception it did not name. It is
pre-existing rather than a regression here, confirmed by running the same probe against
`main`, but it is the one remaining pass that takes a proof and neither records it nor
is retried by anything that can take it again.

**Two orderings were load-bearing and held by nothing.** Reading the record back before
the provider is asked, and writing it after, could each be moved with the whole suite
staying green — and the paragraph above defending that placement was the only thing
standing behind it. The first attempt at a test was still a pass short of the hazard:
on a pass that completes, the provider's overrule reaches the disposition as a
parameter and the parameter wins, so the placement only shows when that pass also
fails. The test now drives three.
