### PR TITLE
feat(store): the trail says when a start was authorized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,14 @@ by its public and operational effects.
   called off. The word is now spelled once, in the adapter, and what
   crosses into the domain is the fact.
 
+- **The trail says when a start was authorized.** Evidence records how far
+  an attempt got and never when it got there, so an attempt held because a
+  start was authorized and its runtime could not be observed showed a
+  timeline that jumped from the lease to the hold — with the authorization
+  that caused it, the at-most-once line a person resolving the hold is
+  deciding about, durable nowhere but a log that rotates. Every advance is
+  in `runpool attempts inspect` now, with a time and with who observed it.
+
 ### Interface
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage

--- a/internal/app/attribution_test.go
+++ b/internal/app/attribution_test.go
@@ -91,8 +91,8 @@ func TestExecutionIsRecordedAgainstTheWorkloadThatRan(t *testing.T) {
 	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 		ID: 901,
 		Started: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-requeued",
-			RuntimeName: "runpool-ghost",
+			SourceWorkloadKey: "job-requeued",
+			RuntimeName:       "runpool-ghost",
 		}},
 	})
 
@@ -120,8 +120,8 @@ func TestAnObservationWithNoAttemptFallsBackToTheRunner(t *testing.T) {
 	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 		ID: 902,
 		Started: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-never-seen",
-			RuntimeName: "runpool-known",
+			SourceWorkloadKey: "job-never-seen",
+			RuntimeName:       "runpool-known",
 		}},
 	})
 
@@ -175,8 +175,8 @@ func TestALateObservationStaysWithTheAttemptThatRanIt(t *testing.T) {
 	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 		ID: 902,
 		Completed: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-requeued",
-			RuntimeName: "runpool-first", Result: "succeeded",
+			SourceWorkloadKey: "job-requeued",
+			RuntimeName:       "runpool-first", Result: "succeeded",
 		}},
 	})
 
@@ -224,8 +224,8 @@ func TestALateCancellationDoesNotCloseTheSuccessor(t *testing.T) {
 	h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 		ID: 903,
 		Completed: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-requeued",
-			RuntimeName: "runpool-first", Result: "canceled", Canceled: true,
+			SourceWorkloadKey: "job-requeued",
+			RuntimeName:       "runpool-first", Result: "canceled", Canceled: true,
 		}},
 	})
 
@@ -263,8 +263,8 @@ func TestASecondServingsHintsAreNotSwallowed(t *testing.T) {
 		h.srv.recordLifecycleEvents(t.Context(), h.bind, &githubactions.Message{
 			ID: 910,
 			Started: []assignment.WorkloadLifecycleEvent{{
-				Kind: assignment.LifecycleStarted, SourceWorkloadKey: "job-retried",
-				RuntimeName: runtime,
+				SourceWorkloadKey: "job-retried",
+				RuntimeName:       runtime,
 			}},
 		})
 	}

