### PR TITLE
refactor(app): the egress policy engine moves under the rules

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ cmd/runpool
         -> internal/capsule      prepare, start, inspect one execution capsule
         -> internal/lease        the lease machine, the cleanup saga, disposition
         -> internal/egress       pure egress policy: deny sets and decisions
+        -> internal/netsandbox   the egress policy lifecycle: discovery, snapshot, fan-out
         -> internal/cache        cache lanes and their garbage collection
         -> internal/disk         the disk-pressure state machine
         -> internal/doctor       host preflight
@@ -48,7 +49,9 @@ The arrow never points from lifecycle or state domains to a provider. An
 architecture test enforces it: core packages may not depend on
 `internal/platform/githubactions` or on the provider SDK, directly or
 transitively. `internal/app` is deliberately exempt because injecting the
-adapter is its job. The configuration schema names GitHub scale-set settings
+adapter is its job -- which is why the egress policy lifecycle lives in
+`internal/netsandbox` rather than beside it: a security decision belongs
+under the rules, not in the one package that is outside them. The configuration schema names GitHub scale-set settings
 because GitHub Actions is the only supported provider; it does not claim a
 generic provider API that does not exist.
 

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -5,10 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"slices"
-
 	"github.com/rhobuild/runpool/internal/cache"
-	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/disk"
 	"github.com/rhobuild/runpool/internal/engine"
@@ -205,30 +202,4 @@ func TestCollectGarbageRunsWhatTheLevelObliges(t *testing.T) {
 		t.Fatalf("a soft emergency left %d free lane(s); AllFree did not reach the planner", lanes())
 	}
 	_ = loc
-}
-
-// TestRediscoverClosesEveryGatewayWhenDiscoveryFails. The policy in force
-// is not a safe fallback, only an older one: a network that appeared
-// since it was computed is reachable and there is no way to tell. So a
-// discovery that cannot be trusted closes every gateway rather than
-// relaying under a set that cannot be shown to be current.
-func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
-	d := &fakeSandboxDaemon{
-		uplinkID:     "up-1",
-		uplinkSubnet: "172.30.0.0/24",
-		probeOut:     "", // saw nothing: the deny set cannot be trusted
-		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
-			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
-		},
-	}
-	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
-
-	n.rediscover(t.Context())
-
-	// Sorted: closing fans out, so the order is the order the daemon
-	// answered in and nothing should depend on it.
-	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
-		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removes())
-	}
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -143,7 +143,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 
 	recorder := s.leases.Recorder(ctx, lease.ID)
 	s.advanceAttempt(ctx, attemptID, store.AttemptLeased, store.AttemptPreparing)
