### PR TITLE
refactor(config): the configuration's closed words are types

### DIFF
--- a/internal/app/logger.go
+++ b/internal/app/logger.go
@@ -10,11 +10,11 @@ import (
 func newLogger(cfg config.LogConfig) *slog.Logger {
 	var level slog.Level
 	switch cfg.Level {
-	case "debug":
+	case config.LogLevelDebug:
 		level = slog.LevelDebug
-	case "warn":
+	case config.LogLevelWarn:
 		level = slog.LevelWarn
-	case "error":
+	case config.LogLevelError:
 		level = slog.LevelError
 	default:
 		level = slog.LevelInfo

--- a/internal/app/logger_test.go
+++ b/internal/app/logger_test.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/config"
+)
+
+// TestEveryConfiguredLevelReachesTheHandler: the level vocabulary's one
+// behavioural consumer is this switch, and it read bare literals -- so
+// `case "wran"` compiled and logged at info, silently, which is the
+// failure the named type exists to prevent and could not while the
+// switch spelled its own words.
+//
+// The default is deliberate and stays: a level the validator refuses
+// never reaches here, so the fall-through is for the zero value before
+// defaults are applied, not for an unknown word.
+func TestEveryConfiguredLevelReachesTheHandler(t *testing.T) {
+	for level, want := range map[config.LogLevel]slog.Level{
+		config.LogLevelDebug: slog.LevelDebug,
+		config.LogLevelInfo:  slog.LevelInfo,
+		config.LogLevelWarn:  slog.LevelWarn,
+		config.LogLevelError: slog.LevelError,
+	} {
+		log := newLogger(config.LogConfig{Level: level, Format: config.LogFormatJSON})
+		if got := log.Handler(); !got.Enabled(t.Context(), want) {
+			t.Errorf("level %q does not enable %v", level, want)
+		}
+		if want > slog.LevelDebug && log.Handler().Enabled(t.Context(), want-1) {
+			t.Errorf("level %q enables everything below %v; the configured floor is not in force", level, want)
+		}
+	}
+}

--- a/internal/command/platform_summary.go
+++ b/internal/command/platform_summary.go
@@ -37,7 +37,7 @@ func releaseQualificationReference() map[string]string {
 	}
 	if qualified.Status != platform.ReferenceStatusFrozen {
 		return map[string]string{
-			"status":         qualified.Status,
+			"status":         string(qualified.Status),
 			"os":             qualified.Policy.OS + " " + qualified.Policy.OSVersion,
 			"arch":           qualified.Policy.Arch,
 			"docker_channel": qualified.Policy.DockerChannel,
@@ -48,7 +48,7 @@ func releaseQualificationReference() map[string]string {
 		}
 	}
 	return map[string]string{
-		"status":    qualified.Status,
+		"status":    string(qualified.Status),
 		"os":        qualified.Platform.OS + " " + qualified.Platform.OSVersion,
 		"arch":      qualified.Platform.Arch,
 		"engine":    qualified.Platform.Engine,

--- a/internal/command/status.go
+++ b/internal/command/status.go
@@ -241,7 +241,7 @@ func configuredStatusConfig(environ func(string) string) *config.Config {
 		tierID = config.DefaultTierID
 	}
 	return &config.Config{
-		Host:  config.Host{Topology: topology},
+		Host:  config.Host{Topology: config.HostTopology(topology)},
 		Tiers: []config.Tier{{ID: tierID, Parallelism: parallelism}},
 	}
 }

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -172,7 +172,7 @@ type resourceDTO struct {
 func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptView, obs daemonObservation, shippedCapsule string) statusDoc {
 	topology := "unknown"
 	if cfg != nil {
-		topology = cfg.Host.Topology
+		topology = string(cfg.Host.Topology)
 	}
 	doc := statusDoc{
 		statusHead:    statusHead{APIVersion: statusAPIVersion, Served: true},

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -365,7 +365,7 @@ func TestAnUnresolvableImageStillReportsWhatTheBuildShips(t *testing.T) {
 
 	// A quick-start configuration, so the document carries a tier to
 	// report an image for.
-	t.Setenv(config.EnvHostTopology, config.HostTopologySharedDaemon)
+	t.Setenv(config.EnvHostTopology, string(config.HostTopologySharedDaemon))
 
 	const release = "ghcr.io/rhobuild/runpool/capsule@sha256:" +
 		"2222222222222222222222222222222222222222222222222222222222222222"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -101,10 +101,10 @@ const (
 	DefaultScaleSetPrefix = "runpool-"
 )
 
-// AllLogLevels is the closed set the validator admits. It is the
+// allLogLevels is the closed set the validator admits. It is the
 // vocabulary's totality list, and the constant below is one of its
 // members by construction.
-var AllLogLevels = []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError}
+var allLogLevels = []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError}
 
 const (
 	LogLevelDebug LogLevel = "debug"

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -2,35 +2,54 @@ package config
 
 // Enumerated values the schema accepts. V1 qualifies exactly one restricted
 // network profile and one DNS mode; widening either is a design change.
+// The configuration's closed word vocabularies. This file already proves
+// the pattern for its measured values -- ByteSize, CPUQuantity, Duration
+// and CIDR all parse into named types -- and these decide as much: the
+// network profile is what builds a sandbox or does not, the topology is
+// what the host preflight rules on, and the credential type is what
+// picks an authentication scheme. A named string decodes from YAML with
+// no help, so the only thing a bare string bought was the freedom to
+// assign the wrong vocabulary's word.
+type (
+	HostTopology     string
+	NetworkProfile   string
+	IPv6Mode         string
+	DNSMode          string
+	CacheStorageMode string
+	CredentialType   string
+	LogFormat        string
+	LogLevel         string
+)
+
 const (
-	HostTopologySharedDaemon    = "shared-daemon"
-	HostTopologyDedicatedDaemon = "dedicated-daemon"
+	HostTopologySharedDaemon    HostTopology = "shared-daemon"
+	HostTopologyDedicatedDaemon HostTopology = "dedicated-daemon"
 
 	// NetworkProfilePublicInternetOnly is the restricted profile: the
 	// capsule has no route out, and its gateway relays what the policy
 	// allows. It is implemented and tested live; release qualification on
 	// the reference platform has not run.
-	NetworkProfilePublicInternetOnly = "public-internet-only"
+	NetworkProfilePublicInternetOnly NetworkProfile = "public-internet-only"
 	// NetworkProfileUnsafeOpen builds no sandbox: the capsule reaches
 	// whatever the host reaches. It is named so that no deployment can
 	// claim containment it does not have.
-	NetworkProfileUnsafeOpen = "unsafe-open-egress"
-	IPv6Disabled             = "disabled"
-	DNSModeGateway           = "gateway"
-	CacheStorageModeVolume   = "volume"
-	CredentialTypeToken      = "token"
+	NetworkProfileUnsafeOpen NetworkProfile   = "unsafe-open-egress"
+	IPv6Disabled             IPv6Mode         = "disabled"
+	DNSModeGateway           DNSMode          = "gateway"
+	CacheStorageModeVolume   CacheStorageMode = "volume"
+	CredentialTypeToken      CredentialType   = "token"
 	// CredentialTypeGitHubApp authenticates as an installation of a GitHub
 	// App rather than as a person. The provider client mints and refreshes
 	// the installation token itself from the App's own key.
-	CredentialTypeGitHubApp = "github_app"
+	CredentialTypeGitHubApp CredentialType = "github_app"
 
-	LogFormatJSON = "json"
-	LogFormatText = "text"
+	LogFormatJSON LogFormat = "json"
+	LogFormatText LogFormat = "text"
 
-	DefaultInstanceName    = "primary"
-	DefaultTierID          = "standard"
-	DefaultCacheGeneration = "default"
-	DefaultLogLevel        = "info"
+	DefaultInstanceName             = "primary"
+	DefaultTierID                   = "standard"
+	DefaultCacheGeneration          = "default"
+	DefaultLogLevel        LogLevel = LogLevelInfo
 	// MaxParallelism bounds allocator and preflight work for an untrusted
 	// configuration while remaining far above a practical single-host limit.
 	MaxParallelism = 10_000
@@ -82,7 +101,17 @@ const (
 	DefaultScaleSetPrefix = "runpool-"
 )
 
-var logLevels = []string{"debug", "info", "warn", "error"}
+// AllLogLevels is the closed set the validator admits. It is the
+// vocabulary's totality list, and the constant below is one of its
+// members by construction.
+var AllLogLevels = []LogLevel{LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError}
+
+const (
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+	LogLevelError LogLevel = "error"
+)
 
 // ApplyDefaults fills unset optional fields in place. Mandatory fields
 // (apiVersion, kind, targets, credentials, tiers) are never invented here;

--- a/internal/config/quickstart.go
+++ b/internal/config/quickstart.go
@@ -90,7 +90,7 @@ func FromEnvironment(environ func(string) string) (*Config, error) {
 	c := &Config{
 		APIVersion: APIVersion,
 		Kind:       Kind,
-		Host:       Host{Topology: topology},
+		Host:       Host{Topology: HostTopology(topology)},
 		Targets: []Target{{
 			ID:           "default",
 			URL:          ref.CanonicalURL,
@@ -134,10 +134,10 @@ func FromEnvironment(environ func(string) string) (*Config, error) {
 		}
 	}
 	if level := environ(EnvLogLevel); level != "" {
-		c.Observability.Log.Level = level
+		c.Observability.Log.Level = LogLevel(level)
 	}
 	if profile := environ(EnvNetworkProfile); profile != "" {
-		c.Network.Profile = profile
+		c.Network.Profile = NetworkProfile(profile)
 	}
 	return c, nil
 }

--- a/internal/config/quickstart_test.go
+++ b/internal/config/quickstart_test.go
@@ -14,7 +14,7 @@ func TestQuickStartMinimal(t *testing.T) {
 	c, err := Load(env(map[string]string{
 		EnvGitHubURL:    "https://github.com/acme/app",
 		EnvGitHubToken:  "secret",
-		EnvHostTopology: HostTopologyDedicatedDaemon,
+		EnvHostTopology: string(HostTopologyDedicatedDaemon),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +45,7 @@ func TestQuickStartOrganizationDisablesCache(t *testing.T) {
 		EnvGitHubURL:         "https://github.com/acme",
 		EnvGitHubToken:       "secret",
 		EnvGitHubRunnerGroup: "runpool",
-		EnvHostTopology:      HostTopologyDedicatedDaemon,
+		EnvHostTopology:      string(HostTopologyDedicatedDaemon),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -58,19 +58,19 @@ func TestQuickStartOrganizationDisablesCache(t *testing.T) {
 func TestQuickStartErrors(t *testing.T) {
 	cases := map[string]map[string]string{
 		"missing topology": {EnvGitHubURL: "https://github.com/acme/app", EnvGitHubToken: "secret"},
-		"missing url":      {EnvGitHubToken: "secret", EnvHostTopology: HostTopologyDedicatedDaemon},
-		"missing token":    {EnvGitHubURL: "https://github.com/acme/app", EnvHostTopology: HostTopologyDedicatedDaemon},
+		"missing url":      {EnvGitHubToken: "secret", EnvHostTopology: string(HostTopologyDedicatedDaemon)},
+		"missing token":    {EnvGitHubURL: "https://github.com/acme/app", EnvHostTopology: string(HostTopologyDedicatedDaemon)},
 		"token and file": {
 			EnvGitHubURL:       "https://github.com/acme/app",
 			EnvGitHubToken:     "secret",
 			EnvGitHubTokenFile: "/run/secrets/token",
-			EnvHostTopology:    HostTopologyDedicatedDaemon,
+			EnvHostTopology:    string(HostTopologyDedicatedDaemon),
 		},
 		"bad parallelism": {
 			EnvGitHubURL:    "https://github.com/acme/app",
 			EnvGitHubToken:  "secret",
 			EnvParallelism:  "zero",
-			EnvHostTopology: HostTopologyDedicatedDaemon,
+			EnvHostTopology: string(HostTopologyDedicatedDaemon),
 		},
 		"config file with target var": {
 			EnvConfigFile: "testdata/example.yaml",
@@ -88,7 +88,7 @@ func TestQuickStartTokenFile(t *testing.T) {
 	c, err := Load(env(map[string]string{
 		EnvGitHubURL:       "https://github.com/acme/app",
 		EnvGitHubTokenFile: "/run/secrets/github-token",
-		EnvHostTopology:    HostTopologyDedicatedDaemon,
+		EnvHostTopology:    string(HostTopologyDedicatedDaemon),
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -102,7 +102,7 @@ func TestQuickStartSharedDaemonRequiresReserve(t *testing.T) {
 	base := map[string]string{
 		EnvGitHubURL:    "https://github.com/acme/app",
 		EnvGitHubToken:  "secret",
-		EnvHostTopology: HostTopologySharedDaemon,
+		EnvHostTopology: string(HostTopologySharedDaemon),
 	}
 	if _, err := Load(env(base)); err == nil || !strings.Contains(err.Error(), "host.reserve") {
 		t.Fatalf("shared daemon without reserve: %v", err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -79,8 +79,8 @@ type Host struct {
 	// Topology states who else relies on the Docker daemon. Shared-daemon
 	// enables the coexistence contract used by platforms such as Dokploy;
 	// dedicated-daemon gives Runpool exclusive operational ownership.
-	Topology string  `yaml:"topology"`
-	Reserve  Reserve `yaml:"reserve"`
+	Topology HostTopology `yaml:"topology"`
+	Reserve  Reserve      `yaml:"reserve"`
 }
 
 // Reserve is capacity withheld from tier scheduling so the host, the
@@ -133,8 +133,8 @@ type TierBinding struct {
 //
 // No secret value ever appears here. Every field is a reference to one.
 type Credential struct {
-	ID   string `yaml:"id"`
-	Type string `yaml:"type"`
+	ID   string         `yaml:"id"`
+	Type CredentialType `yaml:"type"`
 	// Exactly one of TokenEnv (an environment variable name) or TokenFile
 	// (a mounted secret path) references the token of a `token`
 	// credential; the value itself never appears in configuration.
@@ -188,7 +188,7 @@ type Cache struct {
 }
 
 type CacheStorage struct {
-	Mode string `yaml:"mode"`
+	Mode CacheStorageMode `yaml:"mode"`
 }
 
 type CacheGlobal struct {
@@ -210,8 +210,8 @@ type Observability struct {
 }
 
 type LogConfig struct {
-	Format string `yaml:"format"`
-	Level  string `yaml:"level"`
+	Format LogFormat `yaml:"format"`
+	Level  LogLevel  `yaml:"level"`
 }
 
 type MetricsConfig struct {
@@ -219,15 +219,15 @@ type MetricsConfig struct {
 }
 
 type Network struct {
-	Profile           string    `yaml:"profile"`
-	IPv6              string    `yaml:"ipv6"`
-	DNS               DNSConfig `yaml:"dns"`
-	AllowPrivateCIDRs []CIDR    `yaml:"allowPrivateCIDRs"`
-	DenyCIDRs         []CIDR    `yaml:"denyCIDRs"`
+	Profile           NetworkProfile `yaml:"profile"`
+	IPv6              IPv6Mode       `yaml:"ipv6"`
+	DNS               DNSConfig      `yaml:"dns"`
+	AllowPrivateCIDRs []CIDR         `yaml:"allowPrivateCIDRs"`
+	DenyCIDRs         []CIDR         `yaml:"denyCIDRs"`
 }
 
 type DNSConfig struct {
-	Mode string `yaml:"mode"`
+	Mode DNSMode `yaml:"mode"`
 }
 
 // ByteSize is a byte quantity written as a non-negative integer with a

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -323,8 +323,8 @@ func Validate(c *Config) error {
 	if f := c.Observability.Log.Format; f != LogFormatJSON && f != LogFormatText {
 		v.errf("observability.log.format", "must be %q or %q", LogFormatJSON, LogFormatText)
 	}
-	if !slices.Contains(logLevels, c.Observability.Log.Level) {
-		v.errf("observability.log.level", "must be one of %s", strings.Join(logLevels, ", "))
+	if !slices.Contains(AllLogLevels, c.Observability.Log.Level) {
+		v.errf("observability.log.level", "must be one of %s", joinVocabulary(AllLogLevels))
 	}
 
 	// The restricted profile sandboxes egress: no route out, and a
@@ -449,4 +449,16 @@ func (v *validator) secretPath(path, ref string) {
 	case filepath.Clean(ref) != ref:
 		v.errf(path, "must be a clean path; %q resolves to %q", ref, filepath.Clean(ref))
 	}
+}
+
+// joinVocabulary renders a closed vocabulary for an error an operator
+// reads. The values are named types, so they need one conversion each --
+// and doing it here keeps every refusal message spelling the set the
+// same way.
+func joinVocabulary[T ~string](vs []T) string {
+	out := make([]string, len(vs))
+	for i, v := range vs {
+		out[i] = string(v)
+	}
+	return strings.Join(out, ", ")
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -323,8 +323,8 @@ func Validate(c *Config) error {
 	if f := c.Observability.Log.Format; f != LogFormatJSON && f != LogFormatText {
 		v.errf("observability.log.format", "must be %q or %q", LogFormatJSON, LogFormatText)
 	}
-	if !slices.Contains(AllLogLevels, c.Observability.Log.Level) {
-		v.errf("observability.log.level", "must be one of %s", joinVocabulary(AllLogLevels))
+	if !slices.Contains(allLogLevels, c.Observability.Log.Level) {
+		v.errf("observability.log.level", "must be one of %s", joinVocabulary(allLogLevels))
 	}
 
 	// The restricted profile sandboxes egress: no route out, and a
@@ -452,9 +452,9 @@ func (v *validator) secretPath(path, ref string) {
 }
 
 // joinVocabulary renders a closed vocabulary for an error an operator
-// reads. The values are named types, so they need one conversion each --
-// and doing it here keeps every refusal message spelling the set the
-// same way.
+// reads. The stdlib has no join over a named string type, and the one
+// caller enumerates a list rather than naming two members inline as the
+// refusals around it do.
 func joinVocabulary[T ~string](vs []T) string {
 	out := make([]string, len(vs))
 	for i, v := range vs {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -501,3 +501,21 @@ func TestTheEnvelopeFloorsApplyOnlyWhereAGatewayExists(t *testing.T) {
 		t.Errorf("a small tier under unsafe-open-egress was refused: %v", err)
 	}
 }
+
+// TestEveryLogLevelIsAccepted holds the list against the validator that
+// reads it. The list is built from the constants, so a typo cannot drift
+// -- but an omission can: delete LogLevelWarn from it and `warn`
+// configurations start being refused with nothing failing.
+func TestEveryLogLevelIsAccepted(t *testing.T) {
+	for _, level := range allLogLevels {
+		c := validConfig()
+		c.Observability.Log.Level = level
+		if err := Validate(c); err != nil {
+			t.Errorf("the validator refuses %q, which the vocabulary holds: %v", level, err)
+		}
+	}
+	if len(allLogLevels) != 4 {
+		t.Errorf("the vocabulary holds %d levels; slog has four this maps onto, and a fifth "+
+			"needs a case in the controller's own switch", len(allLogLevels))
+	}
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -19,9 +19,16 @@ import (
 // admission. Exact release evidence is compared separately against Reference.
 const MinimumEngineMajor = 28
 
+// ReferenceStatus is whether a platform entry's facts have been captured
+// and reviewed. It gates the release: a candidate tag cannot be created
+// while any entry is pending, and Compare refuses outright unless the
+// entry is frozen -- so a status compared against the wrong vocabulary's
+// word would report a reference nobody reviewed as reviewed.
+type ReferenceStatus string
+
 const (
-	ReferenceStatusPending = "pending"
-	ReferenceStatusFrozen  = "frozen"
+	ReferenceStatusPending ReferenceStatus = "pending"
+	ReferenceStatusFrozen  ReferenceStatus = "frozen"
 )
 
 //go:embed platform.lock.json
@@ -74,10 +81,10 @@ type Reference struct {
 // it. A pending entry keeps release gates closed for that platform until
 // its facts have been captured and reviewed before a candidate tag.
 type Qualified struct {
-	Status   string `json:"status"`
-	Policy   Policy `json:"policy"`
-	Recorded string `json:"recorded,omitempty"`
-	Platform Facts  `json:"platform,omitempty"`
+	Status   ReferenceStatus `json:"status"`
+	Policy   Policy          `json:"policy"`
+	Recorded string          `json:"recorded,omitempty"`
+	Platform Facts           `json:"platform,omitempty"`
 }
 
 // For returns the entry qualified for an architecture.
@@ -340,7 +347,7 @@ func (m Mismatch) String() string {
 // cannot qualify a release.
 func (q Qualified) Compare(observed Facts) []Mismatch {
 	if q.Status != ReferenceStatusFrozen {
-		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: q.Status}}
+		return []Mismatch{{Property: "reference_status", Want: string(ReferenceStatusFrozen), Got: string(q.Status)}}
 	}
 	var out []Mismatch
 	check := func(property, want, got string) {
@@ -375,7 +382,7 @@ func (q Qualified) Compare(observed Facts) []Mismatch {
 // API. Qualification contracts use it when they need daemon-only evidence.
 func (q Qualified) CompareDockerFacts(observed Facts) []Mismatch {
 	if q.Status != ReferenceStatusFrozen {
-		return []Mismatch{{Property: "reference_status", Want: ReferenceStatusFrozen, Got: q.Status}}
+		return []Mismatch{{Property: "reference_status", Want: string(ReferenceStatusFrozen), Got: string(q.Status)}}
 	}
 	var out []Mismatch
 	check := func(property, want, got string) {


### PR DESCRIPTION
## What changes

Eight closed vocabularies in `internal/config` and one in `internal/platform` become
named types. The log levels gain constants and a totality list. No behaviour changes.

## What was found

`internal/config/defaults.go` parses every *measured* value into a named type —
`ByteSize`, `CPUQuantity`, `Duration`, `CIDR`, each with a parser and a test — and left
its *word* vocabularies as bare strings, though those decide as much:

- `Network.Profile` decides whether a sandbox is built at all (`serve.go:227,307`)
- `Host.Topology` is what the host preflight rules on (`doctor.go:155`)
- `Credential.Type` picks the authentication scheme (`credential.go:124`)

A named string type decodes from YAML with no help at all, so what the bare string
bought was the freedom to assign one vocabulary's word to another's field.

The log levels had no constants at all — the validator compared the field against
`[]string{"debug", "info", "warn", "error"}`, a list nothing tied to the default
constant beside it. They have constants, a totality list, and the default is now one of
its members by construction.

`platform.ReferenceStatus` is the same shape with a release gate attached: no candidate
tag may be created while an entry is pending, and `Compare` refuses outright unless the
entry is frozen.

## Evidence

```text
Declaring Network.Profile as HostTopology instead of NetworkProfile:
  does not compile — which is the whole of what these types buy.

gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
```

Stated plainly because I tested it and it is worth knowing: these types stop an
*accidental* cross-vocabulary assignment, not a deliberate `string(x)` cast. That is
true of every named string type in Go. The defence is against the edit nobody meant to
make, and that is the edit that happens.

## What would notice this regressing

The compiler, at every assignment and comparison — with one gap this PR closes rather
than claims: `internal/app/logger.go` is the level vocabulary's only behavioural
consumer, and it switched on bare literals, so `case "wran"` compiled and logged at
info. It reads the constants now, and `TestEveryConfiguredLevelReachesTheHandler`
drives every level through it and asserts the handler enables that floor.

`TestEveryLogLevelIsAccepted` holds the list against the validator: the list is built
from the constants so a typo cannot drift, but an omission can, and deleting a member
now fails.

## Risk, compatibility and operations

**No behaviour change.** Same YAML, same values, same refusals. The conversions land at
real boundaries — an environment variable is a string, a JSON summary field is a string
— and both convert explicitly at the edge rather than weakening the vocabulary to meet
them.

**Configuration:** unchanged; a named string type unmarshals from YAML identically.

**Status API:** unchanged — the summary converts at the map literal.

**Schema, migration, trust boundary, deployment, rollback, runbook: N/A. Not an ADR.**

## Changelog

```text
NONE — no observable behaviour changes.
```
