### PR TITLE
test(lease): ownership travels to the daemon, and the tests can see it

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -22,6 +22,7 @@ type fakeVolumes struct {
 	removed   []string
 	ensureErr error
 	foreign   bool
+	proofs    []ownershipProof
 }
 
 func (f *fakeVolumes) EnsureOwnedVolume(_ context.Context, name string, labels map[string]string) error {
@@ -36,6 +37,11 @@ func (f *fakeVolumes) EnsureOwnedVolume(_ context.Context, name string, labels m
 }
 
 func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind engine.ObjectKind, name string, instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error) {
+	// The scope is recorded because it is the argument under test: a
+	// proof asked for under a blank or foreign instance matches nothing
+	// at a real daemon, and the fakes discarding it was how deleting the
+	// proof call, or mis-scoping it, stayed green.
+	f.proofs = append(f.proofs, ownershipProof{kind, name, instanceID, leaseID})
 	if f.foreign {
 		return "", engine.ErrForeignResource
 	}
@@ -43,6 +49,13 @@ func (f *fakeVolumes) OwnedIDByName(_ context.Context, kind engine.ObjectKind, n
 		return "", nil
 	}
 	return name, nil
+}
+
+type ownershipProof struct {
+	kind     engine.ObjectKind
+	name     string
+	instance assignment.InstanceID
+	lease    assignment.LeaseID
 }
 
 func (f *fakeVolumes) RemoveVolume(_ context.Context, name string) error {

--- a/internal/cache/gc_test.go
+++ b/internal/cache/gc_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rhobuild/runpool/internal/store"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/engine"
 )
 
 // gcFixture builds lanes with controlled ages and sizes. Ages are set
