### PR TITLE
chore(platform): the amd64 reference is frozen from the host that will run the suites

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -21,7 +21,7 @@ not a support commitment while the project remains unreleased.
 | Area | State |
 | --- | --- |
 | CI provider | GitHub Actions, as the single adapter. The control plane is provider-neutral by construction, but no other adapter exists or is promised. |
-| Host | Linux amd64, rootful Docker Engine 28.0 or newer, cgroup v2 with the memory and pids controllers. Docker Engine 29.7.2 on Debian 13 is selected for the first release qualification; the remaining host facts have not yet been frozen. See the exact support matrix. |
+| Host | Linux amd64, rootful Docker Engine 28.0 or newer, cgroup v2 with the memory and pids controllers. Docker Engine 29.7.2 on Debian 13 is selected for the first release qualification, and the reference host's facts are frozen. See the exact support matrix. |
 | Scope | Repository-scoped and organization-scoped scale sets. Persistent cache lanes are repository-scoped only. |
 | Egress | The restricted profile (implemented and tested live, not yet release-qualified) denies direct egress and permits proxy HTTP or CONNECT to allowed addresses on ports 80/443. See [the runbook](docs/runbook.md). |
 | State | SQLite in a Docker named volume, one controller per state directory, enforced by a lock. |

--- a/build/platform.lock.json
+++ b/build/platform.lock.json
@@ -30,7 +30,7 @@
         "reviewed": "2026-08-16",
         "freeze_point": "before-release-candidate"
       },
