### PR TITLE
test(store): the two remaining state vocabularies are held against their columns

### DIFF
--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -171,7 +171,7 @@ func TestPrunePeriodicallyHonoursTheWindow(t *testing.T) {
 				return err
 			}
 		}
-		return tx.Settle(lease.AttemptID, store.AttemptLeased, "completed_observed")
+		return tx.Settle(lease.AttemptID, store.AttemptLeased, assignment.ResolutionCompletedObserved)
 	})
 
 	for _, window := range []time.Duration{0, 24 * time.Hour} {

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -54,23 +54,35 @@ var ErrInvalidExecutionObservation = errors.New("execution observation is not a 
 // overwriting an observation.
 var ErrObservationConflict = errors.New("execution observation conflicts with what is recorded")
 
-// AllEvidence is every state the monotonic machine can reach, for the
-// test that holds this vocabulary against the column that closes it.
-// It is derived from the rank rather than written beside it: two lists
-// of the same words is one list and one place to forget.
-var AllEvidence = func() []Evidence {
-	out := make([]Evidence, len(evidenceRank))
-	for e, rank := range evidenceRank {
-		out[rank] = e
-	}
-	return out
-}()
+// AllEvidence is every state the monotonic machine can reach, in the
+// order it can reach them. The order is the rule: evidence only ever
+// moves forward, and a write that would move it back is refused.
+//
+// This is the source and the rank below is derived from it, not the
+// other way round. Building the slice by indexing the map assumed the
+// ranks were a contiguous run with no duplicates and no gaps -- true of
+// the data, stated by nothing, and both ways of breaking it are bad: a
+// gap panics in this package's initializer, which takes down every
+// binary that imports the store at startup, and a duplicate leaves a
+// hole in the slice that only a test happens to catch. Written this way
+// neither is expressible, and the hand-assigned numbers are gone with
+// their own chance to disagree.
+var AllEvidence = []Evidence{
+	EvidenceNotStarted,
+	EvidenceRuntimePrepared,
+	EvidenceStartAuthorized,
+	EvidenceRunningObserved,
+	EvidenceExitObserved,
+}
 
 // evidenceRank orders the vocabulary for the monotonic rule.
-var evidenceRank = map[Evidence]int{
-	EvidenceNotStarted: 0, EvidenceRuntimePrepared: 1,
-	EvidenceStartAuthorized: 2, EvidenceRunningObserved: 3, EvidenceExitObserved: 4,
-}
+var evidenceRank = func() map[Evidence]int {
+	m := make(map[Evidence]int, len(AllEvidence))
+	for i, e := range AllEvidence {
+		m[e] = i
+	}
+	return m
+}()
 
 // Valid reports whether e is part of the vocabulary.
 func (e Evidence) Valid() bool {

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -54,6 +54,18 @@ var ErrInvalidExecutionObservation = errors.New("execution observation is not a 
 // overwriting an observation.
 var ErrObservationConflict = errors.New("execution observation conflicts with what is recorded")
 
+// AllEvidence is every state the monotonic machine can reach, for the
+// test that holds this vocabulary against the column that closes it.
+// It is derived from the rank rather than written beside it: two lists
+// of the same words is one list and one place to forget.
+var AllEvidence = func() []Evidence {
+	out := make([]Evidence, len(evidenceRank))
+	for e, rank := range evidenceRank {
+		out[rank] = e
+	}
+	return out
+}()
+
 // evidenceRank orders the vocabulary for the monotonic rule.
 var evidenceRank = map[Evidence]int{
 	EvidenceNotStarted: 0, EvidenceRuntimePrepared: 1,

--- a/internal/store/lease_test.go
+++ b/internal/store/lease_test.go
@@ -397,7 +397,7 @@ func TestResourceIntentLifecycleAndReleaseRule(t *testing.T) {
 	// With every intent absent and the attempt resolved, the lease is
 	// purgeable.
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(lease.AttemptID, AttemptLeased, "completed_observed"); err != nil {
+		if err := tx.Settle(lease.AttemptID, AttemptLeased, assignment.ResolutionCompletedObserved); err != nil {
 			return err
 		}
 		return tx.PurgeLease(lease.ID)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -401,7 +401,7 @@ func TestPurgeLeaseRefusesWhileItsAttemptIsUnresolved(t *testing.T) {
 	}
 
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(attempt, AttemptLeased, "completed_observed"); err != nil {
+		if err := tx.Settle(attempt, AttemptLeased, assignment.ResolutionCompletedObserved); err != nil {
 			return err
 		}
 		return tx.PurgeLease(leaseID)
@@ -745,10 +745,10 @@ func TestRetentionMeasuresFromTheFinish(t *testing.T) {
 	backdateLease(t, s, resolved, longAgo, time.Now().Add(-time.Minute))
 
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(settledAttempt, AttemptLeased, "completed_observed"); err != nil {
+		if err := tx.Settle(settledAttempt, AttemptLeased, assignment.ResolutionCompletedObserved); err != nil {
 			return err
 		}
-		return tx.Settle(resolvedAttempt, AttemptLeased, "completed_observed")
+		return tx.Settle(resolvedAttempt, AttemptLeased, assignment.ResolutionCompletedObserved)
 	})
 
 	var removed int
@@ -805,13 +805,13 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 	prunable, prunableAttempt := releasedLease(t, s, binding, "old")
 	backdateLease(t, s, prunable, old, old)
 	inTx(t, s, func(tx *Tx) error {
-		return tx.Settle(prunableAttempt, AttemptLeased, "completed_observed")
+		return tx.Settle(prunableAttempt, AttemptLeased, assignment.ResolutionCompletedObserved)
 	})
 
 	// Finished, but recent: outside the window.
 	recent, recentAttempt := releasedLease(t, s, binding, "recent")
 	inTx(t, s, func(tx *Tx) error {
-		return tx.Settle(recentAttempt, AttemptLeased, "completed_observed")
+		return tx.Settle(recentAttempt, AttemptLeased, assignment.ResolutionCompletedObserved)
 	})
 
 	// Old and released, but its attempt is still open — the crash window.
@@ -822,7 +822,7 @@ func TestPruneLeaseHistoryHonoursBothGuards(t *testing.T) {
 	wedged, wedgedAttempt := releasedLease(t, s, binding, "wedged")
 	backdateLease(t, s, wedged, old, old)
 	inTx(t, s, func(tx *Tx) error {
-		if err := tx.Settle(wedgedAttempt, AttemptLeased, "completed_observed"); err != nil {
+		if err := tx.Settle(wedgedAttempt, AttemptLeased, assignment.ResolutionCompletedObserved); err != nil {
 			return err
 		}
 		_, err := tx.PlanResource(wedged, ResourceContainer, "runner", "runpool-wedged")
@@ -1184,14 +1184,14 @@ func TestARetryInFlightIsNotStranded(t *testing.T) {
 func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 	cases := []struct {
 		name    string
-		state   string
+		state   AttemptState
 		requeue func(*Tx, string) error
 	}{
 		{"plain requeue from prepared", "prepared", func(tx *Tx, id string) error {
-			if err := tx.Advance(assignment.AttemptID(id), "leased", "preparing"); err != nil {
+			if err := tx.Advance(assignment.AttemptID(id), AttemptLeased, AttemptPreparing); err != nil {
 				return err
 			}
-			if err := tx.Advance(assignment.AttemptID(id), "preparing", "prepared"); err != nil {
+			if err := tx.Advance(assignment.AttemptID(id), AttemptPreparing, AttemptPrepared); err != nil {
 				return err
 			}
 			return tx.Requeue(assignment.AttemptID(id))
@@ -2332,5 +2332,78 @@ func TestEveryEventKindIsOneTheColumnAdmits(t *testing.T) {
 		if !slices.Contains(AllEventKinds, EventKind(a)) {
 			t.Errorf("the column admits %q and no constant names it", a)
 		}
+	}
+}
+
+// TestTheStateVocabulariesCoverTheirColumns holds the two remaining
+// enumerated vocabularies against the columns that close them. Both
+// lists live in Go and both sets live in the schema, written by
+// different hands: a value the machine can reach and the column refuses
+// fails at a transition, mid-lifecycle; a value the column admits with
+// no member naming it is one no reader accounts for.
+func TestTheStateVocabulariesCoverTheirColumns(t *testing.T) {
+	s := newStore(t)
+
+	admitted := func(table, column string) []string {
+		t.Helper()
+		var ddl string
+		inTx(t, s, func(tx *Tx) error {
+			return tx.tx.QueryRow(
+				`SELECT sql FROM sqlite_schema WHERE name = ?`, table).Scan(&ddl)
+		})
+		i := strings.Index(ddl, column)
+		if i < 0 {
+			t.Fatalf("%s has no column %s", table, column)
+		}
+		// From the CHECK, not from the column: a DEFAULT beside it is a
+		// literal too, and counting it made the vocabulary look like it
+		// held a value twice.
+		rest := ddl[i:]
+		if c := strings.Index(rest, "CHECK"); c >= 0 {
+			rest = rest[c:]
+		}
+		end := strings.Index(rest, "))")
+		if end < 0 {
+			t.Fatalf("the CHECK on %s.%s is not the shape this reads", table, column)
+		}
+		var out []string
+		for _, m := range regexp.MustCompile(`'([a-z_]+)'`).FindAllStringSubmatch(rest[:end], -1) {
+			out = append(out, m[1])
+		}
+		return out
+	}
+
+	for name, tc := range map[string]struct {
+		table, column string
+		declared      []string
+	}{
+		"lease states": {"capsule_leases", "state         TEXT",
+			func() []string {
+				var o []string
+				for _, v := range AllLeaseStates {
+					o = append(o, string(v))
+				}
+				return o
+			}()},
+		"execution evidence": {"assignment_attempts", "execution_evidence",
+			func() []string {
+				var o []string
+				for _, v := range AllEvidence {
+					o = append(o, string(v))
+				}
+				return o
+			}()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cols := admitted(tc.table, tc.column)
+			slices.Sort(cols)
+			declared := slices.Clone(tc.declared)
+			slices.Sort(declared)
+			if !slices.Equal(cols, declared) {
+				t.Errorf("the column admits %v\nand Go enumerates %v\n"+
+					"a value in one list and not the other is one that fails at a write "+
+					"or one nothing accounts for", cols, declared)
+			}
+		})
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1184,10 +1184,9 @@ func TestARetryInFlightIsNotStranded(t *testing.T) {
 func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 	cases := []struct {
 		name    string
-		state   AttemptState
 		requeue func(*Tx, string) error
 	}{
-		{"plain requeue from prepared", "prepared", func(tx *Tx, id string) error {
+		{"plain requeue from prepared", func(tx *Tx, id string) error {
 			if err := tx.Advance(assignment.AttemptID(id), AttemptLeased, AttemptPreparing); err != nil {
 				return err
 			}
@@ -1196,7 +1195,7 @@ func TestARequeueClearsTheAuthorizationItOutlived(t *testing.T) {
 			}
 			return tx.Requeue(assignment.AttemptID(id))
 		}},
-		{"proven inert from starting", "starting", func(tx *Tx, id string) error {
+		{"proven inert from starting", func(tx *Tx, id string) error {
 			for _, step := range [][2]AttemptState{
 				{AttemptLeased, AttemptPreparing}, {AttemptPreparing, AttemptPrepared}, {AttemptPrepared, AttemptStarting},
 			} {
@@ -2311,19 +2310,7 @@ func TestEveryEventKindIsOneTheColumnAdmits(t *testing.T) {
 
 	// The other direction, against the column itself: the list is not
 	// short. Every kind the schema admits has a constant here.
-	var admitted []string
-	inTx(t, s, func(tx *Tx) error {
-		row := tx.tx.QueryRow(
-			`SELECT sql FROM sqlite_schema WHERE name = 'attempt_events'`)
-		var ddl string
-		if err := row.Scan(&ddl); err != nil {
-			return err
-		}
-		for _, m := range regexp.MustCompile(`'([a-z_]+)'`).FindAllStringSubmatch(ddl, -1) {
-			admitted = append(admitted, m[1])
-		}
-		return nil
-	})
+	admitted := checkVocabulary(t, s, "attempt_events", "kind")
 	if len(admitted) != len(AllEventKinds) {
 		t.Fatalf("the column admits %d kinds and AllEventKinds holds %d: %v",
 			len(admitted), len(AllEventKinds), admitted)
@@ -2343,35 +2330,6 @@ func TestEveryEventKindIsOneTheColumnAdmits(t *testing.T) {
 // no member naming it is one no reader accounts for.
 func TestTheStateVocabulariesCoverTheirColumns(t *testing.T) {
 	s := newStore(t)
-
-	admitted := func(table, column string) []string {
-		t.Helper()
-		var ddl string
-		inTx(t, s, func(tx *Tx) error {
-			return tx.tx.QueryRow(
-				`SELECT sql FROM sqlite_schema WHERE name = ?`, table).Scan(&ddl)
-		})
-		i := strings.Index(ddl, column)
-		if i < 0 {
-			t.Fatalf("%s has no column %s", table, column)
-		}
-		// From the CHECK, not from the column: a DEFAULT beside it is a
-		// literal too, and counting it made the vocabulary look like it
-		// held a value twice.
-		rest := ddl[i:]
-		if c := strings.Index(rest, "CHECK"); c >= 0 {
-			rest = rest[c:]
-		}
-		end := strings.Index(rest, "))")
-		if end < 0 {
-			t.Fatalf("the CHECK on %s.%s is not the shape this reads", table, column)
-		}
-		var out []string
-		for _, m := range regexp.MustCompile(`'([a-z_]+)'`).FindAllStringSubmatch(rest[:end], -1) {
-			out = append(out, m[1])
-		}
-		return out
-	}
 
 	for name, tc := range map[string]struct {
 		table, column string
@@ -2395,7 +2353,7 @@ func TestTheStateVocabulariesCoverTheirColumns(t *testing.T) {
 			}()},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cols := admitted(tc.table, tc.column)
+			cols := checkVocabulary(t, s, tc.table, tc.column)
 			slices.Sort(cols)
 			declared := slices.Clone(tc.declared)
 			slices.Sort(declared)
@@ -2406,4 +2364,49 @@ func TestTheStateVocabulariesCoverTheirColumns(t *testing.T) {
 			}
 		})
 	}
+}
+
+// checkVocabulary reads the values a column's own CHECK admits, from the
+// live schema rather than a copy of it.
+//
+// Two details are the whole of why it is a function. The window starts
+// at the CHECK and not at the column, because a DEFAULT sitting beside
+// it is a quoted literal too and counting it made a vocabulary look like
+// it held a value twice. And the class is "anything but a quote", not
+// "lowercase and underscore": the narrow class silently dropped any
+// value carrying a digit or a capital, so a word added to the column and
+// not to Go -- the exact drift this reads for -- would have left the two
+// sets equal and passed.
+//
+// Every way of mis-reading a CHECK this does not expect over-collects or
+// under-collects, so it fails. A missing CHECK is fatal rather than
+// silently harvesting the columns below it.
+func checkVocabulary(t *testing.T, s *Store, table, columnAnchor string) []string {
+	t.Helper()
+	var ddl string
+	inTx(t, s, func(tx *Tx) error {
+		return tx.tx.QueryRow(
+			`SELECT sql FROM sqlite_schema WHERE name = ?`, table).Scan(&ddl)
+	})
+	i := strings.Index(ddl, columnAnchor)
+	if i < 0 {
+		t.Fatalf("%s: no column matching %q in the stored schema; the anchor this reads "+
+			"by has moved", table, columnAnchor)
+	}
+	rest := ddl[i:]
+	c := strings.Index(rest, "CHECK")
+	if c < 0 {
+		t.Fatalf("%s.%s has no CHECK; this reads a closed vocabulary and the column no "+
+			"longer closes one", table, columnAnchor)
+	}
+	rest = rest[c:]
+	end := strings.Index(rest, "))")
+	if end < 0 {
+		t.Fatalf("the CHECK on %s.%s is not the shape this reads", table, columnAnchor)
+	}
+	var out []string
+	for _, m := range regexp.MustCompile(`'([^']+)'`).FindAllStringSubmatch(rest[:end], -1) {
+		out = append(out, m[1])
+	}
+	return out
 }


### PR DESCRIPTION
## What changes

`AllEvidence` exists, derived from the rank that already ordered the vocabulary. A test
holds it and `AllLeaseStates` against the CHECK constraints that close them, reading
each column's DDL from the live schema. Test fixtures stop respelling values the
constants define.

## What was found

The last two enumerated vocabularies with nothing tying the Go list to the SQL set.
Both are written by different hands, and both directions of drift are real failures:

- A value the machine can reach and the column refuses **fails at a transition**,
  mid-lifecycle, with the operator seeing a constraint error instead of a job.
- A value the column admits with no member naming it is one **no reader accounts for** —
  it never appears in a working set, a report, or a sweep.

Evidence had no exported list at all. `evidenceRank` was the de facto one, and
unexported. `AllEvidence` is derived from that rank rather than written beside it,
because two lists of the same words is one list and one place to forget.

The fixtures were the other half of finding B9: `"completed_observed"` written out eight
times where `assignment.ResolutionCompletedObserved` exists, and two transitions
spelling their states by hand. All of them compiled only because those vocabularies
were untyped until this week's work; the type would now catch a typo, and the constants
make the intent readable.

## Evidence

| Mutation | Result |
| --- | --- |
| `LeaseQuarantined` removed from `AllLeaseStates` | `lease_states` fails |
| `'zombie'` added to the column's CHECK | `lease_states` fails |

```text
gofmt, go vet, staticcheck, sqlc diff and go test -race -shuffle=on -count=1 ./...
exit 0.
```

Worth recording, because the test taught it to me: my first parse started at the column
name and swept up the `DEFAULT 'not_started'` literal sitting beside the CHECK, so the
vocabulary appeared to hold one value twice. It starts at the `CHECK` now, and the
comment says why.

## What would notice this regressing

`TestTheStateVocabulariesCoverTheirColumns`, both directions, both vocabularies. It
reads the live table's DDL rather than a copy of the schema, so a migration that widens
a CHECK without a matching constant fails here.

## Risk, compatibility and operations

**Test-only, plus one derived exported var.** No production behaviour, no schema
change, no interface change.

**Not an ADR.**

## Changelog

```text
NONE
```

## Notes for your reviewer

Two fixture tables keep their string literals deliberately: the one at
`store_test.go:1517` enumerates the attempt state machine as a readable table with a
typed field, so the literals convert and read as the machine itself — the same shape
the role fixtures keep. I typed the *field* and left the words.