--- a/internal/app/fault_test.go
+++ b/internal/app/fault_test.go
@@ -482,8 +482,8 @@ func TestRemoteCancellationClosesOnlyReadyWork(t *testing.T) {
 	_, busyAttempt := leaseFor(t, h, "job-busy") // now leased, not ready
 
 	cancelled := &githubactions.Message{ID: 900, Completed: []assignment.WorkloadLifecycleEvent{
-		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-idle", Result: "canceled", Canceled: true},
-		{Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-busy", Result: "canceled", Canceled: true},
+		{SourceWorkloadKey: "job-idle", Result: "canceled", Canceled: true},
+		{SourceWorkloadKey: "job-busy", Result: "canceled", Canceled: true},
 	}}
 	s := h.srv
 	s.recordLifecycleEvents(t.Context(), h.bind, cancelled)

--- a/internal/app/redelivery_test.go
+++ b/internal/app/redelivery_test.go
@@ -373,8 +373,8 @@ func TestAWedgedRedeliveryStillLandsItsHints(t *testing.T) {
 	// loop iteration: the session hands over exactly this message, then
 	// blocks.
 	msg.Completed = []assignment.WorkloadLifecycleEvent{{
-		Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-cancelled-upstream",
-		Result: "canceled", Canceled: true,
+		SourceWorkloadKey: "job-cancelled-upstream",
+		Result:            "canceled", Canceled: true,
 	}}
 	redelivery := &replaySession{msg: msg, drained: make(chan struct{})}
 	h.bind.session = redelivery
@@ -503,8 +503,8 @@ func TestACancellationIsDurableBeforeTheMessageIsAcknowledged(t *testing.T) {
 		ID:       901,
 		Assigned: []assignment.WorkloadAssignment{demand("job-closed", "app", 44)},
 		Completed: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-closed",
-			Result: "canceled", Canceled: true,
+			SourceWorkloadKey: "job-closed",
+			Result:            "canceled", Canceled: true,
 		}},
 	}
 	h.bind.session = &cancellingSession{msg: msg, cancel: cancel}
@@ -571,8 +571,8 @@ func TestAnUnrecordedLifecycleEventIsReported(t *testing.T) {
 	msg := &githubactions.Message{
 		ID: 993,
 		Completed: []assignment.WorkloadLifecycleEvent{{
-			Kind: assignment.LifecycleCompleted, SourceWorkloadKey: "job-unrecorded",
-			Result: "canceled", Canceled: true,
+			SourceWorkloadKey: "job-unrecorded",
+			Result:            "canceled", Canceled: true,
 		}},
 	}
 	if err := h.srv.recordLifecycleEvents(ctx, h.bind, msg); err == nil {

--- a/internal/assignment/assignment.go
+++ b/internal/assignment/assignment.go
@@ -96,18 +96,6 @@ func Fingerprint(assignments []WorkloadAssignment) [32]byte {
 	return sha256.Sum256([]byte(strings.Join(lines, "\n")))
 }
 
-// LifecycleKind is what a provider observed about a workload.
-type LifecycleKind string
-
-const (
-	// LifecycleStarted: the provider saw the workload begin executing.
-	LifecycleStarted LifecycleKind = "started"
-	// LifecycleCompleted: the provider saw the workload finish. It is a
-	// hint — completion truth is the runtime exiting plus
-	// reconciliation, and this observation can lag it by minutes.
-	LifecycleCompleted LifecycleKind = "completed"
-)
-
 // Resolution says exactly what was observed and what was decided, never
 // more. "Executed" is not in the vocabulary on purpose: the provider
 // keeps the truth about the workload's functional result, and Runpool
@@ -157,7 +145,6 @@ var AllResolutions = []Resolution{
 // runtime cannot be correlated to the attempt it belongs to, which is
 // how a cancellation aimed at an old attempt could hit a new one.
 type WorkloadLifecycleEvent struct {
-	Kind              LifecycleKind
 	SourceWorkloadKey string
 	TenantKey         string
 	ProjectKey        string

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -63,11 +63,7 @@ const (
 
 // Resource kinds and roles stamped on every capsule object, mirrored
 // into the resource intents so reconciliation can find and order them.
-const (
-	KindContainer = engine.KindContainer
-	KindNetwork   = engine.KindNetwork
-	KindVolume    = engine.KindVolume
-)
+const ()
 
 const (
 	// GatewayProxyPort is where a sandboxed capsule's egress relay
@@ -313,15 +309,15 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	// there is one — its gateway, and placed under one parent cgroup.
 	cgroupParent := LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID))
 	capsuleShare := SplitEnvelope(spec.Resources, sandboxed)
-	netID, err := m.create(ctx, rec, KindNetwork, engine.RoleCapsuleNetwork, name(engine.RoleCapsuleNetwork),
+	netID, err := m.create(ctx, rec, engine.KindNetwork, engine.RoleCapsuleNetwork, name(engine.RoleCapsuleNetwork),
 		func() (string, error) {
 			return m.dock.CreateNetwork(ctx, engine.NetworkSpec{
 				Name:     name(engine.RoleCapsuleNetwork),
 				Internal: sandboxed,
 				Isolated: sandboxed,
-				Labels:   labels(KindNetwork, engine.RoleCapsuleNetwork),
+				Labels:   labels(engine.KindNetwork, engine.RoleCapsuleNetwork),
 			})
-		}, resolve(KindNetwork, name(engine.RoleCapsuleNetwork)))
+		}, resolve(engine.KindNetwork, name(engine.RoleCapsuleNetwork)))
 	if err != nil {
 		return "", err
 	}
@@ -334,10 +330,10 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 		}
 	}
 
-	dindData, err := m.create(ctx, rec, KindVolume, engine.RoleDindData, name(engine.RoleDindData),
+	dindData, err := m.create(ctx, rec, engine.KindVolume, engine.RoleDindData, name(engine.RoleDindData),
 		func() (string, error) {
-			return m.dock.CreateVolume(ctx, name(engine.RoleDindData), labels(KindVolume, engine.RoleDindData))
-		}, resolve(KindVolume, name(engine.RoleDindData)))
+			return m.dock.CreateVolume(ctx, name(engine.RoleDindData), labels(engine.KindVolume, engine.RoleDindData))
+		}, resolve(engine.KindVolume, name(engine.RoleDindData)))
 	if err != nil {
 		return "", err
 	}
@@ -350,7 +346,7 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 	capsuleSpec := engine.ContainerSpec{
 		Name:       name(engine.RoleCapsule),
 		Image:      spec.CapsuleImage,
-		Labels:     labels(KindContainer, engine.RoleCapsule),
+		Labels:     labels(engine.KindContainer, engine.RoleCapsule),
 		Privileged: true,
 		Network:    netID,
 		Mounts:     mounts,
@@ -386,10 +382,10 @@ func (m *Launcher) prepare(ctx context.Context, spec Spec, rec ResourceRecorder)
 			"NO_PROXY="+noProxy, "no_proxy="+noProxy,
 		)
 	}
