### PR TITLE
test(egress): the ruleset is held line by line

### DIFF
--- a/internal/egress/egress_test.go
+++ b/internal/egress/egress_test.go
@@ -376,3 +376,121 @@ func TestTheDenySetIsIPv4WhateverTheDaemonReports(t *testing.T) {
 		t.Errorf("the policy built from what the daemon reported does not validate: %v", err)
 	}
 }
+
+// outputRules extracts the OUTPUT chain in order. The order is the
+// decision: iptables evaluates top to bottom, so a terminal ACCEPT that
+// renders above a REJECT does not "mostly work" — it makes every rule
+// below it unreachable and the deny layer an accept-all.
+func outputRules(out string) []string {
+	var rules []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "-A OUTPUT ") {
+			rules = append(rules, line)
+		}
+	}
+	return rules
+}
+
+// TestTheRulesetIsHeldLineByLine: the existing render test checks that
+// lines exist, and existence is not a ruleset. Moving the terminal
+// ACCEPT above the deny loop kept every line present and every test
+// green while the kernel accepted everything; adding one INPUT accept
+// for the proxy port without a source subnet did the same while any
+// gateway on the uplink relayed any capsule's traffic under its own
+// policy. A chain is asserted as the ordered sequence it is evaluated
+// as, and INPUT as the exact set of accepts it may hold.
+func TestTheRulesetIsHeldLineByLine(t *testing.T) {
+	out := policy().RenderIPTables("eth0", 3128)
+
+	rules := outputRules(out)
+	if len(rules) == 0 {
+		t.Fatal("no OUTPUT rules at all, so this proves nothing")
+	}
+	last := rules[len(rules)-1]
+	if last != "-A OUTPUT -j ACCEPT" {
+		t.Fatalf("the last OUTPUT rule is %q; the unconditional accept must be the final rule", last)
+	}
+	for _, r := range rules[:len(rules)-1] {
+		if r == "-A OUTPUT -j ACCEPT" {
+			t.Fatalf("an unconditional accept renders above %q; every rule below it is unreachable "+
+				"and the deny layer is an accept-all", rules[len(rules)-1])
+		}
+	}
+	// Every REJECT is above the terminal accept by the assertion above;
+	// what remains is that each is present for the whole deny set.
+	for _, c := range policy().Deny {
+		want := "-A OUTPUT -d " + c + " -j REJECT --reject-with icmp-admin-prohibited"
+		if !slices.Contains(rules, want) {
+			t.Errorf("the deny set entry %s has no REJECT rule", c)
+		}
+	}
+
+	// INPUT is enumerated exactly. A rule added here is a door into the
+	// gateway, and the door the source subnet exists to close is another
+	// capsule's traffic arriving over the shared uplink.
+	var input []string
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "-A INPUT ") {
+			input = append(input, line)
+		}
+	}
+	wantInput := []string{
+		"-A INPUT -i lo -j ACCEPT",
+		"-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT",
+		"-A INPUT -i eth0 -s 172.20.0.0/24 -p udp --dport 53 -j ACCEPT",
+		"-A INPUT -i eth0 -s 172.20.0.0/24 -p tcp --dport 53 -j ACCEPT",
+		"-A INPUT -i eth0 -s 172.20.0.0/24 -p tcp --dport 3128 -j ACCEPT",
+	}
+	if !slices.Equal(input, wantInput) {
+		t.Errorf("INPUT chain =\n%s\nwant exactly\n%s", strings.Join(input, "\n"), strings.Join(wantInput, "\n"))
+	}
+}
+
+// TestTheIP6RulesetIsExactlyLoopback: the previous assertion here could
+// not fire — it excused any ACCEPT whenever "-o lo" appeared anywhere in
+// the ruleset, and the loopback accept is always in it, so a fully open
+// IPv6 ruleset passed. The capsule has no IPv6 and the ruleset is what
+// turns "not enabled" into "denied even if something enables it", so it
+// is asserted as the exact document it is.
+func TestTheIP6RulesetIsExactlyLoopback(t *testing.T) {
+	want := strings.Join([]string{
+		"*filter",
+		":INPUT DROP [0:0]",
+		":FORWARD DROP [0:0]",
+		":OUTPUT DROP [0:0]",
+		"-A INPUT -i lo -j ACCEPT",
+		"-A OUTPUT -o lo -j ACCEPT",
+		"COMMIT",
+		"",
+	}, "\n")
+	if got := RenderIP6Tables(); got != want {
+		t.Errorf("ip6 ruleset =\n%s\nwant exactly\n%s", got, want)
+	}
+}
+
+// TestTheBaselineDenyIsTheTwelveRanges. Writing the twelve out is the
+// point: the baseline is the floor under every discovered deny, the
+// validator refuses operator allowances against what it withholds, and
+// a range deleted from it was withheld from capsules on every host —
+// while the previous test pinned seven of the twelve, so the other five
+// could go without a failure anywhere.
+func TestTheBaselineDenyIsTheTwelveRanges(t *testing.T) {
+	want := []string{
+		"0.0.0.0/8",
+		"10.0.0.0/8",
+		"100.64.0.0/10",
+		"127.0.0.0/8",
+		"169.254.0.0/16",
+		"172.16.0.0/12",
+		"192.0.0.0/24",
+		"192.168.0.0/16",
+		"198.18.0.0/15",
+		"224.0.0.0/4",
+		"240.0.0.0/4",
+		"255.255.255.255/32",
+	}
+	if !slices.Equal(baselineDeny, want) {
+		t.Errorf("baselineDeny = %v\nwant the twelve ranges written here, so a deletion is a diff "+
+			"in a security constant and not a silent narrowing", baselineDeny)
+	}
+}

