### PR TITLE
test(command): uninstall refuses a scale set that is no longer the one it recorded

### DIFF
--- a/internal/command/cleanup.go
+++ b/internal/command/cleanup.go
@@ -194,13 +194,13 @@ func deleteConfiguredScaleSets(ctx context.Context, streams IO, bindings []store
 		if err != nil {
 			return err
 		}
-		if !found {
-			fmt.Fprintf(streams.Out, "  scale set %s is already absent\n", gb.ScaleSetName)
-			continue
+		delete, note, err := scaleSetVerdict(gb, int64(remote.ID), found)
+		if err != nil {
+			return err
 		}
-		if int64(remote.ID) != gb.ScaleSetID {
-			return fmt.Errorf("scale set %s now has id %d, but this instance recorded %d; refusing to delete a different resource",
-				gb.ScaleSetName, remote.ID, gb.ScaleSetID)
+		if !delete {
+			fmt.Fprintf(streams.Out, "  %s\n", note)
+			continue
 		}
 		if err := gh.DeleteScaleSet(ctx, int(gb.ScaleSetID)); err != nil {
 			return fmt.Errorf("delete scale set %s: %w", gb.ScaleSetName, err)
@@ -419,4 +419,26 @@ func liveLeaseCount(snap store.Snapshot) int {
 		}
 	}
 	return n
+}
+
+// scaleSetVerdict decides what uninstall does about one recorded scale
+// set, given what the provider currently answers for its name.
+//
+// The refusal is the reason this is a function rather than four lines
+// inline: a scale set whose remote id no longer matches the recorded one
+// is a different resource wearing a name this instance used, and
+// deleting it destroys somebody else's runners. The path that decides
+// that builds its own provider client, so nothing could reach it from a
+// test; the decision is separated so the one ruling that must never be
+// wrong can be.
+func scaleSetVerdict(gb store.GitHubBinding, remoteID int64, found bool) (delete bool, note string, err error) {
+	if !found {
+		return false, fmt.Sprintf("scale set %s is already absent", gb.ScaleSetName), nil
+	}
+	if remoteID != gb.ScaleSetID {
+		return false, "", fmt.Errorf(
+			"scale set %s now has id %d, but this instance recorded %d; refusing to delete a different resource",
+			gb.ScaleSetName, remoteID, gb.ScaleSetID)
+	}
+	return true, "", nil
 }

--- a/internal/command/cleanup_test.go
+++ b/internal/command/cleanup_test.go
@@ -162,3 +162,50 @@ func TestUninstallRefusesBeforeItDescribes(t *testing.T) {
 		t.Errorf("the refusal printed a description first:\n%s", stdout)
 	}
 }
+
+// TestUninstallRefusesAScaleSetThatIsNoLongerTheOneItRecorded: names are
+// reusable and ids are not. A scale set deleted and recreated under the
+// same name — by a person, by another instance, by a rerun of setup — is
+// a different resource, and deleting it destroys runners this instance
+// never owned.
+//
+// The path that decides this builds its own provider client from
+// configuration, so nothing could reach it from a test; the ruling is
+// separated so the one that must never be wrong can be held.
+func TestUninstallRefusesAScaleSetThatIsNoLongerTheOneItRecorded(t *testing.T) {
+	recorded := store.GitHubBinding{ScaleSetName: "runpool-standard", ScaleSetID: 42}
+
+	for name, tc := range map[string]struct {
+		remoteID   int64
+		found      bool
+		wantDelete bool
+		wantRefuse bool
+	}{
+		"the same resource is deleted":             {42, true, true, false},
+		"a different id under the name is refused": {77, true, false, true},
+		"an absent scale set is skipped":           {0, false, false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			del, note, err := scaleSetVerdict(recorded, tc.remoteID, tc.found)
+			if tc.wantRefuse {
+				if err == nil {
+					t.Fatal("a scale set wearing the recorded name with another id was deleted")
+				}
+				if !strings.Contains(err.Error(), "77") || !strings.Contains(err.Error(), "42") {
+					t.Errorf("error = %q; it has to name both ids, which is what tells an "+
+						"operator this is not their resource", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected refusal: %v", err)
+			}
+			if del != tc.wantDelete {
+				t.Errorf("delete = %v; want %v", del, tc.wantDelete)
+			}
+			if !del && note == "" {
+				t.Error("a skipped scale set says nothing; the operator reads this output")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changes

The deletion verdict in `deleteConfiguredScaleSets` becomes a function, and its three
answers are tested. No behaviour changes.

## What was found

`uninstall --confirm` deletes the scale sets an instance created. Before deleting one it
compares the provider's current id for that name against the id it recorded, and refuses
if they differ — because **names are reusable and ids are not**. A scale set deleted and
recreated under the same name, by a person or by a rerun of setup, is a different
resource; deleting it destroys runners this instance never owned.

That refusal was unreachable from any test: the function builds its own provider client
from configuration inside the loop, so it measured 0% coverage and its one ruling that
must never be wrong was held by reading it.

## Evidence

```text
Removing the id comparison fails the "a different id under the name is refused"
subtest.

gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
```

The test also asserts the refusal names **both** ids — the recorded one and the current
one — because that is what tells an operator the resource is not theirs.

## What would notice this regressing

`TestUninstallRefusesAScaleSetThatIsNoLongerTheOneItRecorded`, over the three answers:
delete, skip-because-absent, and refuse.

## Risk, compatibility and operations

**No behaviour change.** The same three outcomes in the same order; the branch moved into
a named function and the skip messages are produced by it.

**Trust boundary:** unchanged, but the check that keeps uninstall inside this instance's
own resources is now held by a test rather than by inspection.

**Schema, status API, configuration, deployment, rollback, runbook: N/A. Not an ADR.**

## Changelog

```text
NONE — no observable behaviour changes.
```