-	outerID, err := m.create(ctx, rec, KindContainer, engine.RoleCapsule, name(engine.RoleCapsule),
+	outerID, err := m.create(ctx, rec, engine.KindContainer, engine.RoleCapsule, name(engine.RoleCapsule),
 		func() (string, error) {
 			return m.dock.CreateContainer(ctx, capsuleSpec)
-		}, resolve(KindContainer, name(engine.RoleCapsule)))
+		}, resolve(engine.KindContainer, name(engine.RoleCapsule)))
 	if err != nil {
 		return "", err
 	}
@@ -518,7 +514,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 		return netip.Addr{}, "", err
 	}
 
-	gwID, err := m.create(ctx, rec, KindContainer, engine.RoleGateway, name(engine.RoleGateway),
+	gwID, err := m.create(ctx, rec, engine.KindContainer, engine.RoleGateway, name(engine.RoleGateway),
 		func() (string, error) {
 			return m.dock.CreateContainer(ctx, engine.ContainerSpec{
 				Name:       name(engine.RoleGateway),
@@ -527,7 +523,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 				// The policy is configuration, not secret; the one
 				// secret in the system never touches the gateway.
 				Env:     []string{"RUNPOOL_GATEWAY_POLICY=" + string(policyJSON)},
-				Labels:  labels(KindContainer, engine.RoleGateway),
+				Labels:  labels(engine.KindContainer, engine.RoleGateway),
 				Network: netID,
 				// NET_ADMIN for the ruleset, and nothing else: not
 				// privileged, no socket, no volumes, no credentials.
@@ -543,7 +539,7 @@ func (m *Launcher) prepareGateway(ctx context.Context, spec Spec, rec ResourceRe
 				PIDsLimit:       GatewayEnvelope().PIDsLimit,
 				CgroupParent:    LeaseCgroupParent(spec.CgroupDriver, string(spec.LeaseID)),
 			})
-		}, resolve(KindContainer, name(engine.RoleGateway)))
+		}, resolve(engine.KindContainer, name(engine.RoleGateway)))
 	if err != nil {
 		return netip.Addr{}, "", err
 	}

--- a/internal/platform/githubactions/message.go
+++ b/internal/platform/githubactions/message.go
@@ -85,10 +85,10 @@ func translate(msg *scaleset.RunnerScaleSetMessage) (Message, []assignment.Workl
 		out.Assigned = append(out.Assigned, workload(j.JobMessageBase))
 	}
 	for _, j := range msg.JobStartedMessages {
-		out.Started = append(out.Started, observation(assignment.LifecycleStarted, j.JobMessageBase, j.RunnerName, ""))
+		out.Started = append(out.Started, observation(j.JobMessageBase, j.RunnerName, ""))
 	}
 	for _, j := range msg.JobCompletedMessages {
-		out.Completed = append(out.Completed, observation(assignment.LifecycleCompleted, j.JobMessageBase, j.RunnerName, j.Result))
+		out.Completed = append(out.Completed, observation(j.JobMessageBase, j.RunnerName, j.Result))
 	}
 	return out, available
 }
