### PR TITLE
fix(config): the operator surface refuses what it cannot honour

### DIFF
--- a/internal/capsule/envelope_test.go
+++ b/internal/capsule/envelope_test.go
@@ -35,6 +35,26 @@ func TestSplitEnvelopeIsConserving(t *testing.T) {
 	if got := capsuleShare.PIDsLimit + gw.PIDsLimit; got != tier.PIDs {
 		t.Errorf("pids: %d + %d = %d; want %d", capsuleShare.PIDsLimit, gw.PIDsLimit, got, tier.PIDs)
 	}
+
+	// Conservation alone holds for any reserve, zero included: the
+	// identity (tier - K) + K == tier says nothing about K. And zero is
+	// the one value Docker reads as a different word — Memory 0,
+	// NanoCPUs 0 and PidsLimit 0 are unlimited, so a zeroed reserve turns
+	// the gateway into an unbounded container outside any tier budget,
+	// with this test green. Both shares are bounded, strictly.
+	for name, pair := range map[string][2]int64{
+		"memory": {gw.MemoryBytes, capsuleShare.MemoryBytes},
+		"cpu":    {gw.NanoCPUs, capsuleShare.NanoCPUs},
+		"pids":   {gw.PIDsLimit, capsuleShare.PIDsLimit},
+	} {
+		if pair[0] <= 0 {
+			t.Errorf("the gateway's %s share is %d; zero is unlimited to the daemon, an unbounded "+
+				"container outside any tier budget", name, pair[0])
+		}
+		if pair[1] <= 0 {
+			t.Errorf("the capsule's %s share is %d; nothing can boot under it", name, pair[1])
+		}
+	}
 }
 
 // TestSplitEnvelopeWithoutGateway: the unsafe-open profile has no

