### PR TITLE
test(store): the open-attempt set is spelled once for every reader

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2523,3 +2523,115 @@ func TestEveryEvidenceAdvanceReachesTheTrail(t *testing.T) {
 			"observation is one fact, not two", after-before)
 	}
 }
+
+// stateIn finds every `state IN (…)` list in a SQL body.
+//
+// The word boundary keeps it off ack_state, which is the delivery
+// vocabulary and shares neither values nor meaning with this one.
+var stateIn = regexp.MustCompile(`(?is)\bstate\s+IN\s*\(([^)]*)\)`)
+
+func quotedStates(list string) []AttemptState {
+	var out []AttemptState
+	for _, part := range strings.Split(list, "'") {
+		part = strings.TrimSpace(part)
+		if part == "" || strings.ContainsAny(part, "(),") {
+			continue
+		}
+		out = append(out, AttemptState(part))
+	}
+	slices.Sort(out)
+	return out
+}
+
+// TestTheOpenAttemptSetIsSpelledOnceForEveryReader: four readers decide
+// which attempts are still live, and each carries its own copy of the
+// answer.
+//
+// The index enforces one open attempt per workload; openAttemptStates
+// gates the two hand-written queries that prune lease history and find
+// stranded work; and two generated queries ask the same question again.
+// The comment above openAttemptStates already names the index as the
+// authority the others agree with — and nothing checked that they do.
+//
+// A state added to the index and missed in the Go copy makes a live
+// attempt's lease prunable, and an attempt whose lease was pruned is
+// reachable by no working set: it is not requeued, not settled, and not
+// held for anyone. The subsets are deliberate and are not compared with
+// the rest; what they must be is spelled from the same vocabulary, which
+// is where a typo would otherwise live.
+func TestTheOpenAttemptSetIsSpelledOnceForEveryReader(t *testing.T) {
+	schema, err := migrationsFS.ReadFile("migrations/000001_initial.up.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(schema)
+	start := strings.Index(body, "CREATE UNIQUE INDEX one_open_attempt_per_workload")
+	if start < 0 {
+		t.Fatal("the open-attempt index moved; this test can no longer find it")
+	}
+	indexed := stateIn.FindStringSubmatch(body[start:])
+	if indexed == nil {
+		t.Fatal("the open-attempt index no longer selects by state")
+	}
+	authority := quotedStates(indexed[1])
+	if len(authority) == 0 {
+		t.Fatal("the index names no state, so this proves nothing")
+	}
+
+	if got := quotedStates(openAttemptStates); !slices.Equal(got, authority) {
+		t.Errorf("openAttemptStates is %v; the index is %v. The Go copy gates pruning "+
+			"lease history, and a state it omits makes a live attempt's lease prunable",
+			got, authority)
+	}
+
+	known := make(map[AttemptState]bool, len(AllAttemptStates))
+	for _, s := range AllAttemptStates {
+		known[s] = true
+	}
+	// The authority is spelled from the vocabulary too: a lease state
+	// reads as an attempt state here and selects nothing, which is an
+	// index that silently enforces less than it names.
+	for _, s := range authority {
+		if !known[s] {
+			t.Errorf("the index selects attempt state %q, which is not one", s)
+		}
+	}
+	files, err := filepath.Glob("query/*.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no query source found, so this proves nothing")
+	}
+	agreed, checked := 0, 0
+	for _, file := range files {
+		source, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, match := range stateIn.FindAllStringSubmatch(string(source), -1) {
+			states := quotedStates(match[1])
+			checked++
+			// Every list is spelled from the vocabulary, subsets
+			// included: that is where a typo hides.
+			for _, s := range states {
+				if !known[s] {
+					t.Errorf("%s selects attempt state %q, which is not one", file, s)
+				}
+			}
+			if len(states) == len(authority) {
+				agreed++
+				if !slices.Equal(states, authority) {
+					t.Errorf("%s selects %v; the index selects %v", file, states, authority)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no query selects by attempt state, so this proves nothing")
+	}
+	if agreed < 2 {
+		t.Errorf("%d generated queries ask the open-attempt question; two did, and a "+
+			"reader that stopped matching the index by length is one this no longer compares", agreed)
+	}
+}


### PR DESCRIPTION
## What changes

One test in `internal/store` holds the four spellings of the open-attempt state
set to each other, and every `state IN` list in the query sources to the
vocabulary.

## What was found

Four readers decide which attempts are still live, and each carries its own
copy of the answer:

- `internal/store/migrations/000001_initial.up.sql:292-295` — the
  `one_open_attempt_per_workload` index's predicate
- `internal/store/leasetx.go:245-246` — `openAttemptStates`, spliced into the
  hand-written `StrandedAttempts` and `PurgeLease` queries
- `internal/store/query/attempts.sql:34-35` — `GetOpenAttemptByWorkload`
- `internal/store/query/reconciliation.sql:29-30` — `CountOpenAttempts`

The comment at `leasetx.go:241-243` already names the relationship — "The
schema keeps its own copy in the `one_open_attempt_per_workload` index, which
is the authority the two agree with" — and states which copy wins without
anything checking that they agree.

The cost of a disagreement is stated in the same file: an attempt whose lease
was pruned is reachable by no working set. `prunableReleasedLeases` and
`PurgeLease` both gate on the Go copy, so a state added to the index and missed
there makes a live attempt's lease prunable — and the attempt is then not
requeued, not settled, and not held for anyone.

All four agree today. This is a future-edit hazard, which is why it belongs
before v1.1.0 touches the schema rather than after.

This file already closes three loops of exactly this shape:
`TestAttemptStatesCoverTheSchema` parses the CHECK constraint out of the
embedded migration, `TestTheSetReadAgreesWithTheGeneratedQuery` runs the
hand-written column list against the generated one, and
`TestForgettingABindingReachesEveryChildOfIt` walks the live foreign-key graph.
The technique is borrowed from the first.

The deliberate subsets — `reconciliation.sql:19` and `attempts.sql:107` — are
not compared with the whole, because they are not it. They are held to the
vocabulary instead, which is where a typo would otherwise live: a misspelled
state selects nothing and reads as one that simply does not occur.

## Evidence

```text
# with the index gaining a state the Go copy lacks
--- FAIL: TestTheOpenAttemptSetIsSpelledOnceForEveryReader
    openAttemptStates is [leased manual_review prepared preparing ready running
    starting]; the index is [leased manual_review prepared preparing quarantined
    ready running starting]. The Go copy gates pruning lease history, and a state
    it omits makes a live attempt's lease prunable

# with a typo in a generated query
    query/attempts.sql selects attempt state "prepard", which is not one

# with a lease state in the index
    the index selects attempt state "quarantined", which is not one
```

The third case is one the first version of this test missed: it compared the
index with the others but never held the index itself to the vocabulary, so an
index enforcing less than it names would have passed on set equality alone.

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean.

## What would notice this regressing

`TestTheOpenAttemptSetIsSpelledOnceForEveryReader`, on every pull request. It
fatals rather than passing quietly when the index moves, when it stops selecting
by state, when no query source is found, or when fewer than two generated
queries still ask the open-attempt question — the last because a reader that
drifts to a different length would otherwise leave the comparison silently
narrower.

## Risk, compatibility and operations

Test-only. No product code, schema, configuration or deployment effect. It
records what the tree already does; nothing had to move to satisfy it.

The pattern deliberately stops at `ack_state`, which is the broker delivery
vocabulary and shares neither values nor meaning with this one — a word
boundary, and the comment says why.

## Changelog

```text
NONE
```
