### PR TITLE
fix(egress): a sandbox that closed itself says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ a version speaks for are listed in
 
 ## Unreleased
 
+### Isolation and egress
+
+- **An egress sandbox that closed itself says so.** Rediscovery runs every
+  five minutes, and a pass it cannot complete closes every gateway on the
+  host to all egress — the right answer to a policy that cannot be shown to
+  be current, and also every running job losing its network at once, for as
+  long as discovery keeps failing. The same failure refuses to let `serve`
+  start at all; once running, the only account of it was a line in the
+  controller's log. `runpool status --json` now carries `egress_sandbox`
+  with the last pass's time and, when it failed, why.
+
 ### Operations
 
 - **A release page says what changed.** The body carried the qualified commit

--- a/docs/reference/status-api.md
+++ b/docs/reference/status-api.md
@@ -15,8 +15,10 @@ them under the wrong schema.
 - **Collections are always arrays.** An empty one is `[]`, never
   `null`, so a consumer branches on length rather than presence.
 - **`null` means absent, not empty.** `disk_pressure` is `null` before
-  the monitor has run once; `discrepancies` is `null` when the daemon
-  could not be reached, which is different from finding none.
+  the monitor has run once; `egress_sandbox` is `null` before the first
+  rediscovery pass and for the whole life of an instance that maintains
+  no policy; `discrepancies` is `null` when the daemon could not be
+  reached, which is different from finding none.
 
 ## The two forms, and their discriminator
 
@@ -53,6 +55,7 @@ absent state, because the attempt it was asked about cannot exist.
 | `schema_version` | number | The state schema in use |
 | `scheduling` | object, optional | Present when status can read configuration: `mode`, `instance_parallelism`, `effective_parallelism`, `active`, `available`, `queued`, and `tiers[]` |
 | `disk_pressure` | object or null | `level`, `free_bytes`, `free_inodes`, `managed_bytes`, `measured_at` |
+| `egress_sandbox` | object or null | `last_pass_at`, and `error` when the last rediscovery failed. A non-empty `error` means every gateway on this host is closed to all egress; a `last_pass_at` that has stopped moving means the pass itself has stopped running |
 | `bindings` | array | `target_id`, `provider_kind`, `source_binding_key`, and the provider reach fields below |
 | `leases` | array | `id`, `state`, `terminal`, `attempt_id`, `project`, `runtime_name`, `evidence`, `created_at`, `resources[]`. Every live lease, plus recent finished ones — see below |
 | `leases[].resources` | array | What the lease owns on the daemon: `kind`, `role`, `name`, `lease_id`, and `state` — one of `planned`, `creating`, `present`, `cleanup_pending`, `deleting`, which is the books' account of the object rather than the daemon's |

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -239,3 +239,29 @@ func (m *diskMonitor) collectGarbage(ctx context.Context, level disk.Level) {
 // before admitting work. It is the whole of the monitor the controller
 // takes part in.
 func (s *Controller) currentPressure() disk.Level { return s.disk.current() }
+
+// recordSandboxPass writes down what the egress sandbox's last
+// rediscovery concluded.
+//
+// The pass already logs, and a log is not enough for this one. A
+// rediscovery that cannot be trusted closes every gateway to all egress
+// -- correct, and also every running job losing its network at once,
+// indefinitely, for as long as discovery keeps failing. The same failure
+// refuses to let serve start at all; once running it was invisible to
+// `runpool status`, which is the document an operator is sent to.
+//
+// The write is best effort and says so: a store that will not take this
+// must not stop the loop that maintains the policy. The failure is
+// already logged by the pass itself, so nothing is lost that was not
+// already lost.
+func (s *Controller) recordSandboxPass(ctx context.Context, cause error) {
+	pass := store.SandboxPass{At: time.Now().Unix()}
+	if cause != nil {
+		pass.Error = cause.Error()
+	}
+	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+		return tx.SetSandboxPass(pass)
+	}); err != nil {
+		s.log.Error("cannot record the sandbox rediscovery outcome", "error", err)
+	}
+}

