### PR TITLE
fix(qualification): the collector looks where the netfilter tools live

### DIFF
--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -67,8 +67,24 @@ backing=$(findmnt -no FSTYPE --target "$docker_root")
 # iptables-restore inside the gateway container, from the image this
 # build ships, which installs its own. They record the netfilter
 # userspace the evidence was gathered under.
-iptables_version=$(iptables --version 2>/dev/null || true)
-nft_version=$(nft --version 2>/dev/null || true)
+#
+# Looked for where they live, not only on PATH. Both are sbin tools, and
+# a service account does not carry sbin: the runner executing the
+# qualification has /usr/local/bin:/usr/bin:/bin and nothing more, while
+# the freeze was collected over a root shell that does. A PATH-only probe
+# therefore reported no netfilter userspace on a host holding both, and
+# the comparison read one host as two -- as the wrong host, rather than
+# as the wrong PATH. What remains after looking is the fact the swallowing
+# above is for.
+netfilter_version() {
+  for candidate in "$1" "/usr/sbin/$1" "/sbin/$1" "/usr/local/sbin/$1"; do
+    command -v "$candidate" >/dev/null 2>&1 || continue
+    "$candidate" --version 2>/dev/null && return 0
+  done
+  return 0
+}
+iptables_version=$(netfilter_version iptables)
+nft_version=$(netfilter_version nft)
 
 case "$(uname -m)" in
   x86_64) arch=amd64 ;;

--- a/scripts/qualification/platform-facts.sh
+++ b/scripts/qualification/platform-facts.sh
@@ -68,18 +68,25 @@ backing=$(findmnt -no FSTYPE --target "$docker_root")
 # build ships, which installs its own. They record the netfilter
 # userspace the evidence was gathered under.
 #
-# Looked for where they live, not only on PATH. Both are sbin tools, and
-# a service account does not carry sbin: the runner executing the
-# qualification has /usr/local/bin:/usr/bin:/bin and nothing more, while
-# the freeze was collected over a root shell that does. A PATH-only probe
-# therefore reported no netfilter userspace on a host holding both, and
-# the comparison read one host as two -- as the wrong host, rather than
-# as the wrong PATH. What remains after looking is the fact the swallowing
-# above is for.
+# Looked for where they live, not only on PATH. Both install into sbin,
+# which a service account's PATH commonly omits and a root shell's
+# carries, so a PATH-only probe reports no netfilter userspace on a host
+# that has both -- and the comparison reads one host as two, as the wrong
+# host rather than as the wrong PATH. The directories are searched in the
+# order a root PATH lists them, so a host carrying different binaries in
+# two of them answers the same whichever account asks. What remains after
+# looking is the fact the swallowing above is for.
 netfilter_version() {
-  for candidate in "$1" "/usr/sbin/$1" "/sbin/$1" "/usr/local/sbin/$1"; do
+  local candidate version
+  for candidate in "$1" "/usr/local/sbin/$1" "/usr/sbin/$1" "/sbin/$1"; do
     command -v "$candidate" >/dev/null 2>&1 || continue
-    "$candidate" --version 2>/dev/null && return 0
+    # Per candidate, and emitted only once one answers: a wrapper that
+    # prints and then fails would otherwise have its half-line captured
+    # alongside the next candidate's whole one, and the two arrive in the
+    # record as one value with a newline through it.
+    version=$("$candidate" --version 2>/dev/null) || continue
+    printf '%s' "$version"
+    return 0
   done
   return 0
 }


### PR DESCRIPTION
## What changes

`scripts/qualification/platform-facts.sh` looks for `iptables` and `nft` in the
sbin directories as well as on `PATH`, instead of only on `PATH`.

## What was found

The v1.0.0 qualification refused the release:

```text
observed amd64 host does not match the release-qualification reference:
 - iptables: reference "iptables v1.8.11 (nf_tables)", host has ""
 - nftables: reference "nftables v1.1.3 (Commodore Bullmoose #4)", host has ""
```

The host has both. They are in `/usr/sbin`, and the account the self-hosted
runner executes as carries `PATH=/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games`
— no sbin. The reference was frozen over a root shell, whose PATH does carry
sbin, so the lock records what the host really runs and the collector reported
nothing.

The two swallowed probes are deliberate, and the reasoning behind them is
unchanged: a missing firewall tool is a fact about the host and belongs in the
record for the comparison to refuse. What was wrong is that the probe could not
tell "not installed" from "not on this account's PATH", so it reported the first
while the second was true. That is the failure the `findmnt` guard above it
exists to prevent for the backing filesystem — a broken instrument reporting a
false fact — reached by a different route.

What an operator observes is the refusal above: it names iptables and nftables
as differing, which reads as the wrong host. The host was right.

## Evidence

The corrected collector, run on the qualification host under both accounts,
reports the same thing, and it is what the frozen reference records:

```text
=== as the runner account:
  "iptables": "iptables v1.8.11 (nf_tables)",
  "nftables": "nftables v1.1.3 (Commodore Bullmoose #4)",
=== as root:
  "iptables": "iptables v1.8.11 (nf_tables)",
  "nftables": "nftables v1.1.3 (Commodore Bullmoose #4)",
```

That the two agree is the point: the defect was one host answering two ways.

The partial-output edge was exercised with a stub that prints a line and exits
non-zero ahead of a working one on the search path. The failing candidate is
skipped entirely and the captured value is the working candidate's alone, on one
line.

`bash -n` and `shellcheck` are clean.

## What would notice this regressing

The release qualification itself, which is what noticed it: an empty firewall
version fails the platform comparison and stops the release before any
publication, as it did for the tag this fixes. Nothing hermetic can cover it —
the collector reads a real host, and CI runners are not the reference platform.

## Risk, compatibility and operations

No trust boundary, credential, ownership, cleanup or networking effect. Nothing
here execs the firewall: the ruleset is applied by `iptables-restore` inside the
gateway container from the image the build ships. The probe reads a version
string and is unprivileged — verified as the runner account, which is not root.

The frozen reference in `build/platform.lock.json` is unchanged and needs no
re-freeze: the values it records are the ones the host reports, which is what
this restores the collector's ability to see. A re-freeze is not merely
unnecessary but unavailable — `internal/platform` refuses to load a frozen entry
whose firewall versions are empty, so the blind collector could not have
produced one.

The search order mirrors a root PATH (`/usr/local/sbin` before `/usr/sbin`), so
a host carrying different binaries in both answers the same whichever account
asks.

A host that genuinely has no netfilter userspace still reports empty and is
still refused.

## Changelog

```text
NONE
```
