### PR TITLE
fix(capsule): the exit code carries the decision the state already made

### DIFF
--- a/cmd/capsule-supervisor/main.go
+++ b/cmd/capsule-supervisor/main.go
@@ -157,10 +157,7 @@ func supervise(log *slog.Logger) int {
 		log.Error("capsule run failed", "error", err)
 		state := terminalFailure(currentState(), err)
 		setState(state)
-		if strings.HasPrefix(string(state), protocol.AbortedPrefix) {
-			return exitAborted
-		}
-		return 1
+		return failureExit(state)
 	}
 	reported := runnerExit(code)
 	if reported != code {
@@ -716,6 +713,28 @@ func terminalFailure(state protocol.State, err error) protocol.State {
 		return protocol.State(protocol.FailedPrefix + err.Error())
 	}
 	return protocol.State(protocol.AbortedPrefix + err.Error())
+}
+
+// failureExit is the code that carries the state's own decision out to
+// the controller, which cannot see the state file.
+//
+// terminalFailure already decided the only thing that matters -- whether
+// the runner was ever handed the job -- and this must not decide it
+// again. It did: the exit was chosen by re-reading the prefix of the
+// string terminalFailure had just built, so the two could disagree.
+//
+// What a disagreement costs is not symmetric. ClassifyExit reads the
+// reserved code as ObservedCreated, which is the account that the job
+// never started, and an attempt with that account is returned to the
+// queue. So reporting a failure that happened after fork/exec as an
+// abort runs a workload twice -- a deploy, a publish, a release -- with
+// no review entry and nobody asked. The other direction holds a job that
+// never ran for a person, which is a delay.
+func failureExit(state protocol.State) int {
+	if strings.HasPrefix(string(state), protocol.AbortedPrefix) {
+		return exitAborted
+	}
+	return 1
 }
 
 func currentState() protocol.State {

--- a/cmd/capsule-supervisor/main_test.go
+++ b/cmd/capsule-supervisor/main_test.go
@@ -561,3 +561,56 @@ func TestTheReaperDeliversEachTrackedExitOnce(t *testing.T) {
 // tracked channel never fires. The production process has one; the test
 // process gets one.
 var testReaper = sync.OnceValue(newReaper)
+
+// TestTheFailureExitCarriesTheStateItWasGiven: the code the controller
+// reads must say what the state already decided, and never decide it
+// again.
+//
+// ClassifyExit reads the reserved code as the account that the runner
+// never started, and an attempt with that account returns to the queue.
+// So an abort reported for a failure that happened after fork/exec runs
+// a workload a second time — a deploy, a publish — with no review entry
+// and nobody asked. The reverse holds a job that never ran for a person,
+// which is a delay.
+//
+// The decision belongs to terminalFailure, which makes it from the one
+// fact only the supervisor has: whether `running` was written. This
+// carries that decision out; the two used to be made separately, from a
+// typed value and from the prefix of the string built out of it.
+func TestTheFailureExitCarriesTheStateItWasGiven(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		state protocol.State
+		want  int
+	}{
+		{"a failure before the runner was handed the job is an abort",
+			protocol.State(protocol.AbortedPrefix + "dockerd never became ready"), exitAborted},
+		{"a failure after it is not",
+			protocol.State(protocol.FailedPrefix + "the runner was killed"), 1},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := failureExit(c.state); got != c.want {
+				t.Errorf("failureExit(%q) = %d; want %d", c.state, got, c.want)
+			}
+		})
+	}
+}
+
+// TestTheExitAgreesWithTerminalFailure holds the two together: whatever
+// terminalFailure decides from the running state, the exit reports.
+// Testing failureExit alone would let the pair drift while each half
+// stayed correct on its own.
+func TestTheExitAgreesWithTerminalFailure(t *testing.T) {
+	handedOver := terminalFailure(protocol.StateRunning, errors.New("killed"))
+	if got := failureExit(handedOver); got == exitAborted {
+		t.Errorf("a failure with %q reported the abort code; the controller reads that as "+
+			"a job that never started and returns it to the queue", handedOver)
+	}
+	for _, before := range []protocol.State{protocol.StateWaiting, protocol.StateStarting, ""} {
+		never := terminalFailure(before, errors.New("dockerd never became ready"))
+		if got := failureExit(never); got != exitAborted {
+			t.Errorf("a failure from %q exited %d; the runner was never handed the job, "+
+				"and anything but the abort code settles it as one that ran", before, got)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

The supervisor's failure exit code is chosen by one function that reads the
terminal state, instead of by re-parsing the prefix of the string that state
was built from. Two tests pin it.

## What was found

`terminalFailure` decides the only thing the controller cannot see from
outside — whether the runner was ever handed the job — by asking whether
`running` had been written, and returns that as a state. Two lines later the
exit code was chosen again, independently, by
`strings.HasPrefix(string(state), protocol.AbortedPrefix)`. The same decision,
made twice, from two representations.

The two directions do not cost the same. `ClassifyExit`
(`internal/capsule/observation.go:61-66`) maps the reserved abort code to
`assignment.ObservedCreated` — the account that the job never started — and an
attempt carrying that account is returned to the queue. So a failure that
happened *after* fork/exec, reported as an abort, runs the workload a second
time. A deploy, a publish, a release: whatever external effects it already had,
repeated, with no review entry and nobody asked to look.

That is precisely the outcome `internal/capsule` exists to make impossible,
reached through the single line that decides it — and nothing tested that line.
Three plausible edits produced it and compiled: inverting the condition,
deleting it, or merging the block with the `boot()` branch immediately above,
which also returns the abort code and would read as a tidy-up.

The production trigger for the failing side is real, not theoretical: the
drain-timeout kill in `runRunner`, which is a host shutdown or eviction while a
job is running.

## Evidence

Both drift directions were exercised:

```text
# with the condition inverted
--- FAIL: .../a_failure_before_the_runner_was_handed_the_job_is_an_abort
    failureExit("aborted:dockerd never became ready") = 1; want 79

# with the function merged into the boot branch's answer
--- FAIL: .../a_failure_after_it_is_not
```

The second test holds the pair rather than the mapping: it drives
`terminalFailure` from `running`, `waiting`, `starting` and the empty state and
asserts the exit agrees with each. A test of `failureExit` alone would let the
two drift while both stayed correct in isolation, which is the shape the defect
already had.

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean.

## What would notice this regressing

`TestTheFailureExitCarriesTheStateItWasGiven` for the mapping and
`TestTheExitAgreesWithTerminalFailure` for the pair, in
`cmd/capsule-supervisor`, on every pull request. Before this, nothing did:
`exitAborted` appeared in that package's tests only for `runnerExit`, which
answers a different question.

## Risk, compatibility and operations

No behaviour changes. The extracted function returns exactly what the inline
condition returned for every state the supervisor can hold, which is what the
second test asserts against `terminalFailure` rather than against a list
written here.

No trust boundary, credential, schema, configuration or CLI effect. The capsule
image is unchanged in content; the supervisor binary it carries is rebuilt, as
it is for any change to that command.

## Changelog

```text
NONE
```
