### PR TITLE
fix(app): the provider's word for a cancellation stops at the adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -520,6 +520,15 @@ by its public and operational effects.
   refused by the table when they are not a member, and NULL until the
   event they name has happened, like the review timestamps beside them.
 
+- **A cancellation the provider reports is translated where the provider
+  is known.** The controller decided what to do about a cancelled
+  workload by comparing GitHub's own word for it, in the core. A
+  provider that respelled it would have stopped cancellations
+  cancelling — silently, because a comparison that stops matching raises
+  nothing — and Runpool would have burned a capsule on a job already
+  called off. The word is now spelled once, in the adapter, and what
+  crosses into the domain is the fact.
+
 ### Interface
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage

--- a/internal/app/attribution_test.go
+++ b/internal/app/attribution_test.go
@@ -225,7 +225,7 @@ func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
 		ID: 903,
 		Completed: []assignment.WorkloadLifecycleEvent{{
 			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-requeued",
-			RuntimeName: "runpool-first", Result: "canceled",
+			RuntimeName: "runpool-first", Result: "canceled", Canceled: true,
 		}},
 	})
 

--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -470,10 +470,10 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 		// one line up converts, and this one did not, so the key carried
 		// the type of the thing it names.
 		kind, idempotency := "exit_observed", "remote_exit_observed:"+string(ev.RuntimeName)
