### PR TITLE
fix(gateway): deny-all is built once, and what makes it deny is proven

### DIFF
--- a/internal/gateway/policy.go
+++ b/internal/gateway/policy.go
@@ -196,16 +196,32 @@ func Reload(controlDir string, r io.Reader) error {
 // "narrower", it is merely older, and a subnet that appeared since is
 // reachable under it.
 func DenyAll(controlDir string) error {
-	return installPolicy(controlDir, func(current egress.Policy, inForce bool) (egress.Policy, error) {
-		if !inForce {
-			return egress.Policy{}, errNoPolicyInForce
-		}
-		return egress.Policy{
-			InternalSubnet: current.InternalSubnet,
-			UplinkSubnet:   current.UplinkSubnet,
-			Deny:           []string{"0.0.0.0/0"},
-		}, nil
-	})
+	return installPolicy(controlDir, denyAllSuccessor)
+}
+
+// denyAllSuccessor is the policy DenyAll installs, built once.
+//
+// What makes it deny everything is not the deny set: the decider reads
+// the allow list first and returns on a hit, so an allow entry carried
+// forward from the policy in force would still be reachable under a deny
+// of the whole address space. Dropping it is the property, and a
+// successor built by copying the current policy and overwriting Deny --
+// which is how the sibling above builds one, and how this was written
+// twice, once here and once in a test -- keeps it.
+//
+// It is a function so there is one of it. The exported entry point
+// applies to the kernel, which a hermetic test cannot do, so the test
+// that raced this against a reload held a second copy of the builder:
+// correct, and free to stay correct while this one stopped being.
+func denyAllSuccessor(current egress.Policy, inForce bool) (egress.Policy, error) {
+	if !inForce {
+		return egress.Policy{}, errNoPolicyInForce
+	}
+	return egress.Policy{
+		InternalSubnet: current.InternalSubnet,
+		UplinkSubnet:   current.UplinkSubnet,
+		Deny:           []string{"0.0.0.0/0"},
+	}, nil
 }
 
 // installPolicy is the part both paths share: read what is in force,

--- a/internal/gateway/policy_test.go
+++ b/internal/gateway/policy_test.go
@@ -196,13 +196,9 @@ func TestAConcurrentInstallLeavesAPolicyInForce(t *testing.T) {
 			return next, next.Validate()
 		}, noKernel)
 	}
