### PR TITLE
fix(capsule): a capsule that died says why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Notable changes, newest first. Runpool follows
 a version speaks for are listed in
 [the product contract](docs/product-contract.md).
 
+## Unreleased
+
+### Operations
+
+- **A capsule that died before it could explain itself now carries what it
+  said.** An operator's own capsule image is built by deriving from the
+  published one, and the published one stays root deliberately: the
+  supervisor is PID 1, boots the inner Docker daemon, and drops the runner
+  to uid 1001 itself. A derived image ending `USER runner` cannot write the
+  root-owned control surface the launcher mounts for it — so it cannot write
+  the abort that would have said so either, and every attempt on that tier
+  was held with an exit code and the words "the capsule image and this
+  controller are not a pair", which sends an operator to re-check a digest
+  that was correct. The reason was in the container's log the whole time.
+  The refusal now quotes it.
+
 ## v1.1.0 — 2026-08-28
 
 A capsule adopted across a controller replacement is read under its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ a version speaks for are listed in
   the abort that would have said so either, and every attempt on that tier
   was held with an exit code and the words "the capsule image and this
   controller are not a pair", which sends an operator to re-check a digest
-  that was correct. The reason was in the container's log the whole time.
-  The refusal now quotes it.
+  that was correct. The reason was in the container's log the whole time,
+  and the refusal now quotes it — in the controller's log, where the
+  refusal is reported. What the held attempt itself records is unchanged:
+  still `capsule_incompatible`, so `runpool attempts` reads as before.
 
 ## v1.1.0 — 2026-08-28
 

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -40,6 +40,11 @@ const (
 	// controlDir is the tmpfs control surface, declared at creation so
 	// nothing under it can reach a disk or a Docker-persisted field.
 	controlDir = "/run/runpool"
+
+	// Enough for the supervisor's own account of why it stopped, which is
+	// the last thing it logs, without pasting a boot transcript into an
+	// error an operator reads at a glance.
+	logTailLines = 5
 	// protocolFile is where the supervisor writes the version of the
 	// control protocol it speaks, at boot, before it is asked anything.
 	protocolFile = controlDir + "/protocol"
@@ -200,7 +205,7 @@ func (m *Launcher) create(ctx context.Context, rec ResourceRecorder, kind engine
 }
 
 // capsuleDaemon is the daemon as a capsule needs it, declared here
-// rather than by the adapter: what this package may know is the eleven
+// rather than by the adapter: what this package may know is the twelve
 // operations a capsule is built from, and a seam is what lets the
 // refusals be asked for. A live daemon cannot be told to be absent, to
 // be unreachable, or to refuse a container that is already running, and
@@ -219,6 +224,7 @@ type capsuleDaemon interface {
 	ExecWithInput(ctx context.Context, containerID string, cmd []string, input []byte) (int, string, error)
 	OwnedIDByName(ctx context.Context, kind engine.ObjectKind, name string,
 		instanceID assignment.InstanceID, leaseID assignment.LeaseID) (string, error)
+	TailLogs(ctx context.Context, id string, lines int) (string, error)
 }
 
 // Launcher builds capsules. It holds no per-capsule state: everything a
@@ -454,8 +460,8 @@ func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
 			// fallback awaitState carries for the same shape.
 			if state, serr := m.dock.ContainerStatus(ctx, outerID); serr == nil &&
 				state.Status != engine.StatusRunning {
-				return fmt.Errorf("%w: the capsule exited %d before declaring a control protocol",
-					ErrIncompatibleImage, state.ExitCode)
+				return fmt.Errorf("%w: the capsule exited %d before declaring a control protocol%s",
+					ErrIncompatibleImage, state.ExitCode, m.lastWords(ctx, outerID))
 			}
 		}
 		if time.Now().After(deadline) {
@@ -473,6 +479,43 @@ func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
 			return ctx.Err()
 		}
 	}
