### PR TITLE
test(release): the gates that authorize a release gate

### DIFF
--- a/.github/workflows/integration-docker.yml
+++ b/.github/workflows/integration-docker.yml
@@ -33,6 +33,13 @@ on:
       - "scripts/drills/**"
       - "test/drills/**"
       - "test/contract/**"
+      # The dependency manifests: the Moby client is a v0.x dependency and
+      # the adapter behind it is proved live rather than hermetically, so a
+      # go.mod-only bump is precisely the change class these contracts
+      # exist for -- and it touched none of the paths above.
+      - "go.mod"
+      - "go.sum"
+      - "build/images.lock.json"
       - ".github/workflows/integration-docker.yml"
   push:
     branches: [main]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,14 +42,20 @@ the egress decision, configuration validation, the lease machine, the
 cache planner — is tested in its own package with no daemon. These are the
 packages where a gap is a real gap:
 
-| Package | Expected |
+| Package | Measured, 2026-08-24 |
 | --- | --- |
-| `internal/assignment`, `internal/allocator`, `internal/disk` | ~100% |
-| `internal/config`, `internal/egress`, `internal/credential` | ~95% |
-| `internal/cache`, `internal/store`, `internal/lease` | ~80%, limited by SQL paths a fault has to be injected to reach |
+| `internal/allocator`, `internal/disk` | ~95% |
+| `internal/config`, `internal/egress`, `internal/cache` | ~85-90% |
+| `internal/assignment`, `internal/credential` | ~80% |
+| `internal/store`, `internal/lease` | ~70%, limited by SQL paths a fault has to be injected to reach |
 
-Those are review expectations, not a gate: `scripts/verify/coverage.sh`
-enforces one repo-wide floor (`RUNPOOL_COVERAGE_MIN`, 35% by default). A
+Measured numbers, kept honest by re-measuring when they are touched: an
+earlier form of this table said ~100% where the tree held 57%, and a
+table nothing checks drifts into advertising. They are review
+expectations, not a gate: `scripts/verify/coverage.sh` enforces one
+repo-wide floor (`RUNPOOL_COVERAGE_MIN`, 55% by default, against a tree
+that measures ~60%) -- a floor twenty-five points under the tree lets a
+quarter of the covered statements go dark before anything trips. A
 per-package gate would fail on the mechanics packages below, which are
 deliberately thin here and proved elsewhere.
 

--- a/internal/assignment/assignment_test.go
+++ b/internal/assignment/assignment_test.go
@@ -1,6 +1,9 @@
 package assignment
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The fingerprint must be insensitive to arrival order — the provider
 // owes no ordering guarantee — and sensitive to every field the domain
