### PR TITLE
test(app): recovery, admission and resolution are held by tests

### DIFF
--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rhobuild/runpool/internal/allocator"
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/cache"
+	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/lease"
@@ -503,4 +504,14 @@ func driveLeaseTo(t *testing.T, h *harness, leaseID assignment.LeaseID, target s
 	if got := reloadLease(t, h, leaseID); got.State != target {
 		t.Fatalf("wanted a lease in %q but it is %q; the test would assert nothing", target, got.State)
 	}
+}
+
+// resolveWithRuntime is the other half of resolveWithoutRuntime: the
+// crash left a container, so the pass can ask it whether the authorized
+// start took effect. The observation the capsule answers with is the
+// caller's to choose, because it is the fact under test.
+func (h *harness) resolveWithRuntime(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) {
+	h.srv.caps = &fakeCapsule{obs: obs}
+	h.srv.resolveInterrupted(ctx, h.bind, lease,
+		engine.OwnedContainer{ID: "runner-x", Role: capsule.RoleCapsule, Running: false}, true)
 }

--- a/internal/app/bindings_test.go
+++ b/internal/app/bindings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"sync"
@@ -535,5 +536,57 @@ func TestARefusedNameStaysRefusedOnTheNextPass(t *testing.T) {
 	}
 	if h.bind.ensured {
 		t.Error("the binding reports itself ensured against a scale set it does not own")
+	}
+}
+
+// TestTheTierImageIsResolvedWhereBindingsAreBuilt: a deployment's
+// tiers[].capsuleImage reaches the binding through one line, and the
+// test that proves the image reaches the capsule sets the binding's
+// field itself — so that line could resolve to the shipped image
+// unconditionally, every test stayed green, and every deployment's
+// configured capsule image was silently ignored.
+func TestTheTierImageIsResolvedWhereBindingsAreBuilt(t *testing.T) {
+	const operators = "ghcr.io/acme/capsule@sha256:" +
+		"2222222222222222222222222222222222222222222222222222222222222222"
+	st, err := store.Open(t.TempDir(), store.DefaultRetryBudget)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { st.Close() })
+	s := &Controller{
+		log:                 slog.New(slog.NewTextHandler(io.Discard, nil)),
+		store:               st,
+		alloc:               allocator.New(),
+		byBinding:           map[assignment.BindingID]*binding{},
+		shippedCapsuleImage: "runpool-capsule:dev",
+	}
+	cfg := &config.Config{
+		Instance:    config.Instance{Name: "test"},
+		Credentials: []config.Credential{{ID: "gh", TokenEnv: "TOKEN"}},
+		Targets: []config.Target{{
+			ID: "app", URL: "https://github.com/acme/app", CredentialID: "gh",
+			Tiers: []config.TierBinding{
+				{TierID: "standard", ScaleSetName: "runpool-standard"},
+				{TierID: "extended", ScaleSetName: "runpool-extended"},
+			},
+		}},
+		Tiers: []config.Tier{
+			{ID: "standard", Parallelism: 1},
+			{ID: "extended", Parallelism: 1, CapsuleImage: operators},
+		},
+	}
+	if err := s.buildBindings(t.Context(), cfg, func(k string) string { return "t0ken" }); err != nil {
+		t.Fatal(err)
+	}
+
+	images := map[string]string{}
+	for _, b := range s.bindings {
+		images[b.tier.ID] = b.capsuleImage
+	}
+	if images["extended"] != operators {
+		t.Errorf("the extended tier's binding runs %q; the configured image was ignored", images["extended"])
+	}
+	if images["standard"] != "runpool-capsule:dev" {
+		t.Errorf("the standard tier's binding runs %q; want the shipped capsule", images["standard"])
 	}
 }

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -524,26 +524,39 @@ func (s *Controller) scheduleReadyAttempts(ctx context.Context, b *binding) {
 	}
 
 	for _, attempt := range ready {
-		if !s.alloc.TryReserve(b.key) {
+		if !s.admit(ctx, b, attempt) {
 			return // admission is full; the attempt stays durable and waits
 		}
-		lease, err := s.createLease(ctx, b, attempt)
-		if err != nil {
-			s.alloc.Release(b.key)
-			if errors.Is(err, store.ErrConflict) {
-				continue // another pass claimed it; nothing is lost
-			}
-			s.log.Error("lease creation failed", "binding", b.key, "error", err)
-			continue
-		}
-		// Claim before the goroutine exists. The lease is already committed
-		// and `reserved` is a live state, so between this commit and
-		// runCapsule's own claim the periodic reconciler could see it as
-		// ownerless and tear down a job that is starting.
-		s.claimLease(lease.ID)
-		s.wg.Add(1)
-		go s.launch(b, lease)
 	}
+}
+
+// admit takes one credit and turns one ready attempt into a running
+// launch. It reports false only when admission is full, because that is
+// the one answer that stops the pass: everything after the reserve keeps
+// going, and everything after the reserve that fails returns the credit
+// -- the claim is a compare-and-swap two passes can race for, so losing
+// it is ordinary, and a credit reserved for a lease that was never
+// created would otherwise be burned for the life of the process.
+func (s *Controller) admit(ctx context.Context, b *binding, attempt store.Attempt) bool {
+	if !s.alloc.TryReserve(b.key) {
+		return false
+	}
+	lease, err := s.createLease(ctx, b, attempt)
+	if err != nil {
+		s.alloc.Release(b.key)
+		if !errors.Is(err, store.ErrConflict) {
+			s.log.Error("lease creation failed", "binding", b.key, "error", err)
+		}
+		return true
+	}
+	// Claim before the goroutine exists. The lease is already committed
+	// and `reserved` is a live state, so between this commit and
+	// runCapsule's own claim the periodic reconciler could see it as
+	// ownerless and tear down a job that is starting.
+	s.claimLease(lease.ID)
+	s.wg.Add(1)
+	go s.launch(b, lease)
+	return true
 }
 
 // sessionGrace is how long a run of broker session conflicts stays the

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -232,6 +232,27 @@ func TestStartFaultMatrix(t *testing.T) {
 			want: store.AttemptSettled, wantRes: assignment.ResolutionCompletedObserved,
 		},
 		{
+			// A clean start whose wait returns the code the supervisor
+			// reserves for "the runner never owned the job". A clean wait
+			// is not an execution: recording an observed exit here settles
+			// an attempt that never ran as complete, and nothing requeues
+			// it afterwards.
+			name: "clean start, supervisor reports the runner never started",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{},
+			wait: &fakeWaiter{exit: int64(capsule.SupervisorAbortedExitCode)},
+			want: store.AttemptReady,
+		},
+		{
+			// The same reserved code against a provider that still holds
+			// the runner busy: the party that assigned the work outranks
+			// the capsule's own account, on the wait path exactly as on
+			// the failed-start path above.
+			name: "clean start, reserved code, provider holds the runner busy",
+			caps: &fakeCapsule{}, reg: &fakeRegistry{removeErr: githubactions.ErrJobStillRunning},
+			wait: &fakeWaiter{exit: int64(capsule.SupervisorAbortedExitCode)},
+			want: store.AttemptSettled, wantRes: assignment.ResolutionStartedObserved,
+		},
+		{
 			// Start errored and the container is gone: nothing can be
 			// proven in either direction, so a person decides.
 			name: "start error, runtime absent",

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -65,6 +65,11 @@ func TestAFailedMeasurementKeepsTheLevelInForce(t *testing.T) {
 // than admitting, and the change is audited.
 func TestPassClosesAdmissionAndPersistsIt(t *testing.T) {
 	h := newHarness(t, 1)
+	h.srv.alloc.SetAssignedDemand(h.bind.key, 2)
+	before := h.srv.alloc.Advertised(h.bind.key)
+	if before == 0 {
+		t.Fatal("a binding with demand and room must advertise before the emergency")
+	}
 	h.probe.free = engine.FilesystemFree{FreeBytes: 0, FreeInodes: 0}
 
 	h.srv.disk.pass(t.Context())
@@ -72,6 +77,15 @@ func TestPassClosesAdmissionAndPersistsIt(t *testing.T) {
 	level := h.srv.currentPressure()
 	if !level.AdmissionClosed() {
 		t.Fatalf("level on a full filesystem = %s; admission must be closed", level)
+	}
+	// The gate itself, not only the level: the pass owns its own Hold
+	// call, separate from resume's, and a pass that recorded the level
+	// without moving the gate kept the broker fed on a full filesystem.
+	if got := h.srv.alloc.Advertised(h.bind.key); got != 0 {
+		t.Errorf("advertised %d under the emergency; want 0", got)
+	}
+	if h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("a reserve succeeded under the emergency; the capsule would start on the full filesystem")
 	}
 	h.inStore(func(tx *store.Tx) error {
 		p, err := tx.Pressure()
@@ -92,6 +106,19 @@ func TestPassClosesAdmissionAndPersistsIt(t *testing.T) {
 	}
 	if got := resumed.current(); got != level {
 		t.Errorf("resumed level = %s; want %s", got, level)
+	}
+
+	// And the way back. No test drove recovery through the pass itself:
+	// the one that covered the closing direction lifted the hold by hand,
+	// so a host that recovered kept advertising nothing -- silently out
+	// of service while status reported normal pressure.
+	h.probe.free = engine.FilesystemFree{FreeBytes: 1 << 40, FreeInodes: 1 << 20}
+	h.srv.disk.pass(t.Context())
+	if got := h.srv.currentPressure(); got.AdmissionClosed() {
+		t.Fatalf("level after recovery = %s; admission must reopen", got)
+	}
+	if got := h.srv.alloc.Advertised(h.bind.key); got != before {
+		t.Errorf("advertised %d after recovery; want %d back", got, before)
 	}
 }
 

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -185,3 +185,55 @@ func TestPrunePeriodicallyHonoursTheWindow(t *testing.T) {
 		})
 	}
 }
+
+// TestRecoveryRefinesFromTheRuntimeItStillHolds is the half of the
+// matrix above that a crash with a surviving container reaches: the
+// authorized start whose outcome the container itself can answer. The
+// matrix hands recovery no runtime, so its start_authorized row is held
+// for a person — right when nothing remains to ask, and the only
+// answer when something does. An exited runtime settles the attempt as
+// completed; one the daemon proves never started returns it to the
+// queue. Both otherwise land in manual review, which is a person paged
+// for a question the pass could have answered itself.
+func TestRecoveryRefinesFromTheRuntimeItStillHolds(t *testing.T) {
+	for name, tc := range map[string]struct {
+		obs            assignment.ExecutionObservation
+		wantState      store.AttemptState
+		wantResolution string
+	}{
+		"an exited runtime settles as completed": {
+			obs: assignment.ObservedExited, wantState: store.AttemptSettled,
+			wantResolution: assignment.ResolutionCompletedObserved,
+		},
+		"a runtime that never started returns the attempt to the queue": {
+			obs: assignment.ObservedCreated, wantState: store.AttemptReady,
+		},
+		"a runtime that cannot answer holds the attempt for a person": {
+			obs: assignment.ObservedUnavailable, wantState: store.AttemptManualReview,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t, 1)
+			workload := "job-refine-" + string(tc.obs)
+			if err := h.deliver(demand(workload, "app", 4)); err != nil {
+				t.Fatal(err)
+			}
+			lease, attemptID := leaseFor(t, h, assignment.SourceWorkloadKey(workload))
+			driveLeaseTo(t, h, lease.ID, store.LeaseWorkloadRunning)
+			h.recordEvidence(lease.ID, store.EvidenceStartAuthorized)
+
+			h.resolveWithRuntime(t.Context(), reloadLease(t, h, lease.ID), tc.obs)
+
+			if got := reloadLease(t, h, lease.ID); got.State != store.LeaseReleased {
+				t.Errorf("lease = %s; want released", got.State)
+			}
+			got := attemptState(t, h, attemptID)
+			if got.State != tc.wantState {
+				t.Errorf("attempt = %s with observation %s; want %s", got.State, tc.obs, tc.wantState)
+			}
+			if got.Resolution != tc.wantResolution {
+				t.Errorf("resolution = %q; want %q", got.Resolution, tc.wantResolution)
+			}
+		})
+	}
+}

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -235,11 +235,19 @@ func TestAttemptStrandedOnAReleasedLeaseIsRecovered(t *testing.T) {
 			"leased to a released lease is invisible to every other query", stranded)
 	}
 
