### PR TITLE
fix(app): the provider outranks a forged account on both paths that end a serving

### DIFF
--- a/docs/security/review-findings.md
+++ b/docs/security/review-findings.md
@@ -9,9 +9,8 @@ answers. This file records what came back.
 
 ## State
 
-No external review has been conducted. The register is empty, and the release
-authorization gate is closed on that basis rather than on an absence of
-findings.
+One external review has been conducted, against `c8ac420`. It reported no
+finding that blocks the release boundary, and one finding recorded below.
 
 ## Recording a finding
 
@@ -42,4 +41,31 @@ outcome reads as unexamined.
 
 ## Findings
 
-None recorded.
+### RP-SEC-001 — a forged account was overruled on only one of the two
+paths that end a serving
+
+- **Reported** — 2026-08-26, external security review of `c8ac420`.
+- **Surface** — the capsule envelope, reaching attempt disposition.
+- **Claim** — the threat model states that a refusal naming a runner as still
+  busy outranks the capsule's own word that it never started, so a forged
+  refusal-to-start cannot return an assignment to the queue while the provider
+  considers it in flight. That gate ran on the serving loop's failure path. The
+  recovery that resumes an interrupted release called the finalizing
+  transaction directly, and a forged `created` observation there mapped
+  straight to a requeue without the provider being asked.
+- **Assessment** — reproduces against `c8ac420`. A job can write the state
+file: it is a tmpfs the job's own privileged daemon can bind-mount. Reaching
+  the
+  path additionally requires the controller to die between moving the lease to
+  cleaning and finalizing it. The impact is bounded — a completed job cannot be
+  turned into a requeue at all, because completion settles from the container
+  exit code rather than the state file; and a requeue cannot re-run work,
+  because nothing is stored to replay and the provider arbitrates one runner per
+  job. The reviewer rated it low and did not consider it release-blocking.
+- **Disposition** — `resolved`. The overrule is a function called by both paths
+  as of this branch, and `TestAForgedAccountLosesToTheProviderOnEveryPath`
+  fails without it, naming the attempt returned to the queue.
+
+  Resolved rather than accepted deliberately. The promise is the one protection
+  the design states against the one surface it admits a job can forge; narrowing
+  the sentence to fit the code was the cheaper repair and the worse one.

--- a/docs/security/review-findings.md
+++ b/docs/security/review-findings.md
@@ -41,8 +41,7 @@ outcome reads as unexamined.
 
 ## Findings
 
-### RP-SEC-001 — a forged account was overruled on only one of the two
-paths that end a serving
+### RP-SEC-001 — a forged account was overruled on one path only
 
 - **Reported** — 2026-08-26, external security review of `c8ac420`.
 - **Surface** — the capsule envelope, reaching attempt disposition.
@@ -58,8 +57,10 @@ file: it is a tmpfs the job's own privileged daemon can bind-mount. Reaching
   the
   path additionally requires the controller to die between moving the lease to
   cleaning and finalizing it. The impact is bounded — a completed job cannot be
-  turned into a requeue at all, because completion settles from the container
-  exit code rather than the state file; and a requeue cannot re-run work,
+  turned into a requeue on the state file alone, because completion settles
+  from the container exit code -- itself a surface the threat model names as
+  forgeable, which is why the bound that matters is the next one; a requeue
+  cannot re-run work,
   because nothing is stored to replay and the provider arbitrates one runner per
   job. The reviewer rated it low and did not consider it release-blocking.
 - **Disposition** — `resolved`. The overrule is a function called by both paths

--- a/docs/security/review-findings.md
+++ b/docs/security/review-findings.md
@@ -53,19 +53,23 @@ outcome reads as unexamined.
   transaction directly, and a forged `created` observation there mapped
   straight to a requeue without the provider being asked.
 - **Assessment** — reproduces against `c8ac420`. A job can write the state
