### PR TITLE
test(gateway): the address the policy was checked against is the address dialed

### DIFF
--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -101,6 +101,21 @@ type Relay struct {
 	// so a revocation can be observed without waiting out the real
 	// interval.
 	pollInterval time.Duration
+
+	// resolve and dialAddr are how the one property this relay exists for
+	// can be asserted: that the address a policy was checked against is
+	// the address the connection is made to. Zero means the host resolver
+	// and a real dialer, which is what production runs.
+	//
+	// They are two fields because the property has two halves. A name
+	// that answers differently the second time it is asked is the attack
+	// -- so a test has to control what a name resolves to, and observe
+	// which of those answers was dialed. Neither half is decidable
+	// against a real resolver, and the alternative is a control the live
+	// suite cannot see either: its own rebinding case uses literal
+	// addresses, which prove what the literal-address tests already do.
+	resolve  func(ctx context.Context, host string) ([]netip.Addr, error)
+	dialAddr func(ctx context.Context, addr netip.Addr, port int) (net.Conn, error)
 }
 
 func (r *Relay) poll() time.Duration {
@@ -692,7 +707,7 @@ func (r *Relay) dial(ctx context.Context, host string, port int) (net.Conn, erro
 	}
 	resolveCtx, cancel := context.WithTimeout(ctx, DNSTimeout)
 	defer cancel()
-	addrs, err := net.DefaultResolver.LookupNetIP(resolveCtx, "ip4", host)
+	addrs, err := r.resolver()(resolveCtx, host)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", host, err)
 	}
@@ -707,8 +722,7 @@ func (r *Relay) dial(ctx context.Context, host string, port int) (net.Conn, erro
 			lastErr = fmt.Errorf("%w: %s resolves to %s", ErrDenied, host, addr)
 			continue
 		}
-		dialer := net.Dialer{Timeout: DialTimeout}
-		conn, err := dialer.DialContext(ctx, "tcp4", net.JoinHostPort(addr.String(), strconv.Itoa(port)))
+		conn, err := r.dialer()(ctx, addr, port)
 		if err == nil {
 			return conn, nil
 		}
@@ -784,4 +798,25 @@ func (c *limitConn) CloseWrite() error {
 		return errors.New("the underlying connection cannot be half-closed")
 	}
 	return cw.CloseWrite()