-	sandbox, err := s.netSandbox.forLaunch(prepCtx)
+	sandbox, err := s.netSandbox.ForLaunch(prepCtx)
 	if err != nil {
 		log.Error("network sandbox refresh failed", "error", err)
 		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
@@ -180,7 +180,7 @@ func (s *Controller) runCapsule(b *binding, lease store.Lease) {
 	// the policy it carries can be checked against the one in force --
 	// and the last moment before the capsule is authorized to start, so
 	// it is the only one at which a stale gateway is still free.
-	if err := s.netSandbox.confirmLaunch(prepCtx, lease.ID, sandbox); err != nil {
+	if err := s.netSandbox.ConfirmLaunch(prepCtx, lease.ID, sandbox); err != nil {
 		log.Error("the capsule's gateway does not carry the egress policy in force", "error", err)
 		s.recoverCapsuleFailure(ctx, b, lease.ID, startObs)
 		return

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/engine/docker"
 	"github.com/rhobuild/runpool/internal/lease"
+	"github.com/rhobuild/runpool/internal/netsandbox"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
 )
@@ -302,9 +303,9 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 	// The restricted profile's sandbox: uplink and deny-set snapshot,
 	// assembled before any binding exists. A discovery failure fails
 	// serve closed — a capsule must never launch with a partial policy.
-	var netSandbox *networkSandbox
+	var netSandbox *netsandbox.Manager
 	if cfg.Network.Profile == config.NetworkProfilePublicInternetOnly {
-		netSandbox, err = newNetworkSandbox(ctx, dock, st.InstanceID(), capsuleImg, cfg, log)
+		netSandbox, err = netsandbox.New(ctx, dock, st.InstanceID(), capsuleImg, cfg, log)
 		if err != nil {
 			return fmt.Errorf("network sandbox: %w", err)
 		}
@@ -383,7 +384,7 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 	loops.Add(1)
 	go func() {
 		defer loops.Done()
-		s.netSandbox.watch(ctx)
+		s.netSandbox.Watch(ctx)
 	}()
 	for _, b := range s.bindings {
 		loops.Add(1)
@@ -536,7 +537,7 @@ type Controller struct {
 	// set, the snapshot each launch is cut from, and the installs into
 	// running gateways. Nil is the explicit unsafe-open-egress profile,
 	// which its own methods answer for.
-	netSandbox *networkSandbox
+	netSandbox *netsandbox.Manager
 
 	// cgroupDriver is the daemon's driver, read once at startup. It
 	// decides the form of a lease's parent cgroup, and the daemon

--- a/internal/netsandbox/netsandbox.go
+++ b/internal/netsandbox/netsandbox.go
@@ -1,4 +1,14 @@
-package app
+// Package netsandbox owns the restricted profile's egress policy: the
+// deny set discovered from the host and the daemon, the snapshot each
+// launch is cut from, and the rule that a restriction is recorded as in
+// force only once it has reached every gateway that could be named.
+//
+// It is its own package because that rule is a security decision, and
+// the composition root it used to live in is exempt from every
+// dependency rule the architecture suite enforces -- so the one package
+// deciding what a capsule can reach was the one package free to import
+// anything.
+package netsandbox
 
 import (
 	"context"
@@ -21,34 +31,34 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 )
 
-// sandboxNetworks is what computing an egress policy needs from the
+// networks is what computing an egress policy needs from the
 // daemon: the instance uplink, its subnet, every subnet the daemon knows
 // and a probe container to look at the host with.
-type sandboxNetworks interface {
+type networks interface {
 	EnsureOwnedNetwork(ctx context.Context, spec engine.NetworkSpec) (string, error)
 	NetworkSubnet(ctx context.Context, id string) (string, error)
 	AllNetworkSubnets(ctx context.Context) ([]string, error)
 	RunTask(ctx context.Context, spec engine.ContainerSpec) (int64, string, error)
 }
 
-// sandboxGateways is what installing one needs: find the gateways, hand
+// gateways is what installing one needs: find the gateways, hand
 // each the new sets, and remove the ones that will not take them.
-type sandboxGateways interface {
+type gateways interface {
 	ListOwnedContainers(ctx context.Context, instanceID assignment.InstanceID) ([]engine.OwnedContainer, error)
 	Exec(ctx context.Context, id string, cmd []string) (int, string, error)
 	ExecWithInput(ctx context.Context, id string, cmd []string, input []byte) (int, string, error)
 	RemoveContainer(ctx context.Context, id string) error
 }
 
-// sandboxDaemon is both halves, which one *docker.Client satisfies. They
+// Daemon is both halves, which one *docker.Client satisfies. They
 // are named apart because they are two jobs, and because a fake for one
 // can embed the other and leave it unimplemented.
-type sandboxDaemon interface {
-	sandboxNetworks
-	sandboxGateways
+type Daemon interface {
+	networks
+	gateways
 }
 
-// sandboxState owns the current restricted-network snapshot. Capsule
+// state owns the current restricted-network snapshot. Capsule
 // launches receive deep copies, so a rediscovery cannot mutate policy while
 // a concurrent launch is serializing it. refreshing also serializes the
 // external discovery/reload operation: policy changes must be applied in the
@@ -65,23 +75,23 @@ type sandboxDaemon interface {
 // loops is unbounded by design. Past the grace period that is a SIGKILL,
 // which leaves every message session open for the next start to wait out
 // as a conflict.
-type sandboxState struct {
+type state struct {
 	mu         sync.RWMutex
 	refreshing chan struct{}
 	current    *capsule.Sandbox
 }
 
-func newSandboxState(initial *capsule.Sandbox) *sandboxState {
-	return &sandboxState{current: cloneSandbox(initial), refreshing: make(chan struct{}, 1)}
+func newSandboxState(initial *capsule.Sandbox) *state {
+	return &state{current: cloneSandbox(initial), refreshing: make(chan struct{}, 1)}
 }
 
-func (s *sandboxState) snapshot() *capsule.Sandbox {
+func (s *state) snapshot() *capsule.Sandbox {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return cloneSandbox(s.current)
 }
 
-func (s *sandboxState) replace(next *capsule.Sandbox) {
+func (s *state) replace(next *capsule.Sandbox) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.current = cloneSandbox(next)
@@ -97,17 +107,17 @@ func cloneSandbox(in *capsule.Sandbox) *capsule.Sandbox {
 	return &out
 }
 
-// networkSandbox owns the restricted profile's egress policy: it
+// Manager owns the restricted profile's egress policy: it
 // computes the deny set from the host, keeps the snapshot capsule
 // launches are cut from, and installs changes into the running gateways.
 //
-// A nil *networkSandbox is the unsafe-open-egress profile — there is no
+// A nil *Manager is the unsafe-open-egress profile — there is no
 // policy to maintain — and every method here answers for that, so the
 // serving paths ask without first asking whether there is anything to
 // ask.
-type networkSandbox struct {
+type Manager struct {
 	log        *slog.Logger
-	daemon     sandboxDaemon
+	daemon     Daemon
 	instanceID assignment.InstanceID
 	probeImage string
 	// allow and denies are the operator's own two lists, read once. They
@@ -117,16 +127,16 @@ type networkSandbox struct {
 	allow  []string
 	denies []string
 
-	state *sandboxState
+	state *state
 }
 
-// newNetworkSandbox assembles the initial policy and fails closed. Any
+// New assembles the initial policy and fails closed. Any
 // gap in the deny set is a hole in every capsule's egress, so serve does
 // not start without a complete one.
-func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
+func New(ctx context.Context, daemon Daemon,
 	instanceID assignment.InstanceID, probeImage string,
-	cfg *config.Config, log *slog.Logger) (*networkSandbox, error) {
-	n := &networkSandbox{
+	cfg *config.Config, log *slog.Logger) (*Manager, error) {
+	n := &Manager{
 		log: log, daemon: daemon, instanceID: assignment.InstanceID(instanceID), probeImage: probeImage,
 	}
 	for _, c := range cfg.Network.AllowPrivateCIDRs {
@@ -150,7 +160,7 @@ func newNetworkSandbox(ctx context.Context, daemon sandboxDaemon,
 // interface networks discovered through a short-lived host-namespace
 // probe, every Docker subnet the daemon knows, the baseline ranges, and
 // the uplink itself.
-func (n *networkSandbox) build(ctx context.Context, budget time.Duration) (*capsule.Sandbox, error) {
+func (n *Manager) build(ctx context.Context, budget time.Duration) (*capsule.Sandbox, error) {
 	ctx, cancel := context.WithTimeout(ctx, budget)
 	defer cancel()
 
@@ -193,7 +203,7 @@ const rediscoverInterval = 5 * time.Minute
 // which step hung does not change that.
 //
 // They differ because their callers do. The first build runs from
-// newNetworkSandbox, before the state exists and before any binding does:
+// New, before the state exists and before any binding does:
 // nothing holds the refresh slot, nothing waits for it, and the probe
 // image may still have to be pulled — it is the capsule image, which is
 // hundreds of megabytes. Failing that for being slow is a controller
@@ -296,7 +306,7 @@ func ClassifyPolicy(inForce, next []string) PolicyChange {
 	}
 }
 
-// watch repeats discovery and installs what it finds.
+// Watch repeats discovery and installs what it finds.
 //
 // The old policy is not a safe fallback. It is merely older: if a host
 // interface or a Docker network appeared since it was computed, the
@@ -306,7 +316,7 @@ func ClassifyPolicy(inForce, next []string) PolicyChange {
 // everything, and discovery that cannot be trusted at all does the same
 // for every gateway, because an undiscovered subnet is indistinguishable
 // from one that was never there.
-func (n *networkSandbox) watch(ctx context.Context) {
+func (n *Manager) Watch(ctx context.Context) {
 	if n == nil {
 		return // unsafe-open-egress: there is no policy to maintain
 	}
@@ -322,11 +332,11 @@ func (n *networkSandbox) watch(ctx context.Context) {
 	}
 }
 
-// forLaunch re-proves the instance uplink and the complete deny set
+// ForLaunch re-proves the instance uplink and the complete deny set
 // immediately before a capsule is admitted. This makes an idle uplink removed
 // by a platform cleanup recoverable, and it prevents a shared daemon's newly
 // created networks from remaining reachable until the periodic refresh.
-func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error) {
+func (n *Manager) ForLaunch(ctx context.Context) (*capsule.Sandbox, error) {
 	if n == nil {
 		return nil, nil
 	}
@@ -336,7 +346,7 @@ func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error
 	return n.state.snapshot(), nil
 }
 
-// confirmLaunch proves the gateway this launch created carries the set in
+// ConfirmLaunch proves the gateway this launch created carries the set in
 // force, before the capsule it fronts is authorized to start.
 //
 // A policy pass fans a change out to the gateways it can enumerate. One
@@ -351,7 +361,7 @@ func (n *networkSandbox) forLaunch(ctx context.Context) (*capsule.Sandbox, error
 // both enumerable and not yet serving work. It costs two comparisons in
 // the ordinary case, where the policy did not move while the capsule was
 // being built, and reaches the daemon only when it did.
-func (n *networkSandbox) confirmLaunch(ctx context.Context, leaseID assignment.LeaseID, launched *capsule.Sandbox) error {
+func (n *Manager) ConfirmLaunch(ctx context.Context, leaseID assignment.LeaseID, launched *capsule.Sandbox) error {
 	if n == nil || launched == nil {
 		return nil
 	}
@@ -399,7 +409,7 @@ func sameSandbox(a, b *capsule.Sandbox) bool {
 	return ClassifyPolicy(a.Deny, b.Deny) == PolicyUnchanged && a.UplinkNetworkID == b.UplinkNetworkID
 }
 
-func (n *networkSandbox) refresh(ctx context.Context) error {
+func (n *Manager) refresh(ctx context.Context) error {
 	select {
 	case n.state.refreshing <- struct{}{}:
 	case <-ctx.Done():
@@ -418,7 +428,7 @@ func (n *networkSandbox) refresh(ctx context.Context) error {
 }
 
 // rediscover is one pass, separated so a test can drive it directly.
-func (n *networkSandbox) rediscover(ctx context.Context) {
+func (n *Manager) rediscover(ctx context.Context) {
 	err := n.refresh(ctx)
 	if err == nil {
 		return
@@ -451,7 +461,7 @@ func (n *networkSandbox) rediscover(ctx context.Context) {
 // caller's fail-closed paths turn on exactly that: a discovery pass that
 // cannot say what is installed anywhere closes every gateway, and a
 // launch under an unprovable policy is refused.
-func (n *networkSandbox) applyPolicy(ctx context.Context, next *capsule.Sandbox) error {
+func (n *Manager) applyPolicy(ctx context.Context, next *capsule.Sandbox) error {
 	previous := n.state.snapshot()
 	change := ClassifyPolicy(previous.Deny, next.Deny)
 	uplinkChanged := previous.UplinkNetworkID != next.UplinkNetworkID
@@ -568,7 +578,7 @@ func eachGateway[T any](items []T, fn func(T)) {
 // here would be a second mechanism for a property nothing reads — the
 // one caller takes a length and iterates order-blind, and a test that
 // compares the set sorts what it compares.
-func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []string) (failed []string, err error) {
+func (n *Manager) reloadGateways(ctx context.Context, allow, deny []string) (failed []string, err error) {
 	containers, err := n.ownedContainers(ctx)
 	if err != nil {
 		return nil, err
@@ -600,7 +610,7 @@ func (n *networkSandbox) reloadGateways(ctx context.Context, allow, deny []strin
 // gateway it just created carries the set in force -- and a reload that
 // judged its exit code differently on those two paths would be two
 // answers to the same question.
-func (n *networkSandbox) reloadGateway(ctx context.Context, c engine.OwnedContainer, payload []byte) error {
+func (n *Manager) reloadGateway(ctx context.Context, c engine.OwnedContainer, payload []byte) error {
 	code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
 		return n.daemon.ExecWithInput(ctx, c.ID,
 			[]string{capsule.SupervisorPath, "gateway-reload"}, payload)
@@ -631,14 +641,14 @@ const gatewayControlTimeout = 30 * time.Second
 // on the context to end the wait. It is the same reason the exec and the
 // removal below are bounded, and leaving it out left the pass unbounded
 // at its very first step.
-func (n *networkSandbox) ownedContainers(ctx context.Context) ([]engine.OwnedContainer, error) {
+func (n *Manager) ownedContainers(ctx context.Context) ([]engine.OwnedContainer, error) {
 	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
 	defer cancel()
 	return n.daemon.ListOwnedContainers(ctx, n.instanceID)
 }
 
 // execGateway runs one gateway control command under its own bound.
-func (n *networkSandbox) execGateway(ctx context.Context,
+func (n *Manager) execGateway(ctx context.Context,
 	call func(context.Context) (int, string, error)) (int, string, error) {
 
 	ctx, cancel := context.WithTimeout(ctx, gatewayControlTimeout)
@@ -653,7 +663,7 @@ func (n *networkSandbox) execGateway(ctx context.Context,
 // is already through the check — so the gateway is stopped afterwards,
 // which takes its connections with it. A capsule whose gateway is gone
 // has no egress at all, which is the state this is trying to reach.
-func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) error {
+func (n *Manager) closeGateway(ctx context.Context, containerID string) error {
 	code, out, err := n.execGateway(ctx, func(ctx context.Context) (int, string, error) {
 		return n.daemon.Exec(ctx, containerID,
 			[]string{capsule.SupervisorPath, protocol.GatewayDenyAllCommand})
@@ -679,7 +689,7 @@ func (n *networkSandbox) closeGateway(ctx context.Context, containerID string) e
 }
 
 // closeGateways closes every live gateway this instance owns.
-func (n *networkSandbox) closeGateways(ctx context.Context) error {
+func (n *Manager) closeGateways(ctx context.Context) error {
 	containers, err := n.ownedContainers(ctx)
 	if err != nil {
 		return err
@@ -710,7 +720,7 @@ func (n *networkSandbox) closeGateways(ctx context.Context) error {
 // capabilities, no socket, no volumes — it looks and reports. An empty
 // answer is a failure, not a finding: a host has interfaces, and a
 // deny set built from a blind probe would allow what it cannot see.
-func (n *networkSandbox) discoverHostCIDRs(ctx context.Context) ([]string, error) {
+func (n *Manager) discoverHostCIDRs(ctx context.Context) ([]string, error) {
 	nonce := make([]byte, 4)
 	if _, err := rand.Read(nonce); err != nil {
 		return nil, err

--- a/internal/netsandbox/netsandbox_test.go
+++ b/internal/netsandbox/netsandbox_test.go
@@ -1,4 +1,4 @@
-package app
+package netsandbox
 
 import (
 	"context"
@@ -86,10 +86,10 @@ func TestPolicyChangeNamesItself(t *testing.T) {
 	}
 }
 
-// fakeSandboxDaemon answers for both halves of the daemon the sandbox
+// fakeDaemon answers for both halves of the daemon the sandbox
 // uses. Its point is the states that decide the design: a probe that sees
 // nothing, and a gateway that refuses the policy it is handed.
-type fakeSandboxDaemon struct {
+type fakeDaemon struct {
 	uplinkID     string
 	uplinkSubnet string
 	subnets      []string
@@ -110,7 +110,7 @@ type fakeSandboxDaemon struct {
 	// has been taken. Appending there is how a gateway appears between a
 	// pass listing them and that pass finishing, which is the moment a
 	// launch creates one.
-	onList func(*fakeSandboxDaemon)
+	onList func(*fakeDaemon)
 	// delay is how long each gateway control command takes, which is
 	// what makes a serial pass distinguishable from a concurrent one.
 	delay time.Duration
@@ -151,7 +151,7 @@ type fakeSandboxDaemon struct {
 
 // serve models one gateway control command occupying the daemon for as
 // long as it takes, which is what the concurrency counters below see.
-func (f *fakeSandboxDaemon) serve() {
+func (f *fakeDaemon) serve() {
 	f.enter()
 	defer f.leave()
 	if f.delay > 0 {
@@ -159,7 +159,7 @@ func (f *fakeSandboxDaemon) serve() {
 	}
 }
 
-func (f *fakeSandboxDaemon) note(into *[]string, id string) {
+func (f *fakeDaemon) note(into *[]string, id string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	*into = append(*into, id)
@@ -168,7 +168,7 @@ func (f *fakeSandboxDaemon) note(into *[]string, id string) {
 // enter and leave track how many control commands the daemon is serving
 // at once. That is what a refresh's cost turns on, and unlike wall-clock
 // time it does not change with how loaded the machine is.
-func (f *fakeSandboxDaemon) enter() {
+func (f *fakeDaemon) enter() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.inFlight++
@@ -177,19 +177,19 @@ func (f *fakeSandboxDaemon) enter() {
 	}
 }
 
-func (f *fakeSandboxDaemon) leave() {
+func (f *fakeDaemon) leave() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.inFlight--
 }
 
-func (f *fakeSandboxDaemon) peakInFlight() int {
+func (f *fakeDaemon) peakInFlight() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.peak
 }
 
-func (f *fakeSandboxDaemon) sorted(from *[]string) []string {
+func (f *fakeDaemon) sorted(from *[]string) []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	out := slices.Clone(*from)
@@ -197,10 +197,10 @@ func (f *fakeSandboxDaemon) sorted(from *[]string) []string {
 	return out
 }
 
-func (f *fakeSandboxDaemon) reloads() []string { return f.sorted(&f.reloaded) }
+func (f *fakeDaemon) reloads() []string { return f.sorted(&f.reloaded) }
 
 // eventsFor is the ordered record for one container.
-func (f *fakeSandboxDaemon) eventsFor(id string) []string {
+func (f *fakeDaemon) eventsFor(id string) []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	var out []string
@@ -211,24 +211,24 @@ func (f *fakeSandboxDaemon) eventsFor(id string) []string {
 	}
 	return out
 }
-func (f *fakeSandboxDaemon) removes() []string { return f.sorted(&f.removed) }
+func (f *fakeDaemon) removes() []string { return f.sorted(&f.removed) }
 
-func (f *fakeSandboxDaemon) EnsureOwnedNetwork(context.Context, engine.NetworkSpec) (string, error) {
+func (f *fakeDaemon) EnsureOwnedNetwork(context.Context, engine.NetworkSpec) (string, error) {
 	return f.uplinkID, nil
 }
-func (f *fakeSandboxDaemon) NetworkSubnet(context.Context, string) (string, error) {
+func (f *fakeDaemon) NetworkSubnet(context.Context, string) (string, error) {
 	return f.uplinkSubnet, nil
 }
-func (f *fakeSandboxDaemon) AllNetworkSubnets(context.Context) ([]string, error) {
+func (f *fakeDaemon) AllNetworkSubnets(context.Context) ([]string, error) {
 	return f.subnets, nil
 }
-func (f *fakeSandboxDaemon) RunTask(ctx context.Context, _ engine.ContainerSpec) (int64, string, error) {
+func (f *fakeDaemon) RunTask(ctx context.Context, _ engine.ContainerSpec) (int64, string, error) {
 	f.mu.Lock()
 	f.buildDeadline, f.buildBounded = ctx.Deadline()
 	f.mu.Unlock()
 	return 0, f.probeOut, f.probeErr
 }
-func (f *fakeSandboxDaemon) ListOwnedContainers(ctx context.Context, _ assignment.InstanceID) ([]engine.OwnedContainer, error) {
+func (f *fakeDaemon) ListOwnedContainers(ctx context.Context, _ assignment.InstanceID) ([]engine.OwnedContainer, error) {
 	f.mu.Lock()
 	f.listDeadline, f.listBounded = ctx.Deadline()
 	f.lists++
@@ -242,7 +242,7 @@ func (f *fakeSandboxDaemon) ListOwnedContainers(ctx context.Context, _ assignmen
 	}
 	return answer, nil
 }
-func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
+func (f *fakeDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
 	f.serve()
 	// The command, not merely that some exec happened: closing a gateway
 	// and reloading one are both execs, and only one of them revokes.
@@ -252,7 +252,7 @@ func (f *fakeSandboxDaemon) Exec(_ context.Context, id string, cmd []string) (in
 	}
 	return 0, "", nil
 }
-func (f *fakeSandboxDaemon) ExecWithInput(_ context.Context, id string, _ []string, _ []byte) (int, string, error) {
+func (f *fakeDaemon) ExecWithInput(_ context.Context, id string, _ []string, _ []byte) (int, string, error) {
 	f.serve()
 	if f.refuse[id] {
 		return 1, "refused", nil
@@ -260,7 +260,7 @@ func (f *fakeSandboxDaemon) ExecWithInput(_ context.Context, id string, _ []stri
 	f.note(&f.reloaded, id)
 	return 0, "", nil
 }
-func (f *fakeSandboxDaemon) RemoveContainer(ctx context.Context, id string) error {
+func (f *fakeDaemon) RemoveContainer(ctx context.Context, id string) error {
 	f.mu.Lock()
 	f.removeDeadline, f.removeBounded = ctx.Deadline()
 	f.mu.Unlock()
@@ -273,9 +273,9 @@ func (f *fakeSandboxDaemon) RemoveContainer(ctx context.Context, id string) erro
 	return nil
 }
 
-func newTestSandbox(t *testing.T, daemon sandboxDaemon, inForce *capsule.Sandbox) *networkSandbox {
+func newTestSandbox(t *testing.T, daemon Daemon, inForce *capsule.Sandbox) *Manager {
 	t.Helper()
-	return &networkSandbox{
+	return &Manager{
 		log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		daemon:     daemon,
 		instanceID: "instance-0001",
@@ -316,7 +316,7 @@ func TestParseHostCIDRs(t *testing.T) {
 func TestBuildRefusesABlindDenySet(t *testing.T) {
 	// `ip ... scope global` filters, so a probe that saw nothing prints
 	// nothing. Scope is not re-checked here — the command is the filter.
-	n := newTestSandbox(t, &fakeSandboxDaemon{
+	n := newTestSandbox(t, &fakeDaemon{
 		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: "",
 	}, nil)
 	if _, err := n.build(t.Context(), sandboxRefreshBudget); err == nil {
@@ -329,7 +329,7 @@ func TestBuildRefusesABlindDenySet(t *testing.T) {
 // reach the deny set. Any one of them missing is a hole in every
 // capsule's egress, which is why this fails serve rather than warning.
 func TestBuildDeniesEverythingItDiscovered(t *testing.T) {
-	n := newTestSandbox(t, &fakeSandboxDaemon{
+	n := newTestSandbox(t, &fakeDaemon{
 		uplinkID:     "up-1",
 		uplinkSubnet: "172.30.0.0/24",
 		subnets:      []string{"172.18.0.0/16"},
@@ -370,7 +370,7 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	inForce := &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}}
 
 	t.Run("a restriction that did not land closes the gateway", func(t *testing.T) {
-		d := &fakeSandboxDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
+		d := &fakeDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{
 			UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8", "192.168.0.0/16"},
@@ -384,7 +384,7 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	})
 
 	t.Run("a relaxation that did not land leaves the work running", func(t *testing.T) {
-		d := &fakeSandboxDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
+		d := &fakeDaemon{containers: gateways, refuse: map[string]bool{"gw-bad": true}}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1"})
 		if len(d.removes()) != 0 {
@@ -393,7 +393,7 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	})
 
 	t.Run("nothing changed installs nothing", func(t *testing.T) {
-		d := &fakeSandboxDaemon{containers: gateways}
+		d := &fakeDaemon{containers: gateways}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}})
 		if len(d.reloads())+len(d.removes()) != 0 {
@@ -402,7 +402,7 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	})
 
 	t.Run("a recreated uplink is a change even with the same deny set", func(t *testing.T) {
-		d := &fakeSandboxDaemon{containers: gateways}
+		d := &fakeDaemon{containers: gateways}
 		n := newTestSandbox(t, d, inForce)
 		n.applyPolicy(t.Context(), &capsule.Sandbox{UplinkNetworkID: "up-2", Deny: []string{"10.0.0.0/8"}})
 		if !slices.Equal(d.reloads(), []string{"gw-bad", "gw-ok"}) {
@@ -422,7 +422,7 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 // daemon takes to answer, which is exactly the window the deny-all is
 // there to close.
 func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
-	d := &fakeSandboxDaemon{
+	d := &fakeDaemon{
 		containers: []engine.OwnedContainer{
 			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
 			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
@@ -453,12 +453,12 @@ func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 // A nil sandbox is the unsafe-open-egress profile, and every serving path
 // asks it the same questions.
 func TestANilSandboxIsTheOpenProfile(t *testing.T) {
-	var n *networkSandbox
-	sb, err := n.forLaunch(t.Context())
+	var n *Manager
+	sb, err := n.ForLaunch(t.Context())
 	if sb != nil || err != nil {
 		t.Errorf("forLaunch on the open profile = (%v, %v); want no policy and no error", sb, err)
 	}
-	n.watch(t.Context()) // returns rather than ticking forever
+	n.Watch(t.Context()) // returns rather than ticking forever
 }
 
 // TestNewNetworkSandboxFailsServeClosed. The constructor is where the
@@ -471,12 +471,12 @@ func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
 	cfg := &config.Config{}
 	config.ApplyDefaults(cfg)
 
-	blind := &fakeSandboxDaemon{uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: ""}
-	if _, err := newNetworkSandbox(t.Context(), blind, "instance-0001", "probe", cfg, log); err == nil {
+	blind := &fakeDaemon{uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24", probeOut: ""}
+	if _, err := New(t.Context(), blind, "instance-0001", "probe", cfg, log); err == nil {
 		t.Error("serve would have started on a deny set built from a probe that saw nothing")
 	}
 
-	seeing := &fakeSandboxDaemon{
+	seeing := &fakeDaemon{
 		uplinkID: "up-1", uplinkSubnet: "172.30.0.0/24",
 		probeOut: "2: eth0    inet 192.0.2.10/24 scope global eth0",
 	}
@@ -495,12 +495,12 @@ func TestNewNetworkSandboxFailsServeClosed(t *testing.T) {
 	}
 	cfg.Network.DenyCIDRs = []config.CIDR{deny}
 	cfg.Network.AllowPrivateCIDRs = []config.CIDR{allow}
-	n, err := newNetworkSandbox(t.Context(), seeing, "instance-0001", "probe", cfg, log)
+	n, err := New(t.Context(), seeing, "instance-0001", "probe", cfg, log)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// The snapshot a launch is cut from is in force from the start.
-	sb, err := n.forLaunch(t.Context())
+	sb, err := n.ForLaunch(t.Context())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +531,7 @@ func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
 		UplinkSubnet:    "172.30.0.0/24",
 		Deny:            []string{"10.0.0.0/8"},
 	}
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		refuse:  map[string]bool{},
 		listErr: errors.New("daemon unreachable"),
 		containers: []engine.OwnedContainer{
@@ -608,7 +608,7 @@ func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 			ID: id, Name: id, Role: capsule.RoleGateway, Running: true,
 		})
 	}
-	d := &fakeSandboxDaemon{containers: containers, delay: perCall}
+	d := &fakeDaemon{containers: containers, delay: perCall}
 	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
 
 	failed, err := n.reloadGateways(t.Context(), nil, []string{"10.0.0.0/8"})
@@ -651,7 +651,7 @@ func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 // behind it. Bounding the exec and not the removal left that in the same
 // function as the bound.
 func TestClosingAGatewayIsBoundedInBothSteps(t *testing.T) {
-	d := &fakeSandboxDaemon{containers: []engine.OwnedContainer{
+	d := &fakeDaemon{containers: []engine.OwnedContainer{
 		{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
 	}}
 	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
@@ -692,7 +692,7 @@ func TestClosingAGatewayIsBoundedInBothSteps(t *testing.T) {
 // The bound is asserted rather than waited out: a test that waits two
 // minutes to prove a two-minute budget is a test nobody runs.
 func TestDiscoveringTheEnvironmentIsBounded(t *testing.T) {
-	d := &fakeSandboxDaemon{
+	d := &fakeDaemon{
 		uplinkID:     "up-1",
 		uplinkSubnet: "172.30.0.0/24",
 		subnets:      []string{"172.18.0.0/16"},
@@ -735,18 +735,18 @@ func TestDiscoveringTheEnvironmentIsBounded(t *testing.T) {
 func TestEnumeratingGatewaysIsBounded(t *testing.T) {
 	for _, tc := range []struct {
 		name string
-		run  func(*networkSandbox) error
+		run  func(*Manager) error
 	}{
-		{"reloading", func(n *networkSandbox) error {
+		{"reloading", func(n *Manager) error {
 			_, err := n.reloadGateways(context.Background(), nil, []string{"10.0.0.0/8"})
 			return err
 		}},
-		{"closing", func(n *networkSandbox) error {
+		{"closing", func(n *Manager) error {
 			return n.closeGateways(context.Background())
 		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			d := &fakeSandboxDaemon{containers: []engine.OwnedContainer{
+			d := &fakeDaemon{containers: []engine.OwnedContainer{
 				{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
 			}}
 			n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
@@ -784,7 +784,7 @@ func TestEnumeratingGatewaysIsBounded(t *testing.T) {
 // deployment's grace period the difference is a SIGKILL, which leaves
 // every message session open for the next start to wait out.
 func TestARefreshGivesUpWhenItsCallerIsDone(t *testing.T) {
-	n := newTestSandbox(t, &fakeSandboxDaemon{}, &capsule.Sandbox{})
+	n := newTestSandbox(t, &fakeDaemon{}, &capsule.Sandbox{})
 
 	// Stand in for the launch that is holding it.
 	n.state.refreshing <- struct{}{}
@@ -832,7 +832,7 @@ func TestARefreshGivesUpWhenItsCallerIsDone(t *testing.T) {
 func TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency(t *testing.T) {
 	// A gateway to close, so "nothing was closed" is an observation
 	// rather than an empty daemon answering emptily.
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		containers: []engine.OwnedContainer{{ID: "gw-1", Role: capsule.RoleGateway, LeaseID: "lse-1", Running: true}},
 	}
 	n := newTestSandbox(t, daemon, &capsule.Sandbox{})
@@ -875,7 +875,7 @@ func sandboxFixture() *capsule.Sandbox {
 // compares that set against itself. The launch that created the gateway
 // is what closes the gap, before its capsule is authorized to start.
 func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T) {
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
 			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
@@ -883,7 +883,7 @@ func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T)
 	}
 	// The launch's gateway appears just after the pass has listed, which
 	// is the whole of the window this closes.
-	daemon.onList = func(f *fakeSandboxDaemon) {
+	daemon.onList = func(f *fakeDaemon) {
 		f.containers = append(f.containers, engine.OwnedContainer{
 			ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"})
 		f.onList = nil
@@ -898,7 +898,7 @@ func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T)
 		t.Fatalf("the pass reloaded %v; a gateway it never named cannot be among them", got)
 	}
 
-	if err := n.confirmLaunch(t.Context(), "lse-late", launched); err != nil {
+	if err := n.ConfirmLaunch(t.Context(), "lse-late", launched); err != nil {
 		t.Fatalf("confirmLaunch: %v", err)
 	}
 	if got := daemon.reloads(); !slices.Contains(got, "gw-late") {
@@ -912,7 +912,7 @@ func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T)
 // cost one exec per gateway per launch, which is the cost the fan-out is
 // bounded to avoid.
 func TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon(t *testing.T) {
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
 			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
@@ -920,7 +920,7 @@ func TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon(t *testing.T) {
 	}
 	n := newTestSandbox(t, daemon, sandboxFixture())
 
-	if err := n.confirmLaunch(t.Context(), "lse-1", n.state.snapshot()); err != nil {
+	if err := n.ConfirmLaunch(t.Context(), "lse-1", n.state.snapshot()); err != nil {
 		t.Fatalf("confirmLaunch: %v", err)
 	}
 	if got := daemon.reloads(); len(got) != 0 {
@@ -957,10 +957,10 @@ func TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			daemon := &fakeSandboxDaemon{refuse: tc.refuse, containers: tc.containers}
+			daemon := &fakeDaemon{refuse: tc.refuse, containers: tc.containers}
 			n := newTestSandbox(t, daemon, tighter(launched))
 
-			if err := n.confirmLaunch(t.Context(), "lse-late", launched); err == nil {
+			if err := n.ConfirmLaunch(t.Context(), "lse-late", launched); err == nil {
 				t.Fatal("the launch was confirmed against a policy no gateway of its own carries")
 			}
 			if got := daemon.removes(); len(got) != 0 {
@@ -976,21 +976,21 @@ func TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch(t *testing.T) {
 // set that was current a moment ago.
 func TestAConfirmationThatWasOvertakenFailsTheLaunch(t *testing.T) {
 	launched := sandboxFixture()
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
 			{ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"},
 		},
 	}
 	n := newTestSandbox(t, daemon, tighter(launched))
-	daemon.onList = func(f *fakeSandboxDaemon) {
+	daemon.onList = func(f *fakeDaemon) {
 		f.onList = nil
 		moved := *launched
 		moved.Deny = []string{"10.0.0.0/8", "192.168.0.0/16", "172.16.0.0/12"}
 		n.state.replace(&moved)
 	}
 
-	if err := n.confirmLaunch(t.Context(), "lse-late", launched); err == nil {
+	if err := n.ConfirmLaunch(t.Context(), "lse-late", launched); err == nil {
 		t.Fatal("the launch was confirmed against a set that had already been superseded")
 	}
 }
@@ -1002,7 +1002,7 @@ func TestAConfirmationThatWasOvertakenFailsTheLaunch(t *testing.T) {
 // itself and never attempts it again, while a gateway keeps relaying past
 // a deny the operator was promised.
 func TestARestrictionThatCouldNotBeClosedIsRetried(t *testing.T) {
-	daemon := &fakeSandboxDaemon{
+	daemon := &fakeDaemon{
 		refuse:    map[string]bool{"gw-bad": true},
 		removeErr: map[string]error{"gw-bad": errors.New("container is wedged")},
 		containers: []engine.OwnedContainer{
@@ -1028,5 +1028,31 @@ func TestARestrictionThatCouldNotBeClosedIsRetried(t *testing.T) {
 	}
 	if got := n.state.snapshot().Deny; len(got) != 2 {
 		t.Errorf("the books record %v after a retry that reached the gateway", got)
+	}
+}
+
+// TestRediscoverClosesEveryGatewayWhenDiscoveryFails. The policy in force
+// is not a safe fallback, only an older one: a network that appeared
+// since it was computed is reachable and there is no way to tell. So a
+// discovery that cannot be trusted closes every gateway rather than
+// relaying under a set that cannot be shown to be current.
+func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
+	d := &fakeDaemon{
+		uplinkID:     "up-1",
+		uplinkSubnet: "172.30.0.0/24",
+		probeOut:     "", // saw nothing: the deny set cannot be trusted
+		containers: []engine.OwnedContainer{
+			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
+			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
+		},
+	}
+	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
+
+	n.rediscover(t.Context())
+
+	// Sorted: closing fans out, so the order is the order the daemon
+	// answered in and nothing should depend on it.
+	if !slices.Equal(d.removes(), []string{"gw-1", "gw-2"}) {
+		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removes())
 	}
 }

--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -51,6 +51,7 @@ var corePackages = []string{
 	module + "/internal/credential",
 	module + "/internal/platform",
 	module + "/internal/engine",
+	module + "/internal/netsandbox",
 	module + "/internal/engine/docker",
 	module + "/internal/config",
 	module + "/internal/doctor",
@@ -65,6 +66,38 @@ var corePackages = []string{
 // Direct imports, not the closure: the closure is checked separately
 // where transitive weight is the point.
 var narrowDeps = map[string][]string{
+	// The four packages every other one stands on, pinned at what they
+	// hold today. They are not narrow because an edge was removed: they
+	// are narrow because nothing has been added, and nothing states that.
+	// An edge from any of them compiles, creates no cycle, and trips no
+	// other rule here -- so the vocabulary every layer shares would learn
+	// configuration, or the clientless port would learn persistence, and
+	// the suite would say the architecture still holds.
+	module + "/internal/assignment":          {},
+	module + "/internal/capsule/protocol":    {},
+	module + "/internal/platform/atomicfile": {},
+	// The port names what a container engine does and holds no client.
+	module + "/internal/engine": {module + "/internal/assignment"},
+	// And its adapter translates; an adapter that learned the store would
+	// put persistence behind the port every consumer thinks is a daemon.
+	module + "/internal/engine/docker": {
+		module + "/internal/assignment",
+		module + "/internal/engine",
+	},
+	// The egress policy engine: discovery, the snapshot a launch is cut
+	// from, and the fail-closed rule that a restriction must reach every
+	// gateway before it is recorded as in force. It lived in the
+	// composition root, which is exempt from every rule in this file --
+	// so the one package that decides what a capsule can reach was the
+	// one package free to import anything.
+	module + "/internal/netsandbox": {
+		module + "/internal/assignment",
+		module + "/internal/capsule",
+		module + "/internal/capsule/protocol",
+		module + "/internal/config",
+		module + "/internal/egress",
+		module + "/internal/engine",
+	},
 	// config validates egress prefixes against the baseline deny set.
 	// Restating those prefixes here instead would let the validator and
 	// the enforcer disagree about what "private" means, which is a
@@ -160,7 +193,6 @@ func TestCoreDoesNotDependOnTheProviderAdapter(t *testing.T) {
 		module + "/internal/command": true,
 		module + "/cmd/runpool":      true,
 		adapter:                      true,
-		adapter + "/jit":             true,
 	}
 	graph := importGraph(t)
 	for importer, imports := range graph {
@@ -219,7 +251,8 @@ func TestAdapterDependsOnTheDomainNotTheReverse(t *testing.T) {
 func importGraph(t *testing.T) map[string][]string {
 	t.Helper()
 	cmd := exec.Command("go", "list", "-f",
-		`{{.ImportPath}} {{join .Imports " "}}`, module+"/...")
+		`{{.ImportPath}} {{join .Imports " "}} {{join .TestImports " "}} {{join .XTestImports " "}}`,
+		module+"/...")
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
## What changes

`internal/app/sandbox.go` becomes `internal/netsandbox`, with its dependency set
pinned. The architecture suite gains three rules that were true of the tree and stated
by nothing, and loses one exemption for a package that does not exist.

## What was found

An architecture and modularity review of the whole tree. Its verdict on the
architecture was sound — the dependency arrow is enforced by tests rather than
convention, and every deviation from textbook layering carries a comment naming a real
constraint. Four findings, all here.

**A file that was a package.** `sandbox.go` was 765 lines that never mention
`Controller` — its own state type, its own three consumer interfaces, and a pointer
held by `serve.go`. It is not wiring: it is the egress policy lifecycle, including the
fail-closed rule that a restriction is in force only once it has reached every gateway
that could be named. And it lived in `internal/app`, which is exempt from every
dependency rule the suite enforces — so the one package deciding what a capsule can
reach was the one package free to import anything. Now `internal/netsandbox`, with
`narrowDeps` pinning it to six edges.

**The load-bearing leaves were unpinned.** `assignment`, `engine`, `capsule/protocol`
and `platform/atomicfile` are narrow because nothing has been added, not because a
rule says so. An edge from any of them compiles, creates no cycle, and trips nothing —
the vocabulary every layer shares could learn configuration, or the clientless port
could learn persistence, and the suite would report the architecture intact.

**SDK containment ignored tests.** The walk read `.Imports` and not `.TestImports`, so
a `_test.go` in any domain package could import the provider SDK while the rule's own
error text says only the adapter and its contract suites may see it.

**A stale exemption** for `…/githubactions/jit`, a package `go list` does not return.

## Evidence

Each new rule verified by adding the edge it forbids and watching it fail.

| Mutation | Failure |
| --- | --- |
| `assignment` imports `egress` | `internal imports of …/internal/assignment changed` |
| a core `_test.go` imports the provider SDK | `internal/disk imports github.com/actions/scaleset` |
| `netsandbox` imports `store` | `internal imports of …/internal/netsandbox changed` |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... clean.
Two mutation runs first reported zero failures against Go's test cache; both were
redone with -count=1 before being credited.
```

## What would notice this regressing

`TestNarrowPackagesStayNarrow` now covers the leaves, the port, its adapter and the
policy engine; `TestCoreDoesNotDependOnTheProviderAdapter` now sees test imports.

## Risk, compatibility and operations

**No behaviour changes.** A package move, three renames at two call sites
(`Watch`/`ForLaunch`/`ConfirmLaunch`), and test-file edits. One test that exercised
`rediscover` moved with the code it tests.

**Trust boundary:** the egress policy engine is now inside the rules rather than
outside them — the point of the move.

**Schema, migration, status API, CLI, configuration, deployment, rollback, runbook:
N/A.**

**Not an ADR** — no decision changes; `docs/architecture.md` gains the package and the
reason it is separate.

## Changelog

```text
NONE — no observable behaviour changes.
```

## Notes for your reviewer

The reviewer also raised, and I did not take: renaming `internal/platform` (three
unrelated things under one name — the release-qualification reference, the CI provider
adapter, and atomic file replacement). It is a mechanical rename of `internal/` paths
users never see, and it would touch every adapter import in the tree for taxonomy
alone. Worth doing if you want it before the tag; say so and it is one commit.