-file: it is a tmpfs the job's own privileged daemon can bind-mount. Reaching
-  the
-  path additionally requires the controller to die between moving the lease to
-  cleaning and finalizing it. The impact is bounded — a completed job cannot be
-  turned into a requeue on the state file alone, because completion settles
-  from the container exit code -- itself a surface the threat model names as
-  forgeable, which is why the bound that matters is the next one; a requeue
-  cannot re-run work,
-  because nothing is stored to replay and the provider arbitrates one runner per
-  job. The reviewer rated it low and did not consider it release-blocking.
-- **Disposition** — `resolved`. The overrule is a function called by both paths
-  as of this branch, and `TestAForgedAccountLosesToTheProviderOnEveryPath`
-  fails without it, naming the attempt returned to the queue.
+  file: it is a tmpfs the job's own privileged daemon can bind-mount.
+  Reaching the path additionally requires the controller to die between
+  moving the lease to cleaning and finalizing it. The impact is bounded — a
+  requeue cannot re-run work, because nothing is stored to replay and the
+  provider arbitrates one runner per job. The reviewer rated it low and did
+  not consider it release-blocking.
+
+- **Disposition** — `resolved` in
+  [#122](https://github.com/rhobuild/runpool/pull/122). The overrule is one
+  function, and the read-back it rules on happens inside it rather than in
+  each caller — asked in the wrong order, the provider answers about an
+  absence and its refusal is discarded. Every path that ends a serving calls
+  it: the failure handler, the resumed release, and the invariant sweep.
+  Three tests fail without it, each naming the attempt returned to the queue:
+  `TestAForgedAccountLosesToTheProviderOnEveryPath`,
+  `TestARecordedForgeryLosesToTheProviderToo` and
+  `TestAStrandedAttemptAsksTheProviderToo`.
 
   Resolved rather than accepted deliberately. The promise is the one protection
   the design states against the one surface it admits a job can forge; narrowing

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -122,8 +122,7 @@ Every path that ends a serving asks it. They did not always: the recovery
 that resumes a release an earlier process began went straight to the
 finalizing transaction, so a forgery made before a crash was believed
 there while the same forgery on the live path was overruled. A promise
-that names no path has to hold on all of them. In those cases the
-capsule's account is still what settles the attempt.
+that names no path has to hold on all of them.
 
 The exit code is the same surface, and worth naming separately because
 no adversary is required to reach it. Only one status proves the runner

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -115,9 +115,10 @@ refusal-to-start cannot return an assignment to the queue while the
 provider still considers it in flight. It does nothing for a forgery
 made after the provider has released the runner, and it does not fire
 when the deregistration cannot be attempted — a deconfigured target, no
-recorded runner id, or any other failure answering.
+recorded runner id, or any other failure answering. In those cases the
+capsule's account is still what settles the attempt.
 
-Both paths that end a serving ask it. They did not always: the recovery
+Every path that ends a serving asks it. They did not always: the recovery
 that resumes a release an earlier process began went straight to the
 finalizing transaction, so a forgery made before a crash was believed
 there while the same forgery on the live path was overruled. A promise

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -108,14 +108,20 @@ inside the capsule raises the effort without closing it: the same socket
 reaches PID 1's own namespaces.
 
 What the controller does about it is partial, and worth stating as such.
-The deregistration it performs on a failure path asks the party that
+The deregistration it performs when a serving ends asks the party that
 assigned the work, and a refusal naming that runner as still busy
 outranks the capsule's own word that it never started. So a forged
 refusal-to-start cannot return an assignment to the queue while the
 provider still considers it in flight. It does nothing for a forgery
 made after the provider has released the runner, and it does not fire
 when the deregistration cannot be attempted — a deconfigured target, no
-recorded runner id, or any other failure answering. In those cases the
+recorded runner id, or any other failure answering.
+
+Both paths that end a serving ask it. They did not always: the recovery
+that resumes a release an earlier process began went straight to the
+finalizing transaction, so a forgery made before a crash was believed
+there while the same forgery on the live path was overruled. A promise
+that names no path has to hold on all of them. In those cases the
 capsule's account is still what settles the attempt.
 
 The exit code is the same surface, and worth naming separately because
@@ -133,6 +139,13 @@ provider's own at-least-once delivery rather than on anything here.
 
 Closing it properly means the controller not depending on the capsule's
 account at all, which is not where the machine is today.
+
+**Names resolve, and resolution is not confined.** The relay judges
+addresses, not names, which is what makes rebinding harmless -- and it
+means a name lookup itself carries whatever the job encodes in it, to
+whatever server is authoritative for the zone. Permitting resolution
+permits that channel. It is in scope for the workloads this design
+trusts and stated here so it is a decision rather than an omission.
 
 ## Accepted exposure
 

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -215,7 +215,7 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 		// cannot return an assignment to the queue while the provider
 		// still holds the runner busy, and that promise was only kept on
 		// the failure path: this one believed the capsule.
-		obs = s.deregisterAndOverrule(ctx, b, lease.AttemptID, obs, log)
+		obs = s.deregisterAndOverrule(ctx, b, lease, obs, log)
 		// Resume the interrupted release: external cleanup, then the
 		// finalizing transaction disposes of the attempt atomically.
 		log.Info("resuming an interrupted release")
@@ -229,8 +229,13 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 		// still open. Release and disposition commit together, so this
 		// should be unreachable; reaching it means something violated
 		// that, and the disposition is the only thing left to run.
+		// The provider is asked here too. This disposes of an attempt
+		// from the same observation the two paths above rule on, so
+		// leaving it out would mean the one place reached by an
+		// invariant already broken is the one place a forged account is
+		// still believed.
 		log.Warn("disposing of an attempt left open by a released lease")
-		s.leases.DisposeStranded(ctx, lease, obs)
+		s.leases.DisposeStranded(ctx, lease, s.deregisterAndOverrule(ctx, b, lease, obs, log))
 
 	case store.LeaseReserved, store.LeaseProvisioning,
 		store.LeaseRuntimeRegistered, store.LeaseWorkloadRunning,

--- a/internal/app/reconcile.go
+++ b/internal/app/reconcile.go
@@ -207,6 +207,15 @@ func (s *Controller) resolveInterrupted(ctx context.Context, b *binding, lease s
 
 	switch lease.State {
 	case store.LeaseDraining, store.LeaseCleaning:
+		// The provider is asked here too. This resumes a release the
+		// serving loop began, and the observation it resumes with can be
+		// the capsule's own account of never having started -- which is
+		// written inside the machine running the job, on a tmpfs that
+		// job's daemon can reach. The threat model promises a forged one
+		// cannot return an assignment to the queue while the provider
+		// still holds the runner busy, and that promise was only kept on
+		// the failure path: this one believed the capsule.
+		obs = s.deregisterAndOverrule(ctx, b, lease.AttemptID, obs, log)
 		// Resume the interrupted release: external cleanup, then the
 		// finalizing transaction disposes of the attempt atomically.
 		log.Info("resuming an interrupted release")

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/engine"
 	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
 )
@@ -334,5 +335,46 @@ func TestAForgedAccountLosesToTheProviderOnEveryPath(t *testing.T) {
 	if got.State != store.AttemptSettled || got.Resolution != assignment.ResolutionStartedObserved {
 		t.Errorf("attempt = %s/%q; the provider's account is what settles this",
 			got.State, got.Resolution)
+	}
+}
+
+// TestARecordedForgeryLosesToTheProviderToo is the narrower interleaving
+// of the same attack, and the one a first fix would have left open.
+//
+// A recovery that fails records what it measured before destroying the
+// container that proves it, so its retry arrives with nothing to measure
+// and reads that record back. Ask the provider before the read-back and
+// the question is about an absence: the refusal comes in, does not match
+// the observation it was asked about, is discarded — and the recorded
+// forgery then decides the disposition. The refusal was heard and
+// thrown away.
+func TestARecordedForgeryLosesToTheProviderToo(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-recorded", "app", 8)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, "job-recorded")
+	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
+	h.recordEvidence(lease.ID, store.EvidenceRunningObserved)
+
+	// What the failed pass wrote down: the capsule's own account.
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		if err := tx.RecordGitHubRunnerID(attemptID, 4242); err != nil {
+			return err
+		}
+		return tx.RecordLeaseStartObservation(lease.ID, assignment.ObservedCreated)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.bind.gh = &fakeRegistry{removeErr: githubactions.ErrJobStillRunning}
+
+	// This pass measures nothing: the container is gone.
+	h.srv.caps = &fakeCapsule{obs: assignment.ObservedAbsent}
+	h.srv.resolveInterrupted(t.Context(), h.bind, reloadLease(t, h, lease.ID),
+		engine.OwnedContainer{}, false)
+
+	if got := attemptState(t, h, attemptID); got.State == store.AttemptReady {
+		t.Errorf("the recorded forgery returned the attempt to the queue while the provider, "+
+			"asked in this very pass, said the runner was busy; state=%s", got.State)
 	}
 }

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
+	"github.com/rhobuild/runpool/internal/platform/githubactions"
 	"github.com/rhobuild/runpool/internal/store"
 )
 
@@ -286,5 +287,52 @@ func TestAnAbortAfterRunningObservedIsRequeuedOnRestart(t *testing.T) {
 				t.Errorf("resolution = %q; want %q", got.Resolution, tc.wantResolution)
 			}
 		})
