### PR TITLE
refactor(engine): the role vocabulary lives at the port it crosses

### DIFF
--- a/internal/app/assignment_test.go
+++ b/internal/app/assignment_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rhobuild/runpool/internal/allocator"
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/cache"
-	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/lease"
@@ -513,5 +512,5 @@ func driveLeaseTo(t *testing.T, h *harness, leaseID assignment.LeaseID, target s
 func (h *harness) resolveWithRuntime(ctx context.Context, lease store.Lease, obs assignment.ExecutionObservation) {
 	h.srv.caps = &fakeCapsule{obs: obs}
 	h.srv.resolveInterrupted(ctx, h.bind, lease,
-		engine.OwnedContainer{ID: "runner-x", Role: capsule.RoleCapsule, Running: false}, true)
+		engine.OwnedContainer{ID: "runner-x", Role: engine.RoleCapsule, Running: false}, true)
 }

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -192,7 +192,7 @@ func (m *diskMonitor) measure(ctx context.Context) (disk.Facts, error) {
 	}
 	var managed int64
 	for _, u := range usage {
-		if u.Role == cache.RoleCacheLane && u.Size > 0 {
+		if u.Role == engine.RoleCacheLane && u.Size > 0 {
 			managed += u.Size
 		}
 	}

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rhobuild/runpool/internal/cache"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/disk"
 	"github.com/rhobuild/runpool/internal/engine"
@@ -21,10 +20,10 @@ func TestMeasureWeighsOnlyThisInstancesLanes(t *testing.T) {
 	h := newHarness(t, 1)
 	h.probe.free = engine.FilesystemFree{FreeBytes: 500, FreeInodes: 90}
 	h.probe.usage = []engine.VolumeUsage{
-		{Name: "lane-a", Size: 100, Role: cache.RoleCacheLane},
-		{Name: "lane-b", Size: 40, Role: cache.RoleCacheLane},
+		{Name: "lane-a", Size: 100, Role: engine.RoleCacheLane},
+		{Name: "lane-b", Size: 40, Role: engine.RoleCacheLane},
 		{Name: "workspace", Size: 9000, Role: "workspace"},
-		{Name: "unmeasured", Size: -1, Role: cache.RoleCacheLane},
+		{Name: "unmeasured", Size: -1, Role: engine.RoleCacheLane},
 	}
 
 	facts, err := h.srv.disk.measure(t.Context())

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -70,7 +70,7 @@ func (s *Controller) reconcile(ctx context.Context) error {
 
 	runnerByLease := make(map[assignment.LeaseID]engine.OwnedContainer, len(containers))
 	for _, c := range containers {
-		if c.Role == capsule.RoleCapsule {
+		if c.Role == engine.RoleCapsule {
 			runnerByLease[c.LeaseID] = c
 		}
 	}

--- a/internal/app/startup_test.go
+++ b/internal/app/startup_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/rhobuild/runpool/internal/assignment"
-	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/store"
 )
@@ -32,7 +31,7 @@ func TestReconcileAdoptsWhatIsStillRunning(t *testing.T) {
 	}
 
 	h.objects.containers = []engine.OwnedContainer{
-		{ID: "runner-alive", Role: capsule.RoleCapsule, LeaseID: alive.ID, Running: true},
+		{ID: "runner-alive", Role: engine.RoleCapsule, LeaseID: alive.ID, Running: true},
 	}
 	h.srv.caps = &fakeCapsule{obs: assignment.ObservedAbsent}
 	h.srv.wait = &fakeWaiter{}
@@ -83,8 +82,8 @@ func TestSweepPeriodicallyKeepsWhatIsBeingWorkedOn(t *testing.T) {
 	}
 	live, _ := leaseFor(t, h, "job-1")
 	h.objects.containers = []engine.OwnedContainer{
-		{ID: "runner-live", Role: capsule.RoleCapsule, LeaseID: live.ID, Running: true},
-		{ID: "runner-orphan", Role: capsule.RoleCapsule, LeaseID: "lse-vanished"},
+		{ID: "runner-live", Role: engine.RoleCapsule, LeaseID: live.ID, Running: true},
+		{ID: "runner-orphan", Role: engine.RoleCapsule, LeaseID: "lse-vanished"},
 	}
 
 	h.srv.sweepPeriodically(t.Context())

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -22,17 +22,15 @@ import (
 )
 
 // Volume labels a cache lane carries, alongside the instance ownership
-// pair every managed object has. RoleCacheLane distinguishes persistent
+// pair every managed object has. engine.RoleCacheLane distinguishes persistent
 // lanes from a lease's ephemeral volumes in every sweep: a lane belongs
 // to the instance, not to any lease.
 const (
 	// LabelProject carries the opaque source-project id a lane is warm for.
-	LabelProject   = "io.runpool.cache.project"
-	LabelGen       = "io.runpool.cache.generation"
-	LabelLane      = "io.runpool.cache.lane"
-	RoleCacheLane  = "cache-lane"
-	volumePrefix   = "runpool-cache-"
-	labelRoleValue = RoleCacheLane
+	LabelProject = "io.runpool.cache.project"
+	LabelGen     = "io.runpool.cache.generation"
+	LabelLane    = "io.runpool.cache.lane"
+	volumePrefix = "runpool-cache-"
 )
 
 // LaneMount tells a capsule which volume its lane is. There is no path
@@ -100,7 +98,7 @@ func (m *LaneManager) Acquire(ctx context.Context, sourceProjectKey, generation 
 	// The lane's own three go on top of the ownership every managed
 	// object carries: what a lane is warm for is the cache's vocabulary,
 	// not the daemon's.
-	labels := engine.Ownership{Instance: m.instanceID, Role: labelRoleValue}.Labels()
+	labels := engine.Ownership{Instance: m.instanceID, Role: engine.RoleCacheLane}.Labels()
 	labels[LabelProject] = lane.ProjectID
 	labels[LabelGen] = lane.Generation
 	labels[LabelLane] = lane.ID

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -81,7 +81,7 @@ func (f *fakeVolumes) OwnedVolumeUsage(context.Context, assignment.InstanceID) (
 		// volume nobody owns.
 		out = append(out, engine.VolumeUsage{
 			Name:   name,
-			Role:   labels["io.runpool.role"],
+			Role:   engine.Role(labels["io.runpool.role"]),
 			Labels: labels,
 			Size:   size,
 		})
@@ -209,7 +209,7 @@ func TestVolumeNamesAreOpaque(t *testing.T) {
 	if strings.Contains(labels[LabelProject], "acme") {
 		t.Errorf("repository text reached the labels: %q", labels[LabelProject])
 	}
-	if labels["io.runpool.managed"] != "true" || labels["io.runpool.role"] != RoleCacheLane {
+	if labels["io.runpool.managed"] != "true" || engine.Role(labels["io.runpool.role"]) != engine.RoleCacheLane {
 		t.Errorf("ownership labels wrong: %v", labels)
 	}
 }

--- a/internal/cache/gc.go
+++ b/internal/cache/gc.go
@@ -78,7 +78,7 @@ func (m *LaneManager) PlanGC(ctx context.Context, opts GCOptions) (GCPlan, error
 	sizes := map[string]int64{} // lane id -> bytes
 	orphaned := map[string]int64{}
 	for _, u := range usage {
-		if u.Role != RoleCacheLane {
+		if u.Role != engine.RoleCacheLane {
 			continue
 		}
 		size := u.Size
@@ -111,7 +111,7 @@ func (m *LaneManager) PlanGC(ctx context.Context, opts GCOptions) (GCPlan, error
 		}
 	}
 	for _, u := range usage {
-		if u.Role != RoleCacheLane {
+		if u.Role != engine.RoleCacheLane {
 			continue
 		}
 		lane := u.Labels[LabelLane]

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -67,19 +67,6 @@ const (
 	KindContainer = engine.KindContainer
 	KindNetwork   = engine.KindNetwork
 	KindVolume    = engine.KindVolume
-
-	RoleNetwork  = "capsule-net"
-	RoleDindData = "dind-data"
-	// RoleCapsule is the outer container itself — the adoptable object
-	// whose exit is the job's exit.
-	RoleCapsule = "capsule"
-	// RoleGateway is the capsule's egress gateway: the only container on
-	// both the internal isolated bridge and the Runpool uplink.
-	RoleGateway = "gateway"
-	// RoleUplink is the instance's one egress network: gateways' second
-	// leg. Like a cache lane it carries no lease, and sweeps must read
-	// that as "infrastructure", never as "orphan".
-	RoleUplink = "uplink"
 )
 
 const (
@@ -168,14 +155,14 @@ type ResourceRecorder interface {
 // is ours from an earlier incarnation of this same intent — adopted by
 // proven ownership, never by name — or it is foreign and the launch
 // fails closed.
-func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind engine.ObjectKind, role, name string,
+func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind engine.ObjectKind, role engine.Role, name string,
 	createFn func() (string, error), resolve func() (string, error)) (string, error) {
 	// The kind crosses as a string on purpose: the recorder is the lease
 	// machine, which may not know a container runtime -- cleanup that
 	// depends on one stops working exactly when the runtime is what
 	// failed. It names the same vocabulary in its own type on the far
 	// side, and this is the one place the two meet.
-	intentID, err := rec.Plan(string(kind), role, name)
+	intentID, err := rec.Plan(string(kind), string(role), name)
 	if err != nil {
 		return "", err
 	}
@@ -298,8 +285,8 @@ func (m *Launcher) Start(ctx context.Context, prepared PreparedRuntime) error {
 
 func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder) (string, error) {
 	short := engine.ShortID(string(spec.LeaseID))
-	name := func(role string) string { return "runpool-" + role + "-" + short }
-	labels := func(kind engine.ObjectKind, role string) map[string]string {
+	name := func(role engine.Role) string { return "runpool-" + string(role) + "-" + short }
+	labels := func(kind engine.ObjectKind, role engine.Role) map[string]string {
 		return engine.Ownership{
 			Instance: spec.InstanceID,
 			Lease:    spec.LeaseID,
@@ -326,15 +313,15 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	// there is one — its gateway, and placed under one parent cgroup.
 	cgroupParent := LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID))
 	capsuleShare := SplitEnvelope(spec.Resources, sandboxed)
-	netID, err := m.create(ctx, rec, KindNetwork, RoleNetwork, name(RoleNetwork),
+	netID, err := m.create(ctx, rec, KindNetwork, engine.RoleCapsuleNetwork, name(engine.RoleCapsuleNetwork),
 		func() (string, error) {
 			return m.dock.CreateNetwork(ctx, engine.NetworkSpec{
-				Name:     name(RoleNetwork),
+				Name:     name(engine.RoleCapsuleNetwork),
 				Internal: sandboxed,
 				Isolated: sandboxed,
-				Labels:   labels(KindNetwork, RoleNetwork),
+				Labels:   labels(KindNetwork, engine.RoleCapsuleNetwork),
 			})
-		}, resolve(KindNetwork, name(RoleNetwork)))
+		}, resolve(KindNetwork, name(engine.RoleCapsuleNetwork)))
 	if err != nil {
 		return "", err
 	}
@@ -347,10 +334,10 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 		}
 	}
 
-	dindData, err := m.create(ctx, rec, KindVolume, RoleDindData, name(RoleDindData),
+	dindData, err := m.create(ctx, rec, KindVolume, engine.RoleDindData, name(engine.RoleDindData),
 		func() (string, error) {
-			return m.dock.CreateVolume(ctx, name(RoleDindData), labels(KindVolume, RoleDindData))
-		}, resolve(KindVolume, name(RoleDindData)))
+			return m.dock.CreateVolume(ctx, name(engine.RoleDindData), labels(KindVolume, engine.RoleDindData))
+		}, resolve(KindVolume, name(engine.RoleDindData)))
 	if err != nil {
 		return "", err
 	}
@@ -361,9 +348,9 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	}
 
 	capsuleSpec := engine.ContainerSpec{
-		Name:       name(RoleCapsule),
+		Name:       name(engine.RoleCapsule),
 		Image:      spec.CapsuleImage,
-		Labels:     labels(KindContainer, RoleCapsule),
+		Labels:     labels(KindContainer, engine.RoleCapsule),
 		Privileged: true,
 		Network:    netID,
 		Mounts:     mounts,
@@ -399,10 +386,10 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 			"NO_PROXY="+noProxy, "no_proxy="+noProxy,
 		)
 	}
-	outerID, err := m.create(ctx, rec, KindContainer, RoleCapsule, name(RoleCapsule),
+	outerID, err := m.create(ctx, rec, KindContainer, engine.RoleCapsule, name(engine.RoleCapsule),
 		func() (string, error) {
 			return m.dock.CreateContainer(ctx, capsuleSpec)
-		}, resolve(KindContainer, name(RoleCapsule)))
+		}, resolve(KindContainer, name(engine.RoleCapsule)))
 	if err != nil {
 		return "", err
 	}
@@ -510,7 +497,7 @@ func protocolVerdict(code int, out string) error {
 // gateway reporting ready. Any failure here fails the launch closed;
 // a capsule is never started with a half-made sandbox.
 func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRecorder, netID string,
-	name func(string) string, labels func(engine.ObjectKind, string) map[string]string,
+	name func(engine.Role) string, labels func(engine.ObjectKind, engine.Role) map[string]string,
 	resolve func(engine.ObjectKind, string) func() (string, error)) (netip.Addr, string, error) {
 
 	subnet, err := m.dock.NetworkSubnet(ctx, netID)
@@ -531,16 +518,16 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 		return netip.Addr{}, "", err
 	}
 
-	gwID, err := m.create(ctx, rec, KindContainer, RoleGateway, name(RoleGateway),
+	gwID, err := m.create(ctx, rec, KindContainer, engine.RoleGateway, name(engine.RoleGateway),
 		func() (string, error) {
 			return m.dock.CreateContainer(ctx, engine.ContainerSpec{
-				Name:       name(RoleGateway),
+				Name:       name(engine.RoleGateway),
 				Image:      m.gatewayImage,
 				Entrypoint: []string{supervisorPath, "gateway"},
 				// The policy is configuration, not secret; the one
 				// secret in the system never touches the gateway.
 				Env:     []string{"RUNPOOL_GATEWAY_POLICY=" + string(policyJSON)},
-				Labels:  labels(KindContainer, RoleGateway),
+				Labels:  labels(KindContainer, engine.RoleGateway),
 				Network: netID,
 				// NET_ADMIN for the ruleset, and nothing else: not
 				// privileged, no socket, no volumes, no credentials.
@@ -556,7 +543,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 				PIDsLimit:       GatewayEnvelope().PIDsLimit,
 				CgroupParent:    LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID)),
 			})
-		}, resolve(KindContainer, name(RoleGateway)))
+		}, resolve(KindContainer, name(engine.RoleGateway)))
 	if err != nil {
 		return netip.Addr{}, "", err
 	}

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -4,8 +4,6 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
-	"github.com/rhobuild/runpool/internal/cache"
-	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/store"
@@ -242,14 +240,14 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	doc.ManualReview = append(doc.ManualReview, review...)
 	for _, c := range obs.containers {
 		doc.Containers = append(doc.Containers, containerDTO{
-			Name: c.Name, Role: c.Role, LeaseID: string(c.LeaseID), Running: c.Running,
+			Name: c.Name, Role: string(c.Role), LeaseID: string(c.LeaseID), Running: c.Running,
 		})
 	}
 	for _, n := range obs.networks {
-		doc.Networks = append(doc.Networks, resourceDTO{Kind: "network", Role: n.Role, Name: n.ID, LeaseID: string(n.LeaseID)})
+		doc.Networks = append(doc.Networks, resourceDTO{Kind: "network", Role: string(n.Role), Name: n.ID, LeaseID: string(n.LeaseID)})
 	}
 	for _, v := range obs.volumes {
-		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: v.Role, Name: v.ID, LeaseID: string(v.LeaseID)})
+		doc.Volumes = append(doc.Volumes, resourceDTO{Kind: "volume", Role: string(v.Role), Name: v.ID, LeaseID: string(v.LeaseID)})
 	}
 	if obs.err != nil {
 		doc.EngineError = obs.err.Error()
@@ -349,7 +347,7 @@ func discrepancies(leases []store.Lease, obs daemonObservation) []string {
 		}
 	}
 
-	check := func(kind string, resources []engine.OwnedResource, persistentRole string) {
+	check := func(kind string, resources []engine.OwnedResource, persistentRole engine.Role) {
 		for _, r := range resources {
 			switch {
 			case r.Role == persistentRole:
@@ -362,8 +360,8 @@ func discrepancies(leases []store.Lease, obs daemonObservation) []string {
 			}
 		}
 	}
-	check("network", obs.networks, capsule.RoleUplink)
-	check("volume", obs.volumes, cache.RoleCacheLane)
+	check("network", obs.networks, engine.RoleUplink)
+	check("volume", obs.volumes, engine.RoleCacheLane)
 	return out
 }
 

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rhobuild/runpool/internal/cache"
-	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
 	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/store"
@@ -88,11 +86,11 @@ func TestStatusDiscrepanciesCoverEveryKind(t *testing.T) {
 		},
 		networks: []engine.OwnedResource{
 			{ID: "net-orphan", LeaseID: "lease-done"},
-			{ID: "uplink", Role: capsule.RoleUplink},
+			{ID: "uplink", Role: engine.RoleUplink},
 		},
 		volumes: []engine.OwnedResource{
 			{ID: "vol-unclassified"},
-			{ID: "lane", Role: cache.RoleCacheLane},
+			{ID: "lane", Role: engine.RoleCacheLane},
 		},
 	}
 	got := discrepancies(leases, obs)

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -271,7 +271,7 @@ func checkIsolatedBridge(ctx context.Context, d networkProbeClient, cfg *config.
 			// sweep.
 			Instance: "doctor",
 			Kind:     engine.KindNetwork,
-			Role:     "preflight-probe",
+			Role:     engine.RolePreflightProbe,
 		}.Labels(),
 	})
 	if err != nil {

--- a/internal/engine/docker/diskusage.go
+++ b/internal/engine/docker/diskusage.go
@@ -63,7 +63,7 @@ func (c *Client) ProbeFilesystemFree(ctx context.Context, image string, instance
 		Labels: engine.Ownership{
 			Instance: instanceID,
 			Kind:     engine.KindContainer,
-			Role:     "probe",
+			Role:     engine.RoleProbe,
 		}.Labels(),
 	})
 	if err != nil {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -54,6 +54,47 @@ const (
 	KindVolume    ObjectKind = "volume"
 )
 
+// Role is what an object Runpool owns is for. It is the port's because
+// the port is where it travels -- four structs carry it across, and the
+// only package the Moby adapter may import beside assignment is this
+// one, so a constant anywhere else leaves the adapter spelling its own
+// probe role by hand, as it did.
+//
+// The values are a compatibility surface: they are stamped into labels
+// that outlive the process that wrote them, so an instance upgraded
+// mid-flight must still recognise what the previous build owns. The pin
+// is in this package's own test, which spelled these strings raw while
+// the constants lived where this package could not see them.
+type Role string
+
+const (
+	// RoleCapsule is the outer container itself -- the adoptable object
+	// whose exit is the job's exit.
+	RoleCapsule Role = "capsule"
+	// RoleGateway is the capsule's egress gateway: the only container on
+	// both the internal isolated bridge and the Runpool uplink.
+	RoleGateway Role = "gateway"
+	// RoleCapsuleNetwork is the isolated bridge the capsule sits on. Not
+	// RoleNetwork: beside KindNetwork that would read as a kind, which is
+	// the cross-vocabulary confusion this type exists to end.
+	RoleCapsuleNetwork Role = "capsule-net"
+	// RoleDindData is the volume holding a capsule's inner daemon state.
+	RoleDindData Role = "dind-data"
+	// RoleUplink is the instance's one egress network: gateways' second
+	// leg. Like a cache lane it carries no lease, and sweeps must read
+	// that as "infrastructure", never as "orphan".
+	RoleUplink Role = "uplink"
+	// RoleCacheLane is one project's warm workspace, held across leases.
+	RoleCacheLane Role = "cache-lane"
+	// RoleProbe is a short-lived helper this build runs to ask the host
+	// something -- a filesystem reading, an interface list.
+	RoleProbe Role = "probe"
+	// RolePreflightProbe is the same idea before anything serves: the
+	// host preflight's own container, distinct so a sweep can tell a
+	// preflight still running from a probe a serving instance started.
+	RolePreflightProbe Role = "preflight-probe"
+)
+
 // Ownership is what a Runpool instance stamps on everything it creates,
 // and the only thing that proves an object is its to remove. A name is
 // not proof: a foreign object can carry the name a plan expects, and
@@ -69,7 +110,7 @@ type Ownership struct {
 	Instance assignment.InstanceID
 	Lease    assignment.LeaseID
 	Kind     ObjectKind
-	Role     string
+	Role     Role
 	Attempt  assignment.AttemptID
 	Target   assignment.TargetID
 	Tier     assignment.TierID
@@ -88,7 +129,7 @@ func (o Ownership) Labels() map[string]string {
 	for key, value := range map[string]string{
 		labelKind:    string(o.Kind),
 		labelLease:   string(o.Lease),
-		labelRole:    o.Role,
+		labelRole:    string(o.Role),
 		labelAttempt: string(o.Attempt),
 		labelTarget:  string(o.Target),
 		labelTier:    string(o.Tier),
@@ -188,7 +229,7 @@ type OwnedContainer struct {
 	ID      string
 	Name    string
 	Kind    ObjectKind
-	Role    string
+	Role    Role
 	LeaseID assignment.LeaseID
 	Running bool
 }
@@ -213,7 +254,7 @@ type NetworkSpec struct {
 type OwnedResource struct {
 	ID      string
 	LeaseID assignment.LeaseID
-	Role    string
+	Role    Role
 }
 
 // ShortID trims an object id to the width daemon tooling displays,
@@ -238,7 +279,7 @@ type VolumeUsage struct {
 	// labels so a caller can ask what a volume is for without knowing
 	// how ownership is written down. Labels stays for the vocabulary
 	// that is the caller's own, such as which lane a cache volume is.
-	Role   string
+	Role   Role
 	Labels map[string]string
 	// Size in bytes; -1 when the daemon could not compute it.
 	Size int64
@@ -348,7 +389,7 @@ func OwnershipFrom(labels map[string]string) (Ownership, bool) {
 		Instance: assignment.InstanceID(labels[labelInstance]),
 		Lease:    assignment.LeaseID(labels[labelLease]),
 		Kind:     ObjectKind(labels[labelKind]),
-		Role:     labels[labelRole],
+		Role:     Role(labels[labelRole]),
 		Attempt:  assignment.AttemptID(labels[labelAttempt]),
 		Target:   assignment.TargetID(labels[labelTarget]),
 		Tier:     assignment.TierID(labels[labelTier]),

--- a/internal/engine/ownership_test.go
+++ b/internal/engine/ownership_test.go
@@ -5,8 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"maps"
-	"slices"
+	"strings"
 	"testing"
 )
 
@@ -81,100 +80,118 @@ func marshal(t *testing.T, labels map[string]string) string {
 // carries a lease, and therefore whether an object wearing it is
 // infrastructure or an orphan.
 func TestEveryRoleIsPinnedToItsWireValue(t *testing.T) {
-	pinned := map[Role]string{
-		RoleCapsule:        "capsule",
-		RoleGateway:        "gateway",
-		RoleCapsuleNetwork: "capsule-net",
-		RoleDindData:       "dind-data",
-		RoleUplink:         "uplink",
-		RoleCacheLane:      "cache-lane",
-		RoleProbe:          "probe",
-		RolePreflightProbe: "preflight-probe",
+	pinned := map[string]string{
+		"RoleCapsule":        "capsule",
+		"RoleGateway":        "gateway",
+		"RoleCapsuleNetwork": "capsule-net",
+		"RoleDindData":       "dind-data",
+		"RoleUplink":         "uplink",
+		"RoleCacheLane":      "cache-lane",
+		"RoleProbe":          "probe",
+		"RolePreflightProbe": "preflight-probe",
 	}
-	for role, want := range pinned {
-		if string(role) != want {
-			t.Errorf("role renders %q; the label says %q, and an instance upgraded "+
-				"mid-flight would stop recognising what the previous build owns", role, want)
-		}
-	}
-
-	// Totality: a role added to the vocabulary and not here is one whose
-	// sweep class nobody decided.
-	seen := map[string]bool{}
-	for _, want := range pinned {
-		if seen[want] {
-			t.Errorf("two roles share the wire value %q", want)
-		}
-		seen[want] = true
-	}
-	// Against the source, not against itself: a count written here would
-	// be a number this test also chose, and a ninth constant would pass.
 	declared := roleConstants(t)
-	if len(declared) != len(pinned) {
-		t.Errorf("engine.go declares %d roles and this pin holds %d: %v\n"+
-			"decide the new role's sweep class -- does it carry a lease? -- and add it here",
-			len(declared), len(pinned), declared)
-	}
-	for _, name := range declared {
-		if !slices.ContainsFunc(slices.Collect(maps.Keys(pinned)), func(r Role) bool {
-			return roleName(r) == name
-		}) {
-			t.Errorf("the constant %s is not pinned to a wire value", name)
+
+	for name, value := range declared {
+		want, ok := pinned[name]
+		if !ok {
+			t.Errorf("%s is declared and not pinned. Decide its sweep class -- does it "+
+				"carry a lease? -- and add it here with its wire value", name)
+			continue
 		}
+		if value != want {
+			t.Errorf("%s renders %q; the label says %q, and an instance upgraded mid-flight "+
+				"would stop recognising what the previous build owns", name, value, want)
+		}
+	}
+	for name := range pinned {
+		if _, ok := declared[name]; !ok {
+			t.Errorf("%s is pinned here and no longer declared", name)
+		}
+	}
+	seen := map[string]string{}
+	for name, value := range declared {
+		if other, dup := seen[value]; dup {
+			t.Errorf("%s and %s share the wire value %q", other, name, value)
+		}
+		seen[value] = name
 	}
 }
 
 // roleConstants reads this package's own source for every constant
-// declared with type Role.
-func roleConstants(t *testing.T) []string {
+// declared with type Role, and returns each one's literal value. Taking
+// the value from the source rather than mapping it back by hand is what
+// keeps this to two lists -- the declaration and the pin above -- rather
+// than three, where the third would be the one nobody remembers.
+//
+// It walks every file in the package, not one: a constant added in a new
+// file would otherwise escape the count in silence.
+func roleConstants(t *testing.T) map[string]string {
 	t.Helper()
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "engine.go", nil, 0)
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	var out []string
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok || gen.Tok != token.CONST {
+	out := map[string]string{}
+	for name, pkg := range pkgs {
+		if strings.HasSuffix(name, "_test") {
 			continue
 		}
-		for _, spec := range gen.Specs {
-			v, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			if id, ok := v.Type.(*ast.Ident); !ok || id.Name != "Role" {
-				continue
-			}
-			for _, n := range v.Names {
-				out = append(out, n.Name)
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gen, ok := decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.CONST {
+					continue
+				}
+				for _, spec := range gen.Specs {
+					v, ok := spec.(*ast.ValueSpec)
+					if !ok || len(v.Names) != len(v.Values) || !declaresRole(v) {
+						continue
+					}
+					for i, n := range v.Names {
+						lit, ok := literalOf(v.Values[i])
+						if !ok {
+							t.Errorf("%s is a Role constant this parse cannot read a value from; "+
+								"spell it as a plain string literal so the pin can see it", n.Name)
+							continue
+						}
+						out[n.Name] = lit
+					}
+				}
 			}
 		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no Role constants found, so this proves nothing")
 	}
 	return out
 }
 
-// roleName maps a value back to the constant that names it, which is the
-// half a source parse cannot do.
-func roleName(r Role) string {
-	switch r {
-	case RoleCapsule:
-		return "RoleCapsule"
-	case RoleGateway:
-		return "RoleGateway"
-	case RoleCapsuleNetwork:
-		return "RoleCapsuleNetwork"
-	case RoleDindData:
-		return "RoleDindData"
-	case RoleUplink:
-		return "RoleUplink"
-	case RoleCacheLane:
-		return "RoleCacheLane"
-	case RoleProbe:
-		return "RoleProbe"
-	case RolePreflightProbe:
-		return "RolePreflightProbe"
+// declaresRole covers both spellings a Role constant can take: the typed
+// form `RoleX Role = "x"` and the conversion form `RoleX = Role("x")`.
+// Counting only the first would let the second escape.
+func declaresRole(v *ast.ValueSpec) bool {
+	if id, ok := v.Type.(*ast.Ident); ok && id.Name == "Role" {
+		return true
 	}
-	return ""
+	for _, val := range v.Values {
+		if call, ok := val.(*ast.CallExpr); ok {
+			if id, ok := call.Fun.(*ast.Ident); ok && id.Name == "Role" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func literalOf(expr ast.Expr) (string, bool) {
+	if call, ok := expr.(*ast.CallExpr); ok && len(call.Args) == 1 {
+		expr = call.Args[0]
+	}
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	return strings.Trim(lit.Value, `"`), true
 }

--- a/internal/engine/ownership_test.go
+++ b/internal/engine/ownership_test.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
 	"strings"
 	"testing"
 )
@@ -129,35 +130,38 @@ func TestEveryRoleIsPinnedToItsWireValue(t *testing.T) {
 func roleConstants(t *testing.T) map[string]string {
 	t.Helper()
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	entries, err := os.ReadDir(".")
 	if err != nil {
 		t.Fatal(err)
 	}
 	out := map[string]string{}
-	for name, pkg := range pkgs {
-		if strings.HasSuffix(name, "_test") {
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				gen, ok := decl.(*ast.GenDecl)
-				if !ok || gen.Tok != token.CONST {
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				v, ok := spec.(*ast.ValueSpec)
+				if !ok || len(v.Names) != len(v.Values) || !declaresRole(v) {
 					continue
 				}
-				for _, spec := range gen.Specs {
-					v, ok := spec.(*ast.ValueSpec)
-					if !ok || len(v.Names) != len(v.Values) || !declaresRole(v) {
+				for i, n := range v.Names {
+					lit, ok := literalOf(v.Values[i])
+					if !ok {
+						t.Errorf("%s is a Role constant this parse cannot read a value from; "+
+							"spell it as a plain string literal so the pin can see it", n.Name)
 						continue
 					}
-					for i, n := range v.Names {
-						lit, ok := literalOf(v.Values[i])
-						if !ok {
-							t.Errorf("%s is a Role constant this parse cannot read a value from; "+
-								"spell it as a plain string literal so the pin can see it", n.Name)
-							continue
-						}
-						out[n.Name] = lit
-					}
+					out[n.Name] = lit
 				}
 			}
 		}

--- a/internal/engine/ownership_test.go
+++ b/internal/engine/ownership_test.go
@@ -2,6 +2,11 @@ package engine
 
 import (
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"maps"
+	"slices"
 	"testing"
 )
 
@@ -57,4 +62,119 @@ func marshal(t *testing.T, labels map[string]string) string {
 		t.Fatal(err)
 	}
 	return string(encoded)
+}
+
+// TestEveryRoleIsPinnedToItsWireValue is this vocabulary's totality list
+// and its compatibility pin at once, and both halves need the literals.
+//
+// The values are stamped into labels that outlive the process that wrote
+// them: an instance upgraded mid-flight has to recognise what the
+// previous build owns, so a value edited here is a sweep that stops
+// seeing its own objects. Spelled through the constants this would pin
+// nothing -- edit RoleUplink and a constant-using assertion drifts with
+// it and stays green. The literal is the only thing that fails.
+//
+// There is no production Roles slice, deliberately: the sweep refuses
+// role enumeration (see HelperInFlight and InstanceInfrastructure), so a
+// list nothing branches on would be a second place to keep in step. What
+// adding a role obliges is a decision here and there -- whether it
+// carries a lease, and therefore whether an object wearing it is
+// infrastructure or an orphan.
+func TestEveryRoleIsPinnedToItsWireValue(t *testing.T) {
+	pinned := map[Role]string{
+		RoleCapsule:        "capsule",
+		RoleGateway:        "gateway",
+		RoleCapsuleNetwork: "capsule-net",
+		RoleDindData:       "dind-data",
+		RoleUplink:         "uplink",
+		RoleCacheLane:      "cache-lane",
+		RoleProbe:          "probe",
+		RolePreflightProbe: "preflight-probe",
+	}
+	for role, want := range pinned {
+		if string(role) != want {
+			t.Errorf("role renders %q; the label says %q, and an instance upgraded "+
+				"mid-flight would stop recognising what the previous build owns", role, want)
+		}
+	}
+
+	// Totality: a role added to the vocabulary and not here is one whose
+	// sweep class nobody decided.
+	seen := map[string]bool{}
+	for _, want := range pinned {
+		if seen[want] {
+			t.Errorf("two roles share the wire value %q", want)
+		}
+		seen[want] = true
+	}
+	// Against the source, not against itself: a count written here would
+	// be a number this test also chose, and a ninth constant would pass.
+	declared := roleConstants(t)
+	if len(declared) != len(pinned) {
+		t.Errorf("engine.go declares %d roles and this pin holds %d: %v\n"+
+			"decide the new role's sweep class -- does it carry a lease? -- and add it here",
+			len(declared), len(pinned), declared)
+	}
+	for _, name := range declared {
+		if !slices.ContainsFunc(slices.Collect(maps.Keys(pinned)), func(r Role) bool {
+			return roleName(r) == name
+		}) {
+			t.Errorf("the constant %s is not pinned to a wire value", name)
+		}
+	}
+}
+
+// roleConstants reads this package's own source for every constant
+// declared with type Role.
+func roleConstants(t *testing.T) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "engine.go", nil, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			v, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if id, ok := v.Type.(*ast.Ident); !ok || id.Name != "Role" {
+				continue
+			}
+			for _, n := range v.Names {
+				out = append(out, n.Name)
+			}
+		}
+	}
+	return out
+}
+
+// roleName maps a value back to the constant that names it, which is the
+// half a source parse cannot do.
+func roleName(r Role) string {
+	switch r {
+	case RoleCapsule:
+		return "RoleCapsule"
+	case RoleGateway:
+		return "RoleGateway"
+	case RoleCapsuleNetwork:
+		return "RoleCapsuleNetwork"
+	case RoleDindData:
+		return "RoleDindData"
+	case RoleUplink:
+		return "RoleUplink"
+	case RoleCacheLane:
+		return "RoleCacheLane"
+	case RoleProbe:
+		return "RoleProbe"
+	case RolePreflightProbe:
+		return "RolePreflightProbe"
+	}
+	return ""
 }

--- a/internal/netsandbox/netsandbox.go
+++ b/internal/netsandbox/netsandbox.go
@@ -166,7 +166,7 @@ func (n *Manager) build(ctx context.Context, budget time.Duration) (*capsule.San
 
 	uplinkID, err := n.daemon.EnsureOwnedNetwork(ctx, engine.NetworkSpec{
 		Name:   "runpool-uplink-" + string(n.instanceID)[:8],
-		Labels: engine.Ownership{Instance: n.instanceID, Role: capsule.RoleUplink}.Labels(),
+		Labels: engine.Ownership{Instance: n.instanceID, Role: engine.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("uplink network: %w", err)
@@ -379,7 +379,7 @@ func (n *Manager) ConfirmLaunch(ctx context.Context, leaseID assignment.LeaseID,
 	}
 	var confirmed int
 	for _, c := range containers {
-		if c.Role != capsule.RoleGateway || c.LeaseID != leaseID || !c.Running {
+		if c.Role != engine.RoleGateway || c.LeaseID != leaseID || !c.Running {
 			continue
 		}
 		if err := n.reloadGateway(ctx, c, payload); err != nil {
@@ -589,7 +589,7 @@ func (n *Manager) reloadGateways(ctx context.Context, allow, deny []string) (fai
 	}
 	var mu sync.Mutex
 	eachGateway(containers, func(c engine.OwnedContainer) {
-		if c.Role != capsule.RoleGateway || !c.Running {
+		if c.Role != engine.RoleGateway || !c.Running {
 			return
 		}
 		if err := n.reloadGateway(ctx, c, payload); err != nil {
@@ -699,7 +699,7 @@ func (n *Manager) closeGateways(ctx context.Context) error {
 		failures int
 	)
 	eachGateway(containers, func(c engine.OwnedContainer) {
-		if c.Role != capsule.RoleGateway || !c.Running {
+		if c.Role != engine.RoleGateway || !c.Running {
 			return
 		}
 		if err := n.closeGateway(ctx, c.ID); err != nil {
@@ -731,7 +731,7 @@ func (n *Manager) discoverHostCIDRs(ctx context.Context) ([]string, error) {
 		Entrypoint:  []string{"/bin/sh", "-c"},
 		Cmd:         []string{"ip -o -4 addr show scope global"},
 		NetworkMode: "host",
-		Labels:      engine.Ownership{Instance: n.instanceID, Role: "probe"}.Labels(),
+		Labels:      engine.Ownership{Instance: n.instanceID, Role: engine.RoleProbe}.Labels(),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/netsandbox/netsandbox_test.go
+++ b/internal/netsandbox/netsandbox_test.go
@@ -362,10 +362,10 @@ func TestBuildDeniesEverythingItDiscovered(t *testing.T) {
 // policy it started with, so its work continues.
 func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 	gateways := []engine.OwnedContainer{
-		{ID: "gw-ok", Name: "gw-ok", Role: capsule.RoleGateway, Running: true},
-		{ID: "gw-bad", Name: "gw-bad", Role: capsule.RoleGateway, Running: true},
-		{ID: "gw-stopped", Name: "gw-stopped", Role: capsule.RoleGateway},
-		{ID: "runner", Name: "runner", Role: capsule.RoleCapsule, Running: true},
+		{ID: "gw-ok", Name: "gw-ok", Role: engine.RoleGateway, Running: true},
+		{ID: "gw-bad", Name: "gw-bad", Role: engine.RoleGateway, Running: true},
+		{ID: "gw-stopped", Name: "gw-stopped", Role: engine.RoleGateway},
+		{ID: "runner", Name: "runner", Role: engine.RoleCapsule, Running: true},
 	}
 	inForce := &capsule.Sandbox{UplinkNetworkID: "up-1", Deny: []string{"10.0.0.0/8"}}
 
@@ -424,9 +424,9 @@ func TestApplyPolicyCostsWhatTheChangeWas(t *testing.T) {
 func TestCloseGatewaysRemovesEvenWhatWillNotDeny(t *testing.T) {
 	d := &fakeDaemon{
 		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
-			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
-			{ID: "runner", Role: capsule.RoleCapsule, Running: true},
+			{ID: "gw-1", Role: engine.RoleGateway, Running: true},
+			{ID: "gw-2", Role: engine.RoleGateway, Running: true},
+			{ID: "runner", Role: engine.RoleCapsule, Running: true},
 		},
 		refuse: map[string]bool{"gw-2": true},
 	}
@@ -535,7 +535,7 @@ func TestARestrictionThatCouldNotBeEnumeratedIsRetried(t *testing.T) {
 		refuse:  map[string]bool{},
 		listErr: errors.New("daemon unreachable"),
 		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
+			{ID: "gw-1", Role: engine.RoleGateway, Running: true},
 		},
 	}
 	n := newTestSandbox(t, daemon, inForce)
@@ -605,7 +605,7 @@ func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 	for i := range count {
 		id := fmt.Sprintf("gw-%02d", i)
 		containers = append(containers, engine.OwnedContainer{
-			ID: id, Name: id, Role: capsule.RoleGateway, Running: true,
+			ID: id, Name: id, Role: engine.RoleGateway, Running: true,
 		})
 	}
 	d := &fakeDaemon{containers: containers, delay: perCall}
@@ -652,7 +652,7 @@ func TestARefreshPaysItsExecBoundsInParallel(t *testing.T) {
 // function as the bound.
 func TestClosingAGatewayIsBoundedInBothSteps(t *testing.T) {
 	d := &fakeDaemon{containers: []engine.OwnedContainer{
-		{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
+		{ID: "gw-1", Name: "gw-1", Role: engine.RoleGateway, Running: true},
 	}}
 	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
 
@@ -747,7 +747,7 @@ func TestEnumeratingGatewaysIsBounded(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			d := &fakeDaemon{containers: []engine.OwnedContainer{
-				{ID: "gw-1", Name: "gw-1", Role: capsule.RoleGateway, Running: true},
+				{ID: "gw-1", Name: "gw-1", Role: engine.RoleGateway, Running: true},
 			}}
 			n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})
 
@@ -833,7 +833,7 @@ func TestARediscoveryThatIsStoppedDoesNotAnnounceAnEmergency(t *testing.T) {
 	// A gateway to close, so "nothing was closed" is an observation
 	// rather than an empty daemon answering emptily.
 	daemon := &fakeDaemon{
-		containers: []engine.OwnedContainer{{ID: "gw-1", Role: capsule.RoleGateway, LeaseID: "lse-1", Running: true}},
+		containers: []engine.OwnedContainer{{ID: "gw-1", Role: engine.RoleGateway, LeaseID: "lse-1", Running: true}},
 	}
 	n := newTestSandbox(t, daemon, &capsule.Sandbox{})
 
@@ -878,14 +878,14 @@ func TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy(t *testing.T)
 	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
+			{ID: "gw-1", Role: engine.RoleGateway, Running: true, LeaseID: "lse-1"},
 		},
 	}
 	// The launch's gateway appears just after the pass has listed, which
 	// is the whole of the window this closes.
 	daemon.onList = func(f *fakeDaemon) {
 		f.containers = append(f.containers, engine.OwnedContainer{
-			ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"})
+			ID: "gw-late", Role: engine.RoleGateway, Running: true, LeaseID: "lse-late"})
 		f.onList = nil
 	}
 	n := newTestSandbox(t, daemon, sandboxFixture())
@@ -915,7 +915,7 @@ func TestAConfirmedLaunchUnderAnUnchangedPolicyTouchesNoDaemon(t *testing.T) {
 	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-1"},
+			{ID: "gw-1", Role: engine.RoleGateway, Running: true, LeaseID: "lse-1"},
 		},
 	}
 	n := newTestSandbox(t, daemon, sandboxFixture())
@@ -945,13 +945,13 @@ func TestAConfirmationThatCannotReachTheGatewayFailsTheLaunch(t *testing.T) {
 	}{
 		"the gateway refuses the policy in force": {
 			containers: []engine.OwnedContainer{
-				{ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"},
+				{ID: "gw-late", Role: engine.RoleGateway, Running: true, LeaseID: "lse-late"},
 			},
 			refuse: map[string]bool{"gw-late": true},
 		},
 		"the lease owns no running gateway": {
 			containers: []engine.OwnedContainer{
-				{ID: "gw-other", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-other"},
+				{ID: "gw-other", Role: engine.RoleGateway, Running: true, LeaseID: "lse-other"},
 			},
 			refuse: map[string]bool{},
 		},
@@ -979,7 +979,7 @@ func TestAConfirmationThatWasOvertakenFailsTheLaunch(t *testing.T) {
 	daemon := &fakeDaemon{
 		refuse: map[string]bool{},
 		containers: []engine.OwnedContainer{
-			{ID: "gw-late", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-late"},
+			{ID: "gw-late", Role: engine.RoleGateway, Running: true, LeaseID: "lse-late"},
 		},
 	}
 	n := newTestSandbox(t, daemon, tighter(launched))
@@ -1006,7 +1006,7 @@ func TestARestrictionThatCouldNotBeClosedIsRetried(t *testing.T) {
 		refuse:    map[string]bool{"gw-bad": true},
 		removeErr: map[string]error{"gw-bad": errors.New("container is wedged")},
 		containers: []engine.OwnedContainer{
-			{ID: "gw-bad", Role: capsule.RoleGateway, Running: true, LeaseID: "lse-bad"},
+			{ID: "gw-bad", Role: engine.RoleGateway, Running: true, LeaseID: "lse-bad"},
 		},
 	}
 	n := newTestSandbox(t, daemon, sandboxFixture())
@@ -1042,8 +1042,8 @@ func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
 		uplinkSubnet: "172.30.0.0/24",
 		probeOut:     "", // saw nothing: the deny set cannot be trusted
 		containers: []engine.OwnedContainer{
-			{ID: "gw-1", Role: capsule.RoleGateway, Running: true},
-			{ID: "gw-2", Role: capsule.RoleGateway, Running: true},
+			{ID: "gw-1", Role: engine.RoleGateway, Running: true},
+			{ID: "gw-2", Role: engine.RoleGateway, Running: true},
 		},
 	}
 	n := newTestSandbox(t, d, &capsule.Sandbox{UplinkNetworkID: "up-1"})

--- a/internal/store/lease.go
+++ b/internal/store/lease.go
@@ -109,7 +109,10 @@ type Lease struct {
 }
 
 // ResourceKind is the Docker object type of an owned capsule resource;
-// Role says which part of the capsule it is (runner, dind, workspace...).
+// Role says which part of the capsule it is, spelled as engine.Role and
+// stored as text. Neither is derived from the port's type: this is a row
+// that outlives the build that wrote it, and a role that stopped
+// existing must still read back.
 type ResourceKind string
 
 const (

--- a/test/contract/capsule/budget_test.go
+++ b/test/contract/capsule/budget_test.go
@@ -40,7 +40,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 
 	uplinkID, err := dock.CreateNetwork(ctx, engine.NetworkSpec{
 		Name:   leaseID + "-uplink",
-		Labels: engine.Ownership{Instance: "contract", Role: capsule.RoleUplink}.Labels(),
+		Labels: engine.Ownership{Instance: "contract", Role: engine.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -78,7 +78,7 @@ func TestLeaseResourceBudget(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+short, "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+string(engine.RoleGateway)+"-"+short, "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}

--- a/test/contract/capsule/bypass_test.go
+++ b/test/contract/capsule/bypass_test.go
@@ -43,7 +43,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	// The uplink stands in for the instance's shared egress network.
 	uplinkID, err := dock.CreateNetwork(ctx, engine.NetworkSpec{
 		Name:   string(string(leaseID) + "-uplink"),
-		Labels: engine.Ownership{Instance: "contract", Role: capsule.RoleUplink}.Labels(),
+		Labels: engine.Ownership{Instance: "contract", Role: engine.RoleUplink}.Labels(),
 	})
 	if err != nil {
 		t.Fatalf("uplink: %v", err)
@@ -170,7 +170,7 @@ func TestNetworkSandboxBypass(t *testing.T) {
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+string(engine.RoleGateway)+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Fatalf("resolve gateway: %q, %v", gwID, err)
 	}
@@ -203,7 +203,7 @@ func dumpSandboxDiag(ctx context.Context, t *testing.T, dock *docker.Client,
 	if len(short) > 12 {
 		short = short[:12]
 	}
-	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+capsule.RoleGateway+"-"+string(short), "contract", assignment.LeaseID(leaseID))
+	gwID, err := dock.OwnedIDByName(ctx, engine.KindContainer, "runpool-"+string(engine.RoleGateway)+"-"+string(short), "contract", assignment.LeaseID(leaseID))
 	if err != nil || gwID == "" {
 		t.Logf("could not resolve gateway for diagnostics: %v", err)
 		return

--- a/test/contract/docker/contract_test.go
+++ b/test/contract/docker/contract_test.go
@@ -639,7 +639,7 @@ func TestEnsureOwnedVolume(t *testing.T) {
 	own := map[string]string{
 		"io.runpool.managed":  "true",
 		"io.runpool.instance": instance,
-		"io.runpool.role":     cache.RoleCacheLane,
+		"io.runpool.role":     string(engine.RoleCacheLane),
 	}
 	name := instance + "-ensure"
 	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
@@ -814,7 +814,7 @@ func TestOwnedVolumeUsage(t *testing.T) {
 
 	name := instance + "-usage"
 	t.Cleanup(func() { _ = c.RemoveVolume(context.Background(), name) })
-	if _, err := c.CreateVolume(ctx, name, labels(instance, "", "volume", cache.RoleCacheLane)); err != nil {
+	if _, err := c.CreateVolume(ctx, name, labels(instance, "", "volume", string(engine.RoleCacheLane))); err != nil {
 		t.Fatal(err)
 	}
 	code, out, err := c.RunTask(ctx, engine.ContainerSpec{
@@ -844,7 +844,7 @@ func TestOwnedVolumeUsage(t *testing.T) {
 	if found.Size < 512*1024 {
 		t.Errorf("size = %d; want at least the 512KiB written", found.Size)
 	}
-	if found.Role != cache.RoleCacheLane {
+	if found.Role != engine.RoleCacheLane {
 		t.Errorf("labels did not travel through disk usage: %v", found.Labels)
 	}
 }


### PR DESCRIPTION
## What changes

`engine.Role` names the eight roles Runpool stamps on the objects it owns; the four
port structs carry it; the two packages that held partial copies lose them; the three
inline literals get constants. A pin test in `engine` holds every wire value and reads
the source for totality.

## What was found

Roles decide adoption, sweeping and GC, and the vocabulary was in four states at once:
untyped constants in `internal/capsule` and `internal/cache`, three inline literals
with no constant (`"probe"` spelled independently in `netsandbox` and in the Moby
adapter, `"preflight-probe"` in `doctor`), and a bare `string` on `Ownership.Role`,
`OwnedContainer.Role`, `OwnedResource.Role` and `VolumeUsage.Role`.

The placement is forced rather than preferred, on two independent grounds:

- **Only the port can type its own fields.** `capsule` imports `engine`, so `engine`
  importing `capsule` is a cycle. Typing the vocabulary anywhere the port cannot see
  leaves the port's four fields `string`, which forfeits the exercise at the one
  boundary that matters.
- **Only the port can give the adapter its constant.** `internal/engine/docker` is
  pinned by `narrowDeps` to exactly `{assignment, engine}`, and it stamps `Role:
  "probe"` on its own filesystem probe. Any other home leaves that literal in place.

**The defect worth recording:** `internal/engine/ownership_test.go`
already pinned `"capsule"` and `"uplink"` as raw strings, because the values are a
compatibility surface: they are stamped into labels that outlive the process that wrote
them, so an instance upgraded mid-flight must recognise what the previous build owns.
The pin lived in `engine` while the constants lived where `engine` could not see them —
held together by nothing.

`RoleNetwork` becomes `RoleCapsuleNetwork`: beside `KindNetwork`, the old name read as
a kind, which is exactly the cross-vocabulary confusion this type ends. The wire value
is unchanged.

## Evidence

| Mutation | Failure |
| --- | --- |
| a ninth `Role` constant added | `engine.go declares 9 roles and this pin holds 8: [… RoleNinth]` |
| `RoleUplink`'s value edited to `"uplink-v2"` | the wire-value assertion |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
No change to test/architecture/architecture_test.go — no new edge, no narrowDeps
entry widened. Every consumer already imported engine.
```

## What would notice this regressing

`TestEveryRoleIsPinnedToItsWireValue`, in both halves. Its totality half parses
`engine.go` for constants declared with type `Role` rather than comparing against a
count the test also chose — the first version of it did compare against its own count,
and a ninth role would have passed.

## Risk, compatibility and operations

**No behaviour change, and no wire change.** Every label value is byte-identical; the
pin test is what says so.

**Trust boundary:** unchanged, but the sweep's vocabulary now has one declaration
instead of four partial ones.

**Schema:** unchanged — `store.ResourceIntent.Role` stays `string` and converts once at
the intent boundary, on the precedent `ResourceKind` already states: a row that
outlives the build is not derived from the port's type. A role that stops existing must
still read back.

**Status API:** unchanged — the DTO fields stay `string` and convert at the map
literal, as `Kind` already did.

**CLI, configuration, deployment, rollback, runbook: N/A. Not an ADR** — it implements
the placement the engine-port ADR's own reasoning implies.

## Changelog

```text
NONE — no observable behaviour changes.
```

## Notes for your reviewer

There is deliberately no production `AllRoles` slice. The sweep refuses role
enumeration by design — `HelperInFlight` and `InstanceInfrastructure` record that
naming the persistent roles "only looked equivalent" and that a third such role would
be swept as garbage by anything spelling the rule that way. A list nothing branches on
would be a second place to keep in step; the pin test carries the totality instead, and
its comment says what adding a role obliges: deciding whether it carries a lease.
