### PR TITLE
fix(capsule): the failure paths say what happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,17 @@ by its public and operational effects.
   deciding about, durable nowhere but a log that rotates. Every advance is
   in `runpool attempts inspect` now, with a time and with who observed it.
 
+- **A capsule image that cannot run is refused by name, in about a second.**
+  A tier may name its own capsule image, and one whose entrypoint crashes
+  writes no control protocol — ever. Waiting out the declaration deadline
+  for it spent thirty seconds per attempt and then reported a read
+  failure, which is not the incompatibility the controller holds on: the
+  tier retried the same broken image until its retry budget ran out,
+  under a reason that named none of it. It is now held on the first
+  attempt, naming the exit code. And the inspection an ambiguous start is
+  held on carries the reason it could not be read, where a transport
+  failure previously left the operator an exit code and an empty string.
+
 ### Interface
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -444,6 +444,20 @@ func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
 		if err == nil && code == 0 {
 			return protocolVerdict(code, out)
 		}
+		if err != nil {
+			// A capsule that is no longer running will never write the
+			// file, so waiting out the deadline for it spends thirty
+			// seconds per attempt and then reports a read failure --
+			// which is not the incompatibility the caller holds on, so
+			// the tier retries the same broken image until its budget
+			// runs out, under a reason that names none of this. The
+			// fallback awaitState carries for the same shape.
+			if state, serr := m.dock.ContainerStatus(ctx, outerID); serr == nil &&
+				state.Status != engine.StatusRunning {
+				return fmt.Errorf("%w: the capsule exited %d before declaring a control protocol",
+					ErrIncompatibleImage, state.ExitCode)
+			}
+		}
 		if time.Now().After(deadline) {
 			if err != nil {
 				return fmt.Errorf("read the capsule control protocol: %w", err)

--- a/internal/capsule/inspect_test.go
+++ b/internal/capsule/inspect_test.go
@@ -3,7 +3,9 @@ package capsule
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
 	"github.com/rhobuild/runpool/internal/engine"
@@ -59,5 +61,60 @@ func TestAnUndecidableExecutionIsHeldRatherThanSettled(t *testing.T) {
 				t.Errorf("a decided observation carried an error: %v", err)
 			}
 		})
+	}
+}
+
+// TestAnUnreadableStateSaysWhyItCouldNotBeRead: this inspection is what
+// an ambiguous start is held on, and the operator deciding about that
+// attempt reads its error. A transport failure leaves the exec's output
+// empty, so reporting the exit code alone handed them a page with no
+// reason on it — "capsule state unreadable (exit -1): " and nothing more.
+func TestAnUnreadableStateSaysWhyItCouldNotBeRead(t *testing.T) {
+	boom := errors.New("daemon connection reset")
+	m := &Launcher{dock: &fakeDaemon{
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusRunning}, nil
+		},
+		exec: func(string, []string) (int, string, error) { return -1, "", boom },
+	}}
+
+	obs, err := m.InspectExecution(t.Context(), PreparedRuntime{RuntimeID: "runner-1"})
+	if obs != assignment.ObservedUnavailable {
+		t.Errorf("observation = %s; an unreadable state proves nothing either way", obs)
+	}
+	if !errors.Is(err, boom) {
+		t.Errorf("error = %v; the cause has to travel, or the page names no reason", err)
+	}
+}
+
+// TestACapsuleThatDiedIsRefusedAsIncompatible: a tier may name its own
+// capsule image, and one whose entrypoint crashes writes no protocol
+// file — ever. Waiting out the declaration deadline for it spent thirty
+// seconds per attempt and then reported a read failure, which is not the
+// incompatibility the caller holds on: the tier retried the same broken
+// image until its budget ran out, under a reason that named none of it.
+func TestACapsuleThatDiedIsRefusedAsIncompatible(t *testing.T) {
+	m := &Launcher{dock: &fakeDaemon{
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: 127}, nil
+		},
+		exec: func(string, []string) (int, string, error) {
+			return -1, "", errors.New("container is not running")
+		},
+	}}
+
+	start := time.Now()
+	err := m.awaitProtocol(t.Context(), "runner-1")
+	if !errors.Is(err, ErrIncompatibleImage) {
+		t.Fatalf("error = %v; want ErrIncompatibleImage, which is what holds the attempt "+
+			"instead of retrying the same image", err)
+	}
+	if !strings.Contains(err.Error(), "127") {
+		t.Errorf("error = %q; it has to name the exit code, which is the one fact "+
+			"an operator can act on", err)
+	}
+	if elapsed := time.Since(start); elapsed > protocolTimeout/2 {
+		t.Errorf("refusing a dead capsule took %s against a %s deadline; the point is "+
+			"not spending it", elapsed.Round(time.Millisecond), protocolTimeout)
 	}
 }

