### PR TITLE
docs: the exit code is a trust surface, and resolving a held attempt costs downtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,6 +548,16 @@ by its public and operational effects.
   held on carries the reason it could not be read, where a transport
   failure previously left the operator an exit code and an empty string.
 
+- **The threat model names the exit code as the same surface the control
+  file is.** Only the status the supervisor reserves for stopping before
+  the hand-over proves the runner never owned the job; every other status
+  reads as execution. That is the right direction for at-most-once — and
+  it means a supervisor the kernel kills, an out-of-memory PID 1 on a
+  tight tier, settles an attempt as completed where the runner never
+  picked the job up. Nothing runs twice; the work comes back only because
+  the provider re-offers it, and that dependency is now written down
+  rather than assumed.
+
 ### Interface
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -234,7 +234,14 @@ runpool attempts inspect <id>
 ```
 
 Then decide it. Exactly one of the two decisions, and `--apply` to make
-it:
+it.
+
+The applying form takes the singleton lock, so **the controller has to be
+stopped** — and on a shared host that is every tenant's CI, not just the
+job in question. Read the attempt first, decide, and stop the controller
+for the resolution rather than the other way round. A dry run needs no
+lock, so everything except the last step can be done while serving
+continues.
 
 ```bash
 runpool attempts resolve <id> --retry --reason "..." --actor "<name>" --apply
@@ -254,7 +261,7 @@ is exactly the case where this instance could not tell.
 **`--apply` needs the controller stopped.** It takes the same singleton
 lock `serve` holds, and reports that it could not. A dry run does not.
 
-An attempt is held for one of two reasons:
+An attempt is held for one of three reasons:
 
 | Reason | What it means |
 | --- | --- |

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -118,6 +118,19 @@ when the deregistration cannot be attempted — a deconfigured target, no
 recorded runner id, or any other failure answering. In those cases the
 capsule's account is still what settles the attempt.
 
+The exit code is the same surface, and worth naming separately because
+no adversary is required to reach it. Only one status proves the runner
+never owned the job: the one the supervisor reserves for stopping before
+the hand-over. Every other status is read as execution — which is the
+right direction for at-most-once, and it means a supervisor the kernel
+kills, an out-of-memory PID 1 on a tight tier, settles an attempt as
+completed even where the runner never picked the job up. Nothing runs
+twice, which is the guarantee; what is lost is the work, and it comes
+back only because the provider re-offers a job whose runner never took
+it. That composition is correct and it is a dependency: Runpool's
+promise that accepted work is not lost rests, in this one case, on the
+provider's own at-least-once delivery rather than on anything here.
+
 Closing it properly means the controller not depending on the capsule's
 account at all, which is not where the machine is today.
 


### PR DESCRIPTION
## What changes

The threat model gains the exit-code trust boundary and the provider dependency it
implies. The runbook says what resolving a held attempt costs, and corrects a table
introduced as two rows that has three.

## What was found

**The exit code is the same trust surface the control file is, and it needs no
adversary.** `ClassifyExit` treats exactly one status — the one the supervisor reserves
for stopping before the hand-over — as proof the runner never owned the job. Every other
status reads as execution.

That is the correct direction for at-most-once, and it means a supervisor the **kernel**
kills — an out-of-memory PID 1 on a tight tier — settles an attempt as
`completed_observed` where the runner never picked the job up. Nothing runs twice, which
is the guarantee. What is lost is the work, and it comes back only because the provider
re-offers a job whose runner never took it.

That composition is correct, and it is a dependency that was nowhere written down: the
product contract's promise that accepted work is not lost rests, in this one case, on
GitHub's own at-least-once delivery rather than on anything in this build. Naming it is
the fix — the alternative, distrusting every non-reserved exit code, would rerun work
that did run.

**Resolving a held attempt costs host-wide CI downtime.** The applying form of
`attempts resolve` takes the singleton lock, so the controller must be stopped — and on
a shared host that is every tenant's CI, not just the job in question. The runbook said
the lock was needed without saying what it costs, or that everything up to the last step
can be done while serving continues.

**And it introduced a three-row table as "one of two reasons"** — `capsule_incompatible`
was added to the table and not to the sentence above it.

## Evidence

```text
Documentation only. test/consistency passes — it mechanically verifies the docs' file
paths and arithmetic against the tree.
```

## What would notice this regressing

Nothing automated for prose. The two/three drift is the kind of thing a consistency
check could catch by counting a table's rows against its introduction — noted, not
built.

## Risk, compatibility and operations

**Documentation only.** No code, no schema, no interface.

**Operations:** an operator planning a resolution now knows to schedule it. That is a
real change in what the runbook tells them to do.

**Not an ADR** — it records a boundary that already exists rather than deciding
anything.

## Changelog

```text
One bullet under "State and operations": the threat model names the exit code as the
same surface the control file is.
```

## Notes for your reviewer

Two related things are deliberately not here, both design changes rather than
documentation: an online path for resolving held attempts, so it does not cost downtime,
and a metrics surface.