@@ -224,6 +225,95 @@ func TestAggressiveCollectionPlansLanesTheDaemonCannotSize(t *testing.T) {
 	for _, e := range plan.Evictions {
 		if e.Reason != "emergency" {
 			t.Errorf("lane %s evicted as %q, want emergency", e.LaneID, e.Reason)
+		}
+	}
+}
+
+// TestTheOrphanSweepProvesOwnershipUnderThisInstance: the volume
+// namespace is shared, so the sweep re-proves ownership before removing
+// — and the proof is only a proof under the right scope. Deleting the
+// call, or asking under another instance's id, was invisible: the fake
+// discarded the arguments, and the adapter's own refusal runs only in
+// the live contracts.
+func TestTheOrphanSweepProvesOwnershipUnderThisInstance(t *testing.T) {
+	m, st, vols := gcFixture(t)
+	loc := addLane(t, m, st, vols, repoURL, "gen", "l1", 1, 50)
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.DeleteCacheLane(loc.LaneID)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := m.PlanGC(t.Context(), GCOptions{TargetBytes: -1, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vols.proofs = nil
+	if _, err := m.RunGC(t.Context(), plan, "test"); err != nil {
+		t.Fatal(err)
+	}
+	if len(vols.proofs) != 1 {
+		t.Fatalf("ownership was proven %d times for 1 removal; the namespace is shared and the "+
+			"proof is the only thing between the sweep and somebody else's volume", len(vols.proofs))
+	}
+	p := vols.proofs[0]
+	if p.kind != engine.KindVolume || p.name != loc.Volume ||
+		p.instance != st.InstanceID() || p.lease != "" {
+		t.Errorf("proof = %+v; want volume %q under instance %q with no lease — an orphan has none",
+			p, loc.Volume, st.InstanceID())
+	}
+
+	// And a volume that fails the proof is left alone.
+	loc2 := addLane(t, m, st, vols, repoURL, "gen", "l2", 1, 50)
+	if err := st.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.DeleteCacheLane(loc2.LaneID)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	plan2, err := m.PlanGC(t.Context(), GCOptions{TargetBytes: -1, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	vols.foreign = true
+	before := len(vols.removed)
+	res, err := m.RunGC(t.Context(), plan2, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols.removed) != before {
+		t.Error("a volume that failed the ownership proof was removed anyway")
+	}
+	if len(res.Failed) == 0 {
+		t.Error("a refused removal must be reported, not absorbed")
+	}
+}
+
+// TestTheSweepIsBlindToRolesItDoesNotOwn: the GC's universe is the role
+// label. The fake used to synthesize usage only from Acquire, so every
+// volume it reported was a lane and the two role guards could be deleted
+// with everything green — while the real client returns every volume
+// this instance owns, dind data and workspaces included, and a sweep
+// without the guards would evict a live capsule's daemon state as an
+// "orphan" with no row.
+func TestTheSweepIsBlindToRolesItDoesNotOwn(t *testing.T) {
+	m, _, vols := gcFixture(t)
+	if vols.ensured == nil {
+		vols.ensured = map[string]map[string]string{}
+	}
+	vols.ensured["runpool-dind-1"] = map[string]string{
+		"io.runpool.managed":  "true",
+		"io.runpool.role":     "dind-data",
+		"io.runpool.instance": "instance-1",
+	}
+	vols.sizes["runpool-dind-1"] = 500
+
+	plan, err := m.PlanGC(t.Context(), GCOptions{TargetBytes: -1, Now: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range plan.Evictions {
+		if ev.Volume == "runpool-dind-1" {
+			t.Fatalf("the plan evicts %q, a dind data volume: the sweep reached past its role "+
+				"into a live capsule's daemon state", ev.Volume)
 		}
 	}
 }

--- a/internal/lease/lease_test.go
+++ b/internal/lease/lease_test.go
@@ -29,6 +29,37 @@ func (nopRemover) RemoveOwnedVolume(context.Context, string, assignment.Instance
 	return nil
 }
 
+// recordingRemover keeps every removal it was asked for, with the
+// ownership scope it was asked under. The fakes before it declared those
+// parameters and discarded them, so a removal that blanked its lease id
+// — or swapped in another instance's — reached the daemon unnoticed by
+// every hermetic test: the adapter's refusal is proved live, and the
+// caller's wiring was proved by nothing.
+type recordingRemover struct {
+	calls []removal
+}
+
+type removal struct {
+	kind     store.ResourceKind
+	handle   string
+	instance assignment.InstanceID
+	lease    assignment.LeaseID
+}
+
+func (r *recordingRemover) record(kind store.ResourceKind, handle string, i assignment.InstanceID, l assignment.LeaseID) error {
+	r.calls = append(r.calls, removal{kind, handle, i, l})
+	return nil
+}
+func (r *recordingRemover) RemoveOwnedContainer(_ context.Context, h string, i assignment.InstanceID, l assignment.LeaseID) error {
+	return r.record(store.ResourceContainer, h, i, l)
+}
+func (r *recordingRemover) RemoveOwnedNetwork(_ context.Context, h string, i assignment.InstanceID, l assignment.LeaseID) error {
+	return r.record(store.ResourceNetwork, h, i, l)
+}
+func (r *recordingRemover) RemoveOwnedVolume(_ context.Context, h string, i assignment.InstanceID, l assignment.LeaseID) error {
+	return r.record(store.ResourceVolume, h, i, l)
+}
+
 // wedgedRemover fails every removal until healed — the daemon a
 // quarantined lease is waiting on.
 type wedgedRemover struct{ healed bool }
@@ -269,15 +300,36 @@ func TestFinalizeIsAtomic(t *testing.T) {
 // Release walks a live lease all the way to released, removing every
 // owned object on the way and disposing of the attempt by evidence.
 func TestReleaseRemovesEverythingAndDisposes(t *testing.T) {
-	f := newFixture(t, nopRemover{})
+	remover := &recordingRemover{}
+	f := newFixture(t, remover)
 	f.driveTo(store.LeaseWorkloadRunning)
 	f.recordEvidence(store.EvidenceExitObserved)
+	// The full shape of a sandboxed lease, not one container: the order
+	// is only observable with something to order, and every test that
+	// reached the removal planned exactly one intent — so inverting the
+	// sort, or deleting it, failed nothing, while a release that removes
+	// a network before the containers holding it is refused by the
+	// daemon on every pass and quarantines the lease forever.
 	f.tx(func(tx *store.Tx) error {
-		id, err := tx.PlanResource(f.lease.ID, store.ResourceContainer, "runner", "runpool-runner-1")
-		if err != nil {
-			return err
+		for _, in := range []struct {
+			kind store.ResourceKind
+			role string
+			name string
+		}{
+			{store.ResourceNetwork, "capsule-net", "runpool-net-1"},
+			{store.ResourceVolume, "dind-data", "runpool-dind-1"},
+			{store.ResourceContainer, "runner", "runpool-runner-1"},
+			{store.ResourceVolume, "workspace", "runpool-ws-1"},
+		} {
+			id, err := tx.PlanResource(f.lease.ID, in.kind, in.role, in.name)
+			if err != nil {
+				return err
+			}
+			if err := tx.MarkResourcePresent(assignment.ResourceIntentID(id), in.name); err != nil {
+				return err
+			}
 		}
-		return tx.MarkResourcePresent(assignment.ResourceIntentID(id), "runner-1")
+		return nil
 	})
 
 	if err := f.m.Release(t.Context(), f.lease.ID, store.LeaseWorkloadRunning); err != nil {
@@ -286,6 +338,23 @@ func TestReleaseRemovesEverythingAndDisposes(t *testing.T) {
 	if got := f.reload(); got.State != store.LeaseReleased {
 		t.Errorf("lease = %s; want released", got.State)
 	}
+
+	if len(remover.calls) != 4 {
+		t.Fatalf("removed %d objects; want all 4", len(remover.calls))
+	}
+	if remover.calls[0].kind != store.ResourceContainer {
+		t.Errorf("removed a %s first; containers go first, because the network and the "+
+			"volumes they hold cannot be removed under them", remover.calls[0].kind)
+	}
+	instance := f.m.store.InstanceID()
+	for _, c := range remover.calls {
+		if c.instance != instance || c.lease != f.lease.ID {
+			t.Errorf("removed %s %q as instance %q lease %q; want %q and %q — the scope is "+
+				"what keeps a stale intent from deleting a foreign object that reused its name",
+				c.kind, c.handle, c.instance, c.lease, instance, f.lease.ID)
+		}
+	}
+
 	f.tx(func(tx *store.Tx) error {
 		intents, err := tx.Resources(f.lease.ID)
 		if err != nil {


### PR DESCRIPTION
## What changes

The lease and cache removers record the ownership scope they are asked under, and the
tests assert it: removal order over the full shape of a sandboxed lease, the instance
and lease ids on every destructive call, the cache sweep's ownership proof in both
directions, and the role guards that keep the sweep out of dind data and workspaces.
Test-only, plus one typed field where a bare string had crept in.

## What was found

Audit findings 8, 9 and 30, one shape: **every fake that received an ownership scope
declared the parameters and discarded them.** The adapter's refusal — the mechanism —
is proved by the live contracts; the callers' wiring, which decides what scope reaches
that mechanism, was proved by nothing. Verified by mutation: blanking the lease id in
`removeObject`, proving ownership under `"not-this-instance"` in the cache sweep, and
deleting the proof call entirely all left every suite green.

Removal order had the same blindness for a different reason: every test that reached
`RemoveResources` planned exactly one intent, always a container, so the dependency
sort ordered nothing. Inverted, a release removes the network before the containers
holding it — refused by the daemon on every pass, quarantining the lease with its
credit forever.

The role guards were unfalsifiable by fixture: the fake synthesized usage only from
`Acquire`, so every volume it reported was a lane. The real client returns every
volume the instance owns — dind data and workspaces included — and a sweep without
the guards evicts a live capsule's daemon state as an "orphan" with no row.

## Evidence

Hermetic. Each mutation applied, seen to fail, restored.

| Mutation | Killed by |
| --- | --- |
| the dependency sort inverted | the ordered-removal assertion |
| the lease id blanked in `removeObject` | the scope assertion on every call |
| the sweep's ownership proof deleted | `ownership was proven 0 times for 1 removal` |
| the proof asked under another instance | the proof-scope assertion |
| both role guards deleted | `the plan evicts "runpool-dind-1", a dind data volume` |

```text
hermetic only — the mutations are the observation. gofmt, go vet, staticcheck,
go test -race -shuffle=on -count=1 ./... clean. One mutation needed redoing in a
compiling form (an unused import), and one first test run panicked on a fixture nil
map — both were fixed before any mutation was credited.
```

## What would notice this regressing

The recording removers themselves: any new removal path wired through them carries
its scope into the record, so a future caller that blanks it fails the same
assertions without new test code.

## Risk, compatibility and operations

**Production changes: none.** Test files, and one typed struct field.

**Trust boundary:** these tests now hold hermetically what `docs/architecture.md`
claims and only the live contracts previously touched — that ownership is proven
before removal, under this instance's scope, and that the sweep's universe is the
role label.

**Everything else: N/A. Not an ADR.**

## Changelog

```text
NONE
```