@@ -55,5 +58,30 @@ func TestDeliveryKeyIsVersioned(t *testing.T) {
 func TestDeliveryKeySeparatesQueues(t *testing.T) {
 	if DeliveryKey(7, 41) == DeliveryKey(8, 41) {
 		t.Error("two queues issuing the same delivery id produced one key; the second delivery would be deduplicated away")
+	}
+}
+
+// TestAnAssignmentWithoutAWorkloadKeyIsRefused: the key is what
+// deduplication and recovery recognise an assignment by, so recording
+// one without it plants a row nothing can recognise again. The guard is
+// the first thing persistDelivery runs; without it the schema's own
+// constraint still refuses the row, but as an opaque constraint error on
+// a message at the head of an ordered queue — which stays unacknowledged
+// and wedges the binding.
+func TestAnAssignmentWithoutAWorkloadKeyIsRefused(t *testing.T) {
+	bad := WorkloadAssignment{TenantKey: "acme", ProjectKey: "app", SourceRunID: 7}
+	err := bad.Validate()
+	if err == nil {
+		t.Fatal("an assignment with no workload key validated")
+	}
+	for _, names := range []string{"acme", "app", "7"} {
+		if !strings.Contains(err.Error(), names) {
+			t.Errorf("error = %q; it has to name %q, which is all an operator has to find the run", err, names)
+		}
+	}
+	good := bad
+	good.SourceWorkloadKey = "job-1"
+	if err := good.Validate(); err != nil {
+		t.Errorf("a complete assignment was refused: %v", err)
 	}
 }

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"bytes"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -304,5 +305,80 @@ func TestAnyBuildablePlatformCanBeRecorded(t *testing.T) {
 	if err := (Qualified{Status: ReferenceStatusPending, Policy: unbuildable}).validate(); err == nil {
 		t.Error("a qualification was accepted for a platform no release builds for, so the " +
 			"record would claim evidence about something nobody can run")
+	}
+}
+
+// TestEveryFactIsCompared walks the Facts struct itself, so the domain
+// is the type and not a list a reader keeps in step by hand. The
+// previous shape drifted exactly that way: three properties were driven
+// and fifteen were not, so deleting any of the fifteen checks — kernel,
+// backing filesystem, nftables among them — failed nothing, and Compare
+// is what stands between the host that ran the suites and the host
+// somebody froze. Walking the struct also makes a field added to Facts
+// without a check a failure here rather than a silent hole.
+func TestEveryFactIsCompared(t *testing.T) {
+	ref := frozenQualified()
+	facts := reflect.TypeOf(Facts{})
+
+	for i := 0; i < facts.NumField(); i++ {
+		field := facts.Field(i)
+		property := strings.TrimSuffix(field.Tag.Get("json"), ",omitempty")
+		t.Run(property, func(t *testing.T) {
+			drifted := ref.Platform
+			v := reflect.ValueOf(&drifted).Elem().Field(i)
+			switch field.Type.Kind() {
+			case reflect.String:
+				v.SetString(v.String() + "-drifted")
+			case reflect.Pointer:
+				flipped := !v.Elem().Bool()
+				v.Set(reflect.ValueOf(&flipped))
+			default:
+				t.Fatalf("Facts grew a %s field; teach this walk to drift it", field.Type.Kind())
+			}
+
+			got := ref.Compare(drifted)
+			if len(got) != 1 {
+				t.Fatalf("drifting %s alone produced %d mismatches: %v — the fact is not compared",
+					property, len(got), got)
+			}
+			if got[0].Property != property {
+				t.Errorf("the mismatch names %q; want %q, which is what an operator greps the lock for",
+					got[0].Property, property)
+			}
+		})
+	}
+}
+
+// TestEveryDockerFactIsCompared is the runtime half, over the five facts
+// a serving daemon can answer for. Its previous test built the observed
+// facts from the reference's own fields and asserted zero mismatches, so
+// deleting all five checks passed it — and its only other caller is
+// double-gated behind two environment variables.
+func TestEveryDockerFactIsCompared(t *testing.T) {
+	ref := frozenQualified()
+	base := Facts{
+		Engine: ref.Platform.Engine, API: ref.Platform.API, Arch: ref.Platform.Arch,
+		CgroupVersion: ref.Platform.CgroupVersion, CgroupDriver: ref.Platform.CgroupDriver,
+		Rootless: ref.Platform.Rootless,
+	}
+	if got := ref.CompareDockerFacts(base); len(got) != 0 {
+		t.Fatalf("the matching runtime facts mismatched: %v", got)
+	}
+	for property, drift := range map[string]func(*Facts){
+		"engine":         func(f *Facts) { f.Engine += "-drifted" },
+		"api":            func(f *Facts) { f.API += "-drifted" },
+		"arch":           func(f *Facts) { f.Arch += "-drifted" },
+		"cgroup_version": func(f *Facts) { f.CgroupVersion += "-drifted" },
+		"cgroup_driver":  func(f *Facts) { f.CgroupDriver += "-drifted" },
+		"rootless":       func(f *Facts) { flipped := !*f.Rootless; f.Rootless = &flipped },
+	} {
+		t.Run(property, func(t *testing.T) {
+			observed := base
+			drift(&observed)
+			got := ref.CompareDockerFacts(observed)
+			if len(got) != 1 || got[0].Property != property {
+				t.Errorf("drifting %s produced %v; want exactly that one mismatch", property, got)
+			}
+		})
 	}
 }

--- a/internal/qualification/record.go
+++ b/internal/qualification/record.go
@@ -25,17 +25,26 @@ import (
 	"github.com/rhobuild/runpool/internal/platform"
 )
 
-// suites are the gates a release-qualification run comprises. The record
-// names them so that a reader of the document knows what "qualified"
-// covered on the day it was written.
-var suites = []string{
-	"hermetic",
-	"docker-contract",
-	"capsule-contract",
-	"sqlite-durability",
-	"lifecycle-drills",
-	"contracts-github-actions",
-	"controller-e2e",
+// suites are the gates a release-qualification run comprises, each with
+// the evidence file that proves it ran. The record names them so that a
+// reader of the document knows what "qualified" covered on the day it
+// was written -- and the assembly refuses to write a name it holds no
+// evidence for, because the workflow step that runs a suite and the
+// constant that lists it are otherwise two places nothing holds
+// together: a step deleted from the workflow left the published record
+// still naming its suite, and nothing in the repository could tell.
+//
+// hermetic is the one gate with no artifact of its own: it is the
+// required check the branch protection holds every commit to, and the
+// qualification workflow cannot run on a commit that failed it.
+var suites = []struct{ name, evidence string }{
+	{"hermetic", ""},
+	{"docker-contract", "live/docker-contract.log"},
+	{"capsule-contract", "live/capsule-contract.log"},
+	{"sqlite-durability", "live/sqlite-contract.log"},
+	{"lifecycle-drills", "live/lifecycle-drills.log"},
+	{"contracts-github-actions", "upstream/contract.log"},
+	{"controller-e2e", "controller-e2e"},
 }
 
 // Build identifies what is being qualified, and later what is being
@@ -98,6 +107,10 @@ func Assemble(ref platform.Reference, evidenceDir string, build Build, at time.T
 	if err != nil {
 		return Record{}, err
 	}
+	names, err := provenSuites(evidenceDir)
+	if err != nil {
+		return Record{}, err
+	}
 	return Record{
 		SchemaVersion:       1,
 		Commit:              build.Commit,
@@ -109,7 +122,7 @@ func Assemble(ref platform.Reference, evidenceDir string, build Build, at time.T
 		PlatformReference:   qualified.Platform,
 		PlatformObserved:    observed,
 		StandaloneArtifacts: checksums,
-		Suites:              suites,
+		Suites:              names,
 	}, nil
 }
 
@@ -196,4 +209,25 @@ func readJSON(path string, into any) error {
 		return fmt.Errorf("decode %s: %w", path, err)
 	}
 	return nil
+}
+
+// provenSuites returns the suite names the evidence directory can stand
+// behind, refusing to assemble when any is missing or empty: a record is
+// the artifact a release keeps, and a suite it names without evidence is
+// a claim about a run that may never have happened.
+func provenSuites(evidenceDir string) ([]string, error) {
+	names := make([]string, 0, len(suites))
+	for _, s := range suites {
+		if s.evidence != "" {
+			info, err := os.Stat(filepath.Join(evidenceDir, s.evidence))
+			if err != nil {
+				return nil, fmt.Errorf("suite %s: no evidence at %s: %w", s.name, s.evidence, err)
+			}
+			if info.Mode().IsRegular() && info.Size() == 0 {
+				return nil, fmt.Errorf("suite %s: evidence %s is empty, which is a run that produced nothing", s.name, s.evidence)
+			}
+		}
+		names = append(names, s.name)
+	}
+	return names, nil
 }

--- a/internal/qualification/record_test.go
+++ b/internal/qualification/record_test.go
@@ -393,3 +393,38 @@ func TestTheEmbeddedReferenceIsTheOneARecordIsBuiltFrom(t *testing.T) {
 			"platform it is about", err)
 	}
 }
