### PR TITLE
fix: two races the reviews had circled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -558,6 +558,16 @@ by its public and operational effects.
   the provider re-offers it, and that dependency is now written down
   rather than assumed.
 
+- **A capsule cannot start under an egress policy that has been
+  superseded.** A policy pass records its set only once every gateway
+  that was relaying carries it, so between the moment it stops
+  enumerating and the moment it records, the snapshot still holds the
+  older set — and a gateway created after that enumeration was never
+  reached by the pass either. The confirmation each launch performs
+  compared against that snapshot without waiting for the pass, saw
+  nothing to do, and installed nothing; every later pass then compared
+  the new set against itself and returned before any fan-out. The
+  capsule relayed under a superseded set for the whole of its job.
 ### Interface
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,6 +569,14 @@ by its public and operational effects.
   the new set against itself and returned before any fan-out. The
   capsule relayed under a superseded set for the whole of its job.
 ### Interface
+- **A job that provably never ran is requeued after a restart, not
+  settled.** The supervisor writes `running` once the start hand-over
+  returns, before the runner is forked, so a capsule that aborts in that
+  stretch exits carrying the code reserved for "the runner never owned
+  the job". The live wait and adoption both read that code and requeue;
+  a restart destroyed the container unread and settled the attempt as
+  started. Same facts, answered differently by whether the controller
+  happened to be alive.
 
 - The CLI is **Cobra**: `--help` works, extra arguments are usage
   errors, exit codes are `0`/`1`/`2` and mean what they say, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,7 +568,6 @@ by its public and operational effects.
   nothing to do, and installed nothing; every later pass then compared
   the new set against itself and returned before any fan-out. The
   capsule relayed under a superseded set for the whole of its job.
-### Interface
 - **A job that provably never ran is requeued after a restart, not
   settled.** The supervisor writes `running` once the start hand-over
   returns, before the runner is forked, so a capsule that aborts in that
@@ -578,6 +577,7 @@ by its public and operational effects.
   started. Same facts, answered differently by whether the controller
   happened to be alive.
 
+### Interface
 - The CLI is **Cobra**: `--help` works, extra arguments are usage
   errors, exit codes are `0`/`1`/`2` and mean what they say, and
   destructive commands preview by default.

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -171,8 +171,20 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	// The observation is taken before any cleanup: the container is the
 	// only proof of whether an authorized start took effect, and the
 	// release below destroys it.
+	//
+	// running_observed is asked for too, and that is not belt and braces.
+	// The supervisor writes `running` once the start exec returns, which
+	// is before the runner is forked -- so a capsule that aborted after
+	// that point sits exited carrying the one code reserved for "the
+	// runner never owned the job", which is the entire reason that code
+	// exists. Gated on start_authorized alone, this pass destroyed that
+	// container unread and settled the attempt as started, where the
+	// same capsule reached by the live wait or by adoption is requeued.
+	// Same facts, different answer, decided by whether the controller
+	// happened to be alive.
 	obs := assignment.ObservedAbsent