-	h.resolveWithoutRuntime(t.Context(), reloadLease(t, h, lease.ID))
+	// The real startup pass, not the resolver handed the lease: finding
+	// the stranded attempt is the half that matters. Its lease is
+	// released, so it is outside the live working set, invisible to
+	// ReadyAttempts, and retried by nothing -- the sweep that pulls it
+	// back in by the attempt is the only thing that ever will, and a
+	// build that deleted the sweep kept every other test green.
+	if err := h.srv.reconcile(t.Context()); err != nil {
+		t.Fatalf("startup reconciliation: %v", err)
+	}
 
 	if got := len(h.ready()); got != 1 {
-		t.Errorf("ready attempts = %d; want 1 — recovery did not dispose of an "+
-			"attempt left behind by a crash between the two commits", got)
+		t.Errorf("ready attempts = %d; want 1 — startup did not find the "+
+			"attempt a crash between the two commits left behind", got)
 	}
 }
 
@@ -570,5 +578,78 @@ func TestAnUnrecordedLifecycleEventIsReported(t *testing.T) {
 	if err := h.srv.recordLifecycleEvents(ctx, h.bind, msg); err == nil {
 		t.Fatal("a lifecycle event that could not be recorded reported success; " +
 			"the message that carried it would be acknowledged and never sent again")
+	}
+}
+
+// TestALostLeaseClaimReturnsItsCredit: the reserve and the lease commit
+// are two steps, and losing the second is ordinary — two passes racing
+// one ready attempt is the reason the claim is a compare-and-swap. A
+// credit reserved for a lease that was never created has to come back,
+// or every lost race burns one permanently: a tier at parallelism four
+// decays to zero over a day of contention, and nothing reports why.
+func TestALostLeaseClaimReturnsItsCredit(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-raced", "app", 95)); err != nil {
+		t.Fatal(err)
+	}
+	// The race, made deterministic: the pass read the attempt as ready,
+	// and the other pass wins the claim before this one reserves for it,
+	// so the compare-and-swap refuses.
+	var raced store.Attempt
+	h.inStore(func(tx *store.Tx) error {
+		ready, err := tx.ReadyAttempts(h.bind.bindingID)
+		if err != nil {
+			return err
+		}
+		raced = ready[0]
+		return nil
+	})
+	leaseFor(t, h, "job-raced")
+
+	if !h.srv.admit(t.Context(), h.bind, raced) {
+		t.Fatal("a lost claim reported admission full; the pass would stop instead of continuing")
+	}
+	if got := h.srv.alloc.Active(h.bind.key); got != 0 {
+		t.Errorf("active credits = %d after a claim this pass lost; want 0 — "+
+			"the credit is burned for the life of the process", got)
+	}
+	if !h.srv.alloc.TryReserve(h.bind.key) {
+		t.Error("the pool refused a reserve after the lost claim; the credit did not come back")
+	}
+	h.srv.alloc.Release(h.bind.key)
+}
+
+// TestAFailedAcknowledgementStaysRetryable: the broker took the message
+// and the confirmation could not be delivered — an outcome that is
+// uncertain, not final. Recorded as confirmed, the broker's redelivery
+// of the same message reads as one this binding already acknowledged,
+// which nothing retries: the queue is ordered, so the binding stops
+// serving permanently, one warn line per poll.
+func TestAFailedAcknowledgementStaysRetryable(t *testing.T) {
+	h := newHarness(t, 1)
+	var delivery assignment.DeliveryID
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		var err error
+		delivery, err = tx.RecordDelivery(h.bind.bindingID,
+			assignment.DeliveryKey(h.bind.scaleSetID, 701), [32]byte{}, nil)
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.bind.session = &stubSession{ackErr: errors.New("broker unreachable")}
+
+	if h.srv.acknowledgeDelivery(t.Context(), h.bind, delivery, 701) {
+		t.Fatal("a failed acknowledgement reported the cursor advanced")
+	}
+
+	var proceed bool
+	h.inStore(func(tx *store.Tx) error {
+		var err error
+		proceed, err = tx.AckRequested(delivery)
+		return err
+	})
+	if !proceed {
+		t.Error("the delivery reads as already acknowledged; the broker's redelivery will " +
+			"never be re-acknowledged and the binding stops advancing")
 	}
 }

