### PR TITLE
test(gateway): the race test waits for its race instead of hoping for it

### DIFF
--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -744,6 +745,15 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 	var mu sync.Mutex
 	served := map[uint64]*http.Transport{}
 
+	// installed counts the policies that have actually landed. The
+	// readers below wait on it rather than on a fixed number of their
+	// own iterations, because a reader here never blocks: it is a map
+	// read and an atomic load, so on a host with fewer cores than this
+	// test has goroutines the installer can be starved for the whole run
+	// and every reader finish having seen one generation. That is what
+	// the guard at the end catches, and catching it is the test failing
+	// rather than the code.
+	var installed atomic.Uint64
 	stop := make(chan struct{})
 	var installers sync.WaitGroup
 	installers.Add(1)
@@ -756,15 +766,27 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 			default:
 			}
 			install(fmt.Sprintf("10.%d.0.0/16", i%256))
+			installed.Add(1)
 		}
 	}()
 
+	// The deadline is the whole test's, not one reader's: it bounds a
+	// starved installer into a failure that says so instead of a hang.
+	deadline := time.Now().Add(30 * time.Second)
 	var readers sync.WaitGroup
 	for range 8 {
 		readers.Add(1)
 		go func() {
 			defer readers.Done()
-			for range 400 {
+			// At least 400 reads, and not finished until the policy has
+			// moved twice under this reader. Twice and not once: one
+			// install may have landed before the first read, which would
+			// leave the reader having seen a single generation again.
+			from := installed.Load()
+			for reads := 0; reads < 400 || installed.Load() < from+2; reads++ {
+				if time.Now().After(deadline) {
+					return
+				}
 				got := r.transportInForce()
 				mu.Lock()
 				if prev, seen := served[got.gen]; seen && prev != got.transport {
@@ -773,6 +795,11 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 				}
 				served[got.gen] = got.transport
 				mu.Unlock()
+				// Nothing in this loop blocks, so nothing yields. On a
+				// host with fewer cores than this test has goroutines,
+				// that is enough to keep the installer off a processor
+				// for the whole run.
+				runtime.Gosched()
 			}
 		}()
 	}
@@ -781,8 +808,9 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 	installers.Wait()
 
 	if len(served) < 2 {
-		t.Fatalf("only %d generation(s) were observed; the policy never moved under the readers "+
-			"and the race this rules out was never given a chance", len(served))
+		t.Fatalf("only %d generation(s) were observed in %s; the policy never moved under the "+
+			"readers and the race this rules out was never given a chance",
+			len(served), 30*time.Second)
 	}
 }
 

--- a/internal/gateway/proxy_test.go
+++ b/internal/gateway/proxy_test.go
@@ -745,7 +745,14 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 	var mu sync.Mutex
 	served := map[uint64]*http.Transport{}
 
-	// installed counts the policies that have actually landed. The
+	// installed counts the installer's attempts, not the generations any
+	// reader saw: the store advances a generation when a caller observes
+	// a changed file, so two writes with no read between them still move
+	// it once. That is fine for what this is used for -- it is how a
+	// reader knows the installer is running at all, and the count of
+	// generations actually observed is asserted separately at the end,
+	// unconditionally, which is what makes the answer true rather than
+	// this. The
 	// readers below wait on it rather than on a fixed number of their
 	// own iterations, because a reader here never blocks: it is a map
 	// read and an atomic load, so on a host with fewer cores than this
@@ -770,9 +777,13 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 		}
 	}()
 
-	// The deadline is the whole test's, not one reader's: it bounds a
+	// The budget is the whole test's, not one reader's: it bounds a
 	// starved installer into a failure that says so instead of a hang.
-	deadline := time.Now().Add(30 * time.Second)
+	// Named because the message at the end quotes it, and a second
+	// literal there would keep saying thirty seconds after someone
+	// changed this one.
+	const readerBudget = 30 * time.Second
+	deadline := time.Now().Add(readerBudget)
 	var readers sync.WaitGroup
 	for range 8 {
 		readers.Add(1)
@@ -810,7 +821,7 @@ func TestConcurrentReadersNeverSplitThePoolFromItsGeneration(t *testing.T) {
 	if len(served) < 2 {
 		t.Fatalf("only %d generation(s) were observed in %s; the policy never moved under the "+
 			"readers and the race this rules out was never given a chance",
-			len(served), 30*time.Second)
+			len(served), readerBudget)
 	}
 }
 


### PR DESCRIPTION
## What changes

`TestConcurrentReadersNeverSplitThePoolFromItsGeneration` no longer depends on
goroutine scheduling to reach the state it measures. Test-only.

## What was found

CI failed this on a **documentation-only** branch:

```text
--- FAIL: TestConcurrentReadersNeverSplitThePoolFromItsGeneration
    proxy_test.go:784: only 1 generation(s) were observed; the policy never
    moved under the readers and the race this rules out was never given a chance
```

The guard did exactly its job. It refuses to pass without having measured
anything, so what it caught was the test rather than the code — which is the
right failure to have, and still a red build on a branch that changed no Go.

Locally the readers see **around four hundred** generations against a required
two — a margin of two hundred times. Observing *one* is not a slow installer; it
is an installer that never ran.

That is reachable, and the reason is in the readers: nothing in one blocks. It is
a map read and an atomic load, eight goroutines deep, four hundred iterations
each, so nothing ever yields. On a host with fewer cores than the test has
goroutines, the installer can be kept off a processor for the whole run.

## Evidence

The diagnosis is reproducible, which is the part worth checking:

```text
main, GOMAXPROCS=1, -race, 10 runs        1 failure
this branch, GOMAXPROCS=1, -race, 10 runs 0 failures
this branch, -race -shuffle=on, 20 runs   0 failures
go test ./... -count=1                    all packages ok
```

Instrumented on main to size the margin before changing anything — six runs
observed 394, 457, 430, 379, 426 and 413 generations. That is what made "the
installer never ran" the diagnosis rather than "the installer was slow".

## What would notice this regressing

The guard itself, unchanged in intent: fewer than two generations still fails,
and now says how long it waited. The difference is that reaching two is no longer
left to the scheduler — each reader runs at least its four hundred reads *and* is
not finished until the policy has moved twice under it.

Twice rather than once, because one install may have landed before a reader's
first read, which would leave that reader having seen a single generation again.

A whole-test deadline turns a genuinely starved installer into a failure that
says so instead of a hang.

## Risk, compatibility and operations

Test-only: `internal/gateway/proxy_test.go`. No product code, no configuration,
schema, CLI, status API, deployment or rollback effect. What the test asserts is
unchanged — a generation served by two pools is still the failure it hunts.

The added `runtime.Gosched()` is what lets the installer onto a processor at all
on a constrained host; without it the new wait would be a spin.

Worst case is now a 30-second wait before failing, against an immediate failure
before. That is the cost of telling a starved installer apart from a passing run,
and it is only paid on a host where the test could not run correctly anyway.

## Changelog

```text
NONE
```

## Notes for your reviewer

This is not from the area the rest of this week's work touched. It surfaced
because it blocked an unrelated merge, and re-running the job would have hidden
it — which is the same trade as the registry retries: a transient failure nobody
fixes is a release cycle someone loses later.

Worth checking that thirty seconds is enough on the slowest runner in the matrix,
and that requiring two installs per reader cannot deadlock if the installer dies.