### PR TITLE
fix(store): the pre-migration backup is proven to be one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,18 @@ by its public and operational effects.
 
 ### State and operations
 
+- **The pre-migration backup is proven to be one.** It is the only rollback
+  that exists — there are no down migrations, deliberately — and what was
+  proven about it was that a file appeared: an empty file passes that, and
+  so does a copy taken after the upgrade. The suite now opens the copy and
+  requires the pre-upgrade schema version, the rows that were live, and
+  nothing the upgrade added. The schema identity check also covers the
+  prefix already applied while migrations are pending, and each migration
+  commits the fingerprint of the set up to itself — so an edited migration
+  below a pending one is refused by name instead of failing later on a raw
+  error, and an upgrade interrupted between two migrations resumes instead
+  of refusing the database it is resuming. The runbook says what nothing
+  prunes: the copies accumulate until removed by hand.
 - **Capacity a lease consumed comes back.** An admission credit is returned
   by one read that says the lease reached released, and that read used to be
   abandoned on its first failure — on a store whose single connection is

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -381,6 +381,12 @@ version. Runpool has no down migrations: a schema change is not assumed to
 be losslessly reversible, and restore also covers an upgrade that failed
 half-way.
 
+Nothing prunes those copies. Each is a full copy of the state database,
+they survive `runpool uninstall`, and the disk monitor never evicts
+state -- so on a long-lived deployment they accumulate until removed by
+hand. Keep the newest copy for each version you might roll back to and
+remove the rest once an upgrade has proven itself.
+
 A database written by a build this one does not know is **refused, not
 repaired**: the error says how to export from the build that wrote it,
 or how to start clean. Runpool does not guess at a schema it cannot

--- a/internal/store/fingerprint_test.go
+++ b/internal/store/fingerprint_test.go
@@ -65,8 +65,9 @@ func TestSchemaIdentifiedByContentsNotCount(t *testing.T) {
 		if err == nil {
 			t.Fatal("a database written from different migrations was opened for reporting")
 		}
-		if strings.Contains(err.Error(), "no such table") {
-			t.Errorf("error = %q; the raw error is what this check exists to replace", err)
+		if !strings.Contains(err.Error(), "different migrations") {
+			t.Errorf("error = %q; want the schema refusal itself -- excluding the raw error also "+
+				"accepted any unrelated failure, which is not this check working", err)
 		}
 	})
 
@@ -122,4 +123,92 @@ func openRaw(t *testing.T, dir string) *Store {
 	}
 	db.SetMaxOpenConns(1)
 	return &Store{db: db, dir: dir, retryBudget: DefaultRetryBudget}