--- a/internal/capsule/observation.go
+++ b/internal/capsule/observation.go
@@ -29,8 +29,17 @@ func (m *Launcher) InspectExecution(ctx context.Context, prepared PreparedRuntim
 	}
 
 	code, out, err := m.dock.Exec(ctx, string(prepared.RuntimeID), []string{supervisorPath, "state"})
-	if err != nil || code != 0 {
-		return assignment.ObservedUnavailable, fmt.Errorf("capsule state unreadable (exit %d): %s", code, out)
+	if err != nil {
+		// The cause travels. This is the inspection an ambiguous start is
+		// held on, and a transport failure leaves out empty -- so
+		// reporting the exit code alone handed the operator deciding
+		// about that attempt a page with no reason on it.
+		return assignment.ObservedUnavailable,
+			fmt.Errorf("capsule state unreadable: %w", err)
+	}
+	if code != 0 {
+		return assignment.ObservedUnavailable,
+			fmt.Errorf("capsule state unreadable (exit %d): %s", code, out)
 	}
 	return classifySupervisorState(protocol.State(strings.TrimSpace(out)))
 }


### PR DESCRIPTION
## What changes

`InspectExecution` carries the exec error it reports. `awaitProtocol` refuses a capsule
that has already exited, by name and in about a second, instead of spending its
declaration deadline.

## What was found

The prepare→start→observe path was traced end to end, including the supervisor side.
Its structural conclusion is worth recording: there is **no ordering that loses a start and none that reports a start which may
have run as never started**. Crashes inside the ambiguous window, container death
mid-poll, truncated exec output and daemon failures during inspection all land in the
safe direction. Two findings, both diagnosability rather than correctness.

**The inspection an ambiguous start is held on said nothing.** `InspectExecution` tests
the exec error and then reports `capsule state unreadable (exit %d): %s` — but on a
transport failure `out` is empty and the code is -1, so the operator deciding what to do
about that held attempt reads `capsule state unreadable (exit -1): ` and nothing after
the colon. That string is what the controller logs as `inspect_error`. The cause travels
now.

**A broken capsule image cost thirty seconds an attempt and was never named.** A tier may
name its own `capsuleImage` — a supported extension point. One whose entrypoint crashes
writes no protocol file ever, so every poll's exec failed, `awaitProtocol` spent the full
30s deadline, and returned a read failure — which is *not* `ErrIncompatibleImage`, so the
fast hold never fired. The tier retried the same broken image until its retry budget ran
out, converging on review under a transient-looking reason that named neither the image
nor the exit code. `awaitState` already carries a `ContainerStatus` fallback for this
exact shape and documents why; `awaitProtocol` missed it.

## Evidence

| Mutation | Failure |
| --- | --- |
| the cause dropped again | `the cause has to travel, or the page names no reason` |
| the dead-container check removed | `want ErrIncompatibleImage, which is what holds the attempt instead of retrying` |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
```

The second test also asserts the refusal costs less than half the deadline — the point
of it is not spending that time.

## What would notice this regressing

`TestAnUnreadableStateSaysWhyItCouldNotBeRead` and
`TestACapsuleThatDiedIsRefusedAsIncompatible`.

## Risk, compatibility and operations

**Behaviour: two failure paths change what they report and one changes how fast.** No
success path moves. Neither touches at-most-once — nothing is delivered or authorized in
either, and both already landed in the safe direction.

**Operations:** a deployment running a broken custom capsule image now sees the hold on
the first attempt with the exit code, instead of three slow attempts and a budget
message.

**Trust boundary, schema, status API, CLI, configuration, deployment, rollback: N/A.
Not an ADR.**

## Changelog

```text
One bullet under "State and operations": a capsule image that cannot run is refused by
name, in about a second.
```

## Notes for your reviewer

One related thing is deliberately not here: `deleteConfiguredScaleSets`
(`internal/command/cleanup.go`, 0% coverage, provider-mutating) has a property worth
pinning — it refuses to delete a scale set whose remote ID no longer matches the recorded
one. That is a test against the provider adapter's fake, in a different package from
these two changes, and belongs in its own change rather than riding here.