@@ -118,9 +118,8 @@ const resultCanceled = "canceled"
 // events that named only the runner could not be correlated to the
 // attempt they belong to, and a cancellation aimed at an old attempt
 // could then hit a new one.
-func observation(kind assignment.LifecycleKind, b scaleset.JobMessageBase, runnerName, result string) assignment.WorkloadLifecycleEvent {
+func observation(b scaleset.JobMessageBase, runnerName, result string) assignment.WorkloadLifecycleEvent {
 	return assignment.WorkloadLifecycleEvent{
-		Kind:              kind,
 		SourceWorkloadKey: b.JobID,
 		TenantKey:         b.OwnerName,
 		ProjectKey:        b.RepositoryName,

--- a/internal/platform/githubactions/message_test.go
+++ b/internal/platform/githubactions/message_test.go
@@ -66,12 +66,11 @@ func TestTranslate(t *testing.T) {
 	// to the attempt it belongs to.
 	if len(out.Started) != 1 || out.Started[0].RuntimeName != "r1" ||
 		out.Started[0].SourceWorkloadKey != "job-0" ||
-		out.Started[0].Kind != assignment.LifecycleStarted || out.Started[0].Result != "" {
+		out.Started[0].Result != "" {
 		t.Errorf("started = %+v", out.Started)
 	}
 	if len(out.Completed) != 1 || out.Completed[0].Result != "succeeded" ||
-		out.Completed[0].SourceWorkloadKey != "job-0" ||
-		out.Completed[0].Kind != assignment.LifecycleCompleted {
+		out.Completed[0].SourceWorkloadKey != "job-0" {
 		t.Errorf("completed = %+v", out.Completed)
 	}
 }
@@ -99,8 +98,7 @@ func TestTheProviderWordForCancellationStopsHere(t *testing.T) {
 		"failed":    false,
 		"":          false,
 	} {
-		got := observation(assignment.LifecycleCompleted,
-			scaleset.JobMessageBase{JobID: "job-1"}, "runner-1", result)
+		got := observation(scaleset.JobMessageBase{JobID: "job-1"}, "runner-1", result)
 		if got.Canceled != want {
 			t.Errorf("result %q translated to Canceled=%v; want %v", result, got.Canceled, want)
 		}

--- a/internal/store/events.go
+++ b/internal/store/events.go
@@ -1,6 +1,6 @@
 package store
 
-// EventKind is what an attempt_events row records. The fourteen values
+// EventKind is what an attempt_events row records. The twelve values
 // are closed by the column and were spelled as literals in four
 // packages, with no list anywhere -- so a kind the schema does not admit
 // failed at the write, in a delivery path, at the moment the trail was
@@ -27,10 +27,9 @@ const (
 	EventRunningObserved EventKind = "running_observed"
 	// EventExitObserved: the runtime was seen to exit.
 	EventExitObserved EventKind = "exit_observed"
-	// EventRuntimeObservationFailed: the daemon could not be asked.
-	EventRuntimeObservationFailed EventKind = "runtime_observation_failed"
-	// EventCleanupStarted and EventCleanupCompleted bracket the release.
-	EventCleanupStarted   EventKind = "cleanup_started"
+	// EventCleanupCompleted is the serving's finalizing transaction:
+	// the disposition commits with it. There is no started event -- the
+	// trail rules on evidence, never on how far cleanup got.
 	EventCleanupCompleted EventKind = "cleanup_completed"
 	// EventManualReviewRequested: the attempt is waiting for a person.
 	EventManualReviewRequested EventKind = "manual_review_requested"
@@ -56,8 +55,6 @@ var AllEventKinds = []EventKind{
 	EventStartAuthorized,
 	EventRunningObserved,
 	EventExitObserved,
-	EventRuntimeObservationFailed,
-	EventCleanupStarted,
 	EventCleanupCompleted,
 	EventManualReviewRequested,
 	EventOperatorResolved,

--- a/internal/store/evidence.go
+++ b/internal/store/evidence.go
@@ -184,7 +184,37 @@ func (t *Tx) RecordEvidence(attemptID assignment.AttemptID, e Evidence) error {
 		return fmt.Errorf("%w: attempt %s moved while recording %s",
 			ErrObservationConflict, attemptID, e)
 	}
-	return nil
+	// The advance goes in the trail too, with a time. Evidence is a
+	// high-water mark and says only where an attempt got, never when --
+	// so an attempt held because a start was authorized and its runtime
+	// could not be observed showed an operator a trail that jumped from
+	// lease_attached to the hold, with the authorization that caused it
+	// durable nowhere but a log that rotates.
+	//
+	// Here rather than at the call sites: every caller is already inside
+	// this transaction, so the event and the column can never disagree,
+	// and an advance to a rung happens at most once per attempt -- the
+	// equal case returned above, backwards errored, and a racing loser
+	// rolls this back with it. That is what makes the key unique.
+	return t.RecordEventDetail(attemptID, "evidence:"+string(e), eventKindOf(e),
+		map[string]string{"observer": "controller"})
+}
+
+// eventKindOf names the trail entry for an evidence advance. Only the
+// rungs above the floor appear: nothing advances to not_started, which
+// is where every attempt begins.
+func eventKindOf(e Evidence) EventKind {
+	switch e {
+	case EvidenceRuntimePrepared:
+		return EventRuntimePrepared
+	case EvidenceStartAuthorized:
+		return EventStartAuthorized
+	case EvidenceRunningObserved:
+		return EventRunningObserved
+	case EvidenceExitObserved:
+		return EventExitObserved
+	}
+	return ""
 }
 
 // RecordEvidenceForLease advances the evidence of the attempt a lease is

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -85,10 +85,15 @@ func (t *Tx) SetLeaseRuntimeName(id assignment.LeaseID, runtimeName assignment.R
 // It is written on the way into the cleanup that ends a serving, after
 // every refinement that can overrule the measurement and before the
 // first destructive step -- so a retry of that cleanup reads back the
-// answer the pass that failed had already reached. The write is
-// unconditional because a later establishing measurement is a better one:
-// the capsule's own account of itself arrives after the daemon's, and the
-// provider's after that.
+// answer the pass that failed had already reached. A later measurement
+// overwrites an earlier one rather than being refused, because a later
+// establishing measurement is a better one: the capsule's own account of
+// itself arrives after the daemon's, and the provider's after that.
+//
+// Only an observation that establishes something may be written: the
+// column admits those four and refuses the rest, so a caller that has
+// measured nothing must not reach here. The lease manager is that filter
+// today, and a test holds the two subsets against each other.
 func (t *Tx) RecordLeaseStartObservation(id assignment.LeaseID, obs assignment.ExecutionObservation) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE capsule_leases SET start_observation = ?, updated_at = unixepoch() WHERE id = ?`,

--- a/internal/store/leasetx.go
+++ b/internal/store/leasetx.go
@@ -90,10 +90,13 @@ func (t *Tx) SetLeaseRuntimeName(id assignment.LeaseID, runtimeName assignment.R
 // establishing measurement is a better one: the capsule's own account of
 // itself arrives after the daemon's, and the provider's after that.
 //
-// Only an observation that establishes something may be written: the
-// column admits those four and refuses the rest, so a caller that has
-// measured nothing must not reach here. The lease manager is that filter
-// today, and a test holds the two subsets against each other.
+// Only an observation that establishes something belongs here: the
+// column admits those four and refuses the rest, which is deliberate and
+// stays that way. A guard in this method would swallow the refusal --
+// and TestTheColumnRefusesAnEmptyMeasurement exists to say the table,
+// not a removable Go check, is what keeps the two spellings of "nothing"
+// from both being storable. The lease manager filters before calling so
+// that nothing is asked for; the column is what makes that true.
 func (t *Tx) RecordLeaseStartObservation(id assignment.LeaseID, obs assignment.ExecutionObservation) error {
 	return t.mustAffect(t.tx.Exec(
 		`UPDATE capsule_leases SET start_observation = ?, updated_at = unixepoch() WHERE id = ?`,

--- a/internal/store/migrations/000001_initial.up.sql
+++ b/internal/store/migrations/000001_initial.up.sql
@@ -130,7 +130,7 @@ CREATE TABLE attempt_events (
 	kind             TEXT NOT NULL CHECK (kind IN (
 		'attempt_created', 'lease_attached', 'runtime_prepared',
 		'execution_start_authorized', 'running_observed', 'exit_observed',
-		'runtime_observation_failed', 'cleanup_started', 'cleanup_completed',
+		'cleanup_completed',
 		'manual_review_requested', 'operator_resolved', 'attempt_settled',
 		'attempt_superseded', 'remote_canceled')),
 	detail_json      TEXT NOT NULL DEFAULT '{}',

--- a/internal/store/schema/current.sql
+++ b/internal/store/schema/current.sql
@@ -50,7 +50,7 @@ CREATE TABLE attempt_events (
 	kind             TEXT NOT NULL CHECK (kind IN (
 		'attempt_created', 'lease_attached', 'runtime_prepared',
 		'execution_start_authorized', 'running_observed', 'exit_observed',
-		'runtime_observation_failed', 'cleanup_started', 'cleanup_completed',
+		'cleanup_completed',
 		'manual_review_requested', 'operator_resolved', 'attempt_settled',
 		'attempt_superseded', 'remote_canceled')),
 	detail_json      TEXT NOT NULL DEFAULT '{}',

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2343,6 +2343,22 @@ func TestTheStateVocabulariesCoverTheirColumns(t *testing.T) {
 				}
 				return o
 			}()},
+		"resolutions": {"assignment_attempts", "resolution",
+			func() []string {
+				var o []string
+				for _, v := range assignment.AllResolutions {
+					o = append(o, string(v))
+				}
+				return o
+			}()},
+		"review reasons": {"assignment_attempts", "review_reason",
+			func() []string {
+				var o []string
+				for _, v := range AllReviewReasons {
+					o = append(o, string(v))
+				}
+				return o
+			}()},
 		"execution evidence": {"assignment_attempts", "execution_evidence",
 			func() []string {
 				var o []string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1925,7 +1925,7 @@ func seedEverything(t *testing.T, s *Store) {
 		if err := tx.RecordGitHubAttemptMetadata(attempt, "job-seed", 7, 9); err != nil {
 			return err
 		}
-		if err := tx.RecordRepeatableEvent(attempt, "runtime_observation_failed", map[string]string{"why": "seeding"}); err != nil {
+		if err := tx.RecordRepeatableEvent(attempt, EventManualReviewRequested, map[string]string{"why": "seeding"}); err != nil {
 			return err
 		}
 		lease, err := tx.LeaseAttempt(attempt, binding, "standard")
@@ -2457,5 +2457,69 @@ func TestTheEstablishingObservationsAreExactlyWhatTheColumnAdmits(t *testing.T) 
 			"a value that establishes and the column refuses fails the write that ends a "+
 			"serving; a value the column admits and nothing establishes is one no pass writes",
 			admitted, establishes)
+	}
+}
+
+// TestEveryEvidenceAdvanceReachesTheTrail: evidence is a high-water mark
+// and says only where an attempt got, never when. An attempt held
+// because a start was authorized and its runtime could not be observed
+// therefore showed an operator a trail that jumped from lease_attached
+// to the hold, with the authorization that caused it durable nowhere but
+// a log that rotates — and that authorization is the at-most-once line,
+// the one fact a person resolving the hold is deciding about.
+func TestEveryEvidenceAdvanceReachesTheTrail(t *testing.T) {
+	s := newStore(t)
+	binding := seedBinding(t, s)
+	id := seedAttempt(t, s, binding, "msg-trail", "job-trail")
+
+	for _, e := range AllEvidence[1:] {
+		if err := s.Tx(t.Context(), func(tx *Tx) error {
+			return tx.RecordEvidence(id, e)
+		}); err != nil {
+			t.Fatalf("recording %s: %v", e, err)
+		}
+	}
+
+	var kinds []EventKind
+	inTx(t, s, func(tx *Tx) error {
+		events, err := tx.Events(id)
+		if err != nil {
+			return err
+		}
+		for _, ev := range events {
+			kinds = append(kinds, EventKind(ev.Kind))
+		}
+		return nil
+	})
+	for _, e := range AllEvidence[1:] {
+		want := eventKindOf(e)
+		if want == "" {
+			t.Errorf("the advance to %s names no trail entry", e)
+			continue
+		}
+		if !slices.Contains(kinds, want) {
+			t.Errorf("advancing to %s wrote no %s into the trail: %v", e, want, kinds)
+		}
+		if !slices.Contains(AllEventKinds, want) {
+			t.Errorf("%s is not a kind the column admits", want)
+		}
+	}
+
+	// Re-observing a fact is idempotent, and so is its trail entry.
+	before := len(kinds)
+	if err := s.Tx(t.Context(), func(tx *Tx) error {
+		return tx.RecordEvidence(id, EvidenceExitObserved)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var after int
+	inTx(t, s, func(tx *Tx) error {
+		events, err := tx.Events(id)
+		after = len(events)
+		return err
+	})
+	if after != before {
+		t.Errorf("re-observing the same evidence wrote %d more entries; a repeated "+
+			"observation is one fact, not two", after-before)
 	}
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2410,3 +2410,36 @@ func checkVocabulary(t *testing.T, s *Store, table, columnAnchor string) []strin
 	}
 	return out
 }
+
+// TestTheEstablishingObservationsAreExactlyWhatTheColumnAdmits.
+// start_observation holds what a serving measured about whether the
+// workload began, and it admits four of the vocabulary's seven values.
+// Which four is decided in another package, by
+// ExecutionObservation.Establishes, and the only thing between a value
+// the column refuses and a write that fails is one `if` in the lease
+// manager.
+//
+// A fifth establishing observation added there passes that guard, the
+// write is attempted, and the column refuses it -- inside the cleanup
+// that ends a serving, which then quarantines the lease it could not
+// finish. The subset is a correspondence between two packages and a
+// schema, and nothing held it.
+func TestTheEstablishingObservationsAreExactlyWhatTheColumnAdmits(t *testing.T) {
+	admitted := checkVocabulary(t, newStore(t), "capsule_leases", "start_observation")
+	slices.Sort(admitted)
+
+	var establishes []string
+	for _, o := range assignment.AllExecutionObservations {
+		if o.Establishes() {
+			establishes = append(establishes, string(o))
+		}
+	}
+	slices.Sort(establishes)
+
+	if !slices.Equal(admitted, establishes) {
+		t.Errorf("the column admits %v\nand Establishes() answers for %v\n"+
+			"a value that establishes and the column refuses fails the write that ends a "+
+			"serving; a value the column admits and nothing establishes is one no pass writes",
+			admitted, establishes)
+	}
+}

--- a/test/contract/capsule/contract_test.go
+++ b/test/contract/capsule/contract_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/capsule"
 	"github.com/rhobuild/runpool/internal/config"
+	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/engine/docker"
 )
 
@@ -96,7 +97,7 @@ func (r *memRecorder) cleanup(t *testing.T, dock *docker.Client) {
 	defer r.mu.Unlock()
 	// Containers before the network and volumes that hold them.
 	for _, o := range r.objects {
-		if o.kind == string(capsule.KindContainer) {
+		if o.kind == string(engine.KindContainer) {
 			if err := dock.RemoveContainer(ctx, o.id); err != nil {
 				t.Errorf("cleanup container %s: %v", o.id, err)
 			}
@@ -104,11 +105,11 @@ func (r *memRecorder) cleanup(t *testing.T, dock *docker.Client) {
 	}
 	for _, o := range r.objects {
 		switch o.kind {
-		case string(capsule.KindNetwork):
+		case string(engine.KindNetwork):
 			if err := dock.RemoveNetwork(ctx, o.id); err != nil {
 				t.Errorf("cleanup network %s: %v", o.id, err)
 			}
-		case string(capsule.KindVolume):
+		case string(engine.KindVolume):
 			if err := dock.RemoveVolume(ctx, o.id); err != nil {
 				t.Errorf("cleanup volume %s: %v", o.id, err)
 			}


### PR DESCRIPTION
## What changes

An evidence advance writes its own entry into the attempt trail, from inside
`RecordEvidence`. The two event kinds nothing produces are removed from the schema and
Go. Three constrained vocabularies gain the reverse-direction check they lacked, a
write-only field and a set of residual aliases are deleted.

## What was found

**Four of fourteen event kinds had no producer**, and the CHECK freezes at v1.0.0. The
decision drew the line: a kind stays if it names a timestamped moment durable nowhere
else, and goes if the fact is already durable elsewhere or belongs to a domain the
trail deliberately does not narrate.

**Two stay, and they were a real hole.** Evidence is a high-water mark: it says where
an attempt got, never *when*. So an attempt held with `start_outcome_unknown` — held
precisely because a start was authorized and its runtime could not be observed — showed
an operator `attempt_created → lease_attached → cleanup_completed →
manual_review_requested`. The authorization that caused the hold, which is the
at-most-once line the person resolving it is deciding about, was durable nowhere but a
log that rotates. Not on the attempt, not on the lease.

The mirror lives in `RecordEvidence`, not at the call sites: every caller is already
inside that transaction, so the event and the column cannot disagree; and an advance to
a rung happens at most once per attempt — the equal case returns before any write,
backwards errors, and a racing loser's `affected == 0` rolls the event back with the
row. That is what makes `evidence:<rung>` unique by construction rather than by hope.

The provider's hint rows stay separate and that is right: they record what the provider
said, per serving, while these record when this controller's own knowledge advanced.
Where no hint ever arrives — an exit observed in the crash window, an adopted capsule's
exit — the mirror is the only record there is. The detail names which observer wrote
each.

**Two go.** `runtime_observation_failed` contradicts the schema's own stated doctrine
("an unobservable outcome is an operational condition, recorded as manual_review with a
reason"), and that condition already is durable, with the reason in the event's detail.
`cleanup_started` has no single producer — three entries into cleaning plus a re-entry
on every quarantine pass — for a fact disposition is explicitly defined not to rest on,
while a lease stuck mid-cleanup is already visible in `runpool status` with its
per-resource errors and retry counts.

**Three columns held only one direction.** `resolution`, `review_reason` and
`start_observation` were held in one direction only — every Go value driven through the
real column, but a value added to a CHECK that no constant names passed everything.
`WorkloadLifecycleEvent.Kind` was set by the adapter and read by nothing; list
membership carries the same fact, so it and `LifecycleKind` are gone. `capsule`'s
`Kind*` aliases were residue of the role move — the same file spelled the alias and
`engine.Kind` in one call.

## Evidence

| Mutation | Failure |
| --- | --- |
| the mirror write removed | `advancing to runtime_prepared wrote no runtime_prepared into the trail` |
| one rung mapped to no kind | the same, for that rung |
| a value added to `resolution`'s CHECK | the reverse-direction comparison |
| `ObservedAbsent` added to `Establishes()` | the `start_observation` comparison |

```text
gofmt, go vet, staticcheck, sqlc diff and go test -race -shuffle=on -count=1 ./...
exit 0.
```

## What would notice this regressing

`TestEveryEvidenceAdvanceReachesTheTrail` walks every rung and also asserts the
idempotence: re-observing a fact writes no second entry.
`TestTheStateVocabulariesCoverTheirColumns` now covers five vocabularies in both
directions.

## Risk, compatibility and operations

**Schema: the baseline changes** — two values leave a CHECK. Pre-release, so existing
state directories are refused on next start with the migrations error naming its two
ways out.

**Behaviour: one added write per evidence advance**, at most four over an attempt's
life, inside a transaction that is already open. `ON CONFLICT DO NOTHING`, so a retried
transaction cannot duplicate.

**Status API / CLI:** `runpool attempts inspect` shows more lifecycle rows than before —
the point of the change. No field or flag changes.

**Trust boundary, deployment, rollback, runbook: N/A. Not an ADR** — it applies the
trail's existing doctrine rather than changing it.

## Changelog

```text
One bullet under "State and operations": the trail says when a start was authorized.
```

## Notes for your reviewer

One change is deliberately **not** here: guarding `RecordLeaseStartObservation` with `Establishes()` in the `Tx` method. Doing
that broke `TestTheColumnRefusesAnEmptyMeasurement`, whose own comment says why: the
refusal belongs below the Go guard rather than beside it, because a guard that can be
removed is not what keeps a table honest. A guard there swallows the write and makes
the column's constraint unreachable from the store's own API. The method's comment now
says that, instead of implying any value may be passed.