--- a/internal/app/sandbox_test.go
+++ b/internal/app/sandbox_test.go
@@ -480,6 +480,21 @@ func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
 		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24",
 		probeOut: "2: eth0    inet 192.0.2.10/24 scope global eth0",
 	}
+	// The operator's own lists ride the constructor too. They are the
+	// only mechanism for denying a range discovery cannot see, and the
+	// only test that exercised them set the fields past the constructor
+	// -- so the two loops that read the configuration could be deleted
+	// and every deployment's denyCIDRs silently ignored.
+	deny, err := config.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	allow, err := config.ParseCIDR("10.9.0.0/16")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Network.DenyCIDRs = []config.CIDR{deny}
+	cfg.Network.AllowPrivateCIDRs = []config.CIDR{allow}
 	n, err := newNetworkSandbox(t.Context(), seeing, "instance-0001", "probe", cfg, log)
 	if err != nil {
 		t.Fatal(err)
@@ -491,6 +506,12 @@ func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
 	}
 	if sb == nil || sb.UplinkNetworkID != "up-1" {
 		t.Errorf("the first launch would get %+v; want the policy just built", sb)
+	}
+	if !slices.Contains(sb.Deny, "100.64.0.0/10") {
+		t.Errorf("deny = %v; the operator's configured range is not in it", sb.Deny)
+	}
+	if !slices.Contains(sb.Allow, "10.9.0.0/16") {
+		t.Errorf("allow = %v; the operator's configured range is not in it", sb.Allow)
 	}
 }
 