+
+// TestASuiteWithoutEvidenceIsNotNamed: the record is a release asset,
+// and its suite list was a constant stamped unconditionally -- assembly
+// opened three evidence paths and never the live logs, so a suite step
+// deleted from the workflow left the published record still naming it,
+// with nothing anywhere able to tell. Each named suite now requires the
+// artifact that proves it ran, and an empty artifact is a run that
+// produced nothing.
+func TestASuiteWithoutEvidenceIsNotNamed(t *testing.T) {
+	for name, breakIt := range map[string]func(dir string) error{
+		"the drill log is missing": func(dir string) error {
+			return os.Remove(filepath.Join(dir, "live", "lifecycle-drills.log"))
+		},
+		"the upstream log is empty": func(dir string) error {
+			return os.WriteFile(filepath.Join(dir, "upstream", "contract.log"), nil, 0o600)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.CopyFS(dir, os.DirFS("testdata/evidence")); err != nil {
+				t.Fatal(err)
+			}
+			if err := breakIt(dir); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Assemble(frozenReference(), dir, testBuild(), qualifiedAt())
+			if err == nil {
+				t.Fatal("a record was assembled naming a suite it holds no evidence for")
+			}
+			if !strings.Contains(err.Error(), "suite ") {
+				t.Errorf("error = %q; it has to name the suite, which is what the operator re-runs", err)
+			}
+		})
+	}
+}