-	if evidence == store.EvidenceStartAuthorized && hasRunner {
+	if hasRunner && (evidence == store.EvidenceStartAuthorized ||
+		evidence == store.EvidenceRunningObserved) {
 		var err error
 		obs, err = s.inspectExecution(ctx, capsule.PreparedRuntime{RuntimeID: assignment.RuntimeID(runner.ID)})
 		if err != nil {
@@ -185,7 +197,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	// transaction then settles from evidence alone. The write is the
 	// whole point — nothing below reads the local copy, because every
 	// disposition re-reads the row inside its own transaction.
-	if obs == assignment.ObservedExited && evidence == store.EvidenceStartAuthorized {
+	if obs == assignment.ObservedExited && evidence != store.EvidenceExitObserved {
 		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 			return tx.RecordEvidence(lease.AttemptID, store.EvidenceExitObserved)
 		}); err != nil {

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -197,7 +197,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 	// transaction then settles from evidence alone. The write is the
 	// whole point — nothing below reads the local copy, because every
 	// disposition re-reads the row inside its own transaction.
-	if obs == assignment.ObservedExited && evidence != store.EvidenceExitObserved {
+	if obs == assignment.ObservedExited {
 		if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 			return tx.RecordEvidence(lease.AttemptID, store.EvidenceExitObserved)
 		}); err != nil {

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -237,3 +237,54 @@ func TestRecoveryRefinesFromTheRuntimeItStillHolds(t *testing.T) {
 		})
 	}
 }
+
+// TestAnAbortAfterRunningObservedIsRequeuedOnRestart: the supervisor
+// writes `running` once the start exec returns — before the runner is
+// forked. A capsule that aborts in that stretch (no credential, a
+// prepare failure, a fork that fails) exits carrying the one code
+// reserved for "the runner never owned the job", and that code exists
+// for exactly this: by the time a controller inspects it, the daemon
+// says `exited` and nothing inside can be read.
+//
+// The live wait requeues it. Adoption requeues it. Restart destroyed the
+// container unread and settled the attempt as started — the same facts
+// answered differently by whether the controller happened to be alive,
+// with a job that provably never ran never served again locally.
+func TestAnAbortAfterRunningObservedIsRequeuedOnRestart(t *testing.T) {
+	for name, tc := range map[string]struct {
+		obs            assignment.ExecutionObservation
+		wantState      store.AttemptState
+		wantResolution assignment.Resolution
+	}{
+		"an abort returns the attempt to the queue": {
+			obs: assignment.ObservedCreated, wantState: store.AttemptReady,
+		},
+		"a real exit settles as completed": {
+			obs: assignment.ObservedExited, wantState: store.AttemptSettled,
+			wantResolution: assignment.ResolutionCompletedObserved,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t, 1)
+			workload := "job-restart-" + string(tc.obs)
+			if err := h.deliver(demand(workload, "app", 6)); err != nil {
+				t.Fatal(err)
+			}
+			lease, attemptID := leaseFor(t, h, assignment.SourceWorkloadKey(workload))
+			driveLeaseTo(t, h, lease.ID, store.LeaseWorkloadRunning)
+			// The evidence a serving reaches once its start exec returns.
+			h.recordEvidence(lease.ID, store.EvidenceRunningObserved)
+
+			h.resolveWithRuntime(t.Context(), reloadLease(t, h, lease.ID), tc.obs)
+
+			got := attemptState(t, h, attemptID)
+			if got.State != tc.wantState {
+				t.Errorf("attempt = %s after a capsule reporting %s; want %s",
+					got.State, tc.obs, tc.wantState)
+			}
+			if got.Resolution != tc.wantResolution {
+				t.Errorf("resolution = %q; want %q", got.Resolution, tc.wantResolution)
+			}
+		})
+	}
+}

