### PR TITLE
fix(engine): a registry blip does not end as an attempt held for a person

### DIFF
--- a/internal/engine/docker/docker.go
+++ b/internal/engine/docker/docker.go
@@ -7,6 +7,7 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -28,6 +29,8 @@ type Client struct {
 	// leaked helper is; the default is silent because the ownership
 	// labels guarantee a later sweep finds it.
 	onCleanupError func(name string, err error)
+	// pullPause shortens the wait between pull attempts for a test.
+	pullPause time.Duration
 }
 
 // OnCleanupError registers an observer for helper removals that failed.
@@ -134,7 +137,61 @@ func (c *Client) StartContainer(ctx context.Context, id string) error {
 	return err
 }
 
+// pullAttempts is how many times a pull is tried when the registry
+// answered in a way it may not answer again.
+//
+// A pull is the one step in a launch that depends on a third party being
+// reachable, and a failed one is not free: it fails the create, which
+// spends the attempt's retry budget, and an attempt that spends all of it
+// is held for a person. So minutes of registry trouble became an operator
+// resolving attempts by hand -- which until this release meant stopping
+// the controller.
+//
+// Three, and no more: the budget above this is what covers a registry
+// that is properly down, and a launch that waits longer holds a lease
+// while it does.
+const pullAttempts = 3
+
+// pullRetryPause is held on the client so a test can exercise the retry
+// without waiting out real seconds.
+func (c *Client) pullRetryPause() time.Duration {
+	if c.pullPause > 0 {
+		return c.pullPause
+	}
+	return 2 * time.Second
+}
+
 func (c *Client) pull(ctx context.Context, ref string) error {
+	return pullWithRetry(ctx, ref, c.pullRetryPause(), c.pullOnce)
+}
+
+// pullWithRetry is the retry policy, separated from the wire so it is
+// provable without a registry: the adapter's own behaviour is shown
+// live, and how many times it tries is not something a live suite can
+// demonstrate without an outage to demonstrate it in.
+func pullWithRetry(ctx context.Context, ref string, pause time.Duration,
+	once func(context.Context, string) error) error {
+
+	for attempt := 1; ; attempt++ {
+		err := once(ctx, ref)
+		if err == nil || attempt == pullAttempts || !worthPullingAgain(err) {
+			return err
+		}
+		// Asked before the pause, not inside it: a select between a
+		// cancelled context and an elapsed timer picks either one, so a
+		// launch already abandoned could pull again on its way out.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("pull %s: %w", ref, err)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("pull %s: %w", ref, ctx.Err())
+		case <-time.After(pause):
+		}
+	}
+}
+
+func (c *Client) pullOnce(ctx context.Context, ref string) error {
 	resp, err := c.cli.ImagePull(ctx, ref, client.ImagePullOptions{})
 	if err != nil {
 		return fmt.Errorf("pull %s: %w", ref, err)
@@ -146,6 +203,27 @@ func (c *Client) pull(ctx context.Context, ref string) error {
 		return fmt.Errorf("pull %s: %w", ref, err)
 	}
 	return nil
+}
+
+// worthPullingAgain reports whether the registry might answer differently.
+//
+// Named the other way round -- the answers that will not change -- because
+// that list is the one this package can state. A reference nobody
+// published, a credential that does not carry, a malformed reference: no
+// pause makes any of them true. Everything else, including an error the
+// daemon reported inside the progress stream and did not type, is tried
+// again, because a transport failure arrives untyped and is the case this
+// exists for.
+func worthPullingAgain(err error) bool {
+	switch {
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return false
+	case cerrdefs.IsNotFound(err), cerrdefs.IsUnauthorized(err),
+		cerrdefs.IsPermissionDenied(err), cerrdefs.IsInvalidArgument(err),
+		cerrdefs.IsNotImplemented(err):
+		return false
+	}
+	return true
 }
 
 // RunTask creates, starts and awaits a short-lived container (a chown or

--- a/internal/engine/docker/pull_test.go
+++ b/internal/engine/docker/pull_test.go
@@ -1,0 +1,88 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	cerrdefs "github.com/containerd/errdefs"
+)
+
+// TestAPullIsTriedAgainOnlyWhileTheAnswerMightChange: a pull is the one
+// step of a launch that depends on a third party being reachable, and a
+// failed one spends the attempt's retry budget. An attempt that spends
+// all of it is held for a person, so a registry that was briefly
+// unreachable became work for an operator.
+//
+// Trying again is only right where the answer might differ. A reference
+// nobody published answers the same every time, and pausing between
+// three identical refusals delays the error the operator needs.
+func TestAPullIsTriedAgainOnlyWhileTheAnswerMightChange(t *testing.T) {
+	unreachable := errors.New("dial tcp: connection reset by peer")
+
+	for _, c := range []struct {
+		name  string
+		fail  error
+		tries int
+	}{
+		{"a transport failure arrives untyped and is retried", unreachable, pullAttempts},
+		{"an unpublished reference answers the same every time",
+			fmt.Errorf("manifest unknown: %w", cerrdefs.ErrNotFound), 1},
+		{"a credential that does not carry is not a blip",
+			fmt.Errorf("denied: %w", cerrdefs.ErrPermissionDenied), 1},
+		{"a malformed reference is refused the same way every time",
+			fmt.Errorf("invalid reference: %w", cerrdefs.ErrInvalidArgument), 1},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tries := 0
+			err := pullWithRetry(t.Context(), "img", 0, func(context.Context, string) error {
+				tries++
+				return c.fail
+			})
+			if !errors.Is(err, c.fail) {
+				t.Errorf("returned %v; want the failure it was given", err)
+			}
+			if tries != c.tries {
+				t.Errorf("pulled %d times; want %d. A permanent refusal retried delays the "+
+					"error, and a blip not retried holds an attempt", tries, c.tries)
+			}
+		})
+	}
+}
+
+// TestAPullThatSucceedsOnASecondTryIsNotAFailure holds the case this
+// exists for: the launch continues rather than spending budget.
+func TestAPullThatSucceedsOnASecondTryIsNotAFailure(t *testing.T) {
+	tries := 0
+	err := pullWithRetry(t.Context(), "img", 0, func(context.Context, string) error {
+		tries++
+		if tries == 1 {
+			return errors.New("unexpected EOF")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("pull failed with %v; the second answer was success", err)
+	}
+	if tries != 2 {
+		t.Errorf("pulled %d times; want 2", tries)
+	}
+}
+
+// TestACancelledLaunchStopsPulling: the pause must not outlive the job.
+func TestACancelledLaunchStopsPulling(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	tries := 0
+	err := pullWithRetry(ctx, "img", 0, func(context.Context, string) error {
+		tries++
+		cancel()
+		return errors.New("unexpected EOF")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("returned %v; want the cancellation", err)
+	}
+	if tries != 1 {
+		t.Errorf("pulled %d times after cancellation; want 1", tries)
+	}
+}


### PR DESCRIPTION
## What changes

`internal/engine/docker` retries a pull up to three times when the registry
answered in a way it might not answer again, pausing between tries, and does not
retry an answer that will be the same.

## What was found

A pull had one try (`docker.go:137-149` before this change). It is the one step
of a launch that depends on a third party being reachable, and its failure is
not contained: `CreateContainer` pulls only after a not-found create, so a failed
pull fails the create, which spends one of the attempt's `scheduling.retryBudget`
(default 3, `internal/config/defaults.go`). An attempt that spends all of it is
held for a person (`internal/lease/lease.go:407`), and resolving a held attempt
takes the singleton lock — so it means stopping the controller, which on a shared
host is every tenant's CI.

So a registry unreachable for a few minutes, on a host that does not already
have the image, converted into an operator and an outage. Three transient
registry failures during this project's own release today — two from Docker Hub,
one from `proxy.golang.org` — are the same class from the other side of the
fence.

Three tries is the bound because the retry budget above this is what covers a
registry that is properly down; a launch that waits longer holds a lease while
it waits.

The classification is stated as the answers that will **not** change — an
unpublished reference, a credential that does not carry, a malformed reference,
a cancelled context — because that is the list this package can state. Everything
else is retried, including an error the daemon reported inside the progress
stream and did not type, since a transport failure arrives untyped and is the
case this exists for.

The context is asked before the pause rather than only inside the select. A
select between a cancelled context and an elapsed timer picks either one, so an
abandoned launch could pull again on its way out. The test caught that before
review did.

## Evidence

The policy is separated from the wire (`pullWithRetry`) so it is provable without
a registry — how many times the adapter tries is not something the live contract
suite can demonstrate without an outage to demonstrate it in.

Both halves were exercised by breaking them:

```text
# with pullAttempts = 1
--- FAIL: TestAPullThatSucceedsOnASecondTryIsNotAFailure
    pulled 1 times; want 2

# with worthPullingAgain always true
--- FAIL: .../an_unpublished_reference_answers_the_same_every_time
    pulled 3 times; want 1. A permanent refusal retried delays the error,
    and a blip not retried holds an attempt
```

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean.

## What would notice this regressing

`TestAPullIsTriedAgainOnlyWhileTheAnswerMightChange`,
`TestAPullThatSucceedsOnASecondTryIsNotAFailure` and
`TestACancelledLaunchStopsPulling` in `internal/engine/docker`, on every pull
request. The first pins both directions: a permanent refusal retried and a blip
not retried each fail it.

## Risk, compatibility and operations

The failure mode it removes is an attempt held for a person. The one it adds is
latency: a launch whose registry is genuinely down now takes up to two pauses
longer before failing, while holding its lease. That is bounded at three tries
against a retry budget of up to ten above it.

No configuration surface is added — the bound and the pause are constants, and
the pause is a field only so a test does not wait real seconds. No CLI, schema,
image or deployment effect. `RunTask` and every capsule launch reach this through
the same `CreateContainer` path and inherit it.

## Changelog

```text
### Operations

- A pull the registry refused in a way it might not repeat is tried again, up to
  three times, instead of spending an attempt's retry budget on a blip. An answer
  that will not change — an unpublished reference, a credential that does not
  carry, a malformed reference — is not retried.
```