--- a/internal/command/attempts.go
+++ b/internal/command/attempts.go
@@ -211,6 +211,23 @@ func runAttemptsResolve(streams IO, id string, retry, settle bool, reason, actor
 		decision = "retry"
 	}
 	if !apply {
+		// The preview reads the attempt it promises to act on. Printed
+		// from the argument alone, a typo'd or already-settled id
+		// previewed as a confident action and exited zero, and only
+		// --apply discovered the truth.
+		if err := inReadOnlyStore(func(tx *store.Tx) error {
+			attempt, err := tx.Get(assignment.AttemptID(id))
+			if err != nil {
+				return fmt.Errorf("attempt %s: %w", id, err)
+			}
+			if attempt.State != store.AttemptManualReview {
+				return fmt.Errorf("attempt %s is %s, not %s; the applying form would refuse it",
+					id, attempt.State, store.AttemptManualReview)
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
 		fmt.Fprintf(streams.Out, "would %s attempt %s\n  actor:  %s\n  reason: %s\nre-run with --apply to perform it\n",
 			decision, id, actor, reason)
 		return nil

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -96,11 +96,7 @@ func exitCodeFor(err error, root *cobra.Command, streams IO) int {
 		fmt.Fprintf(streams.Err, "run 'runpool --help' for usage.\n")
 		return exitUsage
 	}
-	// A command that already reported its own failure says so by
-	// returning errSilent; printing again would double the message.
-	if !errors.Is(err, errSilent) {
-		fmt.Fprintln(streams.Err, "runpool:", err)
-	}
+	fmt.Fprintln(streams.Err, "runpool:", err)
 	return exitError
 }
 
@@ -196,9 +192,3 @@ func NewRootCommand(build BuildInfo, streams IO) *cobra.Command {
 // operational marks a command as past parsing: from here a failure is
 // the world's, not the caller's, so the usage text would be noise.
 func operational(cmd *cobra.Command) { cmd.SilenceUsage = true }
-
-// errSilent is a failure whose detail a command already wrote to its
-// own output — the doctor's per-check lines, a gc pass's per-eviction
-// errors. Returning it sets the exit code without printing a second,
-// emptier version of the same news.
-var errSilent = errors.New("")

--- a/internal/command/doctor.go
+++ b/internal/command/doctor.go
@@ -58,6 +58,14 @@ func runDoctor(streams IO, asJSON bool) error {
 	switch {
 	case cfgErr != nil:
 		return fmt.Errorf("configuration: %w", cfgErr)
+	case dockErr != nil:
+		// The connection error, not the check's fixed remedy: the check
+		// answers "not connected -- mount the socket" for every failure,
+		// and construction distinguishes an unreachable daemon from one
+		// whose API version is unusable. The one command whose job is
+		// diagnosis must not tell the operator to do what they already
+		// did.
+		return fmt.Errorf("container engine: %w", dockErr)
 	case !report.OK():
 		return errors.New("host does not meet the runtime contract; see the failing checks above")
 	}

--- a/internal/command/gc.go
+++ b/internal/command/gc.go
@@ -51,7 +51,14 @@ func runGC(streams IO, apply, aggressive bool) error {
 		}
 		defer unlock()
 	} else {
-		st, err = store.OpenReadOnly(stateDir())
+		// The shared preview open, not a bare read-only one: gc alone went
+		// around it, so a gc preview against a schema the controller had
+		// not migrated failed with the raw store error and without the
+		// sentence explaining that the safe path is closed while the
+		// irreversible one is open -- and a daemon that could not be
+		// reached leaked the store handle it had already opened.
+		var release func()
+		st, dock, release, err = previewStore(ctx)
 		if errors.Is(err, store.ErrNoState) {
 			fmt.Fprintf(streams.Out, "no state in %s: this instance has not run yet\n", stateDir())
 			return nil
@@ -59,10 +66,7 @@ func runGC(streams IO, apply, aggressive bool) error {
 		if err != nil {
 			return err
 		}
-		dock, err = docker.New(ctx)
-		if err != nil {
-			return fmt.Errorf("docker: %w", err)
-		}
+		defer release()
 	}
 	defer st.Close()
 	defer dock.Close()
@@ -123,6 +127,13 @@ func runGC(streams IO, apply, aggressive bool) error {
 	}
 	if len(res.Failed) > 0 {
 		return fmt.Errorf("%d eviction(s) failed; the next pass retries them", len(res.Failed))
+	}
+	if len(res.AuditFailed) > 0 {
+		// A failed eviction exits non-zero and is retried; a hole in the
+		// audit trail is not retried by anything, which makes it the more
+		// serious of the two and it exited zero -- a script reading $?
+		// saw success for a run that left the trail incomplete.
+		return fmt.Errorf("%d eviction(s) evicted but not recorded in the audit log; the trail is incomplete and no pass rewrites it", len(res.AuditFailed))
 	}
 	return nil
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -235,4 +235,11 @@ const (
 	// cannot boot, so a tier that small is a configuration error rather
 	// than a small tier.
 	MinCapsuleMemory = 512 << 20
+	// MinCapsuleCPUs and MinCapsulePIDs are the same floor on the other
+	// two axes. Memory had one and they did not, so a tier of
+	// cpu "0.500000001" or pids 129 validated and handed the capsule one
+	// nano-CPU or a pid limit of two -- shares no runner plus a daemon can
+	// run under, on a tier that reported itself valid.
+	MinCapsuleCPUs = 500_000_000
+	MinCapsulePIDs = 256
 )

--- a/internal/config/quickstart.go
+++ b/internal/config/quickstart.go
@@ -28,14 +28,16 @@ const (
 // set, every setting a Quick Start variable carries comes from the file
 // alone.
 //
-// The list is every one of them, including those the file also has a
-// place for — logging and the network profile. A variable that is
-// neither applied nor refused is the worst of the three outcomes: an
-// operator who set RUNPOOL_LOG_LEVEL=debug beside a configuration file
-// gets no debug logging and no explanation, and looks for the reason
-// somewhere else.
+// The list is every one of them but RUNPOOL_GITHUB_TOKEN, including
+// those the file also has a place for — logging and the network
+// profile. A variable that is neither applied nor refused is the worst
+// of the three outcomes: an operator who set RUNPOOL_LOG_LEVEL=debug
+// beside a configuration file gets no debug logging and no explanation,
+// and looks for the reason somewhere else. The token is the one
+// exemption, because a file's tokenEnv may legitimately name it; the
+// token file path had no such excuse and was silently ignored anyway.
 var quickStartTargetVars = []string{
-	EnvGitHubURL, EnvGitHubRunnerGroup, EnvHostTopology, EnvHostReserveCPU,
+	EnvGitHubURL, EnvGitHubRunnerGroup, EnvGitHubTokenFile, EnvHostTopology, EnvHostReserveCPU,
 	EnvHostReserveMemory, EnvHostReserveSwap, EnvHostReserveFreeDisk, EnvTier, EnvParallelism,
 	EnvLogLevel, EnvNetworkProfile,
 }

--- a/internal/config/quickstart_test.go
+++ b/internal/config/quickstart_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -151,7 +152,7 @@ func TestLoadFileUnknownField(t *testing.T) {
 // sets RUNPOOL_LOG_LEVEL=debug beside a configuration file gets no debug
 // logging and no explanation, and looks for the reason somewhere else.
 func TestFileModeRefusesEveryQuickStartVariable(t *testing.T) {
-	for _, name := range []string{EnvLogLevel, EnvNetworkProfile} {
+	for _, name := range quickStartTargetVars {
 		environ := func(k string) string {
 			switch k {
 			case EnvConfigFile:
@@ -169,5 +170,27 @@ func TestFileModeRefusesEveryQuickStartVariable(t *testing.T) {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("error for %s = %q; want it to name the variable", name, err)
 		}
+	}
+}
+
+// TestTheConflictListIsTheTwelveVariables. The refusal and its test both
+// iterate quickStartTargetVars, so a variable dropped from the list
+// leaves both self-consistent: production stops refusing it beside a
+// configuration file and the test stops checking it, in one edit. The
+// literals here are the independent statement — a deletion is a diff in
+// this constant, reviewed as one.
+func TestTheConflictListIsTheTwelveVariables(t *testing.T) {
+	want := []string{
+		"RUNPOOL_GITHUB_URL", "RUNPOOL_GITHUB_RUNNER_GROUP", "RUNPOOL_GITHUB_TOKEN_FILE",
+		"RUNPOOL_HOST_TOPOLOGY", "RUNPOOL_HOST_RESERVE_CPU", "RUNPOOL_HOST_RESERVE_MEMORY",
+		"RUNPOOL_HOST_RESERVE_SWAP", "RUNPOOL_HOST_RESERVE_FREE_DISK", "RUNPOOL_TIER",
+		"RUNPOOL_PARALLELISM", "RUNPOOL_LOG_LEVEL", "RUNPOOL_NETWORK_PROFILE",
+	}
+	got := slices.Clone(quickStartTargetVars)
+	slices.Sort(got)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("quickStartTargetVars = %v\nwant %v — RUNPOOL_GITHUB_TOKEN alone is exempt, "+
+			"because a file's tokenEnv may name it", quickStartTargetVars, want)
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/reference"
 	"gopkg.in/yaml.v3"
 )
 
@@ -518,16 +519,23 @@ func ParseTargetURL(raw string) (TargetRef, error) {
 		raw)
 }
 
-// digestQualifiedImage matches a reference pinned to a content digest,
-// which is the only form that cannot move underneath the controller.
-var digestQualifiedImage = regexp.MustCompile(`^.+@sha256:[a-f0-9]{64}$`)
-
 // IsDigestQualifiedImage reports whether a reference names an exact
 // image. It lives here because both the validator and the composition
 // root decide the same thing about the same strings, and two copies of
 // the rule is how one of them eventually accepts a tag.
+//
+// The registry's grammar answers it, not a pattern: the pattern accepted
+// anything before the digest, so a reference no registry could resolve
+// validated here and failed at the pull -- of the image that runs
+// privileged. Canonical is the registry's own word for a named reference
+// pinned to a digest.
 func IsDigestQualifiedImage(ref string) bool {
-	return digestQualifiedImage.MatchString(ref)
+	parsed, err := reference.Parse(ref)
+	if err != nil {
+		return false
+	}
+	_, ok := parsed.(reference.Canonical)
+	return ok
 }
 
 func allDigits(s string) bool {

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -319,3 +319,25 @@ func TestParseTargetURLRefusesReservedRoutes(t *testing.T) {
 		}
 	}
 }
+
+// TestDigestQualifiedMeansARegistryCouldResolveIt: the check gates which
+// image a tier's privileged payload runs, and as a pattern it accepted
+// anything before the digest — a reference no registry could resolve
+// validated and failed at the pull.
+func TestDigestQualifiedMeansARegistryCouldResolveIt(t *testing.T) {
+	const sha = "@sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	for ref, want := range map[string]bool{
+		"ghcr.io/acme/capsule" + sha:      true,
+		"registry.example:5000/img" + sha: true,
+		"img:tag" + sha:                   true,
+		"IMG Q:tag" + sha:                 false,
+		"upper/CASE" + sha:                false,
+		"ghcr.io/acme/capsule:v1":         false,
+		"ghcr.io/acme/capsule@sha256:abc": false,
+		"":                                false,
+	} {
+		if got := IsDigestQualifiedImage(ref); got != want {
+			t.Errorf("IsDigestQualifiedImage(%q) = %v; want %v", ref, got, want)
+		}
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -116,15 +116,15 @@ func Validate(c *Config) error {
 					"must be at least %s: the egress gateway reserves %s of the lease envelope and the capsule needs the rest",
 					ByteSize(GatewayReserveMemory+MinCapsuleMemory), ByteSize(GatewayReserveMemory))
 			}
-			if int64(t.Resources.CPU) <= GatewayReserveCPUs {
+			if int64(t.Resources.CPU) < GatewayReserveCPUs+MinCapsuleCPUs {
 				v.errf(path+".resources.cpu",
-					"must exceed %.1f: the egress gateway reserves that much of the lease envelope",
-					float64(GatewayReserveCPUs)/1e9)
+					"must be at least %.1f: the egress gateway reserves %.1f of the lease envelope and the capsule needs the rest",
+					float64(GatewayReserveCPUs+MinCapsuleCPUs)/1e9, float64(GatewayReserveCPUs)/1e9)
 			}
-			if t.Resources.PIDs <= GatewayReservePIDs {
+			if t.Resources.PIDs < GatewayReservePIDs+MinCapsulePIDs {
 				v.errf(path+".resources.pids",
-					"must exceed %d: the egress gateway reserves that many of the lease envelope",
-					GatewayReservePIDs)
+					"must be at least %d: the egress gateway reserves %d of the lease envelope and the capsule needs the rest",
+					GatewayReservePIDs+MinCapsulePIDs, GatewayReservePIDs)
 			}
 		}
 	}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -64,6 +64,58 @@ func TestValidateRules(t *testing.T) {
 		path   string
 	}{
 		"wrong apiVersion": {func(c *Config) { c.APIVersion = "v2" }, "apiVersion"},
+		// The rejection rules below each survived deletion when this
+		// table lacked their row -- verified by mutation, which is how a
+		// validator's table has to be read: a rule with no row is a rule
+		// review believes in and nothing holds.
+		"wrong kind": {func(c *Config) { c.Kind = "Deployment" }, "kind"},
+		"instance name is not a slug": {func(c *Config) {
+			c.Instance.Name = "Prod Instance"
+		}, "instance.name"},
+		"duplicate tier id": {func(c *Config) {
+			c.Tiers = append(c.Tiers, c.Tiers[0])
+		}, "tiers[1].id"},
+		"no tiers at all":       {func(c *Config) { c.Tiers = nil }, "tiers"},
+		"no targets at all":     {func(c *Config) { c.Targets = nil }, "targets"},
+		"no credentials at all": {func(c *Config) { c.Credentials = nil }, "credentials"},
+		"duplicate credential id": {func(c *Config) {
+			// Resolution by id is last-wins where credentials are read,
+			// so two entries under one id would have a target silently
+			// authenticate with whichever came later.
+			c.Credentials = append(c.Credentials, c.Credentials[0])
+		}, "credentials[1].id"},
+		"duplicate target id": {func(c *Config) {
+			dup := c.Targets[0]
+			dup.URL = "https://github.com/acme/other"
+			c.Targets = append(c.Targets, dup)
+		}, "targets[1].id"},
+		"scale set name is not a slug": {func(c *Config) {
+			c.Targets[0].Tiers[0].ScaleSetName = "Runpool Standard"
+		}, "targets[0].tiers[0].scaleSetName"},
+		"no tier bindings": {func(c *Config) { c.Targets[0].Tiers = nil }, "targets[0].tiers"},
+		"negative host reserve": {func(c *Config) {
+			c.Host.Reserve.CPU = CPUQuantity(-1)
+		}, "host.reserve"},
+		"zero cpu":    {func(c *Config) { c.Tiers[0].Resources.CPU = 0 }, "tiers[0].resources.cpu"},
+		"zero memory": {func(c *Config) { c.Tiers[0].Resources.Memory = 0 }, "tiers[0].resources.memory"},
+		"zero pids":   {func(c *Config) { c.Tiers[0].Resources.PIDs = 0 }, "tiers[0].resources.pids"},
+		"metrics cannot be enabled": {func(c *Config) {
+			c.Observability.Metrics.Enabled = true
+		}, "observability.metrics.enabled"},
+		// The envelope floors. Under the restricted profile a tier holds
+		// the capsule and its gateway together, and memory had a usable-
+		// remainder floor where cpu and pids required only more-than-the-
+		// reserve: a tier of cpu "0.500000001" validated and handed the
+		// capsule one nano-CPU.
+		"memory below the gateway reserve plus the capsule floor": {func(c *Config) {
+			c.Tiers[0].Resources.Memory = ByteSize(GatewayReserveMemory + MinCapsuleMemory - 1)
+		}, "tiers[0].resources.memory"},
+		"cpu leaves the capsule an unusable share": {func(c *Config) {
+			c.Tiers[0].Resources.CPU = CPUQuantity(GatewayReserveCPUs + 1)
+		}, "tiers[0].resources.cpu"},
+		"pids leave the capsule an unusable share": {func(c *Config) {
+			c.Tiers[0].Resources.PIDs = GatewayReservePIDs + 1
+		}, "tiers[0].resources.pids"},
 		"cache on an enterprise target": {func(c *Config) {
 			c.Targets[0].URL = "https://github.com/enterprises/acme"
 			c.Targets[0].RunnerGroup = "runpool"
@@ -432,5 +484,20 @@ func TestJobCeiling(t *testing.T) {
 	own := Duration(90 * time.Minute)
 	if got := (Tier{JobTimeout: &own}).Ceiling(); got != 90*time.Minute {
 		t.Errorf("a tier naming a ceiling waits %s, want its own", got)
+	}
+}
+
+// TestTheEnvelopeFloorsApplyOnlyWhereAGatewayExists: under
+// unsafe-open-egress no gateway is built and the whole tier is the
+// capsule's, so the floors above the plain positivity checks would
+// refuse tiers the profile can serve.
+func TestTheEnvelopeFloorsApplyOnlyWhereAGatewayExists(t *testing.T) {
+	c := validConfig()
+	c.Network.Profile = NetworkProfileUnsafeOpen
+	c.Tiers[0].Resources.Memory = ByteSize(GatewayReserveMemory + MinCapsuleMemory - 1)
+	c.Tiers[0].Resources.CPU = CPUQuantity(GatewayReserveCPUs + 1)
+	c.Tiers[0].Resources.PIDs = GatewayReservePIDs + 1
+	if err := Validate(c); err != nil {
+		t.Errorf("a small tier under unsafe-open-egress was refused: %v", err)
 	}
 }

--- a/internal/disk/disk_test.go
+++ b/internal/disk/disk_test.go
@@ -155,10 +155,25 @@ func TestObligations(t *testing.T) {
 }
 
 func TestLevelStringsRoundTrip(t *testing.T) {
-	for _, l := range []Level{Normal, High, SoftEmergency, HardEmergency} {
-		got, err := ParseLevel(l.String())
+	// The literals, not String() fed back to ParseLevel: ParseLevel is
+	// defined as the inverse of String, so a round trip can catch a
+	// collision and never a rename -- and these four strings are a
+	// durable contract, persisted in the pressure row and published in
+	// the runbook. A controller upgraded across a rename fails ParseLevel
+	// in resume, which returns before the admission gate is restored, and
+	// admits into the emergency it was resuming.
+	for want, l := range map[string]Level{
+		"normal":         Normal,
+		"high":           High,
+		"soft_emergency": SoftEmergency,
+		"hard_emergency": HardEmergency,
+	} {
+		if got := l.String(); got != want {
+			t.Errorf("%d renders %q; %q is what a persisted row and the runbook hold", int(l), got, want)
+		}
+		got, err := ParseLevel(want)
 		if err != nil || got != l {
-			t.Errorf("round trip %s: %v, %v", l, got, err)
+			t.Errorf("ParseLevel(%q) = %v, %v; a stored level must parse back", want, got, err)
 		}
 	}
 	if _, err := ParseLevel("frobnicated"); err == nil {

--- a/internal/platform/githubactions/client.go
+++ b/internal/platform/githubactions/client.go
@@ -328,7 +328,17 @@ var (
 // opposite outcomes, and a caller that cannot tell them apart logs the
 // same line for a successful cleanup and for a leaked registration.
 func (c *Client) RemoveRunner(ctx context.Context, id int) error {
-	if err := c.c.RemoveRunner(ctx, int64(id)); err != nil {
+	return wrapRemoveRunner(id, c.c.RemoveRunner(ctx, int64(id)))
+}
+
+// wrapRemoveRunner adds the runner to the provider's answer without
+// flattening it: the recovery path switches on the sentinels inside, and
+// a wrap that dropped them would log a leaked registration as an
+// ordinary cleanup failure. Named so the wrap itself is what the test
+// holds -- constructed in the test, the same assertion proved only the
+// standard library.
+func wrapRemoveRunner(id int, err error) error {
+	if err != nil {
 		return fmt.Errorf("remove runner %d: %w", id, err)
 	}
 	return nil

--- a/internal/platform/githubactions/errors_test.go
+++ b/internal/platform/githubactions/errors_test.go
@@ -2,7 +2,6 @@ package githubactions
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/actions/scaleset"
@@ -22,16 +21,21 @@ func TestDeregistrationRefusalsStayDistinguishable(t *testing.T) {
 		notFound  bool
 		stillBusy bool
 	}{
+		// Through the production wrap, not a wrap the test builds:
+		// constructed here, the same assertion held fmt.Errorf and
+		// nothing of this adapter -- flattening the wrap in the client
+		// left it green while recovery logged a leaked registration as
+		// an ordinary cleanup failure.
 		"already removed": {
-			err:      fmt.Errorf("remove runner 7: %w", scaleset.RunnerNotFoundError),
+			err:      wrapRemoveRunner(7, scaleset.RunnerNotFoundError),
 			notFound: true,
 		},
 		"the provider holds it busy": {
-			err:       fmt.Errorf("remove runner 7: %w", scaleset.JobStillRunningError),
+			err:       wrapRemoveRunner(7, scaleset.JobStillRunningError),
 			stillBusy: true,
 		},
 		"some other failure": {
-			err: fmt.Errorf("remove runner 7: %w", errors.New("503 from the broker")),
+			err: wrapRemoveRunner(7, errors.New("503 from the broker")),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## What changes

The envelope floors apply to all three axes, so a tier that validates is one the split
can hand a usable share; the validator's table carries eighteen rejection rows that had
none; `IsDigestQualifiedImage` reads the registry's grammar; the file-mode conflict
list carries the token-file variable it silently ignored; and four operator-surface
commands answer with what they saw — the doctor's connection error, gc's preview
through the shared open and a non-zero exit on audit holes, a resolve preview that
reads the attempt, and `errSilent` deleted. The disk levels are pinned as literals and
the deregistration wrap is tested as production code.

## What was found

All audit findings, each held by a mutation.

**A valid tier could be unusable.** Memory had a usable-remainder floor; CPU and PIDs
required only more-than-the-reserve, so `cpu: "0.500000001"` or `pids: 129` validated
and the split handed the capsule one nano-CPU or a pid limit of two. The block's
comment claimed it prevented an unusable share; it prevented a negative one. The
conservation test also bounds both shares strictly now — its identity held for any
reserve including zero, and zero is the one value the daemon reads as *unlimited*, so
a zeroed reserve made the gateway an unbounded container with the test green.

**Eighteen rules had no row.** Each was deleted and the suite stayed green. Duplicate
credential id matters most: resolution is last-wins where credentials are read, so two
entries under one id had a target silently authenticate with whichever came later.

**Four commands knew more than they said.** The doctor let its check answer "mount the
socket" for every connection failure, including a mounted socket the uid cannot read.
gc's dry run went around `previewStore`, losing the schema-behind explanation and
leaking a store handle on a daemon error, and `--apply` exited zero on audit holes —
which no pass rewrites, making them strictly more serious than the failed evictions
that exit one. The resolve preview printed a promise from its argument alone. And
`errSilent` was dead: nothing returned it, its branch was unreachable, and its comment
described behaviour no command has.

Deliberately deferred, with the reason: the retention pass's per-run limit note and
audit row remain unproven. Driving them needs a released lease backdated past the
window, and backdating crosses the store boundary with raw SQL a test seam would have
to carry. If that seam is acceptable it is a small follow-up; it did not belong as a
side effect here.

## Evidence

Hermetic. Each mutation applied, seen to fail, restored.

| Mutation | Killed by |
| --- | --- |
| the three envelope floors deleted | 3 rows of the validator table |
| the gateway memory reserve zeroed | the strict bound in the conservation test |
| the token-file variable delisted | the twelve-literal list test |
| `soft_emergency` renamed | the literal level test |
| the `%w` wrap flattened to `%v` | the refusal-distinguishability test |

```text
hermetic only — gofmt, go vet, staticcheck, go test -race -shuffle=on -count=1 ./...
clean. Two mutations did not compile on the first attempt (an unused import each);
both were redone in a compiling form before being credited.
```

## What would notice this regressing

The tests above. The literals — the twelve variables, the four level strings — are
restatements on purpose: the production list and its test otherwise iterate the same
slice, and a deletion left both self-consistent.

## Risk, compatibility and operations

**Configuration: previously-accepted documents are now refused**, in exactly the cases
where the accepted document could not serve: a tier whose CPU or PID share cannot boot
a runner, and a Quick Start token-file variable beside a configuration file that was
being ignored. Both refusals say what to change.

**CLI exit codes:** `gc --apply` exits non-zero when eviction audit rows could not be
written. Scripts reading `$?` see the trail's incompleteness now; the eviction itself
still happened, and the message says no pass rewrites the trail.

**CLI behaviour:** the resolve preview can now refuse — on an id that does not exist or
an attempt not in manual review — where it previously printed a promise and exited
zero. That is the applying form's own refusal, moved to where the operator reads it.

**Trust boundary, credentials, networking, schema, migration, status API, deployment,
rollback: N/A.**

**Runbook: N/A** — no procedure changes; two error messages get better.

**Not an ADR.**

## Changelog

```text
Two bullets under "State and operations": a tier that validates is one the split can
hand a usable share, and the operator surface answers with what it saw.
```