--- a/internal/netsandbox/netsandbox.go
+++ b/internal/netsandbox/netsandbox.go
@@ -68,7 +68,10 @@ type Daemon interface {
 // abandonable. What that costs is ownership: the token is bare, so a
 // drain anywhere other than the send's own defer releases it whoever
 // holds it, and two refreshes then run at once with nothing to say so.
-// refresh is the only place that takes it. A launch holds it for as long as a discovery and a
+// Two places take it: refresh, and the confirmation a launch performs --
+// which has to wait for a pass in flight, because a pass records its set
+// only after installing it and the snapshot holds the older one until
+// then. A launch holds it for as long as a discovery and a
 // gateway fan-out take, on a context that deliberately outlives the
 // serve loop so cleanup can still run; a mutex would park the shutdown
 // pass on that launch with no way to give up, and the wait for the serve
@@ -412,10 +415,13 @@ func (n *Manager) ConfirmLaunch(ctx context.Context, leaseID assignment.LeaseID,
 		// gateway that refused it.
 		return fmt.Errorf("lease %s owns no running gateway to confirm the egress policy against", leaseID)
 	}
-	// A pass that moved the set while this ran leaves the gateway one
-	// generation behind. A capsule must not start under a set that was
-	// current a moment ago, and the pass that moved it could not have
-	// reached this gateway either.
+	// An assertion on the slot, not a race this can lose. The only writer
+	// of the snapshot is a pass, and a pass holds the slot this function
+	// holds -- so the set cannot move while this runs, and this can only
+	// fire if two holders exist at once. That is the failure the token
+	// above names and nothing else detects: it costs one comparison, it
+	// fails closed, and it sits in the path that decides what a capsule
+	// may reach.
 	if after := n.state.snapshot(); !sameSandbox(inForce, after) {
 		return fmt.Errorf("the egress policy moved while the gateway was being confirmed")
 	}

--- a/internal/netsandbox/netsandbox.go
+++ b/internal/netsandbox/netsandbox.go
@@ -365,6 +365,25 @@ func (n *Manager) ConfirmLaunch(ctx context.Context, leaseID assignment.LeaseID,
 	if n == nil || launched == nil {
 		return nil
 	}
+	// Under the slot, because the snapshot is not the whole answer. A
+	// pass records its set only once every gateway that was relaying
+	// carries it, so between the moment it stops enumerating and the
+	// moment it records, the snapshot still holds the older set -- and
+	// this gateway was created after that enumeration, so the pass never
+	// reached it either. Comparing outside the slot in that window sees
+	// "unchanged", installs nothing, and every later pass compares the
+	// new set against itself and returns before any fan-out. The capsule
+	// then relays under a superseded set for the whole of its job.
+	//
+	// Waiting is what ForLaunch already does on this same slot, and the
+	// wait is abandonable: a launch whose context ends stops waiting.
+	select {
+	case n.state.refreshing <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	defer func() { <-n.state.refreshing }()
+
 	inForce := n.state.snapshot()
 	if sameSandbox(launched, inForce) {
 		return nil

--- a/internal/netsandbox/netsandbox_test.go
+++ b/internal/netsandbox/netsandbox_test.go
@@ -115,6 +115,9 @@ type fakeDaemon struct {
 	// what makes a serial pass distinguishable from a concurrent one.
 	delay time.Duration
 
+	// lastPayload is what the most recent reload carried.
+	lastPayload string
+
 	// The pass fans out over gateways now, so what it records is written
 	// from several goroutines and in no fixed order. The mutex is the
 	// fake's own; the accessors below sort, so a test asserts what was
@@ -252,13 +255,26 @@ func (f *fakeDaemon) Exec(_ context.Context, id string, cmd []string) (int, stri
 	}
 	return 0, "", nil
 }
-func (f *fakeDaemon) ExecWithInput(_ context.Context, id string, _ []string, _ []byte) (int, string, error) {
+func (f *fakeDaemon) ExecWithInput(_ context.Context, id string, _ []string, input []byte) (int, string, error) {
 	f.serve()
 	if f.refuse[id] {
 		return 1, "refused", nil
 	}
+	f.mu.Lock()
+	f.lastPayload = string(input)
+	f.mu.Unlock()
 	f.note(&f.reloaded, id)
 	return 0, "", nil
+}
+
+// payload is the policy the last reload carried. Asserting that a
+// gateway was reloaded says nothing about what it was reloaded with,
+// and a confirmation marshalling the launch's own set instead of the
+// one in force would pass that weaker assertion.
+func (f *fakeDaemon) payload() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastPayload
 }
 func (f *fakeDaemon) RemoveContainer(ctx context.Context, id string) error {
 	f.mu.Lock()
@@ -1114,5 +1130,9 @@ func TestAConfirmationWaitsForAPassThatHasNotRecordedYet(t *testing.T) {
 	if got := d.reloads(); !slices.Equal(got, []string{"gw-late"}) {
 		t.Errorf("reloaded %v; the gateway created after the pass enumerated has to receive "+
 			"the set that pass recorded, which is the one it was too late to be given", got)
+	}
+	if got := d.payload(); !strings.Contains(got, "192.168.0.0/16") {
+		t.Errorf("the reload carried %q; it has to carry the set the pass recorded, not the "+
+			"one the launch was cut from", got)
 	}
 }

--- a/internal/netsandbox/netsandbox_test.go
+++ b/internal/netsandbox/netsandbox_test.go
@@ -1056,3 +1056,63 @@ func TestRediscoverClosesEveryGatewayWhenDiscoveryFails(t *testing.T) {
 		t.Errorf("removed %v; a failed rediscovery has to close every gateway", d.removes())
 	}
 }
+
+// TestAConfirmationWaitsForAPassThatHasNotRecordedYet is the window
+// between the two the other confirmation tests hold.
+//
+// A pass records its set only once every gateway that was relaying
+// carries it — so between the moment it stops enumerating and the moment
+// it records, the snapshot still holds the older set. A gateway created
+// after that enumeration was never reached by the pass either. A
+// confirmation comparing against the snapshot in that window sees
+// "unchanged", installs nothing, and returns; every later pass then
+// compares the new set against itself, classifies it unchanged, and
+// returns before any fan-out. The capsule relays under a superseded set
+// for the whole of its job, and nothing anywhere says so.
+//
+// The window is not narrow. A pass closing gateways after a failed
+// restriction spends a control timeout on each, which is exactly the
+// pass whose set matters most.
+func TestAConfirmationWaitsForAPassThatHasNotRecordedYet(t *testing.T) {
+	older := &capsule.Sandbox{UplinkNetworkID: "up-1", UplinkSubnet: "172.30.0.0/24",
+		Deny: []string{"10.0.0.0/8"}}
+	newer := &capsule.Sandbox{UplinkNetworkID: "up-1", UplinkSubnet: "172.30.0.0/24",
+		Deny: []string{"10.0.0.0/8", "192.168.0.0/16"}}
+
+	d := &fakeDaemon{
+		containers: []engine.OwnedContainer{
+			{ID: "gw-late", Role: engine.RoleGateway, LeaseID: "lse-late", Running: true},
+		},
+	}
+	n := newTestSandbox(t, d, older)
+
+	// A pass mid-flight: past its enumeration, not yet at its record.
+	n.state.refreshing <- struct{}{}
+
+	done := make(chan error, 1)
+	go func() { done <- n.ConfirmLaunch(t.Context(), "lse-late", older) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("the confirmation returned (%v) while a pass had not recorded its set; "+
+			"it compared against a snapshot the pass was about to replace", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The pass records and releases.
+	n.state.replace(newer)
+	<-n.state.refreshing
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("confirming after the pass recorded: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the confirmation never completed after the slot was released")
+	}
+	if got := d.reloads(); !slices.Equal(got, []string{"gw-late"}) {
+		t.Errorf("reloaded %v; the gateway created after the pass enumerated has to receive "+
+			"the set that pass recorded, which is the one it was too late to be given", got)
+	}
+}


### PR DESCRIPTION
## What changes

`ConfirmLaunch` takes the refresh slot, so a launch cannot confirm against a snapshot a
policy pass is about to replace. Restart resolution inspects a surviving container when
the evidence is `running_observed`, not only `start_authorized`.

## What was found

Two reachable defects, each in an interleaving the existing tests bracket without
covering.

### A capsule could keep a superseded egress policy for the life of its job

**High.** A policy pass records its set only once every gateway that was relaying carries
it — the ordering is deliberate and its comment explains why. So between the moment the
pass stops enumerating and the moment it records, the snapshot still holds the *older*
set. A gateway created after that enumeration was never reached by the pass either.

`ConfirmLaunch`'s fast path read that snapshot without waiting, compared the launch's own
set against it, found them the same, and returned having installed nothing. The pass then
recorded; every later pass compared the new set against itself, classified it
`PolicyUnchanged`, and returned before any fan-out. **Nothing ever installed the newer set
into that gateway.** The capsule relayed under a superseded set for its whole job — on a
shared daemon, reaching exactly what the newer set was written to deny.

The window is not narrow: a pass closing gateways after a restriction it could not install
spends a control timeout on each, and that is precisely the pass whose set matters most.

The two interleavings either side of this one were already closed *and tested* —
`TestAGatewayCreatedDuringATighteningDoesNotKeepTheOlderPolicy` (pass completed before the
confirm) and `TestAConfirmationThatWasOvertakenFailsTheLaunch` (pass replaced during it).
This was the one between them, and `ConfirmLaunch`'s own doc claims the launch "closes that
gap".

### A job that provably never ran was settled instead of requeued after a restart

**Medium** — at-most-once is not violated, nothing reruns; the durable record is wrong and
the local requeue the design promises is lost.

The supervisor writes `running` once the start hand-over returns — **before the runner is
forked**. A capsule that aborts in that stretch exits carrying the one code reserved for
"the runner never owned the job", which is that code's entire reason to exist: by the time
a controller inspects an aborted capsule, the daemon says exited and nothing inside can be
read.

Restart resolution inspected only when the evidence was `start_authorized`. An attempt
already at `running_observed` therefore had its container — the only proof — destroyed
unread, and was settled as `started_observed`. The same capsule reached by the live wait,
or by adoption one Docker-list tick earlier, is requeued. Same facts, different answer,
decided by whether the controller happened to be alive.

The disposition lattice already ranks the capsule's `ObservedCreated` above
`running_observed` evidence; only this path never collected the observation it was
entitled to.

## Evidence

| Mutation | Failure |
| --- | --- |
| the refresh slot removed from `ConfirmLaunch` | `the confirmation returned (<nil>) while a pass had not recorded its set` |
| the gate narrowed back to `start_authorized` | `attempt = settled after a capsule reporting created; want ready` |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
Zero DATA RACE across a full shuffled run and three repeats of the concurrent packages.
```

Deadlock checked before shipping: `ConfirmLaunch` has one production caller, sequential
after `ForLaunch`, which releases the slot before returning. Neither `refresh` nor
`applyPolicy` reaches `ConfirmLaunch`, so the slot cannot be re-entered.

## What would notice this regressing

`TestAConfirmationWaitsForAPassThatHasNotRecordedYet` holds the confirmation open while a
pass has the slot and asserts the gateway receives the set that pass records.
`TestAnAbortAfterRunningObservedIsRequeuedOnRestart` covers both directions — an abort
requeues, a real exit settles as completed.

## Risk, compatibility and operations

**Trust boundary: this is the restricted profile's stated invariant.** A capsule can no
longer start under a policy that has been superseded.

**Timing:** a confirmation now waits for an in-flight pass, up to that pass's own budget.
`ForLaunch` already waits on the same slot in the same launch, so the shape is not new.

**Disposition:** a restart that finds an aborted capsule requeues instead of settling — the
same answer the live path already gives. A restart that finds a cleanly exited capsule now
settles as `completed_observed` rather than `started_observed`, which is also more accurate.

**Schema, status API, CLI, configuration, deployment, rollback: N/A. Not an ADR.**

## Follow-ups applied on this branch

The lock's own doc said `refresh` is the only place that takes the slot; it is not any
more, and that sentence sits in the paragraph defining the token's ownership discipline.
The end-of-confirmation recheck can no longer fire — the only snapshot writer is a pass,
and a pass holds this slot — so it stays as the one runtime detector of the failure the
token's doc names (a stray drain letting two holders run), with a comment saying it is an
assertion rather than a race. The refinement condition dropped a clause that could not be
false. And the confirmation test asserted a reload happened, not what it carried:
marshalling the launch's own set instead of the one in force passed it, and now fails it.

## Changelog

```text
Two bullets under "State and operations": a capsule cannot start under a superseded egress
policy, and a job that provably never ran is requeued after a restart.
```