--- a/internal/app/monitor.go
+++ b/internal/app/monitor.go
@@ -240,6 +240,12 @@ func (m *diskMonitor) collectGarbage(ctx context.Context, level disk.Level) {
 // takes part in.
 func (s *Controller) currentPressure() disk.Level { return s.disk.current() }
 
+// sandboxRecordBudget bounds the detached write below. Five seconds
+// because it is one upsert of two rows against a local file, and well
+// inside LoopStopBudget, whose claim about what a stopping loop may cost
+// this must not be the thing that falsifies.
+const sandboxRecordBudget = 5 * time.Second
+
 // recordSandboxPass writes down what the egress sandbox's last
 // rediscovery concluded.
 //
@@ -259,7 +265,15 @@ func (s *Controller) recordSandboxPass(ctx context.Context, cause error) {
 	if cause != nil {
 		pass.Error = cause.Error()
 	}
-	if err := s.store.Tx(ctx, func(tx *store.Tx) error {
+	// Detached, for the same reason closing the message sessions is: a
+	// pass can conclude and shutdown begin before this runs, and the
+	// context Watch was given is the one that just got cancelled. A
+	// failure recorded nowhere because the process was stopping is the
+	// failure most worth having recorded -- the gateways stay closed
+	// across the restart, and the next pass is five minutes away.
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sandboxRecordBudget)
+	defer cancel()
+	if err := s.store.Tx(writeCtx, func(tx *store.Tx) error {
 		return tx.SetSandboxPass(pass)
 	}); err != nil {
 		s.log.Error("cannot record the sandbox rediscovery outcome", "error", err)

--- a/internal/app/monitor_test.go
+++ b/internal/app/monitor_test.go
@@ -1,7 +1,9 @@
 package app
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,4 +203,64 @@ func TestCollectGarbageRunsWhatTheLevelObliges(t *testing.T) {
 		t.Fatalf("a soft emergency left %d free lane(s); AllFree did not reach the planner", lanes())
 	}
 	_ = loc
+}
+
+// TestASandboxFailureIsRecordedWhileTheControllerIsStopping is the
+// delivery half of the egress report: the pass concludes, and something
+// has to write that down where a reader in another process can find it.
+//
+// The context is cancelled first, deliberately. A rediscovery can fail
+// and a shutdown begin before the write runs, and the context the loop
+// was given is the one that has just been cancelled — so a write on it
+// would fail exactly when it matters most. The gateways stay closed
+// across a restart and the next pass is five minutes away, which is
+// five minutes of an operator being told nothing.
+func TestASandboxFailureIsRecordedWhileTheControllerIsStopping(t *testing.T) {
+	h := newHarness(t, 1)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	h.srv.recordSandboxPass(ctx, errors.New("host discovery: the probe could not run"))
+
+	var got *store.SandboxPass
+	if err := h.srv.store.Tx(t.Context(), func(tx *store.Tx) error {
+		var err error
+		got, err = tx.SandboxPass()
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("a rediscovery that closed every gateway recorded nothing because the " +
+			"controller was stopping; the gateways stay closed across the restart")
+	}
+	if !strings.Contains(got.Error, "the probe could not run") {
+		t.Errorf("recorded %q; it has to carry why, which is what an operator acts on", got.Error)
+	}
+	if got.At == 0 {
+		t.Error("recorded no time; a pass that stopped running is only visible as a " +
+			"timestamp that stopped moving")
+	}
+}
+
+// TestASuccessfulSandboxPassClearsTheReason: recovery has to be
+// readable. A sandbox that reopened while still reporting the failure it
+// recovered from sends an operator after a problem that is over.
+func TestASuccessfulSandboxPassClearsTheReason(t *testing.T) {
+	h := newHarness(t, 1)
+	h.srv.recordSandboxPass(t.Context(), errors.New("the probe could not run"))
+	h.srv.recordSandboxPass(t.Context(), nil)
+
+	var got *store.SandboxPass
+	if err := h.srv.store.Tx(t.Context(), func(tx *store.Tx) error {
+		var err error
+		got, err = tx.SandboxPass()
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.Error != "" {
+		t.Errorf("after a pass that succeeded the record is %+v; a sandbox that "+
+			"recovered would keep reporting the failure it recovered from", got)
+	}
 }

--- a/internal/app/serve.go
+++ b/internal/app/serve.go
@@ -400,7 +400,7 @@ func Serve(ctx context.Context, cfg *config.Config, opts Options) error {
 	loops.Add(1)
 	go func() {
 		defer loops.Done()
-		s.netSandbox.Watch(ctx)
+		s.netSandbox.Watch(ctx, s.recordSandboxPass)
 	}()
 	for _, b := range s.bindings {
 		loops.Add(1)

--- a/internal/command/statusdto.go
+++ b/internal/command/statusdto.go
@@ -45,8 +45,14 @@ type statusDoc struct {
 	SchemaVersion int            `json:"schema_version"`
 	Scheduling    *schedulingDTO `json:"scheduling,omitempty"`
 	DiskPressure  *pressureDTO   `json:"disk_pressure"`
-	Bindings      []bindingDTO   `json:"bindings"`
-	Leases        []leaseDTO     `json:"leases"`
+	// Sandbox is the egress policy's last rediscovery. It is here
+	// because a pass that fails closes every gateway on this host to all
+	// egress -- the right answer to a policy that cannot be shown to be
+	// current, and also every running job losing its network at once. It
+	// is absent on an instance that maintains no policy.
+	Sandbox  *sandboxDTO  `json:"egress_sandbox"`
+	Bindings []bindingDTO `json:"bindings"`
+	Leases   []leaseDTO   `json:"leases"`
 	// ReleasedTotal is how many finished leases the store holds, which the
 	// leases array does not say: that array carries only the most recently
 	// finished, so its length is what was reported and not what exists. A
@@ -98,6 +104,15 @@ type tierCapacityDTO struct {
 	// gates observed, and that should be visible rather than inferred from
 	// a configuration file the reader may not have.
 	CapsuleImage string `json:"capsule_image"`
+}
+
+// sandboxDTO reports the last rediscovery pass. LastPassAt is when one
+// last completed, successful or not, so a loop that stopped reporting is
+// visible as a timestamp that stopped moving -- the same way a disk
+// measurement that stopped arriving is.
+type sandboxDTO struct {
+	LastPassAt string `json:"last_pass_at"`
+	Error      string `json:"error,omitempty"`
 }
 
 type pressureDTO struct {
@@ -188,6 +203,9 @@ func statusDocument(snap store.Snapshot, cfg *config.Config, review []attemptVie
 	}
 	if cfg != nil {
 		doc.Scheduling = schedulingStatus(cfg, snap.Leases, snap.Queued, shippedCapsule)
+	}
+	if sb := snap.Sandbox; sb != nil {
+		doc.Sandbox = &sandboxDTO{LastPassAt: rfc3339(time.Unix(sb.At, 0)), Error: sb.Error}
 	}
 	if p := snap.Pressure; p != nil {
 		doc.DiskPressure = &pressureDTO{

--- a/internal/command/statusdto_test.go
+++ b/internal/command/statusdto_test.go
@@ -39,11 +39,34 @@ func TestStatusDocumentShape(t *testing.T) {
 			t.Errorf("empty collection did not serialize as []: want %s in %s", field, body)
 		}
 	}
+	// Every null the document is allowed to carry, named. A field that
+	// serializes as null and is not on this list is either a collection
+	// that lost its empty slice or a new absence nobody decided was one,
+	// and both read to a consumer as "the daemon could not be asked".
+	// instance_parallelism was on this list before anything asked for
+	// one: it is null whenever no instance-wide ceiling is configured,
+	// which is the default. The comment this replaces called
+	// disk_pressure "the one legitimate null" and was wrong when it was
+	// written -- which is what a spot-check for one field buys, and why
+	// this counts them.
+	nullable := []string{"disk_pressure", "egress_sandbox", "instance_parallelism"}
+	for _, field := range nullable {
+		// Named individually rather than counted: a field that quietly
+		// grew an omitempty would leave the count right and the key
+		// gone, and a consumer told to branch on `served` rather than on
+		// which keys exist would never see the difference.
+		if !strings.Contains(body, `"`+field+`":null`) {
+			t.Errorf("%q is absent from the document rather than null; an absence this "+
+				"document reports has to be a key with null in it, or a consumer "+
+				"cannot tell it from a field that was never specified: %s", field, body)
+		}
+	}
 	if strings.Contains(body, "null,") || strings.HasSuffix(body, "null}") {
-		// disk_pressure is the one legitimate null: an absent
-		// measurement is absent, not empty.
-		if !strings.Contains(body, `"disk_pressure":null`) {
-			t.Errorf("unexpected null in %s", body)
+		nulls := strings.Count(body, ":null")
+		if nulls != len(nullable) {
+			t.Errorf("the document carries %d nulls and %d are accounted for; an "+
+				"unlisted null is an absence nobody decided was one: %s",
+				nulls, len(nullable), body)
 		}
 	}
 	for _, upper := range []string{"InstanceID", "SourceBindingKey", "LeaseID", "AttemptID"} {

--- a/internal/netsandbox/netsandbox.go
+++ b/internal/netsandbox/netsandbox.go
@@ -319,7 +319,13 @@ func ClassifyPolicy(inForce, next []string) PolicyChange {
 // everything, and discovery that cannot be trusted at all does the same
 // for every gateway, because an undiscovered subnet is indistinguishable
 // from one that was never there.
-func (n *Manager) Watch(ctx context.Context) {
+// report is told the outcome of every completed pass, so a failure that
+// closed every gateway is recorded somewhere an operator can read from
+// another process. It is a callback rather than a store this package
+// holds: what is written down is the caller's business, and a policy
+// engine that learned persistence would be one more thing to keep out of
+// the launch path.
+func (n *Manager) Watch(ctx context.Context, report func(context.Context, error)) {
 	if n == nil {
 		return // unsafe-open-egress: there is no policy to maintain
 	}
@@ -331,7 +337,10 @@ func (n *Manager) Watch(ctx context.Context) {
 			return
 		case <-ticker.C:
 		}
-		n.rediscover(ctx)
+		err := n.rediscover(ctx)
+		if report != nil && ctx.Err() == nil {
+			report(ctx, err)
+		}
 	}
 }
 
@@ -453,10 +462,14 @@ func (n *Manager) refresh(ctx context.Context) error {
 }
 
 // rediscover is one pass, separated so a test can drive it directly.
-func (n *Manager) rediscover(ctx context.Context) {
+// rediscover returns what the pass concluded: nil when the set was
+// refreshed, and the failure that closed every gateway otherwise. A pass
+// stopped by its own context returns nil, because a shutdown is not a
+// verdict about the environment.
+func (n *Manager) rediscover(ctx context.Context) error {
 	err := n.refresh(ctx)
 	if err == nil {
-		return
+		return nil
 	}
 	if ctx.Err() != nil {
 		// The pass is being stopped, not failing. Closing every gateway
@@ -466,7 +479,7 @@ func (n *Manager) rediscover(ctx context.Context) {
 		// egress was cut, on an ordinary shutdown, for a thing that
 		// provably did not happen.
 		n.log.Info("sandbox rediscovery stopped", "reason", ctx.Err())
-		return
+		return nil
 	}
 
 	// Discovery failed. The environment may have grown a network this
@@ -474,9 +487,10 @@ func (n *Manager) rediscover(ctx context.Context) {
 	// gateway closes rather than relaying under a set that cannot be
 	// shown to be current.
 	n.log.Error("sandbox rediscovery failed; closing every gateway to all egress", "error", err)
-	if err := n.closeGateways(ctx); err != nil {
-		n.log.Error("could not close every gateway after a failed rediscovery", "error", err)
+	if closeErr := n.closeGateways(ctx); closeErr != nil {
+		n.log.Error("could not close every gateway after a failed rediscovery", "error", closeErr)
 	}
+	return err
 }
 
 // applyPolicy installs a rediscovered set, and decides what a failure

--- a/internal/netsandbox/netsandbox_test.go
+++ b/internal/netsandbox/netsandbox_test.go
@@ -474,7 +474,7 @@ func TestANilSandboxIsTheOpenProfile(t *testing.T) {
 	if sb != nil || err != nil {
 		t.Errorf("forLaunch on the open profile = (%v, %v); want no policy and no error", sb, err)
 	}
-	n.Watch(t.Context()) // returns rather than ticking forever
+	n.Watch(t.Context(), nil) // returns rather than ticking forever
 }
 
 // TestNewNetworkSandboxFailsServeClosed. The constructor is where the
@@ -1134,5 +1134,41 @@ func TestAConfirmationWaitsForAPassThatHasNotRecordedYet(t *testing.T) {
 	if got := d.payload(); !strings.Contains(got, "192.168.0.0/16") {
 		t.Errorf("the reload carried %q; it has to carry the set the pass recorded, not the "+
 			"one the launch was cut from", got)
+	}
+}
+
+// TestAFailedRediscoveryIsReported: closing every gateway is the right
+// answer to a policy that cannot be shown to be current, and it is also
+// every running job losing its network at once. The pass logs that, and
+// a log is not somewhere `runpool status` can read from -- so the
+// outcome travels out of this package to whoever is willing to write it
+// down.
+//
+// A callback rather than a store held here: what is recorded is the
+// caller's business, and a policy engine that learned persistence would
+// be one more thing to keep out of the launch path.
+func TestAFailedRediscoveryIsReported(t *testing.T) {
+	n := newTestSandbox(t, &fakeDaemon{probeErr: errors.New("the probe could not run")}, nil)
+	got := n.rediscover(t.Context())
+	if got == nil {
+		t.Fatal("a rediscovery that failed reported nothing; every gateway was closed " +
+			"to all egress and the only account of it was a log line")
+	}
+	if !strings.Contains(got.Error(), "the probe could not run") {
+		t.Errorf("reported %v; it has to carry why, which is what an operator acts on", got)
+	}
+}
+
+// TestAStoppedRediscoveryIsNotAVerdict: a pass cancelled by shutdown
+// reports nothing wrong. Recording it would tell an operator that every
+// clean stop was an egress failure, and the one that mattered would be
+// lost among them.
+func TestAStoppedRediscoveryIsNotAVerdict(t *testing.T) {
+	n := newTestSandbox(t, &fakeDaemon{probeErr: errors.New("the probe could not run")}, nil)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if got := n.rediscover(ctx); got != nil {
+		t.Errorf("a rediscovery stopped by shutdown reported %v; a clean stop is not a "+
+			"verdict about the environment", got)
 	}
 }

--- a/internal/store/report.go
+++ b/internal/store/report.go
@@ -38,6 +38,10 @@ type Snapshot struct {
 	// Pressure is the disk monitor's last persisted verdict; nil until
 	// the monitor has run once.
 	Pressure *PressureInfo
+	// Sandbox is the egress sandbox's last rediscovery pass; nil until
+	// one has completed, and nil for the whole life of an instance that
+	// maintains no policy at all.
+	Sandbox *SandboxPass
 }
 
 // BindingInfo reports one configured source of work in neutral terms.
@@ -142,6 +146,10 @@ func (s *Store) Snapshot() (Snapshot, error) {
 			return err
 		}
 		snap.Pressure, err = tx.Pressure()
+		if err != nil {
+			return err
+		}
+		snap.Sandbox, err = tx.SandboxPass()
 		return err
 	})
 	return snap, err

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -3,10 +3,17 @@ package store
 import "strconv"
 
 // The egress sandbox's last completed rediscovery pass, as two
-// instance-scoped singletons. They live in meta rather than a table of
-// their own because that is what meta is for and because a new table is
-// a migration, which this does not need: one timestamp and one reason
-// are the whole of what a reader has to know.
+// instance-scoped singletons.
+//
+// A table of their own would match this store's own precedents more
+// closely -- pressure and provider_binding_contact are both a
+// background loop's last outcome, and provider_binding_contact is this
+// exact shape, a timestamp and an error string. They are in meta anyway,
+// and the reason is not that meta is the better home: it is that a new
+// table is a migration, the baseline is immutable, and the first
+// migration this project writes will meet deployed v1.0.0 databases.
+// Spending that on one timestamp and one reason is the wrong trade. If
+// this ever needs a third field, it should take the table instead.
 const (
 	sandboxPassAtKey    = "sandbox_pass_at"
 	sandboxPassErrorKey = "sandbox_pass_error"

--- a/internal/store/sandbox.go
+++ b/internal/store/sandbox.go
@@ -1,0 +1,56 @@
+package store
+
+import "strconv"
+
+// The egress sandbox's last completed rediscovery pass, as two
+// instance-scoped singletons. They live in meta rather than a table of
+// their own because that is what meta is for and because a new table is
+// a migration, which this does not need: one timestamp and one reason
+// are the whole of what a reader has to know.
+const (
+	sandboxPassAtKey    = "sandbox_pass_at"
+	sandboxPassErrorKey = "sandbox_pass_error"
+)
+
+// SandboxPass is the outcome of the sandbox's last rediscovery.
+//
+// It is durable for the reason the disk verdict is: the pass runs inside
+// the controller and the operator reads from another process, so an
+// outcome kept in memory is an outcome nobody can be told about. And the
+// failure it records is not a degraded one -- a rediscovery that cannot
+// be trusted closes every gateway to all egress, which is correct and
+// is also every running job losing its network at once.
+type SandboxPass struct {
+	// At is when the pass completed, successful or not.
+	At int64
+	// Error is why it failed, and empty when it did not. A non-empty
+	// value means every gateway on this host was closed to all egress.
+	Error string
+}
+
+// SetSandboxPass records the outcome of one rediscovery pass.
+func (t *Tx) SetSandboxPass(p SandboxPass) error {
+	if err := t.metaSet(sandboxPassAtKey, strconv.FormatInt(p.At, 10)); err != nil {
+		return err
+	}
+	return t.metaSet(sandboxPassErrorKey, p.Error)
+}
+
+// SandboxPass returns the last recorded outcome, or nil when no pass has
+// ever completed -- which a reader must treat as unknown rather than as
+// healthy, the same way an absent disk verdict is not "normal".
+func (t *Tx) SandboxPass() (*SandboxPass, error) {
+	at, err := t.metaGet(sandboxPassAtKey)
+	if err != nil || at == "" {
+		return nil, err
+	}
+	seconds, err := strconv.ParseInt(at, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	reason, err := t.metaGet(sandboxPassErrorKey)
+	if err != nil {
+		return nil, err
+	}
+	return &SandboxPass{At: seconds, Error: reason}, nil
+}

--- a/internal/store/sandbox_test.go
+++ b/internal/store/sandbox_test.go
@@ -1,0 +1,61 @@
+package store
+
+import "testing"
+
+// TestNoSandboxPassIsNotAHealthyOne: absent and healthy are different
+// answers, and the difference matters more here than in most places. An
+// instance that has never completed a pass is one whose gateways are in
+// whatever state its startup left them, and a reader told "no error" is
+// told the pass ran and found nothing wrong.
+func TestNoSandboxPassIsNotAHealthyOne(t *testing.T) {
+	s := newStore(t)
+	var got *SandboxPass
+	inTx(t, s, func(tx *Tx) error {
+		var err error
+		got, err = tx.SandboxPass()
+		return err
+	})
+	if got != nil {
+		t.Errorf("a store with no pass reported %+v; want nil, which a reader has to "+
+			"treat as unknown rather than as a pass that found nothing", got)
+	}
+}
+
+// TestTheLastSandboxPassIsWhatIsRead: the record is a singleton, so a
+// pass replaces the one before it. A reader that saw the first failure
+// forever would send an operator after a gateway that reopened an hour
+// ago.
+func TestTheLastSandboxPassIsWhatIsRead(t *testing.T) {
+	s := newStore(t)
+	write := func(p SandboxPass) {
+		t.Helper()
+		inTx(t, s, func(tx *Tx) error { return tx.SetSandboxPass(p) })
+	}
+	read := func() *SandboxPass {
+		t.Helper()
+		var got *SandboxPass
+		inTx(t, s, func(tx *Tx) error {
+			var err error
+			got, err = tx.SandboxPass()
+			return err
+		})
+		return got
+	}
+
+	write(SandboxPass{At: 1000, Error: "the probe could not run"})
+	if got := read(); got == nil || got.At != 1000 || got.Error != "the probe could not run" {
+		t.Fatalf("read back %+v; want the failure that was written", got)
+	}
+	// Recovery has to be readable, not only failure. A pass that
+	// succeeds must clear the reason, or a gateway that reopened still
+	// reports as closed.
+	write(SandboxPass{At: 2000})
+	got := read()
+	if got == nil || got.At != 2000 {
+		t.Fatalf("read back %+v; want the later pass", got)
+	}
+	if got.Error != "" {
+		t.Errorf("a successful pass left %q behind; a sandbox that recovered would "+
+			"keep reporting the failure it recovered from", got.Error)
+	}
+}


### PR DESCRIPTION
## What changes

`runpool status --json` gains `egress_sandbox`: when the sandbox's rediscovery
last completed, and why it failed if it did. The pass reports its outcome
outward; the controller writes it down. Nothing about the fail-closed behaviour
changes.

## What was found

`internal/netsandbox`'s `Watch` reruns discovery every five minutes. A pass it
cannot complete calls `closeGateways`, which shuts **every gateway on the host**
to all egress. That is correct, and the comment beside it argues why: an
undiscovered subnet is indistinguishable from one that was never there, so
relaying under a set that cannot be shown to be current is worse than relaying
nothing.

It is also every running job losing its network at once — indefinitely, for as
long as discovery keeps failing. **The only account of it was a log line.**

**The asymmetry is what makes this a defect rather than a gap.** The identical
failure refuses to let `serve` start — *"a capsule must never launch with a
partial policy"* — but once running, the same failure was invisible to
`runpool status`, which is the document an operator is sent to for everything
else. A host can be silently unable to run any network-touching job while its
status reports nothing wrong.

It was found by enumerating this controller's background loops mechanically from
`serve.go`'s own `loops.Add(1)` convention rather than by looking where problems
had already been found. There are five; this was the only one with no durable
trace of its own outcome.

## Evidence

Hermetic. The failing pass is exercised through the package's existing fake
daemon rather than a live one.

```text
go build ./... && go vet ./...          clean
go test ./... -count=1                  all packages ok
runpool status --json (unrun instance)  unchanged: still the short form
```

Mutation-verified. Restoring `rediscover` to swallow its error:

```text
--- FAIL: TestAFailedRediscoveryIsReported
    a rediscovery that failed reported nothing; every gateway was closed
    to all egress and the only account of it was a log line
```

One thing the tests caught: my first assertion named the wrong failure. The fake
daemon's `listErr` fails at a later stage than I assumed, so the error carried
was the probe's, not the daemon's — the reporting worked and the assertion was
wrong about which error it would see. It now uses `probeErr`, whose message the
test controls.

## What would notice this regressing

`TestAFailedRediscoveryIsReported` fails if `rediscover` stops returning what it
concluded. `TestAStoppedRediscoveryIsNotAVerdict` covers the other direction: a
pass cancelled by shutdown reports nothing wrong, because recording it would tell
an operator that every clean stop was an egress failure and bury the one that was
not.

Nothing pins the controller's side — that `recordSandboxPass` is what
`Watch` is given. It is one call site in `serve.go` beside the other four loops.

## Risk, compatibility and operations

**The security behaviour is untouched.** `rediscover` returns what it had already
decided; the close still happens, still first, still logged. The only additions
are a return value and a callback the caller may pass as nil.

**No migration.** The two values are instance-scoped singletons in `meta`, which
is what `meta` is for. A new table would have been the first migration to run
against real v1.0.0 databases, and this does not need one.

**Status API**: `egress_sandbox` is additive within `v1`, and it is `null` — not
absent — before the first pass and for the whole life of an instance under
`unsafe-open-egress`, which is the convention `disk_pressure` already keeps. The
reference documents both the field and the null case.

`internal/netsandbox` still imports no store and the architecture roster is
unchanged: what gets written down is the caller's business. A policy engine that
learned persistence is one more thing to keep out of the launch path.

The write is best effort and says so in the code: a store that will not take it
must not stop the loop that maintains the policy. The failure is already logged
by the pass itself.

One store write every five minutes, on a loop that already talks to the daemon.

## Changelog

```text
### Isolation and egress

- **An egress sandbox that closed itself says so.** Rediscovery runs every
  five minutes, and a pass it cannot complete closes every gateway on the
  host to all egress — the right answer to a policy that cannot be shown to
  be current, and also every running job losing its network at once, for as
  long as discovery keeps failing. The same failure refuses to let `serve`
  start at all; once running, the only account of it was a line in the
  controller's log. `runpool status --json` now carries `egress_sandbox`
  with the last pass's time and, when it failed, why.
```

## Notes for your reviewer

This exists because a review of the metrics decision (#142) kept finding
conditions its watching list did not cover. Three of those were the list not
having caught up to fields the status document already had. This one was not:
the data did not exist anywhere, which is why it is code rather than another
table row.

`#142` stays open until this merges, because its record claims every condition
needing a person is in `status --json`, and that claim is false without this.