--- a/internal/gateway/dns_test.go
+++ b/internal/gateway/dns_test.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"bytes"
 	"encoding/binary"
+	"io"
+	"log/slog"
 	"net"
 	"testing"
 	"time"
@@ -230,4 +232,82 @@ func TestTCPCarriesWhatADatagramCannot(t *testing.T) {
 	if got := binary.BigEndian.Uint16(answer[:2]); got != 0x4321 {
 		t.Errorf("answer transaction id = %#x; want the query's", got)
 	}
+}
+
+// answerWithWrongID answers every query under a transaction id that is
+// not the query's. Which is what the fixtures above cannot express: they
+// copy the query's id into the answer, so the check that an answer
+// belongs to its query was compared against a value derived from the
+// thing under test — an assertion that cannot fail, over both checks
+// that exist, on the one transport where the id is all that keeps
+// pipelined answers matched to their queries.
+func answerWithWrongID(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { pc.Close() })
+	go func() {
+		buf := make([]byte, MaxDNSMessage+1)
+		for {
+			n, client, err := pc.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			if n < MinDNSMessage {
+				continue
+			}
+			answer := header(binary.BigEndian.Uint16(buf[:2])^0xffff, 1, 1, 0)
+			_, _ = pc.WriteTo(answer, client)
+		}
+	}()
+	return pc.LocalAddr().String()
+}
+
+// TestAnAnswerWithAnotherTransactionIDIsNeverForwarded, on both
+// transports. UDP's connected socket makes this defence in depth; TCP's
+// pipelining makes it the only thing keeping answers matched to queries.
+func TestAnAnswerWithAnotherTransactionIDIsNeverForwarded(t *testing.T) {
+	t.Run("udp", func(t *testing.T) {
+		if _, err := exchangeUDP(answerWithWrongID(t), header(0x1234, 1, 0, 30)); err == nil {
+			t.Fatal("an answer under another transaction id was forwarded")
+		}
+	})
+	t.Run("tcp", func(t *testing.T) {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { ln.Close() })
+		go func() {
+			up, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer up.Close()
+			query, err := readDNSMessage(up)
+			if err != nil {
+				return
+			}
+			answer := header(binary.BigEndian.Uint16(query[:2])^0xffff, 1, 1, 0)
+			_ = writeDNSMessage(up, answer)
+		}()
+
+		relay := &DNSRelay{Upstream: ln.Addr().String(), Log: slog.New(slog.NewTextHandler(io.Discard, nil))}
+		client, server := net.Pipe()
+		t.Cleanup(func() { client.Close(); server.Close() })
+		go relay.serveTCPConn(server)
+
+		if err := writeDNSMessage(client, header(0x5678, 1, 0, 30)); err != nil {
+			t.Fatal(err)
+		}
+		// The relay drops the connection rather than forwarding the
+		// mismatched answer: the read ends without a message.
+		client.SetReadDeadline(time.Now().Add(time.Second))
+		if answer, err := readDNSMessage(client); err == nil {
+			t.Fatalf("a mismatched answer was forwarded: id %#x for query 0x5678",
+				binary.BigEndian.Uint16(answer[:2]))
+		}
+	})
 }

