### PR TITLE
docs(readme): the page reads without scrolling sideways

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,33 +11,7 @@
 Runpool is a Docker-native control plane for autoscaling ephemeral CI
 runners on a single, capacity-bounded host. It translates provider demand
 into durable assignments, isolated per-job execution capsules, and optional
-repository-scoped cache lanes—without requiring Kubernetes.
-
-> [!IMPORTANT]
-> A version is release-qualified only after a no-skip qualification run on
-> the exact platform frozen before its candidate in
-> [`build/platform.lock.json`](build/platform.lock.json). Each release
-> carries the record that run produced, bound to its commit and to the image
-> digests it publishes; [release readiness](docs/release-readiness.md) lists
-> the gates and the evidence each one leaves.
-
-## Why Runpool
-
-- **Clean execution:** every workload gets a fresh runner, workspace, Docker
-  daemon data root, and control filesystem.
-- **Bounded capacity:** runner, inner daemon, child containers, and egress
-  gateway share an aggregate cgroup budget.
-- **Durable delivery:** assignments are persisted before broker
-  acknowledgement; redelivery is idempotent and ambiguous execution is held
-  for operator review.
-- **Restricted egress:** the default profile provides kernel-enforced
-  no-route isolation plus a policy-enforcing DNS and HTTP relay.
-- **Safe ownership:** cleanup acts only on resources carrying the expected
-  instance labels; Runpool never performs daemon-wide pruning.
-- **Provider-neutral lifecycle core:** delivery, attempt, lease, cache, and
-  cleanup state use opaque provider keys. GitHub-specific configuration and
-  metadata remain at the composition and adapter boundary; GitHub Actions is
-  the only implemented provider.
+repository-scoped cache lanes — without requiring Kubernetes.
 
 ## Architecture
 
@@ -59,11 +33,34 @@ while scheduling and disk budgets are healthy. See the
 [architecture guide](docs/architecture.md) for package boundaries, identity,
 recovery, and capacity semantics.
 
+## Why Runpool
+
+- **Clean execution:** every workload gets a fresh runner, workspace, Docker
+  daemon data root, and control filesystem.
+- **Bounded capacity:** runner, inner daemon, child containers, and egress
+  gateway share an aggregate cgroup budget.
+- **Durable delivery:** assignments are persisted before broker
+  acknowledgement; redelivery is idempotent and ambiguous execution is held
+  for operator review.
+- **Restricted egress:** the default profile provides kernel-enforced
+  no-route isolation plus a policy-enforcing DNS and HTTP relay.
+- **Safe ownership:** cleanup acts only on resources carrying the expected
+  instance labels; Runpool never performs daemon-wide pruning.
+- **Provider-neutral lifecycle core:** delivery, attempt, lease, cache, and
+  cleanup state use opaque provider keys. GitHub-specific configuration and
+  metadata remain at the composition and adapter boundary; GitHub Actions is
+  the only implemented provider.
+
 ## Security boundary
 
 Runpool is a resource-management, environment-hygiene, and network-policy
-boundary for CI workloads approved by the operator. It is **not** a hostile
-code sandbox:
+boundary for CI workloads approved by the operator.
+
+> [!WARNING]
+> **Runpool is not a hostile code sandbox.** It bounds and cleans up what an
+> approved workload does; it does not contain code you would not have run.
+
+Where that boundary ends:
 
 - the controller holds the Docker socket, which is host-root authority;
 - capsules run a privileged inner Docker daemon;
@@ -106,14 +103,19 @@ docker build -f build/capsule/Dockerfile -t runpool-capsule:dev .
 docker build -f build/controller/Dockerfile -t runpool:dev .
 ```
 
-`runpool-capsule:dev` is the exact name a development build looks for. A
-release binary carries its capsule by digest and refuses to be pointed
-elsewhere; from source, this tag is the pairing.
+> [!NOTE]
+> `runpool-capsule:dev` is the exact name a development build looks for. A
+> release binary carries its capsule by digest and refuses to be pointed
+> elsewhere; from source, this tag is the pairing.
 
 Then a configuration, a credential, and the state directory:
 
 ```bash
