### PR TITLE
test(architecture): the supervisor cannot learn the control plane

### DIFF
--- a/test/architecture/architecture_test.go
+++ b/test/architecture/architecture_test.go
@@ -67,7 +67,9 @@ var corePackages = []string{
 // where transitive weight is the point.
 var narrowDeps = map[string][]string{
 	// The four packages every other one stands on, pinned at what they
-	// hold today. They are not narrow because an edge was removed: they
+	// hold today: the shared vocabulary, the capsule wire format, the
+	// atomic write, and the egress policy both the validator and the
+	// enforcer read. They are not narrow because an edge was removed: they
 	// are narrow because nothing has been added, and nothing states that.
 	// An edge from any of them compiles, creates no cycle, and trips no
 	// other rule here -- so the vocabulary every layer shares would learn
@@ -76,6 +78,25 @@ var narrowDeps = map[string][]string{
 	module + "/internal/assignment":          {},
 	module + "/internal/capsule/protocol":    {},
 	module + "/internal/platform/atomicfile": {},
+	module + "/internal/egress":              {},
+	// The capsule supervisor is PID 1 beside the job, and the gateway it
+	// starts is the process that decides what that job reaches. What it
+	// links is what an escape finds already loaded: the engine adapter
+	// would put the host's Docker socket vocabulary there, the store its
+	// persistence, the provider adapter the credential paths. None of
+	// that is needed to boot a runner and report its state, and none of
+	// it trips another rule here -- the rosters below cover internal
+	// packages, and a command is not one.
+	//
+	// The controller is the other half and is pinned by the release
+	// instead: it carries the capsule's digest stamped into it and
+	// refuses any other, which is a pairing a single binary could not
+	// express.
+	module + "/cmd/capsule-supervisor": {
+		module + "/internal/capsule/protocol",
+		module + "/internal/gateway",
+		module + "/internal/platform/atomicfile",
+	},
 	// The port names what a container engine does and holds no client.
 	module + "/internal/engine": {module + "/internal/assignment"},
 	// And its adapter translates; an adapter that learned the store would


### PR DESCRIPTION
## What changes

`test/architecture/architecture_test.go` pins `cmd/capsule-supervisor` to its
three direct internal imports, and pins `internal/egress` as a leaf.

## What was found

`narrowDeps` covers `internal/` packages, and a command is not one. Nothing
stopped `cmd/capsule-supervisor` importing `internal/store`, `internal/engine/docker`
or `internal/platform/githubactions`: the edge compiles, creates no cycle, and
trips no other rule in the file.

It is the process the threat model places as PID 1 inside the capsule, beside
the runner and the job, and it is what starts the gateway that decides what that
job reaches. What it links is what an escape finds already loaded — the host's
Docker socket vocabulary, the state database, the credential paths — and none of
it is needed to boot a runner and report its state. Today `go list -deps
./cmd/capsule-supervisor` shows four internal packages and no engine or provider
SDK; that was a property of the tree rather than a rule about it.

The controller is the other half of the same boundary and is already pinned,
elsewhere and differently: the release stamps the capsule image's digest into
the binary (`release.yml:340`) and `internal/app/images.go:34` refuses any
override of it. That pairing is why the two cannot become one binary — a unified
executable ships inside the capsule image and cannot carry the digest of an
image that does not exist when it is compiled.

`internal/egress` is the fourth of the four leaves the group's own comment names,
and only three were listed. It is the vocabulary the configuration validator and
the gateway enforcer both read so they cannot disagree about what "private"
means, which the file argues at length is a security property rather than a
duplication — and an edge from it tripped nothing.

## Evidence

Both pins were exercised by adding the edge they exist to refuse:

```text
--- FAIL: TestNarrowPackagesStayNarrow/cmd/capsule-supervisor
    internal imports of .../cmd/capsule-supervisor changed.
     got: [.../capsule/protocol .../gateway .../platform/atomicfile .../store]
    want: [.../capsule/protocol .../gateway .../platform/atomicfile]

--- FAIL: TestNarrowPackagesStayNarrow/internal/egress
    internal imports of .../internal/egress changed.
     got: [.../internal/platform/atomicfile]
    want: []
```

The first probe against `internal/egress` was invalid and is reported here
because it looked like a pass: importing `internal/config` creates a cycle, so
the compiler refuses it before the suite runs and the failure proves nothing
about this rule. `internal/platform/atomicfile` is a leaf and reaches the check.

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean.

## What would notice this regressing

`TestNarrowPackagesStayNarrow`, on every pull request, naming the added import
and the roster it is missing from.

## Risk, compatibility and operations

Test-only. No product code, no CLI, configuration, schema, image or deployment
effect. It records what the tree already does; nothing had to move to satisfy it.

## Changelog

```text
NONE
```