+}
+
+// lastWords is what a stopped container said, folded onto one line and
+// prefixed for an error that would otherwise name only an exit code.
+//
+// It exists because the capsule that cannot start is usually the capsule
+// that cannot say so. Its control surface is a root-owned tmpfs this
+// launcher mounts, so an image whose configured user is not root fails
+// its first write, fails again writing the abort that would have
+// explained it, and leaves a container that exited 79 -- from which the
+// only account is "not a pair", sending an operator to re-check a digest
+// that was correct. The reason was in the container log the whole time,
+// and nothing read it.
+//
+// Best effort by construction: this runs on a path that is already
+// failing, and a log that cannot be read must not replace the error that
+// sent us here. Empty is the honest answer, and the error stands without
+// it.
+func (m *Launcher) lastWords(ctx context.Context, id string) string {
+	tail, err := m.dock.TailLogs(ctx, id, logTailLines)
+	if err != nil {
+		return ""
+	}
+	var said []string
+	for _, line := range strings.Split(strings.TrimSpace(tail), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			said = append(said, line)
+		}
+	}
+	if len(said) == 0 {
+		return ""
+	}
+	// Joined rather than kept as lines: this lands in an error that is
+	// logged and recorded as the evidence an operator reads beside a
+	// held attempt, and a multi-line value there is one field that reads
+	// as several.
+	return "; it last said: " + strings.Join(said, " / ")
 }
 
 // ErrIncompatibleImage reports a capsule that does not speak this
