### PR TITLE
refactor(protocol): the supervisor's states are a type

### DIFF
--- a/cmd/capsule-supervisor/gateway.go
+++ b/cmd/capsule-supervisor/gateway.go
@@ -32,7 +32,7 @@ func runGateway(log *slog.Logger) int {
 	})
 	if err != nil {
 		log.Error("gateway failed", "error", err)
-		setState(protocol.FailedPrefix + err.Error())
+		setState(protocol.State(protocol.FailedPrefix + err.Error()))
 		return 1
 	}
 	return 0

--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -148,7 +148,7 @@ func supervise(log *slog.Logger) int {
 	if err := boot(log); err != nil {
 		log.Error("capsule boot failed", "error", err)
 		// Boot is entirely before the runner: nothing was ever handed over.
-		setState(protocol.AbortedPrefix + err.Error())
+		setState(protocol.State(protocol.AbortedPrefix + err.Error()))
 		return exitAborted
 	}
 
@@ -157,7 +157,7 @@ func supervise(log *slog.Logger) int {
 		log.Error("capsule run failed", "error", err)
 		state := terminalFailure(currentState(), err)
 		setState(state)
-		if strings.HasPrefix(state, protocol.AbortedPrefix) {
+		if strings.HasPrefix(string(state), protocol.AbortedPrefix) {
 			return exitAborted
 		}
 		return 1
@@ -167,7 +167,7 @@ func supervise(log *slog.Logger) int {
 		log.Warn("the runner exited with the reserved abort code; reporting it as a plain failure",
 			"runner_exit", code, "reported", reported)
 	}
-	setState(protocol.ExitedPrefix + strconv.Itoa(reported))
+	setState(protocol.State(protocol.ExitedPrefix + strconv.Itoa(reported)))
 	log.Info("capsule finished", "exit", reported)
 	return reported
 }
@@ -696,13 +696,13 @@ func authorizeStart(replace func(string, []byte, os.FileMode, int, int) error) e
 //
 // replace is a parameter so the fallback can be exercised without
 // filling a filesystem.
-func replaceState(path, state string, replace func(string, []byte, os.FileMode, int, int) error) {
+func replaceState(path string, state protocol.State, replace func(string, []byte, os.FileMode, int, int) error) {
 	if err := replace(path, []byte(state), 0o644, -1, -1); err != nil {
 		_ = os.WriteFile(path, []byte(state), 0o644)
 	}
 }
 
-func setState(s string) { replaceState(stateFile, s, atomicfile.Replace) }
+func setState(s protocol.State) { replaceState(stateFile, s, atomicfile.Replace) }
 
 // terminalFailure names a failure by whether the runner ever started,
 // which is the one thing the controller cannot infer from the outside.
@@ -711,19 +711,19 @@ func setState(s string) { replaceState(stateFile, s, atomicfile.Replace) }
 // outcome. Before it — no credential delivered, configuration unprepared,
 // dockerd never ready — the job never ran, and reporting an exit would settle
 // it as complete and never retry it.
-func terminalFailure(state string, err error) string {
+func terminalFailure(state protocol.State, err error) protocol.State {
 	if state == protocol.StateRunning {
-		return protocol.FailedPrefix + err.Error()
+		return protocol.State(protocol.FailedPrefix + err.Error())
 	}
-	return protocol.AbortedPrefix + err.Error()
+	return protocol.State(protocol.AbortedPrefix + err.Error())
 }
 
-func currentState() string {
+func currentState() protocol.State {
 	body, err := os.ReadFile(stateFile)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(body))
+	return protocol.State(strings.TrimSpace(string(body)))
 }
 
 // maxJITBundle bounds the credential delivery. A real bundle is a few

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -99,14 +99,16 @@ func TestPrepareRunnerConfigRejectsPathsAndCollisions(t *testing.T) {
 func TestTerminalFailureDistinguishesUnstartedRunners(t *testing.T) {
 	err := errors.New("no credential was delivered")
 
-	for _, state := range []string{"", "waiting", "starting"} {
-		if got := terminalFailure(state, err); !strings.HasPrefix(got, "aborted:") {
+	// Raw, deliberately: these are the wire values, and a pin spelled
+	// through the constants would follow them anywhere they moved.
+	for _, state := range []protocol.State{"", "booting", "waiting", "starting"} {
+		if got := terminalFailure(state, err); !strings.HasPrefix(string(got), "aborted:") {
 			t.Errorf("failure from state %q = %q; want an aborted state", state, got)
 		}
 	}
 	// Past `running` the runner owned the job; claiming it never started
 	// would run it a second time.
-	if got := terminalFailure("running", err); !strings.HasPrefix(got, "failed:") {
+	if got := terminalFailure("running", err); !strings.HasPrefix(string(got), "failed:") {
 		t.Errorf("failure after the runner started = %q; want a failed state", got)
 	}
 }
@@ -370,7 +372,7 @@ func TestTheStartAuthorizationRecordsItselfBeforeItLands(t *testing.T) {
 	if err := authorizeStart(record); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"state=" + protocol.StateStarting, "start=" + protocolVersion}
+	want := []string{"state=" + string(protocol.StateStarting), "start=" + protocolVersion}
 	if !slices.Equal(wrote, want) {
 		t.Errorf("the authorization wrote %v; want %v.\nUntil the state is recorded the capsule "+
 			"answers `waiting`, which is read as proof that no runner ever started.", wrote, want)
@@ -399,7 +401,7 @@ func TestAnAuthorizationThatCannotLandSaysSo(t *testing.T) {
 	if err := authorizeStart(record); !errors.Is(err, full) {
 		t.Fatalf("authorize returned %v; want the write's own failure", err)
 	}
-	if len(wrote) == 0 || wrote[len(wrote)-1] != protocol.StateWaiting {
+	if len(wrote) == 0 || protocol.State(wrote[len(wrote)-1]) != protocol.StateWaiting {
 		t.Errorf("the capsule was left saying %v after an authorization that never landed; "+
 			"it has to say the state a launcher requeues from", wrote)
 	}

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -595,11 +595,11 @@ func (m *Launcher) awaitReady(ctx context.Context, outerID string) error {
 // where the cost is — a terminal state carries the reason the container
 // failed, that reason dies with the container, and treating it as "not
 // yet" spends the whole deadline and then reports a timeout instead.
-func stateVerdict(want string, code int, out string, execErr error) (done bool, err error) {
+func stateVerdict(want protocol.State, code int, out string, execErr error) (done bool, err error) {
 	if execErr != nil || code != 0 {
 		return false, nil
 	}
-	switch s := strings.TrimSpace(out); {
+	switch s := protocol.State(strings.TrimSpace(out)); {
 	case s == want:
 		return true, nil
 	case protocol.Terminal(s):
@@ -620,7 +620,7 @@ func stateVerdict(want string, code int, out string, execErr error) (done bool, 
 // stateVerdict exists to prevent for a container that stays up. Asking
 // the daemon whether the container is still there is what covers the one
 // that does not.
-func (m *Launcher) awaitState(ctx context.Context, containerID, want string) error {
+func (m *Launcher) awaitState(ctx context.Context, containerID string, want protocol.State) error {
 	deadline := time.Now().Add(readyTimeout)
 	for {
 		code, out, err := m.dock.Exec(ctx, containerID, []string{supervisorPath, "state"})

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -32,7 +32,7 @@ func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntim
 	if err != nil || code != 0 {
 		return assignment.ObservedUnavailable, fmt.Errorf("capsule state unreadable (exit %d): %s", code, out)
 	}
-	return classifySupervisorState(strings.TrimSpace(out))
+	return classifySupervisorState(protocol.State(strings.TrimSpace(out)))
 }
 
 // SupervisorAbortedExitCode is the status the capsule supervisor exits
@@ -66,7 +66,7 @@ func ClassifyExit(code int) assignment.ExecutionObservation {
 // `waiting` proves an authorization never took effect; `starting` says one
 // did and its outcome is not yet knowable, which is not something to guess
 // at when guessing wrong runs a job twice.
-func classifySupervisorState(state string) (assignment.ExecutionObservation, error) {
+func classifySupervisorState(state protocol.State) (assignment.ExecutionObservation, error) {
 	switch {
 	case state == protocol.StateBooting, state == protocol.StateWaiting:
 		return assignment.ObservedCreated, nil
@@ -79,9 +79,9 @@ func classifySupervisorState(state string) (assignment.ExecutionObservation, err
 		return assignment.ObservedUnavailable, nil
 	case state == protocol.StateRunning:
 		return assignment.ObservedRunning, nil
-	case strings.HasPrefix(state, protocol.AbortedPrefix):
+	case strings.HasPrefix(string(state), protocol.AbortedPrefix):
 		return assignment.ObservedCreated, nil
-	case strings.HasPrefix(state, protocol.ExitedPrefix), strings.HasPrefix(state, protocol.FailedPrefix):
+	case strings.HasPrefix(string(state), protocol.ExitedPrefix), strings.HasPrefix(string(state), protocol.FailedPrefix):
 		return assignment.ObservedExited, nil
 	default:
 		return assignment.ObservedUnavailable, fmt.Errorf("capsule reports unrecognized state %q", state)

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -18,7 +18,13 @@ import (
 // exit_observed, which disposes the attempt as completed and never requeues
 // it — a job GitHub handed over, that never ran, and that nobody retries.
 func TestClassifySupervisorStateSeparatesAbortFromExit(t *testing.T) {
-	for state, want := range map[string]assignment.ExecutionObservation{
+	// The keys are raw strings on purpose: they are the on-disk vocabulary
+	// the supervisor writes and this reads, and spelling them through the
+	// constants would pin nothing -- edit StateWaiting's value and an
+	// assertion using it drifts along and stays green. Do not "clean these
+	// up" into constants; the literal is the guard.
+	for state, want := range map[protocol.State]assignment.ExecutionObservation{
+		"booting":  assignment.ObservedCreated,
 		"waiting":  assignment.ObservedCreated,
 		"starting": assignment.ObservedUnavailable,
 		"running":  assignment.ObservedRunning,
@@ -42,7 +48,7 @@ func TestClassifySupervisorStateSeparatesAbortFromExit(t *testing.T) {
 // An unknown state refuses to guess rather than settling the attempt on an
 // assumption: the whole point of the observation is that it is observed.
 func TestClassifySupervisorStateRefusesToGuess(t *testing.T) {
-	for _, state := range []string{"", "wat", "exited", "aborted", "done:0"} {
+	for _, state := range []protocol.State{"", "wat", "exited", "aborted", "done:0"} {
 		got, err := classifySupervisorState(state)
 		if err == nil {
 			t.Errorf("state %q classified %q; want an error", state, got)
@@ -130,9 +136,9 @@ func TestAwaitStateGivesUpOnEveryTerminalState(t *testing.T) {
 		wantDone bool
 		wantErr  string // substring; empty means done with no error, or not done
 	}{
-		"the wanted state":          {0, want, nil, true, ""},
-		"trailing newline":          {0, want + "\n", nil, true, ""},
-		"still booting":             {0, protocol.StateBooting, nil, false, ""},
+		"the wanted state":          {0, string(want), nil, true, ""},
+		"trailing newline":          {0, string(want) + "\n", nil, true, ""},
+		"still booting":             {0, string(protocol.StateBooting), nil, false, ""},
 		"aborted before the runner": {0, protocol.AbortedPrefix + " dockerd did not become ready in time", nil, true, "dockerd did not become ready"},
 		"failed after the runner":   {0, protocol.FailedPrefix + " runner exploded", nil, true, "runner exploded"},
 		"already exited":            {0, protocol.ExitedPrefix + "0", nil, true, "exited:0"},
@@ -167,11 +173,11 @@ func TestAwaitStateGivesUpOnEveryTerminalState(t *testing.T) {
 // `waiting` reads "not yet" as "never", and the assignment is served a
 // second time while the first capsule starts its runner.
 func TestOnlyWaitingProvesTheRunnerNeverStarted(t *testing.T) {
-	requeues := map[string]bool{}
-	for _, state := range []string{
+	requeues := map[protocol.State]bool{}
+	for _, state := range []protocol.State{
 		protocol.StateBooting, protocol.StateWaiting, protocol.StateStarting,
-		protocol.StateRunning, protocol.AbortedPrefix + "no credential",
-		protocol.ExitedPrefix + "0", protocol.FailedPrefix + "drained",
+		protocol.StateRunning, protocol.State(protocol.AbortedPrefix + "no credential"),
+		protocol.State(protocol.ExitedPrefix + "0"), protocol.State(protocol.FailedPrefix + "drained"),
 	} {
 		obs, err := classifySupervisorState(state)
 		if err != nil {
@@ -183,8 +189,8 @@ func TestOnlyWaitingProvesTheRunnerNeverStarted(t *testing.T) {
 		t.Error("a capsule that has accepted a start authorization is classified as one that " +
 			"never started; the assignment is requeued while the runner is being forked")
 	}
-	for _, proves := range []string{protocol.StateBooting, protocol.StateWaiting,
-		protocol.AbortedPrefix + "no credential"} {
+	for _, proves := range []protocol.State{protocol.StateBooting, protocol.StateWaiting,
+		protocol.State(protocol.AbortedPrefix + "no credential")} {
 		if !requeues[proves] {
 			t.Errorf("state %q no longer requeues; a job that was never handed over is left "+
 				"for a person or settled as though it ran", proves)

--- a/internal/capsule/protocol/protocol.go
+++ b/internal/capsule/protocol/protocol.go
@@ -38,18 +38,28 @@ import "strings"
 // the equality check enforces.
 const Version = "3"
 
-// The states a supervisor-family container writes to its control
+// State is what a supervisor-family container writes to its control
 // directory. The capsule's supervisor and the gateway are the same
 // binary in two containers and share this vocabulary; the launcher waits
 // on these names from the outside, so both sides read one declaration.
+//
+// It is a named type because these words cross a process
+// boundary as well as a package one, and because "running" here means
+// something different from "running" in three other vocabularies this
+// build carries -- a container status, a lease state, an execution
+// observation. The declaration is shared, so same-build drift is
+// unrepresentable; what the type adds is that a caller cannot hand one
+// of the other four where this one is meant.
+type State string
+
 const (
 	// StateBooting is the control surface answering before anything it
 	// supervises is proven. Nothing may be handed to a capsule here.
-	StateBooting = "booting"
+	StateBooting State = "booting"
 	// StateWaiting is the daemon proven ready and the runner deliberately
 	// not started: the state in which a credential is delivered and a
 	// start is authorized.
-	StateWaiting = "waiting"
+	StateWaiting State = "waiting"
 	// StateRunning is written once fork/exec has returned, so its
 	// presence is the proof that the job was handed over — not that the
 	// supervisor was about to try.
@@ -60,7 +70,7 @@ const (
 	// as a runtime that ran, settles the attempt, and nothing requeues
 	// it. The distinction this state carries is the difference between
 	// a job retried and a job silently gone.
-	StateRunning = "running"
+	StateRunning State = "running"
 	// StateStarting is the start authorization accepted and the runner
 	// not yet forked: the bundle is being read, its files materialized,
 	// the credential removed, and fork/exec attempted.
@@ -76,9 +86,9 @@ const (
 	//
 	// It settles on its own: the next state is `running` if fork/exec
 	// returned, and an abort if it did not.
-	StateStarting = "starting"
+	StateStarting State = "starting"
 	// StateReady is the gateway's: ruleset installed and relay listening.
-	StateReady = "ready"
+	StateReady State = "ready"
 )
 
 // The prefixes a terminal state carries, each with its reason appended.
@@ -99,10 +109,10 @@ const (
 // another one. A caller waiting for a state it can no longer reach must
 // give up with the reason rather than poll out its deadline: the reason
 // is written here and lost when the container goes.
-func Terminal(state string) bool {
-	return strings.HasPrefix(state, ExitedPrefix) ||
-		strings.HasPrefix(state, FailedPrefix) ||
-		strings.HasPrefix(state, AbortedPrefix)
+func Terminal(state State) bool {
+	return strings.HasPrefix(string(state), ExitedPrefix) ||
+		strings.HasPrefix(string(state), FailedPrefix) ||
+		strings.HasPrefix(string(state), AbortedPrefix)
 }
 
 // AbortedExitCode is the status the supervisor exits with when it stops

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -45,7 +45,7 @@ type Config struct {
 	// SetState reports readiness or failure through the supervisor's
 	// protocol; the controller polls it and refuses to start a capsule
 	// whose gateway never reported ready.
-	SetState func(string)
+	SetState func(protocol.State)
 }
 
 // PolicyPath is the policy in force, on the gateway's tmpfs. The relay


### PR DESCRIPTION
## What changes

`protocol.State` names the supervisor's five states; `Terminal`, `awaitState`,
`stateVerdict`, `classifySupervisorState`, the gateway's `SetState` callback and the
supervisor's `setState`/`replaceState`/`terminalFailure`/`currentState` all carry it.
The wire-pinning tests keep their raw literals. Two states that had no pin get one.

## What was found

`CONTRIBUTING.md` names four vocabularies that all spell `"running"` and decide
different things — a container status, a lease state, an execution observation, and a
supervisor protocol state. Three are named types. This was the fourth, and it is the
one that also crosses a *process* boundary: the supervisor writes these words to a file
inside the capsule; the launcher reads them from outside.

`awaitState(ctx, containerID, want string)` — two adjacent bare strings, transposable
and compiling. It no longer compiles.

**Two states had no raw pin anywhere.** `"booting"` was absent from the classifier's
table, and `"ready"` was only ever spelled through its constant — so an edit to either
value would have changed the on-disk vocabulary with nothing failing. Both are pinned.

## Why the raw-string tests stay raw

An architecture review decided this, and it is the part worth reading twice: a pin
spelled through the constant pins nothing. Edit `StateWaiting`'s value and every
constant-using assertion drifts along with it and stays green — the literal is the only
thing that fails. Go makes keeping them free: an untyped literal converts at the
parameter, so the map keys become `protocol.State` and the spellings are untouched.
Each of those suites now carries a comment saying the literals are the guard, so nobody
"cleans them up" into constants — the cleanup that would delete the guard.

The three prefixes (`exited:`, `failed:`, `aborted:`) stay untyped: they are fragments
composed into a `State` at the write sites and matched by `HasPrefix` at the read site.
Typing a fragment buys nothing the composed value does not already give.

## Evidence

| Mutation | Result |
| --- | --- |
| `StateWaiting`'s value edited to `"idle"` | the wire pin fails |
| `awaitState`'s parameter untyped back to `string` | does not compile |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
No change to test/architecture/architecture_test.go: protocol keeps its empty
dependency pin — the type needs only `strings`, already imported.
```

The repository's own `TestNoDocCommentBelongsToAnotherDeclaration` caught the type doc
leaving an orphaned comment above it. That is the third time this session it has caught
me doing exactly that; the comment is merged rather than stacked.

## What would notice this regressing

The two wire-pin suites, now including `booting` and `ready`. The compiler holds the
`awaitState` transposition and every cross-vocabulary assignment.

## Risk, compatibility and operations

**No behaviour change and no wire change.** Every state value is byte-identical; the
pins are what say so.

**Cross-build compatibility** is `protocol.Version`'s job, unchanged: a capsule
declaring a version this build does not speak is refused before any state is read. A
state value change remains a version-bump event.

**Trust boundary, schema, status API, CLI, configuration, deployment, rollback,
runbook: N/A. Not an ADR** — it completes a rule `CONTRIBUTING.md` already states.

## Changelog

```text
NONE — no observable behaviour changes.
```