-RUNPOOL_GITHUB_URL=https://github.com/<owner>/<repo> RUNPOOL_GITHUB_TOKEN_FILE=/run/secrets/runpool/token RUNPOOL_HOST_TOPOLOGY=dedicated-daemon RUNPOOL_STATE_DIR="$PWD/state" ./runpool doctor
+RUNPOOL_GITHUB_URL=https://github.com/<owner>/<repo> \
+RUNPOOL_GITHUB_TOKEN_FILE=/run/secrets/runpool/token \
+RUNPOOL_HOST_TOPOLOGY=dedicated-daemon \
+RUNPOOL_STATE_DIR="$PWD/state" \
+./runpool doctor
 ```
 
 `RUNPOOL_STATE_DIR` is `$PWD/state` here rather than the default
@@ -140,12 +142,23 @@ The reference Compose deployment asks for a released digest and refuses to
 start with no image at all; that it is a digest rather than a moving tag is
 yours to hold, and [deployment](docs/deployment.md) covers verifying one. The
 images above are how a source checkout runs.
-Do not use a production credential for local experimentation.
+
+> [!CAUTION]
+> Do not use a production credential for local experimentation. A token that
+> can reach real repositories reaches them from a host you are still testing.
 
 ## Deployment
 
 Runpool provides a canonical Docker Compose manifest for its headless
 controller: no domain, reverse-proxy route, or public port is required.
+
+> [!IMPORTANT]
+> A version is release-qualified only after a no-skip qualification run on the
+> exact platform frozen before its candidate in
+> [`build/platform.lock.json`](build/platform.lock.json). Each release carries
+> the record that run produced, bound to its commit and to the image digests it
+> publishes; [release readiness](docs/release-readiness.md) lists the gates and
+> the evidence each one leaves.
 
 | Platform | Entry point |
 | --- | --- |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -247,7 +247,8 @@ runpool attempts resolve <id> --retry --reason "..." --actor "<name>" --apply
 ```
 
 ```bash
-runpool attempts resolve <id> --settle-may-have-run --reason "..." --actor "<name>" --apply
+runpool attempts resolve <id> --settle-may-have-run \
+  --reason "..." --actor "<name>" --apply
 ```
 
 `--retry` returns the attempt to the queue; use it when the evidence
@@ -364,7 +365,8 @@ docker volume ls --filter name=runpool
 ```
 
 ```bash
-docker run --rm -v runpool_runpool-state:/state:ro busybox tar -czf - -C /state . > runpool-state-backup.tgz
+docker run --rm -v runpool_runpool-state:/state:ro busybox \
+  tar -czf - -C /state . > runpool-state-backup.tgz
 ```
 
 ```bash


### PR DESCRIPTION
## What changes

The README's first screen is the project, the diagram, and what it is for. The
statements a reader must not miss are alerts rather than prose. No code block
scrolls sideways, here or in the runbook.

## What was found

**The first command a newcomer types was 202 characters on one line.** A code
block does not wrap, so GitHub renders it behind a horizontal scrollbar — four
environment variables and the command hidden off the right edge of the page. It
is now one variable per line with continuations: the same paste, and each value
reviewable on its own. `docs/runbook.md` had two of the same shape, a backup
`docker run` and a resolve command.

**The statements that matter most were the easiest to read past.** That Runpool
is *not a hostile code sandbox* is the one thing an evaluator has to take in
before deciding, and it was a bolded word in the middle of a paragraph. Not
using a production credential while experimenting was the last line of another
paragraph. Both are alerts now, each with the level that fits what it says, and
the `runpool-capsule:dev` pairing is a note rather than a sentence to skim.

**The release-qualification callout stood on the first screen.** It is accurate
and it belongs in the page — but it answers a question a reader does not have
while the page is still introducing itself. It moves to Deployment, where
somebody is deciding whether to install.

**The diagram arrived third.** It is the only picture the page has and GitHub
renders it natively, so it opens instead.

One em dash was set closed while the other eighteen in the documentation are
spaced.

## Evidence

No line inside a fenced block exceeds 80 characters in `README.md`,
`docs/runbook.md`, `docs/deployment.md` or `docs/reference/configuration.md` —
the mermaid source aside, which renders as a diagram rather than as text. The
wrapped commands were checked as shell syntax rather than only read.

`go test ./... -count=1` is clean, including the documentation consistency
suite that resolves every path these files name.

## What would notice this regressing

Nothing holds line length inside a code block, and adding a gate for it is not
obviously worth its own rule — a long line is visible in review, in a way a
stale path or a false claim is not, which is what that suite is for.

## Risk, compatibility and operations

Documentation only. No command, flag, path or behaviour changes: every wrapped
command is the same command, and every moved paragraph is the same paragraph.

## Changelog

```text
NONE
```