--- a/internal/app/session_test.go
+++ b/internal/app/session_test.go
@@ -32,6 +32,10 @@ type stubSession struct {
 	fail     error
 	block    bool
 	offerErr error
+	// ackErr is returned from every Acknowledge: the broker took the
+	// message and the confirmation could not be delivered, which is the
+	// uncertain outcome.
+	ackErr error
 
 	// backlog is what this session reports it opened holding.
 	backlog *githubactions.Statistics
@@ -66,7 +70,7 @@ func (s *stubSession) Receive(ctx context.Context) (*githubactions.Message, erro
 	return nil, s.fail
 }
 
-func (s *stubSession) Acknowledge(context.Context, int) error { return nil }
+func (s *stubSession) Acknowledge(context.Context, int) error { return s.ackErr }
 func (s *stubSession) SetCapacity(int)                        {}
 func (s *stubSession) Initial() *githubactions.Statistics     { return s.backlog }
 

--- a/internal/platform/githubactions/session.go
+++ b/internal/platform/githubactions/session.go
@@ -101,18 +101,7 @@ func (s *Session) Receive(ctx context.Context) (*Message, error) {
 			out.AcquireError = fmt.Errorf("acquire %d offered jobs: %w", len(ids), err)
 			acquired = nil
 		}
-		for _, id := range acquired {
-			j, ok := byID[id]
-			if !ok {
-				out.StrandedGrants = append(out.StrandedGrants, id)
-				continue
-			}
-			// One grant, one workload: the pairing is spent when it is
-			// used, so a second grant for the same id is stranded rather
-			// than claiming the workload twice.
-			delete(byID, id)
-			out.Acquired = append(out.Acquired, j)
-		}
+		mergeAcquired(&out, acquired, byID)
 	}
 
 	return &out, nil