--- a/internal/qualification/testdata/evidence/live/capsule-contract.log
+++ b/internal/qualification/testdata/evidence/live/capsule-contract.log
@@ -1,0 +1,1 @@
+ok  	(evidence fixture: the qualification suite log this stands in for)

--- a/internal/qualification/testdata/evidence/live/docker-contract.log
+++ b/internal/qualification/testdata/evidence/live/docker-contract.log
@@ -1,0 +1,1 @@
+ok  	(evidence fixture: the qualification suite log this stands in for)

--- a/internal/qualification/testdata/evidence/live/lifecycle-drills.log
+++ b/internal/qualification/testdata/evidence/live/lifecycle-drills.log
@@ -1,0 +1,1 @@
+ok  	(evidence fixture: the qualification suite log this stands in for)

--- a/internal/qualification/testdata/evidence/live/sqlite-contract.log
+++ b/internal/qualification/testdata/evidence/live/sqlite-contract.log
@@ -1,0 +1,1 @@
+ok  	(evidence fixture: the qualification suite log this stands in for)

--- a/internal/qualification/testdata/evidence/upstream/contract.log
+++ b/internal/qualification/testdata/evidence/upstream/contract.log
@@ -1,0 +1,1 @@
+ok  	(evidence fixture: the upstream contract log this stands in for)

--- a/scripts/verify/coverage.sh
+++ b/scripts/verify/coverage.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # cover daemon and provider adapters separately; this floor prevents the
 # hermetic surface from regressing unnoticed.
 profile=${1:-coverage.out}
-minimum=${RUNPOOL_COVERAGE_MIN:-35.0}
+minimum=${RUNPOOL_COVERAGE_MIN:-55.0}
 
 if [ ! -f "$profile" ]; then
   echo "coverage profile not found: $profile" >&2

--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -145,17 +145,51 @@ func deps(t *testing.T, pkg string) map[string]bool {
 	return set
 }
 
