### PR TITLE
refactor(store): the attempt trail's fourteen kinds are a type

### DIFF
--- a/internal/app/delivery.go
+++ b/internal/app/delivery.go
@@ -428,7 +428,7 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 	// independent answer to the same question: after a requeue it named
 	// the successor, so a late cancellation of the run that preceded it
 	// closed work that had just been handed to this instance.
-	record := func(ev assignment.WorkloadLifecycleEvent, kind, idempotency string, cancel bool) error {
+	record := func(ev assignment.WorkloadLifecycleEvent, idempotency string, kind store.EventKind, cancel bool) error {
 		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 			attemptID, err := s.attemptForObservation(tx, b, ev)
 			if err != nil || attemptID == "" {
@@ -459,7 +459,7 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 	for _, ev := range msg.Started {
 		s.log.Info("workload started",
 			"binding", b.key, "workload", ev.SourceWorkloadKey, "runtime", ev.RuntimeName)
-		if err := record(ev, "running_observed", "remote_running_observed:"+string(ev.RuntimeName), false); err != nil {
+		if err := record(ev, "remote_running_observed:"+string(ev.RuntimeName), store.EventRunningObserved, false); err != nil {
 			return err
 		}
 	}
@@ -469,11 +469,11 @@ func (s *Controller) recordLifecycleEvents(ctx context.Context, b *binding, msg 
 		// An idempotency key, not a runtime name: the same concatenation
 		// one line up converts, and this one did not, so the key carried
 		// the type of the thing it names.
-		kind, idempotency := "exit_observed", "remote_exit_observed:"+string(ev.RuntimeName)
+		idempotency, kind := "remote_exit_observed:"+string(ev.RuntimeName), store.EventExitObserved
 		if ev.Canceled {
-			kind, idempotency = "remote_canceled", "remote_canceled"
+			idempotency, kind = "remote_canceled", store.EventRemoteCanceled
 		}
-		if err := record(ev, kind, idempotency, ev.Canceled); err != nil {
+		if err := record(ev, idempotency, kind, ev.Canceled); err != nil {
 			return err
 		}
 	}

--- a/internal/lease/lease.go
+++ b/internal/lease/lease.go
@@ -217,7 +217,7 @@ func (m *Manager) disposeAttempt(tx *store.Tx, lease store.Lease, startObs assig
 	// Keyed by lease: an attempt is served once per lease, and a fixed key
 	// would have the second serving's cleanup swallowed as a replay of the
 	// first.
-	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), "cleanup_completed"); err != nil {
+	if err := tx.RecordEvent(attempt.ID, "cleanup_completed:"+string(lease.ID), store.EventCleanupCompleted); err != nil {
 		return err
 	}
 	d, effective := dispositionFor(lease, attempt, startObs)

--- a/internal/store/assignment_repository.go
+++ b/internal/store/assignment_repository.go
@@ -128,7 +128,7 @@ func (t *Tx) insertAttempt(delivery sqlitedb.BrokerDelivery, w WorkloadRow) erro
 	_, err = t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
 		AttemptID:      id,
 		IdempotencyKey: "attempt_created",
-		Kind:           "attempt_created",
+		Kind:           string(EventAttemptCreated),
 		DetailJson:     "{}",
 	})
 	return err
@@ -175,7 +175,7 @@ func (t *Tx) SupersedeOpenAttempt(bindingID assignment.BindingID, sourceWorkload
 	_, err = t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
 		AttemptID:      open.ID,
 		IdempotencyKey: "attempt_superseded",
-		Kind:           "attempt_superseded",
+		Kind:           string(EventAttemptSuperseded),
 		DetailJson:     "{}",
 	})
 	return err

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1,0 +1,67 @@
+package store
+
+// EventKind is what an attempt_events row records. The fourteen values
+// are closed by the column and were spelled as literals in four
+// packages, with no list anywhere -- so a kind the schema does not admit
+// failed at the write, in a delivery path, at the moment the trail was
+// being written for an operator to read.
+//
+// The type also holds an ordering the compiler could not see.
+// RecordEvent takes the idempotency key before the kind; the controller
+// wraps it in a closure that takes them the other way round. Both are
+// correct today, and an edit that made either match the other would
+// have swapped every event's kind with its key.
+type EventKind string
+
+const (
+	// EventAttemptCreated: a delivery became durable work.
+	EventAttemptCreated EventKind = "attempt_created"
+	// EventLeaseAttached: an attempt was claimed by a lease.
+	EventLeaseAttached EventKind = "lease_attached"
+	// EventRuntimePrepared: a capsule was built and not yet started.
+	EventRuntimePrepared EventKind = "runtime_prepared"
+	// EventStartAuthorized: the start was handed over. Past this line
+	// the work may have run, and nothing may assume it did not.
+	EventStartAuthorized EventKind = "execution_start_authorized"
+	// EventRunningObserved: the runtime was seen running.
+	EventRunningObserved EventKind = "running_observed"
+	// EventExitObserved: the runtime was seen to exit.
+	EventExitObserved EventKind = "exit_observed"
+	// EventRuntimeObservationFailed: the daemon could not be asked.
+	EventRuntimeObservationFailed EventKind = "runtime_observation_failed"
+	// EventCleanupStarted and EventCleanupCompleted bracket the release.
+	EventCleanupStarted   EventKind = "cleanup_started"
+	EventCleanupCompleted EventKind = "cleanup_completed"
+	// EventManualReviewRequested: the attempt is waiting for a person.
+	EventManualReviewRequested EventKind = "manual_review_requested"
+	// EventOperatorResolved: a person ended that wait.
+	EventOperatorResolved EventKind = "operator_resolved"
+	// EventAttemptSettled: the attempt reached its resolution.
+	EventAttemptSettled EventKind = "attempt_settled"
+	// EventAttemptSuperseded: a newer delivery replaced it.
+	EventAttemptSuperseded EventKind = "attempt_superseded"
+	// EventRemoteCanceled: the provider called the workload off. It
+	// shares a spelling with assignment.ResolutionRemoteCanceled and is
+	// a different vocabulary: one is what happened, the other is what
+	// was decided about it.
+	EventRemoteCanceled EventKind = "remote_canceled"
+)
+
+// AllEventKinds is every kind the trail can hold, for the test that
+// holds this list against the column that closes it.
+var AllEventKinds = []EventKind{
+	EventAttemptCreated,
+	EventLeaseAttached,
+	EventRuntimePrepared,
+	EventStartAuthorized,
+	EventRunningObserved,
+	EventExitObserved,
+	EventRuntimeObservationFailed,
+	EventCleanupStarted,
+	EventCleanupCompleted,
+	EventManualReviewRequested,
+	EventOperatorResolved,
+	EventAttemptSettled,
+	EventAttemptSuperseded,
+	EventRemoteCanceled,
+}

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -39,7 +39,7 @@ func (t *Tx) LeaseAttempt(attemptID assignment.AttemptID, bindingID assignment.B
 		id, bindingID, attemptID, tierID, LeaseReserved); err != nil {
 		return Lease{}, err
 	}
-	if err := t.RecordEvent(attemptID, "lease_attached:"+id, "lease_attached"); err != nil {
+	if err := t.RecordEvent(attemptID, "lease_attached:"+id, EventLeaseAttached); err != nil {
 		return Lease{}, err
 	}
 	return t.LeaseByID(assignment.LeaseID(id))

--- a/internal/store/serving.go
+++ b/internal/store/serving.go
@@ -333,7 +333,7 @@ func (t *Tx) CancelReady(attemptID assignment.AttemptID, resolution assignment.R
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is not ready", ErrConflict, attemptID)
 	}
-	return t.RecordEvent(attemptID, "remote_canceled", "remote_canceled")
+	return t.RecordEvent(attemptID, "remote_canceled", EventRemoteCanceled)
 }
 
 // OpenAttemptByWorkload resolves the unresolved attempt for a workload,
@@ -375,7 +375,7 @@ func (t *Tx) ResolveReviewToReady(attemptID assignment.AttemptID, reason, actor 
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is not in manual review", ErrConflict, attemptID)
 	}
-	return t.RecordRepeatableEvent(attemptID, "operator_resolved",
+	return t.RecordRepeatableEvent(attemptID, EventOperatorResolved,
 		map[string]string{"decision": "retry", "actor": actor, "reason": reason})
 }
 
@@ -393,7 +393,7 @@ func (t *Tx) ResolveReviewToSettled(attemptID assignment.AttemptID, resolution a
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is not in manual review", ErrConflict, attemptID)
 	}
-	return t.RecordRepeatableEvent(attemptID, "operator_resolved",
+	return t.RecordRepeatableEvent(attemptID, EventOperatorResolved,
 		map[string]string{"decision": "settle", "actor": actor, "reason": reason})
 }
 
@@ -408,7 +408,7 @@ func (t *Tx) Settle(attemptID assignment.AttemptID, currentState AttemptState, r
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s is no longer %s", ErrConflict, attemptID, currentState)
 	}
-	return t.RecordEvent(attemptID, "attempt_settled", "attempt_settled")
+	return t.RecordEvent(attemptID, "attempt_settled", EventAttemptSettled)
 }
 
 // RequeueServing returns a serving's attempt to the queue, choosing
@@ -447,7 +447,7 @@ func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason ReviewReason) 
 	if affected == 0 {
 		return fmt.Errorf("%w: attempt %s cannot enter review from its state", ErrConflict, attemptID)
 	}