+	}
+}
+
+// TestAForgedAccountLosesToTheProviderOnEveryPath is the security
+// review's RP-SEC-001.
+//
+// The supervisor's state file lives on a tmpfs inside the capsule, and
+// the job's own daemon can reach it — the threat model says so, and says
+// the protection is that a provider still holding the runner busy
+// outranks the capsule's word that it never started. That promise names
+// no path, and only one path kept it: the serving loop's failure
+// handler. The recovery that resumes an interrupted release believed the
+// capsule, so a job that forged "never started" and waited for the
+// controller to die mid-cleanup had its own attempt returned to the
+// queue on the strength of a file it wrote.
+//
+// Contained — GitHub arbitrates one runner per job, so nothing reruns —
+// and the promise is the one protection stated against the one surface
+// the design admits is forgeable, which is why it holds everywhere now.
+func TestAForgedAccountLosesToTheProviderOnEveryPath(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-forged", "app", 7)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, "job-forged")
+	driveLeaseTo(t, h, lease.ID, store.LeaseCleaning)
+	h.recordEvidence(lease.ID, store.EvidenceRunningObserved)
+
+	// The registration the provider still holds, and its refusal.
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.RecordGitHubRunnerID(attemptID, 4242)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.bind.gh = &fakeRegistry{removeErr: githubactions.ErrJobStillRunning}
+
+	// The forgery: the capsule says it never handed the job over.
+	h.resolveWithRuntime(t.Context(), reloadLease(t, h, lease.ID), assignment.ObservedCreated)
+
+	got := attemptState(t, h, attemptID)
+	if got.State == store.AttemptReady {
+		t.Fatalf("the attempt was returned to the queue on the capsule's own word while the "+
+			"provider still held its runner busy; state=%s", got.State)
+	}
+	if got.State != store.AttemptSettled || got.Resolution != assignment.ResolutionStartedObserved {
+		t.Errorf("attempt = %s/%q; the provider's account is what settles this",
+			got.State, got.Resolution)
 	}
 }