--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -155,6 +155,13 @@ func Reload(controlDir string, r io.Reader) error {
 	if len(payload) == 0 {
 		return errors.New("no policy supplied")
 	}
+	if len(payload) > MaxPolicyBytes {
+		// The comparison the read-one-past exists for. Without it the
+		// oversized document was not refused -- its first MaxPolicyBytes+1
+		// bytes went to the decoder, and a prefix that happens to be
+		// complete JSON installed a policy nobody wrote in full.
+		return fmt.Errorf("policy document exceeds %d bytes", MaxPolicyBytes)
+	}
 	var incoming egress.Policy
 	if err := json.Unmarshal(payload, &incoming); err != nil {
 		return err

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -530,3 +530,31 @@ func TestOnlyAFirstInstallMayFindNoPolicyInForce(t *testing.T) {
 		t.Errorf("the first install did not take the lock a reload takes: %v", err)
 	}
 }
+
+// TestAnOversizedPolicyIsRefusedNotTruncated: the reload reads one byte
+// past the bound so a document that exceeds it can be told from one that
+// fits — and then nothing compared the length, so the oversized document
+// was not refused. Its truncated prefix went to the decoder, and a
+// prefix that happens to be complete JSON installed a policy nobody
+// wrote in full: measured before the fix, a two-megabyte document
+// crafted that way moved the deny set.
+func TestAnOversizedPolicyIsRefusedNotTruncated(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(PolicyPath(dir),
+		[]byte(`{"internal_subnet":"172.31.0.0/24","uplink_subnet":"172.31.1.0/24","allow":[],"deny":["10.0.0.0/8"]}`),
+		0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A document whose first MaxPolicyBytes+1 bytes are complete JSON:
+	// the shape truncation turns into a different, valid policy.
+	head := `{"allow":[],"deny":["192.168.0.0/16"]}`
+	oversized := head + strings.Repeat(" ", MaxPolicyBytes)
+	err := Reload(dir, strings.NewReader(oversized))
+	if err == nil {
+		t.Fatal("a document past the bound was installed from its truncated prefix")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %q; it has to name the bound rather than fail parsing the truncation", err)
+	}
+}


### PR DESCRIPTION
## What changes

The gateway's kernel ruleset is asserted as the ordered document iptables evaluates,
the IPv6 ruleset is byte-compared, the baseline deny set is pinned as its twelve
literal ranges, an oversized policy document is refused instead of silently truncated,
and a DNS answer under the wrong transaction id is proven dropped on both transports.

## What was found

All from the audits, each verified by mutation before the fix and killed by one after.

**Order is the decision, and nothing held it.** The render test checked lines exist.
Moving the terminal `-A OUTPUT -j ACCEPT` above the deny loop kept every line present
and the whole suite green — with every REJECT unreachable, the second deny layer under
the relay was an accept-all. An INPUT accept for the proxy port without the source
subnet survived the same way, and that subnet restriction is what keeps one capsule's
gateway from relaying another capsule's traffic under its own policy across the shared
uplink.

**The IPv6 assertion was structurally unable to fire.** It excused any ACCEPT whenever
`-o lo` appeared anywhere in the output, and the loopback accept always does. A fully
open IPv6 ruleset passed.

**`Reload` claimed a refusal it did not perform.** The comment above the read says the
bound is enforced "by ParsePolicy rather than silently truncated"; the code read one
byte past the bound and never compared the length. A two-megabyte document whose first
`MaxPolicyBytes+1` bytes form complete JSON was installed from its prefix — measured,
it moved the deny set. Only the controller writes this channel, so it was latent
rather than capsule-reachable; it is now a refusal that names the bound.

**The DNS id checks were tested against themselves.** Every fixture copied the query's
id into its answer, so the assertion compared the relay's output against a value
derived from its input, over both transports. On TCP, where queries pipeline over one
upstream connection, the id check is the only thing keeping answers matched to
queries.

One audit item in this area is deliberately not here: `ClassifyLegs` has no unit test,
and `CONTRIBUTING.md` names it as proved live — it reads the container's own
interfaces, and faking them would simulate the platform rather than isolate a
dependency.

## Evidence

Hermetic. Each mutation applied, seen to fail, restored.

| Mutation | Killed by |
| --- | --- |
| terminal ACCEPT above the deny loop | the ordered-chain assertion |
| proxy port opened to any source | the exact INPUT enumeration |
| IPv6 ruleset fully opened | the byte comparison |
| a baseline range deleted | the twelve-literal comparison |
| the size comparison removed | `TestAnOversizedPolicyIsRefusedNotTruncated` |
| either transaction-id check removed | its transport's subtest |

```text
hermetic only — the mutations are the observation. gofmt, go vet, staticcheck,
go test -race -shuffle=on -count=1 ./... clean.
```

## What would notice this regressing

The table. The twelve-literal baseline test is deliberately a restatement: a deletion
there is now a diff in a security constant reviewed as one, not a silent narrowing.

## Risk, compatibility and operations

**Production changes: one, a refusal.** A reload whose document exceeds
`MaxPolicyBytes` fails with an error naming the bound. The only writer is the
controller's own fan-out, which never builds a document near the bound, so no
behaviour in any deployed shape changes.

**Trust boundary:** the INPUT enumeration and the ordered OUTPUT chain now hold the
two properties the live bypass suite cannot see from inside a capsule — the source
subnet on the proxy port is about *other* capsules' gateways, and rule order is
invisible when you can only probe outcomes.

**Everything else: N/A.** Test files.

**Not an ADR.**

## Changelog

```text
NONE — the one behaviour change is refusing a document only the controller can send
and never does.
```

## Notes for your reviewer

The TCP transaction-id subtest costs one second of wall clock: the relay's correct
behaviour is to drop the connection, so the test waits out a read deadline to prove
nothing arrived. If that reads as too slow for the hermetic suite, the alternative is
exporting a hook, which did not seem worth it.
