### PR TITLE
fix(capsule-supervisor): the credential channel and the reaper are held by tests

### DIFF
--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -112,19 +112,7 @@ func main() {
 func runSubcommand(args []string) int {
 	switch args[0] {
 	case "deliver":
-		// The bundle arrives on stdin and lands on tmpfs, 0600 and
-		// runner-owned. This delivery step never places it in Docker
-		// metadata or logs it.
-		payload, err := io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
-		if err != nil || len(payload) == 0 {
-			fmt.Fprintln(os.Stderr, "deliver: no credential on stdin")
-			return 1
-		}
-		if err := atomicfile.Replace(jitFile, payload, 0o600, runnerUID, runnerGID); err != nil {
-			fmt.Fprintln(os.Stderr, "deliver:", err)
-			return 1
-		}
-		return 0
+		return deliver(os.Stdin, os.Stderr, jitFile, runnerUID, runnerGID)
 	case "start":
 		// The state goes first. PID 1 does not learn of an authorization
 		// until it polls for the file below, and it writes nothing of its
@@ -357,7 +345,7 @@ func run(log *slog.Logger) (int, error) {
 	}
 	defer stopDockerd(log, dockerd, dockerdExit)
 
-	if err := awaitDockerdReady(ctx); err != nil {
+	if err := awaitDockerdReady(ctx, reap); err != nil {
 		return -1, err
 	}
 	log.Info("dockerd ready", "socket", dockerSocket)
@@ -412,10 +400,10 @@ func stopDockerd(log *slog.Logger, dockerd *exec.Cmd, exit chan int) {
 	}
 }
 
-func awaitDockerdReady(ctx context.Context) error {
+func awaitDockerdReady(ctx context.Context, reap *reaper) error {
 	deadline := time.Now().Add(dockerdReadyTimeout)
 	for {
-		if probeDockerd(ctx) == nil {
+		if probeDockerd(ctx, reap) == nil {
 			return nil
 		}
 		if time.Now().After(deadline) {
@@ -433,7 +421,7 @@ func awaitDockerdReady(ctx context.Context) error {
 // daemon that accepts the socket and then never answers would otherwise
 // spend the whole readiness budget inside a single call, and PID 1 has
 // nobody outside it to cut that short.
-func probeDockerd(ctx context.Context) error {
+func probeDockerd(ctx context.Context, reap *reaper) error {
 	ctx, cancel := context.WithTimeout(ctx, dockerdProbeTimeout)
 	defer cancel()
 	probe := exec.CommandContext(ctx, "docker", "--host=unix://"+dockerSocket, "info")
@@ -443,7 +431,25 @@ func probeDockerd(ctx context.Context) error {
 	// keeps open. The probe would return only when the orphan did,
 	// leaving the bound above describing nothing.
 	probe.Stdout, probe.Stderr = nil, nil
-	return probe.Run()
+	// Started under the reaper, like every child here: its own doc says
+	// there is exactly one place that calls wait4, and this probe was a
+	// second waiter. Whichever won reaped the exit -- and when the reaper
+	// won, Run read "no child processes" and a ready daemon was reported
+	// as not ready, one lost probe per race on every launch.
+	ch, err := reap.start(probe)
+	if err != nil {
+		return err
+	}
+	select {
+	case code := <-ch:
+		if code != 0 {
+			return fmt.Errorf("docker info exited %d", code)
+		}
+		return nil
+	case <-ctx.Done():
+		// CommandContext kills the process; the reaper collects it.
+		return ctx.Err()
+	}
 }
 
 // awaitStart blocks until the controller authorizes the start. The
@@ -718,4 +724,32 @@ func currentState() string {
 		return ""
 	}
 	return strings.TrimSpace(string(body))
+}
+
+// maxJITBundle bounds the credential delivery. A real bundle is a few
+// kilobytes; the bound exists so a runaway writer cannot fill the tmpfs
+// the control surface lives on.
+const maxJITBundle = 1 << 20
+
+// deliver lands the credential bundle from stdin on tmpfs, 0600 and
+// runner-owned, and never places it in Docker metadata or logs it. The
+// read goes one byte past the bound so a bundle that exceeds it is
+// refused rather than silently truncated: a truncated credential is not
+// a smaller credential, it is a corrupt one the runner fails on later
+// with nothing naming the cause.
+func deliver(stdin io.Reader, stderr io.Writer, path string, uid, gid int) int {
+	payload, err := io.ReadAll(io.LimitReader(stdin, maxJITBundle+1))
+	if err != nil || len(payload) == 0 {
+		fmt.Fprintln(stderr, "deliver: no credential on stdin")
+		return 1
+	}
+	if len(payload) > maxJITBundle {
+		fmt.Fprintf(stderr, "deliver: credential exceeds %d bytes\n", maxJITBundle)
+		return 1
+	}
+	if err := atomicfile.Replace(path, payload, 0o600, uid, gid); err != nil {
+		fmt.Fprintln(stderr, "deliver:", err)
+		return 1
+	}
+	return 0
 }

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -10,9 +11,11 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -229,7 +232,7 @@ func TestTheReadinessProbeIsBounded(t *testing.T) {
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	start := time.Now()
-	err := probeDockerd(t.Context())
+	err := probeDockerd(t.Context(), testReaper())
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -468,3 +471,91 @@ func TestTheStartSubcommandAuthorizesThroughTheOrderedPath(t *testing.T) {
 			"beside that and prove nothing", fset.Position(clause.Pos()))
 	}
 }
+
+// TestDeliverIsTheCredentialChannel: the bundle lands 0600 with exactly
+// the bytes that arrived, an empty delivery is refused, and one past the
+// bound is refused rather than silently truncated — a truncated
+// credential is a corrupt one the runner fails on later with nothing
+// naming the cause. Nothing here covered this verb at all, and it is the
+// channel the JIT credential crosses.
+func TestDeliverIsTheCredentialChannel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "jitconfig")
+	var stderr bytes.Buffer
+
+	if code := deliver(strings.NewReader(""), &stderr, path, -1, -1); code != 1 {
+		t.Errorf("an empty delivery returned %d; want refusal", code)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a refused delivery left a file behind")
+	}
+
+	if code := deliver(strings.NewReader(strings.Repeat("x", maxJITBundle+1)), &stderr, path, -1, -1); code != 1 {
+		t.Errorf("a bundle past the bound returned %d; want refusal, not truncation", code)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("an oversized delivery left a truncated credential behind")
+	}
+
+	bundle := `{"runner":{},"credentials":{}}`
+	if code := deliver(strings.NewReader(bundle), &stderr, path, -1, -1); code != 0 {
+		t.Fatalf("deliver = %d, stderr %q", code, stderr.String())
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != bundle {
+		t.Errorf("the file holds %q, %v; want the bytes that arrived", got, err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v; want 0600 — the bundle is readable by whoever the mode admits", info.Mode().Perm())
+	}
+}
+
+// TestTheReaperDeliversEachTrackedExitOnce: the reaper is the one place
+// that calls wait4, and a wrong status here is a wrong disposition — the
+// runner's exit code is the whole of what the observation machine rules
+// on. A child that dies instantly must still be reaped as tracked,
+// because registration and the reap loop hold the same lock.
+//
+// It runs real children, so nothing else in this package may exec
+// concurrently: the reaper's wait4(-1) would steal their statuses. The
+// package's other tests are pure, which is what makes this one safe.
+func TestTheReaperDeliversEachTrackedExitOnce(t *testing.T) {
+	r := testReaper()
+
+	ch, err := r.start(exec.Command("true"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case code := <-ch:
+		if code != 0 {
+			t.Errorf("true exited %d; want 0", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the tracked exit never arrived; a child that died instantly was reaped as an orphan")
+	}
+
+	cmd := exec.Command("sh", "-c", "exit 7")
+	ch, err = r.start(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case code := <-ch:
+		if code != 7 {
+			t.Errorf("the child exited %d; want its own 7 — a wrong status is a wrong disposition", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the tracked exit never arrived")
+	}
+}
+
+// testReaper is the one reaper the package's tests share. Two reapers in
+// one process are two wait4(-1) loops racing for every child — the exact
+// hazard the reaper exists to remove — and under shuffle the loser's
+// tracked channel never fires. The production process has one; the test
+// process gets one.
+var testReaper = sync.OnceValue(newReaper)


### PR DESCRIPTION
## What changes

The supervisor's credential verb is a tested function that refuses an oversized bundle
instead of silently truncating it; the reaper's registration-under-lock property is
held by real children; and the dockerd readiness probe starts under the reaper instead
of racing it for the exit status.

## What was found

**`deliver` had no test, and a real defect.** It is the verb the JIT credential
crosses — the audit named it as the untested credential channel — and its read capped
at the bound without comparing, so a bundle past it was truncated and delivered: not a
smaller credential, a corrupt one the runner fails on later with nothing naming the
cause. The same shape as the gateway's `Reload`, fixed the same way: read one past,
compare, refuse. The test holds the mode, the exact bytes, and both refusals; changing
`0o600` to `0o644` now fails.

**The reaper had no test**, and it decides which exit code reaches the observation
machine — a wrong status is a wrong disposition, which is the property the whole
at-most-once design rules on. Its subtle half is registration-under-lock: a child that
dies instantly must still be reaped as tracked, because the reap loop and `start` hold
one mutex. Held now by an instantly-exiting child and one with a code of its own.

**The probe was the second waiter the reaper's own doc forbids.** `probeDockerd`
called `Run`, whose `Wait` raced the reaper's `wait4(-1)`. Whichever won reaped the
exit; when the reaper won, the probe read "no child processes" and reported a ready
daemon as not ready — one lost probe per race, on every capsule launch. It starts
under the reaper now and reads the exit from the channel like every other child, with
`CommandContext` still enforcing the per-probe bound.

The test process taught the lesson back: my first version spun a second reaper for the
probe test, and under shuffle the two `wait4` loops raced for every child exactly as
the design warns — the package's tests now share one reaper, with the reason written
on it.

## Evidence

```text
hermetic only — the reaper and deliver run real processes and real files inside the
test. gofmt, go vet, staticcheck, go test -race -shuffle=on -count=1 ./... clean;
the supervisor package also passes -count=2 under shuffle, which is what caught the
two-reaper race.
```

The mode mutation (`0o600` → `0o644`), the truncation mutation (dropping the length
compare), and the empty-refusal mutation each fail the deliver test.

## What would notice this regressing

`TestDeliverIsTheCredentialChannel` and `TestTheReaperDeliversEachTrackedExitOnce`.
The probe's routing is held by `TestTheReadinessProbeIsBounded`, which now runs
through the shared reaper.

## Risk, compatibility and operations

**Trust boundary:** the credential file's mode and content are now pinned by a test;
the delivery path itself is unchanged apart from the new refusal.

**Behaviour change: one refusal.** A bundle over 1 MiB is refused with an error naming
the bound. Real bundles are kilobytes; the writer is the controller's own exec.

**Capsule boot:** the probe's success and failure paths are unchanged; what changes is
that a ready daemon is no longer intermittently reported as not ready. Worst case per
race was one 500ms retry inside the existing budget.

**Schema, migration, status API, CLI, configuration, deployment, rollback, runbook:
N/A. Not an ADR.**

## Changelog

```text
NONE — the one behaviour change refuses a bundle no real writer produces.
```