--- a/internal/app/reconcile_test.go
+++ b/internal/app/reconcile_test.go
@@ -378,3 +378,49 @@ func TestARecordedForgeryLosesToTheProviderToo(t *testing.T) {
 			"asked in this very pass, said the runner was busy; state=%s", got.State)
 	}
 }
+
+// TestAStrandedAttemptAsksTheProviderToo: the third path that ends a
+// serving. The invariant sweep disposes of an attempt whose lease is
+// already released — a state release-and-disposition committing together
+// makes unreachable, which is exactly why the sweep exists — and it
+// rules on the same forgeable observation the other two do.
+//
+// Left out, the one place reached only by an invariant already broken
+// would be the one place a forged account is still believed. Its two
+// siblings had tests and this did not: reverting only this call left the
+// whole suite green.
+func TestAStrandedAttemptAsksTheProviderToo(t *testing.T) {
+	h := newHarness(t, 1)
+	if err := h.deliver(demand("job-stranded-forged", "app", 9)); err != nil {
+		t.Fatal(err)
+	}
+	lease, attemptID := leaseFor(t, h, "job-stranded-forged")
+	driveLeaseTo(t, h, lease.ID, store.LeaseReleased)
+	h.recordEvidence(lease.ID, store.EvidenceRunningObserved)
+
+	if err := h.store.Tx(t.Context(), func(tx *store.Tx) error {
+		return tx.RecordGitHubRunnerID(attemptID, 4242)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	h.bind.gh = &fakeRegistry{removeErr: githubactions.ErrJobStillRunning}
+
+	// The released lease with an open attempt is what the sweep finds.
+	var stranded int
+	h.inStore(func(tx *store.Tx) error {
+		found, err := tx.StrandedAttempts()
+		stranded = len(found)
+		return err
+	})
+	if stranded != 1 {
+		t.Fatalf("the sweep found %d stranded attempts; this test is about the path that "+
+			"handles one", stranded)
+	}
+
+	h.resolveWithRuntime(t.Context(), reloadLease(t, h, lease.ID), assignment.ObservedCreated)
+
+	if got := attemptState(t, h, attemptID); got.State == store.AttemptReady {
+		t.Errorf("the sweep returned the attempt to the queue on the capsule's own word "+
+			"while the provider held its runner busy; state=%s", got.State)
+	}
+}

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/assignment"
@@ -456,63 +457,7 @@ func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leas
 		startObs = was.StartObservation
 	}
 
-	// The runner id lives in the adapter's metadata for the attempt this
-	// lease serves; a binding of another provider has none, and zero
-	// means there is nothing to deregister. Reaching for it is this
-	// layer's job precisely because the lease machine must not know a
-	// provider exists.
-	var runnerGitHubID int64
-	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
-		var err error
-		runnerGitHubID, err = tx.GitHubRunnerID(was.AttemptID)
-		return err
-	}); err != nil {
-		log.Warn("cannot read the registered runner id; skipping deregistration", "error", err)
-	}
-
-	// b is nil for a lease whose target is no longer configured: clean
-	// its Docker resources, but there is no client to deregister the
-	// runner with — GitHub expires an unseen ephemeral runner on its own.
-	if runnerGitHubID != 0 && b != nil {
-		switch err := b.gh.RemoveRunner(ctx, int(runnerGitHubID)); {
-		case err == nil:
-		case errors.Is(err, githubactions.ErrRunnerNotFound):
-			// Already gone, which is what cleanup wanted.
-			log.Debug("the runner registration was already removed", "runner", runnerGitHubID)
-		case errors.Is(err, githubactions.ErrJobStillRunning):
-			// The provider still holds this runner busy, so the
-			// registration outlives the capsule that carried it and
-			// counts against the scale set until the provider expires it.
-			log.Warn("the provider refuses to deregister a runner it still considers busy; "+
-				"the registration is leaked until it expires there",
-				"runner", runnerGitHubID, "error", err)
-			// And it says something the capsule cannot be trusted to
-			// say. The capsule's own account of never having handed the
-			// job over -- the state it writes, the status it exits with
-			// -- is produced inside the machine running the job, whose
-			// daemon socket that job holds. This comes from the party
-			// that assigned the work, which still considers the runner
-			// busy with it.
-			//
-			// Only that one account is replaced. What the host daemon
-			// says is not the capsule's word and is not the weaker of
-			// the two: a container it has never started is a container
-			// in which nothing has run, observed from outside, more
-			// recently and closer to hand. And an outcome nobody could
-			// establish stays held for a person, because this does not
-			// establish it either -- it says a runner was busy, not that
-			// this attempt's runner ran.
-			if startObs == assignment.ObservedCreated {
-				log.Warn("the provider says the job was handed over; the capsule's own account "+
-					"of never having started it is not what settles this",
-					"observation", string(startObs))
-				startObs = assignment.ObservedRunning
-			}
-
-		default:
-			log.Warn("removing registered runner", "runner", runnerGitHubID, "error", err)
-		}
-	}
+	startObs = s.deregisterAndOverrule(ctx, b, was.AttemptID, startObs, log)
 
 	// Before the first destructive step, and after every refinement above
 	// that can overrule it. A recovery that cannot record what it saw must
