### PR TITLE
chore(release): the changelog names v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ Notable changes, newest first. Runpool follows
 a version speaks for are listed in
 [the product contract](docs/product-contract.md).
 
-## Unreleased
+## v1.1.0 — 2026-08-28
+
+A capsule adopted across a controller replacement is read under its own
+protocol, a held attempt is resolved without stopping the controller, and a
+registry that blinked no longer costs an attempt. The schema is unchanged, so
+an installation moves by repointing the image and recreating the container;
+[the runbook](docs/runbook.md) names the commands and what to do if it has to
+go back.
 
 ### Isolation and execution
 


### PR DESCRIPTION
## What changes

`CHANGELOG.md`'s newest section is `## v1.1.0 — 2026-08-28` instead of
`## Unreleased`, with a summary of what the release gives an operator and what
moving to it costs.

## What was found

The release gate added before v1.0.0 reads the newest `## ` heading and refuses
a tag the section does not name, before any candidate is built. `## Unreleased`
is the correct heading between releases and the wrong one at a tag, so cutting
it is the last step before tagging rather than something to discover from a
failed run.

The summary names the schema as unchanged, which is the fact that decides how
an installation moves: a repoint and a recreate, not a migration. That is the
first of the three rollback cases the runbook now documents, and the cheapest.

## Evidence

The gate's matching was exercised against this heading: `v1.1.0` passes,
`v1.0.0` is refused, and the prefix `v1.1` is refused. A binary stamped
`v1.1.0` is accepted by `runpool version --check-release`.

`gofmt`, `go vet`, `staticcheck` and `go test ./... -count=1` are clean, and the
platform lock is still `frozen`.

The four live suites were rehearsed on the reference host before this: Docker
contracts, capsule/egress/budget, SQLite durability and the lifecycle drills,
all green with no skips, and no managed object left behind.

## What would notice this regressing

`validate release tag` in `release.yml`, which is what this satisfies.

## Risk, compatibility and operations

Documentation only. The release it names is the tree as it stands.

## Changelog

```text
NONE
```