-	denyAll := func() error {
-		return installPolicyWith(dir, func(current egress.Policy, _ bool) (egress.Policy, error) {
-			next := current
-			next.Allow, next.Deny = nil, []string{"0.0.0.0/0"}
-			return next, nil
-		}, noKernel)
-	}
+	// The builder DenyAll uses, not a copy of it: a second one is free to
+	// stay correct while the shipped one stops being.
+	denyAll := func() error { return installPolicyWith(dir, denyAllSuccessor, noKernel) }
 
 	var wg sync.WaitGroup
 	for i := range 16 {
@@ -556,5 +552,97 @@ func TestAnOversizedPolicyIsRefusedNotTruncated(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds") {
 		t.Errorf("error = %q; it has to name the bound rather than fail parsing the truncation", err)
+	}
+}
+
+// TestDenyAllDropsTheAllowListItInherits: the deny set is not what makes
+// it deny.
+//
+// The decider reads the allow list first and returns on a hit, so an
+// allow entry carried forward from the policy in force stays reachable
+// under a deny of the whole address space. The successor drops it, and
+// nothing said so: the sibling builder nine lines up copies the current
+// policy and overwrites one field, which is the shape a unification of
+// the two would take, and it would readmit the operator's own ranges at
+// the one moment the controller has already decided it cannot trust the
+// policy in force.
+func TestDenyAllDropsTheAllowListItInherits(t *testing.T) {
+	inForce := egress.Policy{
+		InternalSubnet: "10.90.0.0/24",
+		UplinkSubnet:   "10.91.0.0/24",
+		Allow:          []string{"93.184.216.0/24"},
+		Deny:           []string{"10.0.0.0/8"},
+	}
+	allowed := netip.MustParseAddr("93.184.216.34")
+
+	before, err := inForce.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !before.Allowed(allowed) {
+		t.Fatalf("the fixture does not allow %s, so this proves nothing", allowed)
+	}
+
+	next, err := denyAllSuccessor(inForce, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	after, err := next.Compile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Allowed(allowed) {
+		t.Errorf("%s is still reachable after deny-all; the allow list outranks the deny set, "+
+			"so a policy that carries one forward denies nothing it had permitted", allowed)
+	}
+
+	// The legs survive: a gateway whose own subnets were dropped cannot
+	// relay at all, which is dying rather than denying.
+	if next.InternalSubnet != inForce.InternalSubnet || next.UplinkSubnet != inForce.UplinkSubnet {
+		t.Errorf("deny-all changed the gateway's own subnets to %q/%q; it must deny, not disconnect",
+			next.InternalSubnet, next.UplinkSubnet)
+	}
+}
+
+// TestAPolicyIsNotWrittenWhenTheKernelRefusesIt: the file the relay reads
+// must never advance past the ruleset.
+//
+// installPolicy applies to the kernel before writing, so a capsule never
+// sees a window where a newly denied destination is still reachable
+// through the relay. The refusal path was covered for a successor that
+// fails to build; a kernel that refuses one that built fine was not.
+func TestAPolicyIsNotWrittenWhenTheKernelRefusesIt(t *testing.T) {
+	dir := t.TempDir()
+	first := egress.Policy{
+		InternalSubnet: "10.90.0.0/24", UplinkSubnet: "10.91.0.0/24",
+		Deny: []string{"10.0.0.0/8"},
+	}
+	if err := installPolicyWith(dir, func(egress.Policy, bool) (egress.Policy, error) {
+		return first, nil
+	}, func(egress.Policy) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+
+	refused := errors.New("iptables-restore: permission denied")
+	err := installPolicyWith(dir, func(current egress.Policy, _ bool) (egress.Policy, error) {
+		next := current
+		next.Deny = []string{"0.0.0.0/0"}
+		return next, nil
+	}, func(egress.Policy) error { return refused })
+	if !errors.Is(err, refused) {
+		t.Fatalf("a refused ruleset returned %v; the caller cannot know the gateway is unchanged", err)
+	}
+
+	// What the relay reads has to be the policy the kernel is still
+	// enforcing, so an address the first one permits must still pass.
+	// Had the refused successor been written, nothing would.
+	got, err := (&PolicyStore{Path: PolicyPath(dir)}).Current()
+	if err != nil {
+		t.Fatalf("the refused install removed the policy in force: %v", err)
+	}
+	permitted := netip.MustParseAddr("93.184.216.34")
+	if !got.Allowed(permitted) {
+		t.Errorf("%s is refused after a ruleset the kernel rejected; the relay advanced past "+
+			"what is enforced, which is the window the ordering exists to close", permitted)
 	}
 }

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -986,3 +986,24 @@ func TestTheAddressCheckedIsTheAddressDialed(t *testing.T) {
 		})
 	}
 }
+
+// TestTheAllowedPortSetIsExactlyTwo: the set is the relay's contract,
+// and a sample of it is not the contract.
+//
+// A CONNECT tunnel carries any protocol a proxy-aware client speaks, so
+// the port set is what keeps an allowed address from becoming arbitrary
+// TCP to that address. The existing tests prove 80 and 443 are in it and
+// that five other ports are not, which a wider map still satisfies: a
+// sixth port added here is a widening nothing reads back.
+func TestTheAllowedPortSetIsExactlyTwo(t *testing.T) {
+	want := map[int]string{80: "HTTP", 443: "HTTPS"}
+	if len(AllowedConnectPorts) != len(want) {
+		t.Fatalf("the relay allows %d ports: %v. Every one is a protocol a tunnel can carry "+
+			"to an allowed address", len(AllowedConnectPorts), AllowedConnectPorts)
+	}
+	for port, name := range want {
+		if got, ok := AllowedConnectPorts[port]; !ok || got != name {
+			t.Errorf("port %d is %q, %v; want %q", port, got, ok, name)
+		}
+	}
+}