+}
+
+func (r *Relay) resolver() func(context.Context, string) ([]netip.Addr, error) {
+	if r.resolve != nil {
+		return r.resolve
+	}
+	return func(ctx context.Context, host string) ([]netip.Addr, error) {
+		return net.DefaultResolver.LookupNetIP(ctx, "ip4", host)
+	}
+}
+
+func (r *Relay) dialer() func(context.Context, netip.Addr, int) (net.Conn, error) {
+	if r.dialAddr != nil {
+		return r.dialAddr
+	}
+	// The validated address, never the name: re-resolving here is what
+	// rebinding needs, and there is nothing to re-resolve.
+	return func(ctx context.Context, addr netip.Addr, port int) (net.Conn, error) {
+		d := net.Dialer{Timeout: DialTimeout}
+		return d.DialContext(ctx, "tcp4", net.JoinHostPort(addr.String(), strconv.Itoa(port)))
+	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"bufio"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -10,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -902,6 +905,83 @@ func TestAPoolIsNeverOlderThanTheGenerationItServes(t *testing.T) {
 			if got.gen < c.ask {
 				t.Errorf("a caller that observed generation %d was handed a pool built for %d; "+
 					"its connections were authorised by a policy that no longer applies", c.ask, got.gen)
+			}
+		})
+	}
+}
+
+// TestTheAddressCheckedIsTheAddressDialed is the DNS rebinding defence,
+// and until now nothing held it.
+//
+// The attack is a name that answers one address while the policy is
+// consulted and another when the connection is made. This relay is not
+// vulnerable to it because it dials the address it checked rather than
+// the name -- but that is a property of one line, and the line could be
+// changed back to a name with every test in this package and the live
+// bypass suite still passing. That suite calls its own section the
+// rebinding case and gives it literal addresses, which prove what the
+// literal-address tests already prove.
+//
+// So the resolver and the dial are both seams here: one to say what the
+// name answers, the other to observe which of those answers was used.
+func TestTheAddressCheckedIsTheAddressDialed(t *testing.T) {
+	metadata := netip.MustParseAddr("169.254.169.254")
+	allowed := netip.MustParseAddr("93.184.216.34")
+
+	for name, tc := range map[string]struct {
+		answers    []netip.Addr
+		wantDial   string // empty means no connection may be made
+		wantDenied bool
+	}{
+		"a name that answers the metadata address is refused": {
+			answers: []netip.Addr{metadata}, wantDenied: true,
+		},
+		"a name that answers an allowed address is dialed at that address": {
+			answers: []netip.Addr{allowed}, wantDial: allowed.String(),
+		},
+		"a denied answer does not poison the allowed one beside it": {
+			answers: []netip.Addr{metadata, allowed}, wantDial: allowed.String(),
+		},
+		"every answer denied refuses rather than falling through": {
+			answers: []netip.Addr{metadata, netip.MustParseAddr("10.1.2.3")}, wantDenied: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, _ := policyFile(t, "10.0.0.0/8")
+			var dialed []string
+			r := &Relay{
+				Policy: store,
+				Log:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+				resolve: func(context.Context, string) ([]netip.Addr, error) {
+					return tc.answers, nil
+				},
+				dialAddr: func(_ context.Context, addr netip.Addr, _ int) (net.Conn, error) {
+					dialed = append(dialed, addr.String())
+					client, server := net.Pipe()
+					t.Cleanup(func() { client.Close(); server.Close() })
+					return client, nil
+				},
+			}
+
+			conn, err := r.dial(t.Context(), "rebinding.test", 443)
+			if conn != nil {
+				conn.Close()
+			}
+			if tc.wantDenied {
+				if !errors.Is(err, ErrDenied) {
+					t.Fatalf("dial = %v; want ErrDenied", err)
+				}
+				if len(dialed) != 0 {
+					t.Errorf("connected to %v; a denied answer must reach no network at all", dialed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			if len(dialed) != 1 || dialed[0] != tc.wantDial {
+				t.Errorf("connected to %v; want exactly %q — the address the policy was checked "+
+					"against is the address the connection is made to", dialed, tc.wantDial)
 			}
 		})
 	}


### PR DESCRIPTION
## What changes

`Relay.dial` gains two unexported seams — what a name resolves to, and which resolved
address a connection is made to — and a table test that asserts the address dialed, not
only the error returned. No production behaviour changes.

## What was found

The relay resolves a name, checks the policy against the resolved address, and connects
to that address rather than to the name. That is the DNS rebinding defence, stated in
the package comment and in the egress package's own doc, and it is one line of code.

Nothing held it. Every coverage block in `dial` measured zero: the resolve, the
resolved-address cap, the `policy.Allowed` check and the dial itself. Three tests reach
the function and all three return before that point — at the port set, or on a policy
that cannot be read. The one end-to-end test installs a plain `http.Transport`, so the
relay's own dial is never entered.

The live bypass suite does not cover it either. Its section is named for the rebinding
case and every entry in it is a literal IP address — which proves what the
literal-address tests already prove. The attack turns on a name answering one address
while the policy is consulted and another when the connection is made, and that cannot
be expressed with an address.

Why two seams rather than one: the property has two halves, and neither is decidable
alone. A test has to control what the name answers *and* observe which of those answers
was used. They follow `pollInterval`, which is the same shape already in this struct for
the same reason — a test needs to see something production does not expose.

## Evidence

```text
Rewriting dial to drop the policy read and its check:
    proxy_test.go:972: dial = <nil>; want ErrDenied            (x2)
    proxy_test.go:983: connected to [169.254.169.254]; want exactly "93.184.216.34"

Dialing the first answer rather than the checked one:
    proxy_test.go:983: connected to [169.254.169.254]; want exactly "93.184.216.34" —
    the address the policy was checked against is the address the connection is made to
```

Worth recording: dropping only the `policy.Allowed` check does not compile, because
`policy` then goes unused. The compiler holds part of this, which is why the mutation
above has to remove the policy read as well to be a real one.

`gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...` are clean.

## What would notice this regressing

`TestTheAddressCheckedIsTheAddressDialed`, on four cases: the metadata address refused,
an allowed address reached at that address, a denied answer not poisoning the allowed
one beside it, and every answer denied refusing rather than falling through. Each
asserts the address connected to.

## Risk, compatibility and operations

**Trust boundary: unchanged, and now defended by a test.** The behaviour is what it was;
what changes is that a regression in it would be caught here rather than in production.

**Failure behaviour: unchanged.** The seams default to the host resolver and a real
dialer, so production takes exactly the path it took before.

**Credentials, networking, resource limits, schema, migration, status API, CLI,
configuration, deployment, rollback, runbook: N/A.**

**Not an ADR.** No decision is made; a stated property gains its proof.

## Changelog

```text
NONE
```

## Notes for your reviewer

The seams are unexported and default to production behaviour, but they are still two
new fields on a struct in the security boundary. If that is the wrong trade, the
alternative is leaving the one line that defines the defence unprotected — the live
suite cannot see it, for the reason above.
