### PR TITLE
chore(release): the changelog names v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes, newest first. Runpool follows
 a version speaks for are listed in
 [the product contract](docs/product-contract.md).
 
-## Unreleased
+## v1.2.0 — 2026-08-28
 
 Two failures that a host could suffer in silence now report themselves: an
 egress sandbox that closed every gateway, and a binding that can no longer


### PR DESCRIPTION
## What changes

`## Unreleased` becomes `## v1.2.0 — 2026-08-28`. One line.

## What was found

Nothing — this is the release-prep commit the gate requires. `release.yml`'s
`validate` job reads the newest `## ` heading and refuses a tag it does not
name, so the rename has to land before the tag and cannot be part of it.

Em dash (U+2014), matching `v1.1.0` and `v1.0.0`.

## Evidence

The whole `validate` step, extracted and run against the real file exactly as
the tag will see it:

```text
gate: the changelog names v1.2.0
stray links: none
lead: 699 bytes
delimiter: clear
detail: 70 lines
body: 5518 bytes of changelog (limit 125000)
  pinned: …/blob/v1.2.0/docs/runbook.md
  pinned: …/blob/v1.2.0/docs/adrs/2026-08-28-the-status-document-is-the-metrics-interface.md
```

`go test ./... -count=1`, `gofmt`, `go vet`, `staticcheck` and `actionlint` are
clean on the branch.

## What would notice this regressing

`TestTheNewestChangelogSectionCouldBeReleased` in `test/consistency` runs the
shape half of that gate on every pull request — summary present, links pinnable,
no delimiter collision. The version match itself needs a tag and is checked by
`validate`.

## Risk, compatibility and operations

Documentation only. No code, configuration, schema, CLI, status API, deployment
or rollback effect.

**After this merges the tag is the next action, and the tag is what needs the
qualification host.** `publish` depends on `qualify`, which runs on the
self-hosted release-qualification runner; no runner is registered right now, so
a tag pushed today would build candidates and stop. That is a maintainer step,
not something this change can carry.

## Changelog

```text
NONE
```

## Notes for your reviewer

This is the last change before the tag. Everything the three pre-release sweeps
and six security reviews found is already on `main`; this only names the
section they filled.