### PR DESCRIPTION
## What changes

`DenyAll`'s successor policy is built by one named function that both the
shipped path and the concurrency test call. Three properties gain tests: that
the successor drops the allow list it inherits, that a policy is not written
when the kernel refuses the ruleset, and that the relay's port set is exactly
two.

## What was found

**The deny set is not what makes `DenyAll` deny.** `Decider.Allowed`
(`internal/egress/egress.go:163-182`) consults the allow list first and returns
`true` on a hit, before it ever reads the deny list. So an allow entry carried
forward from the policy in force stays reachable under a deny of `0.0.0.0/0`.
The successor was safe only because its struct literal omitted `Allow` — and
nothing stated that, or tested it.

The sibling builder nine lines above (`Reload`) does the opposite: it copies
the current policy and overwrites fields. That is the shape a unification of
the two would take, and it is a shape this code already had in a second place.

**The concurrency test carried a replica.** Exported `DenyAll` hardwires the
kernel applier, so a hermetic test cannot call it; `policy_test.go` therefore
built its own deny-all closure (`next := current; next.Allow, next.Deny = nil,
…`). That copy is correct, which is the problem: the suite exercised it while
the shipped builder's success branch never ran. Changing `DenyAll` to copy
`Allow` forward left everything green. Tested-by-replica is the drift this
repository built `internal/capsule/protocol` to end.

What the lost property costs is the reason `DenyAll` exists at all: it runs
when the controller cannot prove the policy in force is current, and readmitting
the operator's own allow list at that moment denies nothing it had permitted.

**The ordering was covered on one side only.** `installPolicy` applies the
successor to the kernel before writing the file the relay reads, so a newly
denied destination is never reachable in between. A successor that fails to
build was tested; a kernel that refuses one that built fine was not.

**The port set was pinned by sampling.** Two tests proved 80 and 443 present
and five other ports absent — which a wider map still satisfies. Every port in
it is a protocol a CONNECT tunnel can carry to an allowed address, which the
map's own comment says is the point.

## Evidence

Each property was exercised by removing it:

```text
# with the successor copying the current policy, as its sibling does
--- FAIL: TestDenyAllDropsTheAllowListItInherits
    93.184.216.34 is still reachable after deny-all; the allow list outranks
    the deny set, so a policy that carries one forward denies nothing it had
    permitted

# with the file written before the kernel is asked
--- FAIL: TestAPolicyIsNotWrittenWhenTheKernelRefusesIt
    93.184.216.34 is refused after a ruleset the kernel rejected; the relay
    advanced past what is enforced, which is the window the ordering exists
    to close

# with one port added
--- FAIL: TestTheAllowedPortSetIsExactlyTwo
    the relay allows 3 ports: map[22:SSH 80:HTTP 443:HTTPS]
```

The first is the exact edit the finding predicted, and it now fails instead of
passing.

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean.

## What would notice this regressing

`TestDenyAllDropsTheAllowListItInherits` for the property, and it holds the
shipped builder rather than a copy of it — the concurrency test now calls the
same function, so a change to one is a change to both. `TestAPolicyIsNotWrittenWhenTheKernelRefusesIt`
for the ordering. `TestTheAllowedPortSetIsExactlyTwo` for the port set.

## Risk, compatibility and operations

No behaviour changes. `denyAllSuccessor` returns exactly what the inline
closure returned, including the `errNoPolicyInForce` refusal when nothing is in
force, which the existing test still covers through `DenyAll` itself.

Egress-security relevant: the extracted function is what a live gateway installs
when the controller cannot prove its policy is current. Its subnets are
preserved deliberately — a gateway that lost its own legs cannot relay at all,
which is dying rather than denying — and the test asserts that too.

## Changelog

```text
NONE
```