@@ -628,8 +671,8 @@ func (m *Launcher) awaitState(ctx context.Context, containerID string, want prot
 			// Best effort: a daemon that cannot answer this leaves the
 			// poll exactly where it was, which is the deadline below.
 			if state, serr := m.dock.ContainerStatus(ctx, containerID); serr == nil && state.Status != engine.StatusRunning {
-				return fmt.Errorf("container %s exited %d before reaching %q",
-					engine.ShortID(containerID), state.ExitCode, want)
+				return fmt.Errorf("container %s exited %d before reaching %q%s",
+					engine.ShortID(containerID), state.ExitCode, want, m.lastWords(ctx, containerID))
 			}
 		}
 		if time.Now().After(deadline) {

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -486,14 +486,15 @@ func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
 //
 // It exists because the capsule that cannot start is usually the capsule
 // that cannot say so. An image whose configured user is not root fails
-// at boot -- first creating the daemon's socket directory under a
-// root-owned /run, then writing the protocol file into the root-owned
-// tmpfs this launcher mounts -- and then fails again writing the abort
-// that would have explained either, because that goes to the same
-// unwritable tmpfs and its error is discarded. What is left is a
-// container that exited 79, from which the only account is "not a pair",
-// sending an operator to re-check a digest that was correct. The reason
-// was in the container log the whole time, and nothing read it.
+// at boot on its first real write -- creating the daemon's socket
+// directory under a root-owned /run, which returns before the protocol
+// write into the control tmpfs is ever reached -- and then fails a
+// second time writing the abort that would have explained it, onto that
+// same tmpfs this launcher mounts root-owned, where the error is
+// discarded too. What is left is a container that exited 79, from which
+// the only account is "not a pair", sending an operator to re-check a
+// digest that was correct. The reason was in the container log the whole
+// time, and nothing read it.
 //
 // Best effort by construction: this runs on a path that is already
 // failing, and a log that cannot be read must not replace the error that

--- a/internal/capsule/capsule.go
+++ b/internal/capsule/capsule.go
@@ -485,13 +485,15 @@ func (m *Launcher) awaitProtocol(ctx context.Context, outerID string) error {
 // prefixed for an error that would otherwise name only an exit code.
 //
 // It exists because the capsule that cannot start is usually the capsule
-// that cannot say so. Its control surface is a root-owned tmpfs this
-// launcher mounts, so an image whose configured user is not root fails
-// its first write, fails again writing the abort that would have
-// explained it, and leaves a container that exited 79 -- from which the
-// only account is "not a pair", sending an operator to re-check a digest
-// that was correct. The reason was in the container log the whole time,
-// and nothing read it.
+// that cannot say so. An image whose configured user is not root fails
+// at boot -- first creating the daemon's socket directory under a
+// root-owned /run, then writing the protocol file into the root-owned
+// tmpfs this launcher mounts -- and then fails again writing the abort
+// that would have explained either, because that goes to the same
+// unwritable tmpfs and its error is discarded. What is left is a
+// container that exited 79, from which the only account is "not a pair",
+// sending an operator to re-check a digest that was correct. The reason
+// was in the container log the whole time, and nothing read it.
 //
 // Best effort by construction: this runs on a path that is already
 // failing, and a log that cannot be read must not replace the error that
@@ -511,10 +513,16 @@ func (m *Launcher) lastWords(ctx context.Context, id string) string {
 	if len(said) == 0 {
 		return ""
 	}
-	// Joined rather than kept as lines: this lands in an error that is
-	// logged and recorded as the evidence an operator reads beside a
-	// held attempt, and a multi-line value there is one field that reads
-	// as several.
+	// Joined rather than kept as lines, because this lands in a
+	// structured log field and a multi-line value there is one field
+	// that reads as several.
+	//
+	// The log is as far as it goes, and that is worth being exact about:
+	// what a held attempt stores is the review reason alone --
+	// `capsule_incompatible` -- so `runpool attempts` is unchanged by
+	// this. The operator who sees the hold still goes to the controller's
+	// log to find out why, and the difference is that the answer is now
+	// there.
 	return "; it last said: " + strings.Join(said, " / ")
 }
 

--- a/internal/capsule/daemon_test.go
+++ b/internal/capsule/daemon_test.go
@@ -2,6 +2,7 @@ package capsule
 
 import (
 	"context"
+	"errors"
 
 	"github.com/rhobuild/runpool/internal/engine"
 )
@@ -14,6 +15,12 @@ type fakeDaemon struct {
 	capsuleDaemon
 	status func(id string) (engine.ContainerState, error)
 	exec   func(id string, cmd []string) (int, string, error)
+	// logs is what the container said. Unset is a daemon whose logs
+	// could not be read, which is the case every error message here was
+	// written against: the tail is an addition to a diagnosis, never the
+	// diagnosis, so a test that does not set it still asserts the whole
+	// message an operator would see without one.
+	logs func(id string, lines int) (string, error)
 }
 
 func (f *fakeDaemon) ContainerStatus(_ context.Context, id string) (engine.ContainerState, error) {
@@ -22,4 +29,11 @@ func (f *fakeDaemon) ContainerStatus(_ context.Context, id string) (engine.Conta
 
 func (f *fakeDaemon) Exec(_ context.Context, id string, cmd []string) (int, string, error) {
 	return f.exec(id, cmd)
+}
+
+func (f *fakeDaemon) TailLogs(_ context.Context, id string, lines int) (string, error) {
+	if f.logs == nil {
+		return "", errors.New("no logs")
+	}
+	return f.logs(id, lines)
 }

--- a/internal/capsule/inspect_test.go
+++ b/internal/capsule/inspect_test.go
@@ -118,3 +118,75 @@ func TestACapsuleThatDiedIsRefusedAsIncompatible(t *testing.T) {
 			"not spending it", elapsed.Round(time.Millisecond), protocolTimeout)
 	}
 }
+
+// TestACapsuleThatDiedSaysWhy: the exit code is what an operator can act
+// on only if it names something. 79 does not.
+//
+// The case this was written for is an operator's derived capsule image
+// ending `USER runner`. The published capsule stays root deliberately —
+// the supervisor is PID 1, boots the inner daemon and drops the runner
+// to uid 1001 itself — and the control surface it writes is a root-owned
+// tmpfs this launcher mounts. Under any other user the supervisor's
+// first write fails, the abort it would have written fails onto the same
+// unwritable tmpfs, and what is left is a container that exited 79 and
+// an error reading "the capsule image and this controller are not a
+// pair" — which sends an operator to re-check a digest that was correct.
+//
+// The permission denial was in the container log the whole time.
+func TestACapsuleThatDiedSaysWhy(t *testing.T) {
+	const denial = `level=ERROR msg="capsule boot failed" error="mkdir /run/runpool-docker: permission denied"`
+	m := &Launcher{dock: &fakeDaemon{
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: SupervisorAbortedExitCode}, nil
+		},
+		exec: func(string, []string) (int, string, error) {
+			return -1, "", errors.New("container is not running")
+		},
+		logs: func(string, int) (string, error) {
+			return "level=INFO msg=\"capsule starting\"\n" + denial + "\n", nil
+		},
+	}}
+
+	err := m.awaitProtocol(t.Context(), "runner-1")
+	if !errors.Is(err, ErrIncompatibleImage) {
+		t.Fatalf("error = %v; want ErrIncompatibleImage", err)
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error = %q; it has to carry what the capsule said, or the only "+
+			"account of a derived image that cannot write its own control surface "+
+			"is an exit code that names nothing", err)
+	}
+	if strings.Contains(err.Error(), "\n") {
+		t.Errorf("error = %q; it is recorded as the evidence beside a held attempt, "+
+			"and a multi-line value there is one field that reads as several", err)
+	}
+}
+
+// TestACapsuleWhoseLogsCannotBeReadStillReportsTheExit: the tail is an
+// addition to a diagnosis and never the diagnosis. A daemon that will
+// not answer for the logs must not cost the error that sent us here —
+// the path is already failing, and this is the second thing to fail on
+// it.
+func TestACapsuleWhoseLogsCannotBeReadStillReportsTheExit(t *testing.T) {
+	m := &Launcher{dock: &fakeDaemon{
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: 127}, nil
+		},
+		exec: func(string, []string) (int, string, error) {
+			return -1, "", errors.New("container is not running")
+		},
+		logs: func(string, int) (string, error) {
+			return "", errors.New("daemon is unreachable")
+		},
+	}}
+
+	err := m.awaitProtocol(t.Context(), "runner-1")
+	if !errors.Is(err, ErrIncompatibleImage) || !strings.Contains(err.Error(), "127") {
+		t.Fatalf("error = %v; want the exit code and ErrIncompatibleImage, unchanged "+
+			"by a log read that failed", err)
+	}
+	if strings.Contains(err.Error(), "last said") {
+		t.Errorf("error = %q; a log that could not be read has nothing to add, and "+
+			"an empty quotation reads as a capsule that said nothing", err)
+	}
+}