-		if ev.Result == "canceled" {
+		if ev.Canceled {
 			kind, idempotency = "remote_canceled", "remote_canceled"
 		}
-		if err := record(ev, kind, idempotency, ev.Result == "canceled"); err != nil {
+		if err := record(ev, kind, idempotency, ev.Canceled); err != nil {
 			return err
 		}
 	}

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -482,8 +482,8 @@ func TestRemoteCancellationClosesOnlyReadyWork(t *testing.T) {
 	_, busyAttempt := leaseFor(t, h, "job-busy") // now leased, not ready
 
 	cancelled := &githubactions.Message{ID: 900, Completed: []assignment.WorkloadLifecycleEvent{
-		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-idle", Result: "canceled"},
-		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-busy", Result: "canceled"},
+		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-idle", Result: "canceled", Canceled: true},
+		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-busy", Result: "canceled", Canceled: true},
 	}}
 	s := h.srv
 	s.recordLifecycleEvents(t.Context(), h.bind, cancelled)

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -374,7 +374,7 @@ func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
 	// blocks.
 	msg.Completed = []assignment.WorkloadLifecycleEvent{{
 		Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-cancelled-upstream",
-		Result: "canceled",
+		Result: "canceled", Canceled: true,
 	}}
 	redelivery := &replaySession{msg: msg, drained: make(chan struct{})}
 	h.bind.session = redelivery
@@ -504,7 +504,7 @@ func TestACancellationIsDurableBeforeTheMessageIsAcknowledged(t *testing.T) {
 		Assigned: []assignment.WorkloadAssignment{demand("job-closed", "app", 44)},
 		Completed: []assignment.WorkloadLifecycleEvent{{
 			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-closed",
-			Result: "canceled",
+			Result: "canceled", Canceled: true,
 		}},
 	}
 	h.bind.session = &cancellingSession{msg: msg, cancel: cancel}
@@ -572,7 +572,7 @@ func TestAnUnrecordedLifecycleEventIsReported(t *testing.T) {
 		ID: 993,
 		Completed: []assignment.WorkloadLifecycleEvent{{
 			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-unrecorded",
-			Result: "canceled",
+			Result: "canceled", Canceled: true,
 		}},
 	}
 	if err := h.srv.recordLifecycleEvents(ctx, h.bind, msg); err == nil {

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -167,8 +167,15 @@ type WorkloadLifecycleEvent struct {
 	// rather than instead of it.
 	RuntimeName RuntimeName
 	// Result is the provider's stated outcome, populated on completed
-	// observations only.
+	// observations only. It is opaque: the domain reports it and never
+	// rules on it, because its words are the provider's to change.
 	Result string
+	// Canceled is that outcome translated -- the one thing the domain
+	// decides differently for, and therefore the one thing that must
+	// cross the boundary as a fact rather than a word. Read from Result
+	// here, a provider that respelled it would stop cancellations
+	// cancelling, silently, with every test still green.
+	Canceled bool
 }
 
 // ExecutionObservation is what can be proven about a prepared runtime. It

--- a/internal/platform/githubactions/message.go
+++ b/internal/platform/githubactions/message.go
@@ -113,6 +113,11 @@ func workload(b scaleset.JobMessageBase) assignment.WorkloadAssignment {
 // events that named only the runner could not be correlated to the
 // attempt they belong to, and a cancellation aimed at an old attempt
 // could then hit a new one.
+// resultCanceled is the provider's word for a workload the requester
+// stopped. It is spelled once, here, because this is the only layer
+// allowed to know it.
+const resultCanceled = "canceled"
+
 func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runnerName, result string) assignment.WorkloadLifecycleEvent {
 	return assignment.WorkloadLifecycleEvent{
 		Kind:              kind,
@@ -121,5 +126,6 @@ func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runne
 		ProjectKey:        b.RepositoryName,
 		RuntimeName:       assignment.RuntimeName(runnerName),
 		Result:            result,
+		Canceled:          result == resultCanceled,
 	}
 }

--- a/internal/platform/githubactions/message.go
+++ b/internal/platform/githubactions/message.go
@@ -109,15 +109,15 @@ func workload(b scaleset.JobMessageBase) assignment.WorkloadAssignment {
 	}
 }
 
-// observation maps a lifecycle message, keeping the workload's own key:
-// events that named only the runner could not be correlated to the
-// attempt they belong to, and a cancellation aimed at an old attempt
-// could then hit a new one.
 // resultCanceled is the provider's word for a workload the requester
 // stopped. It is spelled once, here, because this is the only layer
 // allowed to know it.
 const resultCanceled = "canceled"
 
+// observation maps a lifecycle message, keeping the workload's own key:
+// events that named only the runner could not be correlated to the
+// attempt they belong to, and a cancellation aimed at an old attempt
+// could then hit a new one.
 func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runnerName, result string) assignment.WorkloadLifecycleEvent {
 	return assignment.WorkloadLifecycleEvent{
 		Kind:              kind,

--- a/internal/platform/githubactions/message_test.go
+++ b/internal/platform/githubactions/message_test.go
@@ -82,3 +82,30 @@ func TestTranslateEmptyStatistics(t *testing.T) {
 		t.Errorf("empty message translated to %+v / %+v", out, available)
 	}
 }
+
+// TestTheProviderWordForCancellationStopsHere: the domain decides
+// differently for a cancelled workload -- it settles the attempt as
+// remote_canceled instead of recording an exit -- and it used to make
+// that decision by comparing the provider's own word. A provider that
+// respelled it would have stopped cancellations cancelling, silently,
+// with every test green: the comparison would simply never match again.
+//
+// So the word is translated here, and this is where it is pinned.
+func TestTheProviderWordForCancellationStopsHere(t *testing.T) {
+	for result, want := range map[string]bool{
+		"canceled":  true,
+		"cancelled": false, // the other spelling is not the one GitHub sends
+		"succeeded": false,
+		"failed":    false,
+		"":          false,
+	} {
+		got := observation(assignment.LifecycleCompleted,
+			scaleset.JobMessageBase{JobID: "job-1"}, "runner-1", result)
+		if got.Canceled != want {
+			t.Errorf("result %q translated to Canceled=%v; want %v", result, got.Canceled, want)
+		}
+		if got.Result != result {
+			t.Errorf("Result = %q; the provider's own word travels for reporting", got.Result)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

The adapter translates GitHub's cancellation word into a neutral fact on
`WorkloadLifecycleEvent`; the controller reads the fact. The word is spelled once, in
the adapter, and pinned by a test there.

## What was found

The one genuine boundary leak the type-safety review found. `internal/app/delivery.go`
compared `ev.Result == "canceled"` to decide whether a completed observation settles
the attempt as `remote_canceled` or records an exit — a provider vocabulary word read
two layers inside the domain, past the adapter whose job is that translation, against
a field whose own doc comment calls it "the provider's stated outcome".

`CONTRIBUTING.md` puts this on the wrong side: provider vocabulary stays in its
adapter. And the failure it invites is the silent kind — a provider that respells the
word breaks no build and raises no error. The comparison stops matching, cancellations
stop cancelling, and the binding burns a capsule on a job the requester already called
off.

## Evidence

Respelling the constant to `"cancelled"`:

```text
--- FAIL: TestTheProviderWordForCancellationStopsHere
    result "canceled" translated to Canceled=false; want true
--- FAIL: TestAWedgedRedeliveryStillLandsItsHints
    the attempt is "ready"/""; want canceled/remote_canceled — the hint in the wedged
    redelivery never landed, and the binding will burn a capsule on a job the provider
    already cancelled
--- FAIL: TestACancellationIsDurableBeforeTheMessageIsAcknowledged
```

Two of those three are controller tests that were green while the leak was in place —
they exercise cancellation end to end and could not see which layer decided it. Moving
the decision is what put them behind the word.

`gofmt`, `go vet`, `staticcheck` and `go test -race -shuffle=on -count=1 ./...` clean.

## What would notice this regressing

`TestTheProviderWordForCancellationStopsHere` pins the exact word and the two spellings
that are not it, and asserts that `Result` still carries the provider's own text for
reporting.

## Risk, compatibility and operations

**No behaviour change today.** The same events produce the same decisions; what changes
is which layer makes them and what a provider rename would cost.

**Trust boundary:** the domain no longer holds a provider vocabulary word.

**Schema, migration, status API, CLI, configuration, deployment, rollback, runbook:
N/A. Not an ADR** — it enforces a decision `CONTRIBUTING.md` already records.

## Changelog

```text
One bullet under "State and operations": a cancellation the provider reports is
translated where the provider is known.
```