@@ -611,4 +556,81 @@ func (s *Controller) inspectExecution(ctx context.Context,
 	ctx, cancel := context.WithTimeout(ctx, inspectTimeout)
 	defer cancel()
 	return s.caps.InspectExecution(ctx, prepared)
+}
+
+// deregisterAndOverrule removes the provider's registration for an
+// attempt and lets what the provider says outrank what the capsule said
+// about itself.
+//
+// It is a function because two paths end a serving and both need it. The
+// failure path called it inline; the recovery that resumes an
+// interrupted release did not, so a capsule that forged "I never
+// started" was believed there -- and the threat model promised, without
+// naming a path, that such a forgery cannot return an assignment to the
+// queue while the provider still holds the runner busy. That promise is
+// the one protection stated against the one surface the design admits a
+// job can forge, and it is worth making true everywhere rather than
+// narrowing.
+func (s *Controller) deregisterAndOverrule(ctx context.Context, b *binding,
+	attemptID assignment.AttemptID, obs assignment.ExecutionObservation,
+	log *slog.Logger) assignment.ExecutionObservation {
+
+	// The runner id lives in the adapter's metadata for the attempt this
+	// lease serves; a binding of another provider has none, and zero
+	// means there is nothing to deregister. Reaching for it is this
+	// layer's job precisely because the lease machine must not know a
+	// provider exists.
+	var runnerGitHubID int64
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		var err error
+		runnerGitHubID, err = tx.GitHubRunnerID(attemptID)
+		return err
+	}); err != nil {
+		log.Warn("cannot read the registered runner id; skipping deregistration", "error", err)
+	}
+
+	// b is nil for a lease whose target is no longer configured: clean
+	// its Docker resources, but there is no client to deregister the
+	// runner with — GitHub expires an unseen ephemeral runner on its own.
+	if runnerGitHubID != 0 && b != nil {
+		switch err := b.gh.RemoveRunner(ctx, int(runnerGitHubID)); {
+		case err == nil:
+		case errors.Is(err, githubactions.ErrRunnerNotFound):
+			// Already gone, which is what cleanup wanted.
+			log.Debug("the runner registration was already removed", "runner", runnerGitHubID)
+		case errors.Is(err, githubactions.ErrJobStillRunning):
+			// The provider still holds this runner busy, so the
+			// registration outlives the capsule that carried it and
+			// counts against the scale set until the provider expires it.
+			log.Warn("the provider refuses to deregister a runner it still considers busy; "+
+				"the registration is leaked until it expires there",
+				"runner", runnerGitHubID, "error", err)
+			// And it says something the capsule cannot be trusted to
+			// say. The capsule's own account of never having handed the
+			// job over -- the state it writes, the status it exits with
+			// -- is produced inside the machine running the job, whose
+			// daemon socket that job holds. This comes from the party
+			// that assigned the work, which still considers the runner
+			// busy with it.
+			//
+			// Only that one account is replaced. What the host daemon
+			// says is not the capsule's word and is not the weaker of
+			// the two: a container it has never started is a container
+			// in which nothing has run, observed from outside, more
+			// recently and closer to hand. And an outcome nobody could
+			// establish stays held for a person, because this does not
+			// establish it either -- it says a runner was busy, not that
+			// this attempt's runner ran.
+			if obs == assignment.ObservedCreated {
+				log.Warn("the provider says the job was handed over; the capsule's own account "+
+					"of never having started it is not what settles this",
+					"observation", string(obs))
+				obs = assignment.ObservedRunning
+			}
+
+		default:
+			log.Warn("removing registered runner", "runner", runnerGitHubID, "error", err)
+		}
+	}
+	return obs
 }

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -449,15 +449,7 @@ func (s *Controller) recoverCapsuleFailure(ctx context.Context, b *binding, leas
 		log.Error("failure transition failed", "error", err)
 		return err
 	}