--- a/internal/capsule/observation_test.go
+++ b/internal/capsule/observation_test.go
@@ -263,6 +263,61 @@ func TestAwaitStateStopsWhenTheContainerHasExited(t *testing.T) {
 	}
 }
 
+// TestAReadinessWaitOnADeadContainerSaysWhy is the sibling of
+// TestACapsuleThatDiedSaysWhy, and exists because it was missing.
+//
+// awaitState backs every readiness wait -- the capsule's own and the
+// gateway's -- so it is at least as likely a place to meet a container
+// that died as the protocol read is. The two diagnose the same shape of
+// failure through the same helper, and only one of them was covered:
+// reverting the awaitState call site alone broke no test at all, which
+// is exactly the sibling this repository's own discipline says to check.
+func TestAReadinessWaitOnADeadContainerSaysWhy(t *testing.T) {
+	const denial = `level=ERROR msg="capsule boot failed" error="mkdir /run/runpool-docker: permission denied"`
+	d := &fakeDaemon{
+		exec: func(string, []string) (int, string, error) {
+			return 0, "", errors.New("container is not running")
+		},
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: SupervisorAbortedExitCode}, nil
+		},
+		logs: func(string, int) (string, error) { return denial + "\n", nil },
+	}
+	err := (&Launcher{dock: d}).awaitState(t.Context(), "capsule-1", protocol.StateWaiting)
+	if err == nil {
+		t.Fatal("a container that had already exited was reported as still becoming ready")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error = %q; a readiness wait that meets a dead container has to carry "+
+			"what that container said, for the same reason the protocol read does", err)
+	}
+	if strings.Contains(err.Error(), "\n") {
+		t.Errorf("error = %q; it is one line, like its sibling", err)
+	}
+}
+
+// TestACapsuleThatSaidNothingIsNotQuoted: a log that was read and was
+// empty adds nothing, and an empty quotation reads as a capsule that
+// said something blank rather than one that said nothing at all.
+func TestACapsuleThatSaidNothingIsNotQuoted(t *testing.T) {
+	d := &fakeDaemon{
+		exec: func(string, []string) (int, string, error) {
+			return 0, "", errors.New("container is not running")
+		},
+		status: func(string) (engine.ContainerState, error) {
+			return engine.ContainerState{Status: engine.StatusExited, ExitCode: 127}, nil
+		},
+		logs: func(string, int) (string, error) { return "\n  \n\n", nil },
+	}
+	err := (&Launcher{dock: d}).awaitState(t.Context(), "capsule-1", protocol.StateWaiting)
+	if err == nil {
+		t.Fatal("a container that had already exited was reported as still becoming ready")
+	}
+	if strings.Contains(err.Error(), "last said") {
+		t.Errorf("error = %q; blank lines are not something the capsule said", err)
+	}
+}
+
 // TestAnAdoptedCapsuleIsReadInItsOwnDictionary: a controller replaced
 // while capsules run adopts them, and the launch that would have checked
 // their protocol belonged to the controller before it.