+}
+
+// TestAnEditedMigrationBelowAPendingOneIsRefused: pending migrations are
+// no exemption from the identity check. Verified only when nothing was
+// pending, an edited migration below the pending one slipped through --
+// the upgrade applied, the edited set's fingerprint was stamped, and
+// every later open verified clean against a database the edit never
+// reached. The first query touching the difference then failed with the
+// raw error the fingerprint exists to replace.
+func TestAnEditedMigrationBelowAPendingOneIsRefused(t *testing.T) {
+	migrations, err := loadMigrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	seed := migrations[len(migrations)-1]
+	seed.up = strings.Replace(seed.up,
+		"CREATE TABLE meta (", "CREATE TABLE unrelated (x INTEGER);\nCREATE TABLE meta (", 1)
+	older := append(append([]migration{}, migrations[:len(migrations)-1]...), seed)
+
+	s := openRaw(t, dir)
+	for _, m := range older {
+		stamp := ""
+		if m.version == len(older) {
+			stamp = schemaFingerprint(older)
+		}
+		if err := s.applyScript(m.up, m.version, stamp); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer s.Close()
+
+	pending := append(append([]migration{}, migrations...), migration{
+		version: len(migrations) + 1,
+		name:    "synthetic",
+		up:      `CREATE TABLE synthetic_two (id INTEGER PRIMARY KEY);`,
+	})
+	err = s.applyMigrations(pending)
+	if err == nil {
+		t.Fatal("a pending migration was applied on top of a prefix another build wrote")
+	}
+	if !strings.Contains(err.Error(), "different migrations") {
+		t.Errorf("error = %q; want the schema refusal", err)
+	}
+	if v, _ := s.SchemaVersion(); v != len(older) {
+		t.Errorf("schema version = %d after the refusal; the pending migration must not have applied", v)
+	}
+}
+
+// TestAnUpgradeInterruptedMidSequenceResumes: each migration commits the
+// fingerprint of the set up to and including itself, in its own
+// transaction. Stamped only with the last, a crash between two pending
+// migrations left a database whose applied prefix had grown while its
+// recorded identity had not — and the resume's own identity check then
+// refused the database it was resuming.
+func TestAnUpgradeInterruptedMidSequenceResumes(t *testing.T) {
+	migrations, err := loadMigrations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	s := openRaw(t, dir)
+	defer s.Close()
+	if err := s.applyMigrations(migrations); err != nil {
+		t.Fatal(err)
+	}
+
+	good := migration{version: len(migrations) + 1, name: "first",
+		up: `CREATE TABLE synthetic_one (id INTEGER PRIMARY KEY);`}
+	bad := migration{version: len(migrations) + 2, name: "second",
+		up: `THIS IS NOT SQL;`}
+	if err := s.applyMigrations(append(append([]migration{}, migrations...), good, bad)); err == nil {
+		t.Fatal("a migration that is not SQL applied")
+	}
+	// The crash-shaped state the failure leaves: the first pending
+	// migration committed, the second did not.
+	if v, _ := s.SchemaVersion(); v != len(migrations)+1 {
+		t.Fatalf("schema version = %d; want %d — each migration commits alone", v, len(migrations)+1)
+	}
+
+	fixed := migration{version: len(migrations) + 2, name: "second",
+		up: `CREATE TABLE synthetic_two (id INTEGER PRIMARY KEY);`}
+	if err := s.applyMigrations(append(append([]migration{}, migrations...), good, fixed)); err != nil {
+		t.Fatalf("resuming an interrupted upgrade: %v", err)
+	}
+	if v, _ := s.SchemaVersion(); v != len(migrations)+2 {
+		t.Errorf("schema version = %d; want %d", v, len(migrations)+2)
+	}
 }

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"os"
@@ -502,8 +503,39 @@ func TestPendingMigrationBacksUpFirst(t *testing.T) {
 		t.Fatalf("schema version = %d; want %d", v, len(synthetic))
 	}
 	backup := filepath.Join(dir, fmt.Sprintf("pre-migration-v%d.db", len(migrations)))
-	if _, err := os.Stat(backup); err != nil {
-		t.Fatalf("pre-migration backup missing: %v", err)
+
+	// Opened raw, not through Open: Open migrates, and a backup this build
+	// re-migrated on inspection could not show what the copy held. What
+	// makes the file a rollback path is its contents -- the version the
+	// schema had before the upgrade, the rows that were live, and nothing
+	// the upgrade added. A file that merely exists proves none of that: an
+	// empty file exists, and a copy taken after the loop exists too.
+	db, err := sql.Open("sqlite", DSN(backup))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var version int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != len(migrations) {
+		t.Errorf("the backup holds schema version %d; want the pre-migration %d -- a copy taken "+
+			"after the upgrade is not a rollback path", version, len(migrations))
+	}
+	var leases int
+	if err := db.QueryRow(`SELECT count(*) FROM capsule_leases`).Scan(&leases); err != nil {
+		t.Fatalf("the backup could not answer for its rows: %v", err)
+	}
+	if leases != 1 {
+		t.Errorf("the backup holds %d leases; want the 1 that was live -- restoring it would lose data", leases)
+	}
+	var added int
+	if err := db.QueryRow(`SELECT count(*) FROM sqlite_schema WHERE name = 'synthetic_two'`).Scan(&added); err != nil {
+		t.Fatal(err)
+	}
+	if added != 0 {
+		t.Error("the backup holds the table the pending migration created; the copy was taken after the upgrade")
 	}
 }
 

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -57,6 +57,9 @@ func embeddedMigrations() ([]migration, error) {
 		if err != nil || version < 1 {
 			return nil, fmt.Errorf("migration %q: invalid version", name)
 		}
+		// Redundant as a detector -- the contiguity check below fails on
+		// any duplicate too -- and kept for its message: this one names
+		// both files, where that one reports a position.
 		if other, dup := seen[version]; dup {
 			return nil, fmt.Errorf("migrations %q and %q share version %d", other, name, version)
 		}
@@ -147,11 +150,22 @@ func (s *Store) applyMigrations(migrations []migration) error {
 	if current > len(migrations) {
 		return newerSchemaError(current, len(migrations), s.dir)
 	}
+	if current > 0 {
+		// The prefix already applied has to be this build's prefix, and
+		// pending migrations are no exemption from that. Checked only
+		// when nothing was pending, an edited migration below the
+		// pending one slipped through: the upgrade applied, the edited
+		// set's fingerprint was stamped, and every later open verified
+		// clean against a database whose contents the edit never
+		// reached. The first query touching the difference then failed
+		// with a raw error -- precisely the outcome alteredSchemaError
+		// exists to replace.
+		if err := s.verifyFingerprint(migrations[:current]); err != nil {
+			return err
+		}
+	}
 	if current == len(migrations) {
-		// Nothing to apply, which is exactly when the version has stopped
-		// being evidence: the schema is only this build's if its contents
-		// are.
-		return s.verifyFingerprint(migrations)
+		return nil
 	}
 
 	if current > 0 {
@@ -167,17 +181,14 @@ func (s *Store) applyMigrations(migrations []migration) error {
 		}
 	}
 
-	fingerprint := schemaFingerprint(migrations)
 	for _, m := range migrations[current:] {
-		// The fingerprint lands with the last migration, in its
-		// transaction: a schema and its identity commit together or
-		// neither does, so a crash mid-upgrade cannot leave a database
-		// claiming to be something it is not.
-		stamp := ""
-		if m.version == len(migrations) {
-			stamp = fingerprint
-		}
-		if err := s.applyScript(m.up, m.version, stamp); err != nil {
+		// Each migration stamps the fingerprint of the set up to and
+		// including itself, in its own transaction: a schema and its
+		// identity commit together or neither does, so a crash anywhere
+		// in the sequence leaves a database whose recorded identity is
+		// exactly its applied prefix — which is what the check above
+		// verifies when the upgrade resumes.
+		if err := s.applyScript(m.up, m.version, schemaFingerprint(migrations[:m.version])); err != nil {
 			return fmt.Errorf("migration %06d_%s: %w", m.version, m.name, err)
 		}
 	}


### PR DESCRIPTION
## What changes

The pre-migration backup is proven to be a restorable pre-upgrade copy, not a file
that exists. The schema identity check covers the prefix already applied while
migrations are pending, and each migration commits the fingerprint of the set up to
itself, so an interrupted upgrade resumes. The read-only refusal's test asserts the
refusal itself. The duplicate-version check says why it exists, and the runbook says
the backups accumulate until removed by hand.

## What was found

**The only rollback was unproven.** There are no down migrations, deliberately —
restoring the pre-migration copy is the documented path — and the test for it never
applied a migration and never called `Backup`; it checked that a file appeared at the
expected name. Two mutations survived: replacing the copy with an empty file, and
taking the copy after the migration loop. Both are shapes in which a rollback path is
not one: an operator restoring either gets an empty database or a post-upgrade one.

The test now opens the copy raw — through `sql.Open` rather than `Open`, because
`Open` migrates and a copy re-migrated on inspection cannot show what it held — and
requires the pre-upgrade schema version, the row that was live, and the absence of the
table the pending migration created.

**The identity check had an uncovered branch.** The fingerprint was verified only when
nothing was pending. A database at version N whose migration N had been edited in
place, with migration N+1 pending, passed: the check was skipped, N+1 applied, and the
edited set's fingerprint was stamped — so every later open verified clean against a
database the edit never reached, until the first query touching the difference failed
with the raw SQLite error the fingerprint exists to replace. The applied prefix is
verified now whenever the database holds one.

**That fix required its other half.** Stamped only with the last migration, an upgrade
interrupted between two pending ones left the applied prefix grown while the recorded
identity had not — and the new prefix check would then refuse the database it was
resuming. Each migration now commits the fingerprint of the set up to and including
itself, in its own transaction, so a crash anywhere leaves a database whose recorded
identity is exactly its applied prefix. The interruption test produces the crash-shaped
state with the code itself: a pending migration that is not SQL fails after its
predecessor committed.

Where something nearby did not change: the duplicate-version check is redundant as a
detector — contiguity fails on any duplicate — and is kept for the message that names
both files, which it now says, so the next reader does not spend the time proving it
redundant and deleting it.

## Evidence

Hermetic. Each row was run with the named line broken, seen to fail, and restored.

| Test | Mutation that kills it |
| --- | --- |
| `TestPendingMigrationBacksUpFirst` | the backup is an empty file — fails naming version 0 and the missing table |
| `TestPendingMigrationBacksUpFirst` | the backup is taken after the loop |
| `TestAnEditedMigrationBelowAPendingOneIsRefused` | the fingerprint is verified only when nothing is pending |
| `TestAnUpgradeInterruptedMidSequenceResumes` | only the last migration stamps |

```text
lease_test.go:523: the backup holds schema version 0; want the pre-migration 1 — a
copy taken after the upgrade is not a rollback path
lease_test.go:528: the backup could not answer for its rows: no such table: capsule_leases
```

Two of the mutations did not compile on the first attempt — an unused import each —
which is worth recording: the compiler holds part of these properties, and a mutation
count of zero from a build failure reads identically to a passing suite unless the raw
output is checked.

## What would notice this regressing

The table above, plus `TestSchemaIdentifiedByContentsNotCount`, whose read-only subtest
now requires the refusal's own words — excluding the raw error also accepted any
unrelated failure.

## Risk, compatibility and operations

**Schema identity: strictly stricter, and only against edits.** A database written by
this build, fully applied or mid-upgrade, verifies clean: the full-set fingerprint is
the prefix fingerprint at the last migration, byte for byte. What is newly refused is a
prefix another build wrote — the same refusal the fully-applied case already made.

**Crash mid-upgrade: strictly better.** Before, only a crash after the last migration
left identity and contents in step; now every intermediate state is consistent and the
resume verifies it.

**Migration and rollback:** the runbook gains the pruning note — the copies are full
copies of the state database, survive `runpool uninstall`, and the disk monitor never
evicts state, so they accumulate until removed by hand.

**Trust boundary, credentials, networking, resource limits, status API, CLI,
configuration, deployment: N/A.**

**Not an ADR.** The no-down-migrations decision is already recorded; this proves the
mechanism that decision leans on.

## Changelog

```text
One bullet under "State and operations": the pre-migration backup is proven to be one.
```

## Notes for your reviewer

The per-migration stamping is the piece to stare at: it changes what a crashed upgrade
leaves behind. The argument that it is safe is in the commit message and the resume
test; the argument that it is necessary is that the prefix check refuses the
crash-shaped state the old stamping left.