@@ -160,3 +149,21 @@ func (s *Session) Acknowledge(ctx context.Context, messageID int) error {
 }
 
 func (s *Session) Close(ctx context.Context) error { return s.mc.Close(ctx) }
+
+// mergeAcquired folds the broker's grants into the message. One grant,
+// one workload: the pairing is spent when it is used, so a second grant
+// for the same id is stranded rather than claiming the workload twice —
+// a broker that answers with a duplicate id would otherwise have one CI
+// job admitted twice, and the strand is also what makes the duplicate
+// visible instead of silently absorbed.
+func mergeAcquired(out *Message, acquired []int64, byID map[int64]assignment.WorkloadAssignment) {
+	for _, id := range acquired {
+		j, ok := byID[id]
+		if !ok {
+			out.StrandedGrants = append(out.StrandedGrants, id)
+			continue
+		}
+		delete(byID, id)
+		out.Acquired = append(out.Acquired, j)
+	}
+}

--- a/internal/platform/githubactions/session_test.go
+++ b/internal/platform/githubactions/session_test.go
@@ -85,12 +85,20 @@ func TestOfferablePairingIsSpentOnce(t *testing.T) {
 	if len(ids) != 1 {
 		t.Fatalf("offered %v; want the one available", ids)
 	}
-	if _, ok := byID[7]; !ok {
-		t.Fatal("the offered id has no workload")
+
+	// The broker answers with the same grant twice. The production merge
+	// is what spends the pairing -- the previous form of this test
+	// deleted from the map itself and asserted the deletion, which is
+	// Go's delete builtin under test, not this package: the merge could
+	// stop spending pairings and every test here stayed green while one
+	// CI job was admitted twice.
+	var out Message
+	mergeAcquired(&out, []int64{7, 7}, byID)
+	if len(out.Acquired) != 1 {
+		t.Fatalf("acquired %d workloads from a duplicated grant; want 1 -- the job would be admitted twice", len(out.Acquired))
 	}
-	delete(byID, 7)
-	if _, ok := byID[7]; ok {
-		t.Error("the pairing survived being spent; a second grant would claim the same workload")
+	if len(out.StrandedGrants) != 1 || out.StrandedGrants[0] != 7 {
+		t.Errorf("stranded = %v; want the duplicate named, which is what makes it visible", out.StrandedGrants)
 	}
 }
 


### PR DESCRIPTION
## What changes

Seven behaviours that could be removed with every gate staying green are held by tests:
the startup sweep for stranded attempts, the refinement that asks a surviving container
whether an authorized start took effect, the exit code the supervisor reserves for a
runner that never owned its job, the credit returned on a lost lease claim, the
acknowledgement that stays retryable when it fails, the disk monitor's gate in both
directions, the tier image resolution, and the operator's configured CIDRs. Two small
production changes make two of them testable: the schedule loop's body is a function,
and the session merge is a function.

## What was found

Every item here is from the test-suite audit: each was verified by mutation — the
production line it names was broken, the whole suite ran green, and the line was
restored. The findings are not that the code is wrong; it is that nothing would say so
when it becomes wrong. Three are worth spelling out.

**The startup sweep was dead code as far as the suite was concerned.** An attempt
stranded by a crash between the release commit and the disposition commit is invisible
to every working set — its lease is released, so live-state queries never return it —
and the sweep that pulls it back in by the attempt is the only thing that ever will.
The one test for the scenario handed the resolver the lease directly, so it proved the
fix and not the finding. Deleting the sweep kept everything green; the test now drives
the real startup pass.

**The refinement path had zero coverage because the fixture could not express it.**
`resolveWithoutRuntime` hard-codes "no runtime", so the recovery matrix's
`start_authorized` row always landed in manual review — correct when nothing remains to
ask, and the only tested outcome even when something does. A second helper hands
recovery a runtime and the observation it answers with. The reserved abort code has the
same shape: the wait fixture only ever exited 0 or 7, so the branch that keeps a clean
wait carrying the reserved code from settling a never-run attempt as complete had no
row — the exact outcome its own comment warns about, and the class of bug the changelog
records being fixed once already.

**The lost-claim test needed the race to be aimable.** The schedule loop reads its own
ready list, so an attempt leased out of band leaves the list before the loop sees it —
the audit's own sketch for this test does not work, and my first two attempts produced
tests that passed vacuously (one emptied the ready list, one was blocked by the
compiler). The loop body is now `admit`, which reports false only when admission is
full because that is the one answer that stops the pass; the test hands it an attempt
whose claim another pass has already won, against the real compare-and-swap.

The session merge extraction is the same move: the previous test deleted from the map
itself and asserted the deletion — Go's `delete` builtin under test. The merge could
stop spending pairings, every test stayed green, and a broker answering with a
duplicated grant had one CI job admitted twice with the strand list empty, so the
warning naming unrecoverable grants never fired.

## Evidence

Hermetic. Each mutation was applied, seen to fail with the message shown, restored.

| Behaviour removed | Failure that names it |
| --- | --- |
| the stranded sweep | `startup did not find the attempt a crash between the two commits left behind` |
| the runtime inspection | 2 subtests fail |
| the exit-observed refinement write | 1 subtest fails |
| the reserved-code branch | `clean start, supervisor reports the runner never started` fails |
| the credit release on a lost claim | `active credits = 1 … burned for the life of the process` |
| uncertain recorded as confirmed | `the broker's redelivery will never be re-acknowledged` |
| the pass's own `Hold` | `a reserve succeeded under the emergency` |
| pairing not spent | `acquired 2 workloads from a duplicated grant` |
| `tier.Image` resolution dropped | `the configured image was ignored` |
| the operator CIDR loops deleted | 1 failure |

```text
hermetic only — the mutations are the observation, and the table is the record.
gofmt, go vet, staticcheck, go test -race -shuffle=on -count=1 ./... clean.
```

## What would notice this regressing

The tests above, each named for the behaviour it holds. The two production changes are
behaviour-preserving: `admit` is the loop body verbatim with the stop condition
inverted at the caller, and `mergeAcquired` is the loop verbatim.

## Risk, compatibility and operations

**Production changes: two, both extractions.** `scheduleReadyAttempts` calls `admit`
per attempt and stops when admission is full, exactly as the inline body did.
`collectMessage`'s grant folding calls `mergeAcquired`, the same statements moved. No
ordering, locking or transaction boundary moves in either.

**Trust boundary, credentials, networking, resource limits, schema, migration, status
API, CLI, configuration, deployment, rollback, runbook: N/A.** Test files otherwise.

**Not an ADR.**

## Changelog

```text
NONE — no observable behaviour changes; the coverage of existing behaviour does.
```

## Notes for your reviewer

`admit` returning `true` on a failed lease creation is deliberate and commented: false
means "stop the pass", and a lost claim must not stop the pass — the next ready attempt
is unrelated. If the bool reads as success to you, that is worth a better name and I
would take the suggestion.