### PR DESCRIPTION
## What changes

When the launcher diagnoses a container by its exit code, the error now quotes
what that container last said. Two call sites, one helper, no other behaviour.

## What was found

An operator's own capsule image is built by deriving from the published one.
The published one stays root deliberately —
[`build/capsule/Dockerfile:26-33`](build/capsule/Dockerfile:26) says why: the
supervisor is PID 1, needs root to boot the inner dockerd, and drops the runner
to uid 1001 itself, "which the image's last `USER` cannot say".

A derived image ending `USER runner` therefore breaks a contract nothing checks.
The chain, verified end to end:

1. The launcher mounts the control surface as a root-owned tmpfs —
   `Tmpfs: {"/run/runpool": "rw,size=1m,mode=0755"}`.
2. `boot()` in the supervisor does `MkdirAll` and `atomicfile.Replace` there.
   Both are `EACCES` under any other user.
3. `setState(aborted:…)` — the thing that would have *explained* it — fails onto
   the same unwritable tmpfs. Silently.
4. The process exits `79`. `awaitProtocol` execs `cat` into a dead container,
   reads the status, and returns `ErrIncompatibleImage`.
5. Every attempt on that tier is held as `capsule_incompatible`, forever, until
   the image changes.

What the operator is left with:

```text
the capsule image and this controller are not a pair:
the capsule exited 79 before declaring a control protocol
```

Every word true, and it points at the wrong thing. "Not a pair" reads as a
version or a digest mismatch, so the operator re-checks a digest that was
correct. Meanwhile this was in the container's log the whole time, and nothing
read it:

```text
level=ERROR msg="capsule boot failed" error="mkdir /run/runpool-docker: permission denied"
```

**Why quoting the capsule rather than checking the image.** A preflight that
refused a non-root `USER` before creating the container would catch this one
defect earlier — and would not have caught the next one. Quoting catches every
failure the capsule can describe, including the ones nobody has thought of, and
it needs no new engine verb, no second boot path to keep from drifting from the
real one, and no decision about whether one tier's bad image should refuse an
instance its other tiers would serve. That preflight is worth its own change;
this is the floor, and it is the part that generalises.