+// TestCoreDoesNotDependOnTheProviderAdapter walks the whole module, the
+// way the engine-SDK rule does, because the rule it enforces is about
+// every package that is not the wiring: iterated over corePackages
+// alone, a new package escaped it by not being listed — the list said
+// which packages were checked, not which were allowed, and nothing
+// failed when those diverged. The wiring layers are the exemption, named
+// here with the reason the corePackages comment already gives: injecting
+// the adapter is their job. corePackages stays as the roster the
+// narrow-dependency rules run over.
 func TestCoreDoesNotDependOnTheProviderAdapter(t *testing.T) {
+	wiring := map[string]bool{
+		module + "/internal/app":     true,
+		module + "/internal/command": true,
+		module + "/cmd/runpool":      true,
+		adapter:                      true,
+		adapter + "/jit":             true,
+	}
+	graph := importGraph(t)
+	for importer, imports := range graph {
+		if wiring[importer] || strings.HasPrefix(importer, adapter+"/") ||
+			strings.HasPrefix(importer, module+"/test/") {
+			continue
+		}
+		for _, imported := range imports {
+			if imported == adapter {
+				t.Errorf("%s imports %s; the domain must stay provider-neutral — "+
+					"translate at the adapter and hand the domain opaque keys", importer, adapter)
+			}
+			if imported == upstream || strings.HasPrefix(imported, upstream+"/") {
+				t.Errorf("%s imports %s; only the adapter, the wiring and their "+
+					"contract suites may see the provider SDK", importer, imported)
+			}
+		}
+	}
+	// Direct imports catch the edge someone adds; the closure is what
+	// catches it arriving through a third package. The roster's packages
+	// keep the transitive check they always had.
 	for _, pkg := range corePackages {
 		t.Run(strings.TrimPrefix(pkg, module+"/"), func(t *testing.T) {
 			d := deps(t, pkg)
 			if d[adapter] {
-				t.Errorf("%s depends on %s; the domain must stay provider-neutral — "+
-					"translate at the adapter and hand the domain opaque keys", pkg, adapter)
+				t.Errorf("%s depends on %s transitively", pkg, adapter)
 			}
 			if d[upstream] {
-				t.Errorf("%s depends on %s; only the adapter and its contract suite "+
-					"may import the provider SDK", pkg, upstream)
+				t.Errorf("%s depends on %s transitively", pkg, upstream)
 			}
 		})
 	}

--- a/test/consistency/release_test.go
+++ b/test/consistency/release_test.go
@@ -38,16 +38,53 @@ func TestTheReleaseBuildsEveryPlatformTheLockDeclares(t *testing.T) {
 	if err := yaml.Unmarshal(body, &workflow); err != nil {
 		t.Fatal(err)
 	}
-	built := valuesOf(&workflow, "platform")
-	slices.Sort(built)
-	built = slices.Compact(built)
 	declared := slices.Clone(lock.Platforms)
 	slices.Sort(declared)
 
-	if !slices.Equal(built, declared) {
-		t.Errorf("the release builds for %s; the lock declares %s. A platform in one list "+
-			"and not the other is one a release claims and does not produce, or one it "+
-			"produces and does not offer.",
-			strings.Join(built, ", "), strings.Join(declared, ", "))
+	// Per matrix, not a union across the workflow: a union stays whole
+	// while one job loses a leg — the capsule matrix down to one
+	// architecture still contributed both values through the controller's
+	// matrix, and the index published without the missing child. Each
+	// matrix that names platforms must name every declared one itself.
+	matrices := platformMatrices(&workflow)
+	if len(matrices) < 2 {
+		t.Fatalf("found %d platform matrices in release.yml; the capsule and controller "+
+			"builds each carry one, so this proves nothing", len(matrices))
 	}
+	for i, built := range matrices {
+		slices.Sort(built)
+		built = slices.Compact(built)
+		if !slices.Equal(built, declared) {
+			t.Errorf("platform matrix %d builds for %s; the lock declares %s. A platform in one "+
+				"list and not the other is one a release claims and does not produce, or one it "+
+				"produces and does not offer.",
+				i+1, strings.Join(built, ", "), strings.Join(declared, ", "))
+		}
+	}
+}
+
+// platformMatrices returns, for each strategy matrix in the document,
+// the platform values its include entries carry — one slice per matrix,
+// so a leg missing from one cannot be papered over by its sibling.
+func platformMatrices(n *yaml.Node) [][]string {
+	var out [][]string
+	var walk func(*yaml.Node)
+	walk = func(n *yaml.Node) {
+		if n.Kind == yaml.MappingNode {
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				if n.Content[i].Value == "matrix" {
+					if built := valuesOf(n.Content[i+1], "platform"); len(built) > 0 {
+						out = append(out, built)
+					}
+				}
+				walk(n.Content[i+1])
+			}
+			return
+		}
+		for _, c := range n.Content {
+			walk(c)
+		}
+	}
+	walk(n)
+	return out
 }


### PR DESCRIPTION
## What changes

Five gates that authorize or shape a release stop being passable by code that is
wrong: every platform fact is compared and proven compared; a suite the
qualification record names requires the artifact that proves it ran; provider
neutrality walks the whole module instead of a hand-kept list; each release matrix
must name every declared platform itself; and the coverage table is measured, with
the floor raised from 35% to 55% and the live Docker contracts running on
dependency-only pull requests.

## What was found

All from the audit, each verified by mutation before and after.

**`Compare` had fifteen unproven facts of eighteen.** It is the only thing between
the host that ran the suites and the host somebody froze, and deleting the kernel,
backing-filesystem or nftables check failed nothing. Its runtime sibling was worse:
the test built the observed facts from the reference's own fields and asserted zero
mismatches, so deleting all five checks passed. The new test walks the `Facts` struct
itself — one field drifted at a time, exactly one mismatch required, named by the
field's own JSON tag — so a field added without a check is a failure rather than a
hole.

**The qualification record could name suites that never ran.** The list was a
constant stamped unconditionally; assembly opened three evidence paths and never the
five live logs the pipeline packages. Deleting a suite's step from the workflow left
the published record — a release asset — still naming it, with nothing anywhere able
to tell. Each suite now requires its artifact, and an empty artifact is refused as a
run that produced nothing. `hermetic` is the one gate with no artifact, and the
pairing says why: it is the required check branch protection holds every commit to.

**The neutrality rule said which packages were checked, not which were allowed.** A
new package importing the provider SDK passed by not being listed — while two rules
in the same file already walk the module. Proven by mutation: an SDK import added to
`internal/disk` now fails twice, on the direct edge and the closure.

**The release-platform check compared a union.** Removing the arm64 leg from one
matrix left the union whole through its sibling's, and the capsule index published
without its arm64 child — a gap the assembly's own built-versus-published check also
cannot see, because both of its sides shrink together.

**The coverage table said ~100% where the tree held 57%.** It carries dated, measured
bands now. The floor rises to 55% against a measured 60% — the old 35% let a quarter
of covered statements go dark silently. The one real gap the measurement exposed is
closed: `WorkloadAssignment.Validate` had no test, and `internal/assignment` moved
from 57.1% to 78.6% with it.

## Evidence

Hermetic. Each mutation applied, seen to fail, restored.

| Mutation | Killed by |
| --- | --- |
| kernel, backing_filesystem, nftables checks deleted | 3 subtests of the struct walk |
| four of five runtime-fact checks deleted | 4 subtests |
| the suites list stamped without evidence | both evidence subtests |
| an SDK import in a core package | the module walk, twice |
| one matrix's arm64 leg removed | the per-matrix comparison |
| the coverage floor | `coverage 60.1% meets the 55.0% floor` |

```text
hermetic only — the mutations are the observation. gofmt, go vet, staticcheck,
actionlint and go test -race -shuffle=on -count=1 ./... clean; the qualification
golden record is unchanged, since the proven suite list equals the constant it
replaces whenever the evidence is whole.
```

## What would notice this regressing

The tests above. The struct walk in particular converts two future mistakes into
failures: a `Facts` field added without a `Compare` check, and a field of a kind the
walk cannot drift.

## Risk, compatibility and operations

**Release pipeline: one behavioural change, in the refusing direction.**
`qualify-release` fails at the record step if any suite's evidence is missing or
empty. The pipeline already uploads all five with `if-no-files-found: error`, so a
complete run is unaffected; what dies is the run where a step was deleted or produced
nothing.

**CI cost:** the live Docker contracts now also run on `go.mod`/`go.sum`/image-lock
pull requests — Dependabot's grouped weekly bump, roughly. That is the change class
the suite exists for, and the daily schedule already pays the larger share.

**Coverage floor:** a future PR that deletes a large tested area may now trip the
floor. That is the floor working; `RUNPOOL_COVERAGE_MIN` still overrides.

**Trust boundary, credentials, schema, migration, status API, CLI, configuration,
deployment, rollback, runbook: N/A.**

**Not an ADR.**

## Changelog

```text
Extended under "Release qualification and gates": the qualification record names only
suites whose evidence it holds, every platform fact is proven compared, and each
release matrix must carry every declared platform itself.
```

## Notes for your reviewer

The fixture logs added under `internal/qualification/testdata/evidence/` are
one-line placeholders that say what they stand in for. If fixture bytes that
plausibly resemble real logs would serve the golden test better, that is a taste
call I left at minimal.