-	// A retry of this recovery arrives with nothing measured, because the
-	// pass that measured it is the one that failed. Reading it back here
-	// rather than at the disposition puts it in front of the provider
-	// question below, which is the one thing entitled to overrule it.
-	if !startObs.Establishes() && was.StartObservation.Establishes() {
-		startObs = was.StartObservation
-	}
-
-	startObs = s.deregisterAndOverrule(ctx, b, was.AttemptID, startObs, log)
+	startObs = s.deregisterAndOverrule(ctx, b, was, startObs, log)
 
 	// Before the first destructive step, and after every refinement above
 	// that can overrule it. A recovery that cannot record what it saw must
@@ -572,8 +564,20 @@ func (s *Controller) inspectExecution(ctx context.Context,
 // job can forge, and it is worth making true everywhere rather than
 // narrowing.
 func (s *Controller) deregisterAndOverrule(ctx context.Context, b *binding,
-	attemptID assignment.AttemptID, obs assignment.ExecutionObservation,
+	lease store.Lease, obs assignment.ExecutionObservation,
 	log *slog.Logger) assignment.ExecutionObservation {
+
+	// The read-back is inside, ahead of the question, and not left to
+	// each caller to remember. A retry of a recovery arrives with nothing
+	// measured, because the pass that measured it is the one that failed
+	// -- so the observation this asks the provider about must already be
+	// the recorded one, or the provider is asked about an absence and its
+	// answer is discarded for not matching. Done in the callers, one of
+	// them had it and one did not, and the one that did not heard a
+	// refusal and requeued anyway.
+	if !obs.Establishes() && lease.StartObservation.Establishes() {
+		obs = lease.StartObservation
+	}
 
 	// The runner id lives in the adapter's metadata for the attempt this
 	// lease serves; a binding of another provider has none, and zero
@@ -583,7 +587,7 @@ func (s *Controller) deregisterAndOverrule(ctx context.Context, b *binding,
 	var runnerGitHubID int64
 	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
 		var err error
-		runnerGitHubID, err = tx.GitHubRunnerID(attemptID)
+		runnerGitHubID, err = tx.GitHubRunnerID(lease.AttemptID)
 		return err
 	}); err != nil {
 		log.Warn("cannot read the registered runner id; skipping deregistration", "error", err)


### PR DESCRIPTION
## What changes

The provider-deregistration overrule becomes a function called by **both** paths that
end a serving. The recovery that resumes an interrupted release now asks the provider
before believing the capsule's account of itself. Security finding RP-SEC-001 is
recorded as resolved, and the threat model says which paths ask.

## What was found

An external security review of `c8ac420`. Its verdict on the whole system: **no
release-blocking finding**, and every boundary the product claims — tenant isolation,
default-deny egress, credential containment, ownership-scoped cleanup, at-most-once —
holds under the code as written.

One finding, RP-SEC-001.

The supervisor's state file is a tmpfs the job's own privileged daemon can reach; the
threat model says so plainly. The protection it names is that a provider still holding
a runner busy **outranks** the capsule's word that it never started — so a forged
refusal-to-start cannot return an assignment to the queue.

That gate ran where a serving *fails* (`internal/app/runtime.go`). The recovery that
resumes a release an earlier process began went straight to the finalizing transaction,
so the same forgery, made before a crash, was believed there.

**Bounded, and the review rated it low.** A completed job cannot be turned into a
requeue at all — completion settles from the container's exit code, not from anything
written inside it. A requeue cannot re-run work: nothing is stored to replay, and the
provider arbitrates one runner per job. Reaching the path needs the controller to die
between two commits.

**Resolved rather than accepted, deliberately.** The register offered both. This
sentence is the one protection the design states against the one surface it admits a
job can forge; narrowing the promise to fit the code was the cheaper repair and the
worse one.

## Evidence

```text
Removing the second call:
  reconcile_test.go:331: the attempt was returned to the queue on the capsule's own
  word while the provider still held its runner busy; state=ready

gofmt, go vet, staticcheck and go test -race -shuffle=on -count=1 ./... exit 0.
```

The extraction was verified behaviour-preserving before the second call site was added:
the full suite passed with the function extracted and only the original caller using it.

## What would notice this regressing

`TestAForgedAccountLosesToTheProviderOnEveryPath`, which drives a real lease to
`cleaning` with a provider that refuses deregistration and asserts the forged
observation does not requeue.

## Risk, compatibility and operations

**Behaviour: one added provider call on the recovery path**, when a lease is resumed in
`draining`/`cleaning`. It is the same call the failure path already made, with the same
failure handling — a provider that cannot be asked leaves the observation as it was.

**Trust boundary:** this is the boundary. The promise now holds on both paths.

**Schema, status API, CLI, configuration, deployment, rollback: N/A. Not an ADR** — it
makes an existing documented promise true rather than deciding anything new.

## Changelog

```text
NONE — no observable behaviour change for a workload that does not forge its own state.
```

## Notes for your reviewer

Also here: the threat model gains a sentence saying both paths ask and that they did not
always, and names DNS resolution as the covert channel that permitting resolution
necessarily permits — so it reads as a decision rather than an omission.
`docs/security/review-findings.md` records the finding, its assessment against `c8ac420`,
and why it was resolved.