`logTailLines` is 5: enough for the supervisor's own account of why it stopped,
which is the last thing it logs, without pasting a boot transcript into an error
read at a glance. `internal/app/runtime.go` uses 40 for a finished runner's
output, where the whole job's tail is the point; here it is not.

## Evidence

Hermetic — the seam is what this package declares so refusals can be asked for,
and a live daemon cannot be told to lose a container's logs.

```text
go build ./... && go vet ./...          clean
go test ./... -count=1                  all packages ok
```

Mutation-verified. With `m.lastWords(...)` replaced by `""`:

```text
--- FAIL: TestACapsuleThatDiedSaysWhy
    error = "…the capsule exited 79 before declaring a control protocol";
    it has to carry what the capsule said, or the only account of a derived
    image that cannot write its own control surface is an exit code that
    names nothing
```

Two things the tests caught that would otherwise have shipped:

- **The fake daemon panicked**, because adding `TailLogs` to the seam left it
  unimplemented over a nil embedded interface. That is the seam working: a new
  operation cannot be added without every fake acknowledging it. Its default is
  now a daemon whose logs *cannot* be read, so every existing test still asserts
  the whole message an operator sees without a tail.
- **`TestNoDocCommentBelongsToAnotherDeclaration` fired.** The helper was
  inserted between `awaitProtocol`'s doc comment and `awaitProtocol`. That is the
  same mistake that test was extended to catch, catching it.

## What would notice this regressing

`TestACapsuleThatDiedSaysWhy` in `internal/capsule` fails if the tail stops
reaching the error, and asserts the result is one line — it is recorded as the
evidence beside a held attempt, and a multi-line value there is one field that
reads as several.

`TestACapsuleWhoseLogsCannotBeReadStillReportsTheExit` covers the other
direction: the tail is an addition to a diagnosis and never the diagnosis. This
runs on a path that is already failing, so a daemon that will not answer for the
logs must not cost the error that sent us there — and an empty quotation would
read as a capsule that said nothing rather than as logs nobody could fetch.

Nothing pins the `awaitState` call site separately; it is the same helper on the
same shape of failure.

## Risk, compatibility and operations

One new operation on the `capsuleDaemon` seam, which is `TailLogs` — already
implemented by the Moby adapter and already used by `internal/app` for runner
output. No new engine port surface, no new dependency, no image inspection.

It runs only after a container has been observed not running, so it adds one
daemon call to a path that is already failing and none to a healthy launch. The
call is unbounded by nothing new: it inherits the caller's context.

Container logs can contain whatever the job's image writes at boot. What is
quoted here is bounded to 5 lines from a capsule that failed before starting a
runner, so it is the supervisor's own output rather than a job's — but it is
worth stating plainly, because this reaches a stored evidence field.

No configuration, schema, migration, CLI, status API, deployment or rollback
effect. Not a decision needing an ADR: it changes what an existing error says.

## Changelog

```text
### Operations

- **A capsule that died before it could explain itself now carries what it
  said.** An operator's own capsule image is built by deriving from the
  published one, and the published one stays root deliberately: the
  supervisor is PID 1, boots the inner Docker daemon, and drops the runner
  to uid 1001 itself. A derived image ending `USER runner` cannot write the
  root-owned control surface the launcher mounts for it — so it cannot write
  the abort that would have said so either, and every attempt on that tier
  was held with an exit code and the words "the capsule image and this
  controller are not a pair", which sends an operator to re-check a digest
  that was correct. The reason was in the container's log the whole time.
  The refusal now quotes it.
```

## Notes for your reviewer

What I deliberately left alone is the image preflight. The design for it exists:
one exported `ImageVerdict` predicate in `internal/capsule` called by both the
launcher and a new `runpool doctor` check, over a new `InspectImage` verb on the
engine port — checking the configured user, the entrypoint, and an inherited
`CMD` that would become `os.Args[1]`. It carries a real open question, which is
whether one tier's bad image should fail `doctor` and refuse serve for the whole
instance or only hold that tier's own jobs. That is a maintainer's call and it
should not ride along inside a change to an error message.