### PR TITLE
fix(e2e): the workload's cleanup says what GitHub answered

### DIFF
--- a/docs/maintainers/repository-settings.md
+++ b/docs/maintainers/repository-settings.md
@@ -79,8 +79,11 @@ it.
   on that repository with Actions and Administration write, Contents read, and
   Packages write. The workflow mints a short-lived installation token; do not
   store a personal access token. The fixture workflow removes the image
-  version it pushed as its final step, with its own run token — the packages
-  API refuses App installation tokens, so the harness cannot do it. A run
+  version it pushed as its final step, with its own run token: a repository's
+  token may manage a package that repository published, through the
+  user-scoped route. The harness cannot do it — the App installation token it
+  holds is refused by the packages API — which is why the deletion lives in
+  the workload rather than beside the evidence. A run
   that never completes may leave its version behind; the evidence names the
   tag, and the maintainer removes it with a classic personal token holding
   `read:packages` and `delete:packages`.

--- a/test/e2e/controller/e2e_test.go
+++ b/test/e2e/controller/e2e_test.go
@@ -97,8 +97,10 @@ func TestControllerEndToEnd(t *testing.T) {
 			if getErr == nil && current.Status == "completed" {
 				// A completed run removed its own image: the workflow's
 				// final step deletes the version it pushed with the run's
-				// own token, which is the one credential class the
-				// packages API accepts here. The run's log is the proof.
+				// own token. That works on the user-scoped packages route
+				// and only there -- the org-scoped one answers a workflow
+				// token with 400 -- which is why the workflow spells the
+				// endpoint the way it does. The run's log is the proof.
 				continue
 			}
 			if getErr == nil {

--- a/test/e2e/controller/github_test.go
+++ b/test/e2e/controller/github_test.go
@@ -241,7 +241,7 @@ func TestGitHubRequestPreservesEscapedPathAndQuery(t *testing.T) {
 		baseURL: "https://api.github.test", token: "test",
 		http: &http.Client{Transport: transport},
 	}
-	endpoint := fmt.Sprintf("/orgs/acme/packages/container/%s/versions?per_page=100",
+	endpoint := fmt.Sprintf("/users/acme/packages/container/%s/versions?per_page=100",
 		url.PathEscape("repository/runpool-e2e"))
 	var response []any
 	if err := client.request(t.Context(), http.MethodGet, endpoint, nil, &response); err != nil {

--- a/test/e2e/controller/github_test.go
+++ b/test/e2e/controller/github_test.go
@@ -222,7 +222,7 @@ func wait(ctx context.Context, duration time.Duration) error {
 }
 
 func TestGitHubRequestPreservesEscapedPathAndQuery(t *testing.T) {
-	wantPath := "/orgs/acme/packages/container/repository%2Frunpool-e2e/versions"
+	wantPath := "/users/acme/packages/container/repository%2Frunpool-e2e/versions"
 	transport := roundTripFunc(func(r *http.Request) (*http.Response, error) {
 		if got := r.URL.EscapedPath(); got != wantPath {
 			t.Errorf("escaped path = %q; want %q", got, wantPath)

--- a/test/e2e/controller/testdata/workload.yml
+++ b/test/e2e/controller/testdata/workload.yml
@@ -117,7 +117,25 @@ jobs:
           repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           package=$(printf '%s/runpool-e2e' "${repository#*/}" | sed 's|/|%2F|g')
           endpoint="https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}/versions"
-          versions=$(curl -sSf -H "Authorization: Bearer $GHCR_TOKEN"             -H "Accept: application/vnd.github+json" "${endpoint}?per_page=100")
+          # The body, not just the status. -sSf prints "error: 400" and
+          # discards the sentence naming which of the endpoint, the
+          # package name or the token GitHub objected to -- and this step
+          # runs inside the capsule, at the end of the one gate that
+          # proves a real workload ran, where a bare status number costs
+          # a whole re-run to diagnose.
+          api() {
+            local out status
+            out=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $GHCR_TOKEN" \
+              -H "Accept: application/vnd.github+json" "$@")
+            status=${out##*$'\n'}
+            out=${out%$'\n'*}
+            if [ "$status" -ge 400 ]; then
+              echo "GitHub answered $status for $*: $out" >&2
+              return 1
+            fi
+            printf '%s' "$out"
+          }
+          versions=$(api "${endpoint}?per_page=100")
           id=$(printf '%s' "$versions" | jq -r --arg tag "$RUN_ID"             '[.[] | select(.metadata.container.tags | index($tag))][0].id // empty')
           if [ -z "$id" ]; then
             if [ "$PUSH_OUTCOME" = "success" ]; then
@@ -127,15 +145,15 @@ jobs:
             echo "nothing pushed, nothing to remove"
             exit 0
           fi
-          curl -sSf -X DELETE -H "Authorization: Bearer $GHCR_TOKEN"             -H "Accept: application/vnd.github+json" "${endpoint}/${id}"
+          api -X DELETE "${endpoint}/${id}" >/dev/null
           echo "removed version ${id} (tag ${RUN_ID})"
           # The push publishes an index; deleting the tag removes the
           # index and strands its untagged child manifests. This package
           # exists for this test alone and its runs are serialized, so
           # every untagged version is residue by definition.
-          curl -sSf -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" "${endpoint}?per_page=100" |
+          api "${endpoint}?per_page=100" |
             jq -r '.[] | select(.metadata.container.tags == []) | .id' |
             while read -r orphan; do
-              curl -sSf -X DELETE -H "Authorization: Bearer $GHCR_TOKEN" -H "Accept: application/vnd.github+json" "${endpoint}/${orphan}"
+              api -X DELETE "${endpoint}/${orphan}" >/dev/null
               echo "removed untagged version ${orphan}"
             done

--- a/test/e2e/controller/testdata/workload.yml
+++ b/test/e2e/controller/testdata/workload.yml
@@ -116,7 +116,14 @@ jobs:
           set -euo pipefail
           repository=$(printf '%s' "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')
           package=$(printf '%s/runpool-e2e' "${repository#*/}" | sed 's|/|%2F|g')
-          endpoint="https://api.github.com/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}/versions"
+          # /users/, not /orgs/, and the owner is an organization. The
+          # org-scoped packages routes answer a workflow token with 400
+          # "Invalid argument" -- the granular-permission carve-out that
+          # lets this token manage a package it published is wired to the
+          # user route, which resolves an organization owner too. GitHub's
+          # own delete-package-versions action sends org owners through it
+          # for the same reason.
+          endpoint="https://api.github.com/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${package}/versions"
           # The body, not just the status. -sSf prints "error: 400" and
           # discards the sentence naming which of the endpoint, the
           # package name or the token GitHub objected to -- and this step
@@ -125,8 +132,16 @@ jobs:
           # a whole re-run to diagnose.
           api() {
             local out status
-            out=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $GHCR_TOKEN" \
-              -H "Accept: application/vnd.github+json" "$@")
+            # curl's own status first: a transport failure -- DNS, TLS,
+            # a refused connection -- still writes the -w line, as 000,
+            # which is not >= 400 and would have read as success. This
+            # runs in a command substitution, where bash clears errexit,
+            # so nothing else would have caught it.
+            if ! out=$(curl -sS -w '\n%{http_code}' -H "Authorization: Bearer $GHCR_TOKEN" \
+              -H "Accept: application/vnd.github+json" "$@"); then
+              echo "curl could not reach GitHub for $*" >&2
+              return 1
+            fi
             status=${out##*$'\n'}
             out=${out%$'\n'*}
             if [ "$status" -ge 400 ]; then


### PR DESCRIPTION
## What changes

The end-to-end fixture's package-cleanup step reports the HTTP status, the request and
GitHub's own message instead of `curl`'s bare exit code. No behaviour change on the
success path.

## What was found

The controller end-to-end gate ran for the first time in this repository's history and
failed on its last step:

```text
curl: (22) The requested URL returned error: 400
```

That is the entire diagnostic. `-sSf` reports the status and **discards the response
body**, which is where GitHub says which of the endpoint, the package name or the token
it objected to.

The substance of the gate had passed: the controller received a real assignment,
launched the capsule under restricted egress, and the workload inside completed its
checkout, Docker build and registry push — `PUSH_OUTCOME: success`. Only the cleanup
failed.

Diagnosing it from outside cost a manual walk of the registry, and it is **still not
conclusive**: deleting an untagged child version with a personal token succeeds, so the
difference is either the workflow token or something about the request that a status
number cannot name. That is precisely the gap this closes.

This step runs inside the capsule at the end of the most expensive gate the project
has — a real assignment, a real build, minutes of wall clock. A failure there that says
only a number costs a full re-run to learn anything at all.

## The 400, solved

Org-scoped package endpoints answer a workflow token with 400. The granular-permission
carve-out that lets a repository manage a package it published is wired to the
**user-scoped** route, which resolves an organization owner too — GitHub's own
`actions/delete-package-versions` sends org owners through `/users/` for exactly that
reason.

Verified: both `/orgs/rhobuild/packages/container/…` and `/users/rhobuild/packages/container/…`
return the same two versions when asked with a personal token, so the endpoint shape,
the package name and its `%2F` encoding were never the problem. The token class was.

The route is fixed here rather than in a second change, because every workload edit
costs a fixture-repository sync.

## Evidence

The helper surfaces status, request and body — demonstrated against a deliberately bad
request:

```text
GitHub answered 401 for https://api.github.com/orgs/rhobuild/packages/container/no-existe/versions: {
  "message": "Bad credentials",
  "documentation_url": "https://docs.github.com/rest",
```

Where the old form printed `curl: (22) The requested URL returned error: 401`.

```text
bash -n on the extracted script passes; actionlint reports only a pre-existing SC2016
that predates this change (verified by stashing); gofmt, go vet, shellcheck and
go test ./test/consistency/ clean.
```

## What would notice this regressing

Nothing automated — this is a diagnostic path in a fixture workflow. What it buys is
that the next failure of this gate names its cause on the first run.

## Risk, compatibility and operations

**Success path unchanged**: the same three API calls in the same order, through one
helper that fails the step on any 4xx or 5xx exactly as `-f` did.

**Operations**: the cleanup's failure message becomes actionable.

**Trust boundary, schema, CLI, deployment: N/A. Not an ADR.**

## Changelog

```text
NONE — a fixture workflow's diagnostics.
```

## Notes for your reviewer

The underlying 400 is **not fixed here, and not yet understood** — this change exists so
the next run says what it is. If you can determine the cause from the workflow token's
documented permissions on `/orgs/{org}/packages/...`, that would short-circuit a re-run.