-	return t.RecordRepeatableEvent(attemptID, "manual_review_requested",
+	return t.RecordRepeatableEvent(attemptID, EventManualReviewRequested,
 		map[string]string{"reason": string(reason)})
 }
 
@@ -464,21 +464,21 @@ func (t *Tx) HoldForReview(attemptID assignment.AttemptID, reason ReviewReason) 
 // reachable conflict to absorb — the query says why. A duplicate it
 // cannot construct would be an error rather than a silent drop, which is
 // the right answer for an append-only log.
-func (t *Tx) RecordRepeatableEvent(attemptID assignment.AttemptID, kind string, detail map[string]string) error {
+func (t *Tx) RecordRepeatableEvent(attemptID assignment.AttemptID, kind EventKind, detail map[string]string) error {
 	encoded, err := json.Marshal(detail)
 	if err != nil {
 		return err
 	}
 	_, err = t.q.InsertSequencedAttemptEvent(t.ctx, sqlitedb.InsertSequencedAttemptEventParams{
-		AttemptID: string(attemptID), Kind: kind, DetailJson: string(encoded),
+		AttemptID: string(attemptID), Kind: string(kind), DetailJson: string(encoded),
 	})
 	return err
 }
 
 // RecordEvent appends one lifecycle event, idempotently per key.
-func (t *Tx) RecordEvent(attemptID assignment.AttemptID, idempotencyKey, kind string) error {
+func (t *Tx) RecordEvent(attemptID assignment.AttemptID, idempotencyKey string, kind EventKind) error {
 	_, err := t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
-		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: "{}",
+		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: string(kind), DetailJson: "{}",
 	})
 	return err
 }