-      "recorded": "2026-08-26T18:53:33Z",
+      "recorded": "2026-08-26T19:08:42Z",
       "platform": {
         "os": "debian",
         "os_version": "13",
@@ -42,7 +42,7 @@
         "cgroup_version": "2",
         "cgroup_driver": "systemd",
         "storage_driver": "overlayfs",
-        "backing_filesystem": "ext2/ext3",
+        "backing_filesystem": "ext4",
         "rootless": false,
         "containerd": "aad11006b869517fcd3009450b6f82da282e1a9b",
         "runc": "v1.4.3-0-gbb14dabe",

--- a/build/platform.lock.json
+++ b/build/platform.lock.json
@@ -17,7 +17,7 @@
   "schema_version": 2,
   "platforms": [
     {
-      "status": "pending",
+      "status": "frozen",
       "policy": {
         "os": "debian",
         "os_version": "13",
@@ -29,6 +29,27 @@
         "target_engine": "29.7.2",
         "reviewed": "2026-08-16",
         "freeze_point": "before-release-candidate"
+      },
+      "recorded": "2026-08-26T18:53:33Z",
+      "platform": {
+        "os": "debian",
+        "os_version": "13",
+        "os_codename": "trixie",
+        "arch": "amd64",
+        "kernel": "6.12.101+deb13-amd64",
+        "engine": "29.7.2",
+        "api": "1.55",
+        "cgroup_version": "2",
+        "cgroup_driver": "systemd",
+        "storage_driver": "overlayfs",
+        "backing_filesystem": "ext2/ext3",
+        "rootless": false,
+        "containerd": "aad11006b869517fcd3009450b6f82da282e1a9b",
+        "runc": "v1.4.3-0-gbb14dabe",
+        "buildx": "v0.36.1",
+        "compose": "5.5.0",
+        "iptables": "iptables v1.8.11 (nf_tables)",
+        "nftables": "nftables v1.1.3 (Commodore Bullmoose #4)"
       }
     }
   ]

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -65,7 +65,7 @@ defines its own expectation.
 | cgroups | v2, systemd driver |
 | Storage and backing filesystem | overlayfs on ext4 |
 | Rootless | no |
-| Firewall backend | iptables v1.8.11 (nf_tables), nftables v1.1.3 |
+| Firewall backend | iptables v1.8.11 (nf_tables), nftables v1.1.3 (Commodore Bullmoose #4) |
 | Buildx / Compose | v0.36.1 / 5.5.0 |
 | Frozen | 2026-08-26 |
 | Policy reviewed | 2026-08-16 |

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -50,23 +50,24 @@ of the no-skip qualification before the support statement expands.
 The policy selects Docker Engine
 [29.7.2](https://docs.docker.com/engine/release-notes/29/#2972) from Docker's
 [official stable Debian channel](https://download.docker.com/linux/debian/dists/trixie/pool/stable/amd64/).
-The exact platform reference is currently **pending**: the
-production-class Linux host has not yet supplied the remaining facts. Release
-qualification is fail-closed until those facts are reviewed and frozen in
-`build/platform.lock.json` before the candidate tag. The host under test never
+The exact platform reference is **frozen** in
+`build/platform.lock.json`, captured from the production-class host before any
+candidate tag exists. Release qualification compares an observed host against
+those values and fails closed on any difference; the host under test never
 defines its own expectation.
 
 | | Reference value |
 | --- | --- |
-| OS | Debian 13 (trixie), amd64 — the selection in the one entry recorded; exact patch pending host capture |
-| Kernel | Pending host capture |
-| Docker Engine | **29.7.2** selected; exact installed package pending capture |
-| Engine API, containerd, runc | Pending host capture |
-| cgroups | v2 required; exact driver pending capture |
-| Storage and backing filesystem | Pending host capture |
+| OS | Debian 13 (trixie), amd64 |
+| Kernel | 6.12.101+deb13-amd64 |
+| Docker Engine | **29.7.2**, stable channel |
+| Engine API, containerd, runc | 1.55, aad11006b869…, v1.4.3-0-gbb14dabe |
+| cgroups | v2, systemd driver |
+| Storage and backing filesystem | overlayfs on ext4 |
 | Rootless | no |
-| Firewall backend | Stable Docker backend required; exact tools pending capture |
-| Buildx / Compose | Pending host capture |
+| Firewall backend | iptables v1.8.11 (nf_tables), nftables v1.1.3 |
+| Buildx / Compose | v0.36.1 / 5.5.0 |
+| Frozen | 2026-08-26 |
 | Policy reviewed | 2026-08-16 |
 
 Once frozen, every value is exact because a release record must identify what

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -8,10 +8,12 @@ the objective publication gates; it is not a development log.
 The first release is `v1.0.0`. Docker Engine 29.7.2, the latest official
 stable Debian 13 package at the 2026-08-16 policy review, is selected for the
 first release qualification. The exact platform reference in
-[`build/platform.lock.json`](../build/platform.lock.json) remains `pending`
-until the production-class host's kernel, API, runtime, cgroup, storage,
-firewall, Buildx, and Compose facts are captured and independently reviewed.
-No candidate tag may be created while the reference is pending.
+[`build/platform.lock.json`](../build/platform.lock.json) is `frozen`: the
+production-class host's kernel, API, runtime, cgroup, storage, firewall,
+Buildx and Compose facts were captured on 2026-08-26 and reviewed before
+any candidate tag exists, which is the point of freezing them there.
+Updating Docker after this freeze requires a new reviewed lock and a
+complete no-skip qualification run.
 
 That exact host is an evidence reference, not an operator-side version pin.
 Runtime admission requires Docker Engine 28.0 or newer and the capabilities it
@@ -29,7 +31,7 @@ tested or supported platform until it passes the relevant live matrix.
 | Host topology contracts | Implemented; qualification not executed | Shared mode enforces positive reserves, restricted egress, organization runner-group isolation, ownership-verified cleanup and idle-uplink recovery; the shared controller E2E and common Docker contracts pass on the reference host |
 | Scheduling and swap envelope | Implemented; live qualification not executed | Global and tier parallelism constrain provider announcements and local admission through restart and quarantine; preflight proves the worst admitted CPU, memory, and swap set plus host reserve fits; configured swap is enforced in a real capsule on the reference host |
 | Immutable release candidates | Implemented; qualification not executed | Controller and capsule images are built before qualification and identified by digest; the standalone binary and completions are retained by checksum; publication promotes or downloads those exact bytes without rebuilding |
-| Exact platform match | Engine 29.7.2 selected; exact host lock pending | The reviewed lock is frozen before the candidate; every observed fact matches and missing facts fail the gate |
+| Exact platform match | **Met** — Engine 29.7.2 frozen from the reference host | The reviewed lock is frozen before the candidate; every observed fact matches and missing facts fail the gate |
 | External security review | Outstanding | Findings affecting the release boundary are [resolved or explicitly accepted](security/review-findings.md) before release approval |
 | Release authorization | Outstanding | The protected `release` environment approves publication only after all prior gates pass |
 

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -280,6 +280,12 @@ func (q Qualified) validate() error {
 		"os":          {q.Policy.OS, q.Platform.OS},
 		"os_version":  {q.Policy.OSVersion, q.Platform.OSVersion},
 		"os_codename": {q.Policy.OSCodename, q.Platform.OSCodename},
+		// The engine belongs in this list for the reason above and was
+		// missing from it. A test held the rule for one architecture by
+		// reading that architecture out of the file; an entry added for
+		// another, frozen from an engine its own policy did not select,
+		// passed validation and qualified hosts against it.
+		"engine": {q.Policy.TargetEngine, q.Platform.Engine},
 	} {
 		if want, got := pair[0], pair[1]; got != "" && got != want {
 			return fmt.Errorf("the %s entry selects %s %q and froze %q; the facts are not from "+

--- a/internal/platform/platform.lock.json
+++ b/internal/platform/platform.lock.json
@@ -30,7 +30,7 @@
         "reviewed": "2026-08-16",
         "freeze_point": "before-release-candidate"
       },
-      "recorded": "2026-08-26T18:53:33Z",
+      "recorded": "2026-08-26T19:08:42Z",
       "platform": {
         "os": "debian",
         "os_version": "13",
@@ -42,7 +42,7 @@
         "cgroup_version": "2",
         "cgroup_driver": "systemd",
         "storage_driver": "overlayfs",
-        "backing_filesystem": "ext2/ext3",
+        "backing_filesystem": "ext4",
         "rootless": false,
         "containerd": "aad11006b869517fcd3009450b6f82da282e1a9b",
         "runc": "v1.4.3-0-gbb14dabe",

--- a/internal/platform/platform.lock.json
+++ b/internal/platform/platform.lock.json
@@ -17,7 +17,7 @@
   "schema_version": 2,
   "platforms": [
     {
-      "status": "pending",
+      "status": "frozen",
       "policy": {
         "os": "debian",
         "os_version": "13",
@@ -29,6 +29,27 @@
         "target_engine": "29.7.2",
         "reviewed": "2026-08-16",
         "freeze_point": "before-release-candidate"
+      },
+      "recorded": "2026-08-26T18:53:33Z",
+      "platform": {
+        "os": "debian",
+        "os_version": "13",
+        "os_codename": "trixie",
+        "arch": "amd64",
+        "kernel": "6.12.101+deb13-amd64",
+        "engine": "29.7.2",
+        "api": "1.55",
+        "cgroup_version": "2",
+        "cgroup_driver": "systemd",
+        "storage_driver": "overlayfs",
+        "backing_filesystem": "ext2/ext3",
+        "rootless": false,
+        "containerd": "aad11006b869517fcd3009450b6f82da282e1a9b",
+        "runc": "v1.4.3-0-gbb14dabe",
+        "buildx": "v0.36.1",
+        "compose": "5.5.0",
+        "iptables": "iptables v1.8.11 (nf_tables)",
+        "nftables": "nftables v1.1.3 (Commodore Bullmoose #4)"
       }
     }
   ]

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -131,6 +131,10 @@ func TestAnEntryFrozenFromAnotherPlatformIsRefused(t *testing.T) {
 		"os":          func(q *Qualified) { q.Platform.OS = "ubuntu" },
 		"os_version":  func(q *Qualified) { q.Platform.OSVersion = "24.04" },
 		"os_codename": func(q *Qualified) { q.Platform.OSCodename = "noble" },
+		// The engine is the same rule and was missing from it: an entry
+		// frozen from an engine its own policy did not select qualifies
+		// hosts against a version nobody reviewed.
+		"engine": func(q *Qualified) { q.Platform.Engine = "29.7.1" },
 	} {
 		q := frozenQualified()
 		break_(&q)
@@ -407,5 +411,30 @@ func TestEveryDockerFactIsCompared(t *testing.T) {
 				t.Errorf("drifting %s produced %v; want exactly that one mismatch", property, got)
 			}
 		})
+	}
+}
+
+// TestTheRefusalsAValidatorOwesAreItsOwn covers the two branches nothing
+// reached. A pending entry carrying frozen facts is a record claiming
+// review that never happened, and a status word outside the vocabulary
+// is what this type's own doc warns about: compared against the wrong
+// word, a reference nobody reviewed reports as reviewed.
+func TestTheRefusalsAValidatorOwesAreItsOwn(t *testing.T) {
+	facts := Facts{
+		OS: "debian", OSVersion: "13", OSCodename: "trixie", Arch: "amd64",
+		Kernel: "k", Engine: "29.7.2", API: "1.55", CgroupVersion: "2",
+		CgroupDriver: "systemd", StorageDriver: "overlayfs", BackingFilesystem: "ext4",
+		Rootless: boolFact(false), Containerd: "c", Runc: "r", Buildx: "b",
+		Compose: "co", IPTables: "ipt", NFTables: "nft",
+	}
+	pending := Qualified{Status: ReferenceStatusPending, Policy: testPolicy(),
+		Recorded: "2026-08-26", Platform: facts}
+	if err := pending.validate(); err == nil {
+		t.Error("a pending entry carrying frozen facts validated; it claims a review nobody did")
+	}
+	unknown := Qualified{Status: "reviewed", Policy: testPolicy()}
+	if err := unknown.validate(); err == nil {
+		t.Error("a status outside the vocabulary validated; the wrong word reports an " +
+			"unreviewed reference as reviewed")
 	}
 }

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -31,17 +31,44 @@ func TestManifestSelectsTheLatestReviewedStableEngine(t *testing.T) {
 	if !ok {
 		t.Fatalf("no entry for amd64; the release records %v", ref.Arches())
 	}
-	if amd64.Status != ReferenceStatusPending {
-		t.Errorf("status = %q; want pending until the server facts are frozen", amd64.Status)
-	}
 	if amd64.Policy.TargetEngine != "29.7.2" || amd64.Policy.DockerChannel != "stable" {
 		t.Errorf("Docker policy = %+v; want stable Engine 29.7.2", amd64.Policy)
 	}
-	if err := amd64.RequireFrozen(); err == nil {
-		t.Fatal("a pending reference was accepted for release qualification")
+	if amd64.Status != ReferenceStatusFrozen {
+		t.Fatalf("status = %q; the entry is frozen and qualification reads it", amd64.Status)
 	}
-	if got := amd64.Compare(Facts{}); len(got) != 1 || got[0].Property != "reference_status" {
+	if err := amd64.RequireFrozen(); err != nil {
+		t.Errorf("the frozen reference was refused for qualification: %v", err)
+	}
+	// The facts are the platform the policy selects, and the engine that
+	// ran the suites is the one the policy named. An entry frozen from
+	// somewhere else qualifies neither host.
+	if amd64.Platform.Engine != amd64.Policy.TargetEngine {
+		t.Errorf("froze engine %q against a policy naming %q",
+			amd64.Platform.Engine, amd64.Policy.TargetEngine)
+	}
+	if got := amd64.Compare(amd64.Platform); len(got) != 0 {
+		t.Errorf("the reference mismatched its own facts: %v", got)
+	}
+}
+
+// TestAPendingReferenceQualifiesNothing keeps the other half of what the
+// test above used to say. It read those refusals off the lock, which
+// held a pending entry then and holds a frozen one now -- so the rules
+// are stated here, over an entry this test owns, rather than over a file
+// whose contents are the thing under review.
+func TestAPendingReferenceQualifiesNothing(t *testing.T) {
+	pending := Qualified{Status: ReferenceStatusPending, Policy: testPolicy()}
+	if err := pending.RequireFrozen(); err == nil {
+		t.Error("a pending reference was accepted for release qualification")
+	}
+	got := pending.Compare(Facts{})
+	if len(got) != 1 || got[0].Property != "reference_status" {
 		t.Fatalf("pending comparison = %v; want a reference_status mismatch", got)
+	}
+	if got := pending.CompareDockerFacts(Facts{}); len(got) != 1 ||
+		got[0].Property != "reference_status" {
+		t.Errorf("pending runtime comparison = %v; want the same refusal", got)
 	}
 }
 

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -43,7 +43,17 @@ compose=$(docker compose version --short 2>/dev/null || true)
 # said here so the next reader does not mistake this for a probe of the
 # image store.
 docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
-backing=$(findmnt -no FSTYPE --target "$docker_root" 2>/dev/null || true)
+# A tool that is not here is not a filesystem that is not there. Swallowed,
+# the absence produced an empty value: the freeze then refused the record as
+# incomplete, and a qualification run reported the host's filesystem as ""
+# against the reference's ext4 -- a mismatch an operator reads as the wrong
+# disk rather than as a missing package. findmnt is util-linux, which every
+# glibc distribution installs by default and busybox ones do not.
+if ! command -v findmnt >/dev/null 2>&1; then
+  echo "platform-facts: findmnt not found; install util-linux to collect the backing filesystem" >&2
+  exit 1
+fi
+backing=$(findmnt -no FSTYPE --target "$docker_root")
 iptables_version=$(iptables --version 2>/dev/null || true)
 nft_version=$(nft --version 2>/dev/null || true)
 

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -29,7 +29,14 @@ case "$security" in *rootless*) rootless=true ;; esac
 
 buildx=$(docker buildx version 2>/dev/null | awk '{print $2}' || true)
 compose=$(docker compose version --short 2>/dev/null || true)
-backing=$(stat -f -c %T /var/lib/docker 2>/dev/null || true)
+# The daemon says where its root is, and findmnt names the filesystem
+# rather than its magic number: stat -f prints "ext2/ext3" for ext4,
+# because the three share one magic, and this value is frozen into a
+# document whose whole purpose is to be read literally. A hardcoded
+# /var/lib/docker would also aim at the graphdriver root, which is not
+# where layers live once the containerd image store is the driver.
+docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
+backing=$(findmnt -no FSTYPE --target "$docker_root" 2>/dev/null || true)
 iptables_version=$(iptables --version 2>/dev/null || true)
 nft_version=$(nft --version 2>/dev/null || true)
 

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -29,12 +29,19 @@ case "$security" in *rootless*) rootless=true ;; esac
 
 buildx=$(docker buildx version 2>/dev/null | awk '{print $2}' || true)
 compose=$(docker compose version --short 2>/dev/null || true)
-# The daemon says where its root is, and findmnt names the filesystem
-# rather than its magic number: stat -f prints "ext2/ext3" for ext4,
-# because the three share one magic, and this value is frozen into a
-# document whose whole purpose is to be read literally. A hardcoded
-# /var/lib/docker would also aim at the graphdriver root, which is not
-# where layers live once the containerd image store is the driver.
+# findmnt names the filesystem; stat -f prints its magic number, and
+# ext2, ext3 and ext4 share one -- so a host running ext4 was frozen into
+# this document as "ext2/ext3", and this document exists to be read
+# literally.
+#
+# The path is the daemon's own data root rather than a hardcoded one, so
+# a relocated --data-root is followed. What it is not is where layers
+# live under the containerd image store: those are under containerd's
+# root, which this does not probe. The fact has always named the
+# daemon's storage, the two roots are the same filesystem on any
+# ordinary host, and widening it to two values is a manifest change --
+# said here so the next reader does not mistake this for a probe of the
+# image store.
 docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || echo /var/lib/docker)
 backing=$(findmnt -no FSTYPE --target "$docker_root" 2>/dev/null || true)
 iptables_version=$(iptables --version 2>/dev/null || true)

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -54,6 +54,19 @@ if ! command -v findmnt >/dev/null 2>&1; then
   exit 1
 fi
 backing=$(findmnt -no FSTYPE --target "$docker_root")
+# These two stay swallowed, and the difference from the guard above is
+# the whole reason. findmnt missing was a broken instrument reporting a
+# false fact -- the disk had a filesystem either way. iptables missing is
+# the fact: the host has no iptables, which is true, and reporting it is
+# this script's whole job. The same shape as rootless -- a disqualifying
+# property the collector states and the judges refuse, at the freeze
+# (the manifest requires both non-empty) and at the comparison, where an
+# empty version reads as "not installed" rather than as a different tool.
+#
+# Nothing here execs them either: the ruleset is applied by
+# iptables-restore inside the gateway container, from the image this
+# build ships, which installs its own. They record the netfilter
+# userspace the evidence was gathered under.
 iptables_version=$(iptables --version 2>/dev/null || true)
 nft_version=$(nft --version 2>/dev/null || true)
 


### PR DESCRIPTION
## What changes

`build/platform.lock.json`'s amd64 entry moves from `pending` to `frozen`, carrying the
facts captured from the reference host. The embedded copy is regenerated, the readiness
document reflects the gate being met, and one test moves from pinning the pending state
to pinning the frozen one.

## What was found

The entry was `pending` because nobody had run the suites on a production-class host.
One exists now, created for this and disposable.

The facts are the collector's own output — `scripts/qualification/platform-facts.sh`
run on the host, frozen verbatim, not transcribed by hand:

| Fact | Value |
| --- | --- |
| os / version / codename | debian 13 trixie |
| arch | amd64 |
| kernel | 6.12.101+deb13-amd64 |
| engine / api | 29.7.2 / 1.55 |
| cgroup | 2, systemd |
| storage / backing | overlayfs / ext4 |
| rootless | false |
| containerd / runc | aad11006… / v1.4.3-0-gbb14dabe |
| buildx / compose | v0.36.1 / 5.5.0 |
| iptables / nftables | v1.8.11 (nf_tables) / v1.1.3 |

`docker-ce`'s candidate on that host was `5:29.7.2-1~debian.13~trixie` — the exact
engine the policy names, from the channel it names, without pinning a version by hand.

`backing_filesystem` reads `ext4`, and getting there was the review's doing. The
collector used `stat -f -c %T`, which prints the *magic number's* name — ext2, ext3 and
ext4 share one, so an ext4 host froze as `ext2/ext3`. The first version of this PR froze
that verbatim and argued the choice was between doing so and hand-editing the lock. It
was not: the third option was to fix the collector, which is one line and costs a
recapture today against a full requalification after the tag. It now asks `findmnt`,
against the daemon's own data root rather than a hardcoded path, and the entry is
refrozen from that capture.

Re-running the corrected collector on the host reproduces every frozen fact with no
field differing, which is the property that matters: the comparison the release gate
performs runs this same script.

**One test had to move with the state.** `TestManifestSelectsTheLatestReviewedStableEngine`
read the *pending* refusals off the real lock — that `RequireFrozen` rejects it and that
`Compare` answers `reference_status`. Those are real rules, but they were only ever true
while the file held a pending entry. They are stated now over an entry the test owns
(`TestAPendingReferenceQualifiesNothing`), and what the test reads off the lock is what a
frozen entry must be: the facts are from the platform the policy selects, the engine is
the one it named, and the reference does not mismatch its own facts.

## The collector's raw output, verbatim

This is what `scripts/qualification/platform-facts.sh` printed on the host. Its
`collected_at` is the entry's `recorded`, so the two can be compared without taking my
word for either:

```json
{
  "os": "debian",
  "os_version": "13",
  "os_codename": "trixie",
  "arch": "amd64",
  "kernel": "6.12.101+deb13-amd64",
  "engine": "29.7.2",
  "api": "1.55",
  "cgroup_version": "2",
  "cgroup_driver": "systemd",
  "storage_driver": "overlayfs",
  "backing_filesystem": "ext4",
  "rootless": false,
  "containerd": "aad11006b869517fcd3009450b6f82da282e1a9b",
  "runc": "v1.4.3-0-gbb14dabe",
  "buildx": "v0.36.1",
  "compose": "5.5.0",
  "iptables": "iptables v1.8.11 (nf_tables)",
  "nftables": "nftables v1.1.3 (Commodore Bullmoose #4)",
  "collected_at": "2026-08-26T19:08:42Z"
}
```

The engine came from the channel the policy names, without a version pinned by hand:

```text
$ apt-cache policy docker-ce
docker-ce:
  Installed: (none)
  Candidate: 5:29.7.2-1~debian.13~trixie
```

## The freeze is machine-verified against the host

`RUNPOOL_CONTRACT_QUALIFY=1 scripts/contracts/docker.sh` runs the Docker contract suite
with the frozen manifest embedded in it, comparing the live host against these exact
facts rather than against anything supplied at the command line:

```text
TestHostInfo: release-qualification reference confirmed:
  engine 29.7.2, api 1.55, cgroup v2/systemd, rootful
PASS — 25 tests, exit 0
```

That answers the "how would a reader who was not present at the capture believe this"
question with something better than a transcription: the suite refuses to pass if any
compared fact differs from what is committed here.

## Evidence

| Mutation | Failure |
| --- | --- |
| the frozen engine changed to `29.7.1` | the entry mismatches the policy it claims |
| `runc` removed from the frozen facts | `platform manifest is incomplete: runc` (2 packages) |

```text
gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
The parity test between build/ and the embedded copy passes; go generate produced it.
```

## What would notice this regressing

`TestEmbeddedManifestMatchesTheReviewedCopy` holds the two files together;
`Qualified.validate` refuses a frozen entry missing any of the eighteen facts, and
refuses one whose facts are not from the platform its policy selects.

## Risk, compatibility and operations

**Release gate: this is the gate being met.** A candidate tag was forbidden while the
reference was pending; it no longer is on this ground. The other two gates — the
controller end-to-end run on this host, and the external security review — remain
outstanding and are unaffected.

**Runtime:** unchanged for operators. The lock is read by the qualification job and by
`runpool status`, and admission still requires Engine 28.0 or newer rather than this
exact version.

**Schema, trust boundary, CLI, configuration, deployment, rollback: N/A.**

**Not an ADR** — it executes the freeze the existing policy already decided.

## Changelog

```text
NONE — no observable behaviour changes; the release-readiness document carries the gate's
new state.
```