@@ -487,13 +487,13 @@ func (t *Tx) RecordEvent(attemptID assignment.AttemptID, idempotencyKey, kind st
 // detail. The detail is marshalled here so nothing unvalidated reaches
 // the column, and it must never contain secrets — it is what an
 // operator reads back.
-func (t *Tx) RecordEventDetail(attemptID assignment.AttemptID, idempotencyKey, kind string, detail map[string]string) error {
+func (t *Tx) RecordEventDetail(attemptID assignment.AttemptID, idempotencyKey string, kind EventKind, detail map[string]string) error {
 	encoded, err := json.Marshal(detail)
 	if err != nil {
 		return err
 	}
 	_, err = t.q.InsertAttemptEvent(t.ctx, sqlitedb.InsertAttemptEventParams{
-		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: kind, DetailJson: string(encoded),
+		AttemptID: string(attemptID), IdempotencyKey: idempotencyKey, Kind: string(kind), DetailJson: string(encoded),
 	})
 	return err
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2289,3 +2289,48 @@ func TestTheVocabulariesCoverTheirColumns(t *testing.T) {
 		t.Error("a resolution outside the vocabulary was stored")
 	}
 }
+
+// TestEveryEventKindIsOneTheColumnAdmits: the trail's fourteen kinds are
+// closed by the schema and enumerated in Go, and the two lists are
+// written by different hands. A kind the machine can produce and the
+// column refuses fails at the write -- in a delivery path, at the moment
+// the trail is being written for an operator to read -- and a kind the
+// column admits with no constant is one the next writer spells by hand.
+func TestEveryEventKindIsOneTheColumnAdmits(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	id := seedAttempt(t, s, binding, "msg-kinds", "job-kinds")
+
+	for _, k := range AllEventKinds {
+		if err := s.Tx(t.Context(), func(tx *Tx) error {
+			return tx.RecordEvent(id, "idem-"+string(k), k)
+		}); err != nil {
+			t.Errorf("the column refuses the kind %q the machine produces: %v", k, err)
+		}
+	}
+
+	// The other direction, against the column itself: the list is not
+	// short. Every kind the schema admits has a constant here.
+	var admitted []string
+	inTx(t, s, func(tx *Tx) error {
+		row := tx.tx.QueryRow(
+			`SELECT sql FROM sqlite_schema WHERE name = 'attempt_events'`)
+		var ddl string
+		if err := row.Scan(&ddl); err != nil {
+			return err
+		}
+		for _, m := range regexp.MustCompile(`'([a-z_]+)'`).FindAllStringSubmatch(ddl, -1) {
+			admitted = append(admitted, m[1])
+		}
+		return nil
+	})
+	if len(admitted) != len(AllEventKinds) {
+		t.Fatalf("the column admits %d kinds and AllEventKinds holds %d: %v",
+			len(admitted), len(AllEventKinds), admitted)
+	}
+	for _, a := range admitted {
+		if !slices.Contains(AllEventKinds, EventKind(a)) {
+			t.Errorf("the column admits %q and no constant names it", a)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

`store.EventKind` names the attempt trail's fourteen values, with constants, a totality
list, and a test holding it against the column in both directions. The controller's
event-recording closure takes the parameter order of the API it wraps.

## What was found

The trail is what an operator reads to find out what happened to a job, and its kind
was a bare string at every write site across four packages — `store` (three files),
`lease` and `app`. The schema closes the vocabulary; Go held no list, no constants, and
no check that the two agreed.

**The ordering is the safety edge.** `RecordEvent(attemptID, idempotencyKey, kind)`;
the controller wrapped it in `record(ev, kind, idempotency, cancel)` — the opposite
order. Both were correct, so nothing was broken; but an edit that made either match the
other would have swapped every event's kind with its key, and the only thing that would
notice is the column's CHECK, at the write, inside a delivery path. Making the closure
take the API's order means the transposition no longer compiles.

The rename surfaced two calls of the form `RecordEvent(id, "remote_canceled",
"remote_canceled")` — one string serving as both key and kind, with nothing in the
source saying which position was which. The type says it now.

## Evidence

```text
Transposing kind and idempotency at the call site:
  cannot use kind (variable of string type store.EventKind) as string value
  cannot use idempotency (variable of type string) as store.EventKind value

Dropping one constant from AllEventKinds fails TestEveryEventKindIsOneTheColumnAdmits.

gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
```

Worth recording: my first attempt at the transposition mutation added explicit
conversions, which of course compiled — that is a deliberate cast, not the careless
edit the type defends against. The mutation above is the honest one.

## What would notice this regressing

`TestEveryEventKindIsOneTheColumnAdmits` reads the live table's DDL and requires the
two lists to be the same set — so a kind added to the schema without a constant, or a
constant the column refuses, fails here rather than at a write in production.

## Risk, compatibility and operations

**No behaviour change.** The same strings reach the same column. What changes is that
the compiler now holds the parameter order and the vocabulary.

**Schema: unchanged** — the column already closed the vocabulary; this is the Go half
catching up.

**Trust boundary, status API, CLI, configuration, deployment, rollback, runbook: N/A.
Not an ADR.**

## Changelog

```text
NONE — no observable behaviour changes.
```