### PR TITLE
fix(release): the job that calls the helper has the tree it lives in

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,6 +270,14 @@ jobs:
     outputs:
       reference: ${{ steps.index.outputs.reference }}
     steps:
+      # This job assembles an index out of digests other jobs pushed, so
+      # it wants nothing from the tree -- except that the command it
+      # assembles them with now runs through a helper that lives in it.
+      - name: Check out the tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
       - name: Download the per-platform digests
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,11 @@ jobs:
       # This job assembles an index out of digests other jobs pushed, so
       # it wants nothing from the tree -- except that the command it
       # assembles them with now runs through a helper that lives in it.
+      #
+      # Before the download below, and that ordering is load-bearing:
+      # checkout cleans the workspace, so the same step placed after it
+      # would delete the digests this job exists to read and leave the
+      # assembly with nothing, which is not what the failure would say.
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -587,5 +587,7 @@ func TestEveryJobThatCallsTheHelperHasTheTreeItLivesIn(t *testing.T) {
 	if checked == 0 {
 		t.Fatal("no job calls the helper, so this proves nothing")
 	}
-	t.Logf("%d jobs call %s, all with the tree", checked, helperPath)
+	if !t.Failed() {
+		t.Logf("%d jobs call %s, all with the tree", checked, helperPath)
+	}
 }

--- a/test/consistency/consistency_test.go
+++ b/test/consistency/consistency_test.go
@@ -444,6 +444,11 @@ func TestTheDeploymentSaysWhichHealthModeItWires(t *testing.T) {
 // `docker image inspect` is local and absent on purpose.
 var registryCommand = regexp.MustCompile(`docker (build|push|pull) |docker buildx imagetools `)
 
+// helperPath is the retry wrapper, named once because two tests
+// reason about it: one about which commands go through it, and one
+// about which jobs can find it.
+const helperPath = "scripts/ci/retry.sh"
+
 // TestEveryRegistryCommandIsRetried: four release cycles were lost to
 // registries answering badly, and nothing asked twice.
 //
@@ -466,10 +471,9 @@ func TestEveryRegistryCommandIsRetried(t *testing.T) {
 		t.Fatal("no workflow runs anything, so this proves nothing")
 	}
 
-	const helper = "scripts/ci/retry.sh"
-	info, err := os.Stat(repoPath(helper))
+	info, err := os.Stat(repoPath(helperPath))
 	if err != nil {
-		t.Fatalf("%s is missing, and every workflow calls it: %v", helper, err)
+		t.Fatalf("%s is missing, and every workflow calls it: %v", helperPath, err)
 	}
 	// Present is not enough. The workflows invoke it as a path, not
 	// through an interpreter, so a helper that lost its execute bit --
@@ -477,7 +481,7 @@ func TestEveryRegistryCommandIsRetried(t *testing.T) {
 	// exists, reads correctly, and fails every step that calls it.
 	if info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("%s is not executable (mode %v); every step calling it would fail to start",
-			helper, info.Mode().Perm())
+			helperPath, info.Mode().Perm())
 	}
 
 	found := 0
@@ -502,9 +506,9 @@ func TestEveryRegistryCommandIsRetried(t *testing.T) {
 					continue
 				}
 				found++
-				if !strings.Contains(line, helper) {
+				if !strings.Contains(line, helperPath) {
 					t.Errorf("%s reaches a registry without %s:\n    %s",
-						rel(workflow), helper, strings.TrimSpace(line))
+						rel(workflow), helperPath, strings.TrimSpace(line))
 				}
 			}
 		}
@@ -512,4 +516,76 @@ func TestEveryRegistryCommandIsRetried(t *testing.T) {
 	if found == 0 {
 		t.Fatal("no workflow reaches a registry, so this proves nothing")
 	}
+}
+
+// TestEveryJobThatCallsTheHelperHasTheTreeItLivesIn.
+//
+// `scripts/ci/retry.sh` is a file in this repository, so a job that
+// calls it and does not check the repository out gets exit 127 and a
+// message about a missing file — not about the registry command it was
+// wrapping.
+//
+// TestEveryRegistryCommandIsRetried cannot see this. It reads the
+// workflows for commands that reach a registry and asks whether each
+// one goes through the helper; whether the job around it has the helper
+// on disk is a different question, and one no amount of reading the
+// command answers.
+//
+// It has already cost a release. `capsule-index` assembles an index out
+// of digests other jobs pushed, so it wanted nothing from the tree and
+// checked nothing out — until the command it assembles them with was
+// routed through a file that only exists there. The tag was cut, four
+// jobs passed, and the fifth could not find a shell script.
+func TestEveryJobThatCallsTheHelperHasTheTreeItLivesIn(t *testing.T) {
+	workflows, err := filepath.Glob(repoPath(".github", "workflows", "*.y*ml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workflows) == 0 {
+		t.Fatal("no workflows found, so this proves nothing")
+	}
+
+	checked := 0
+	for _, path := range workflows {
+		var doc struct {
+			Jobs map[string]struct {
+				Steps []struct {
+					Uses string `yaml:"uses"`
+					Run  string `yaml:"run"`
+				} `yaml:"steps"`
+			} `yaml:"jobs"`
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := yaml.Unmarshal(body, &doc); err != nil {
+			t.Fatalf("%s: %v", filepath.Base(path), err)
+		}
+		for name, job := range doc.Jobs {
+			calls, checksOut := false, false
+			for _, step := range job.Steps {
+				if strings.Contains(step.Run, helperPath) {
+					calls = true
+				}
+				if strings.HasPrefix(step.Uses, "actions/checkout@") {
+					checksOut = true
+				}
+			}
+			if !calls {
+				continue
+			}
+			checked++
+			if !checksOut {
+				t.Errorf("%s: job %q calls %s and checks nothing out. The helper is a file "+
+					"in this repository, so the step exits 127 naming a missing script "+
+					"rather than whatever it was wrapping",
+					filepath.Base(path), name, helperPath)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no job calls the helper, so this proves nothing")
+	}
+	t.Logf("%d jobs call %s, all with the tree", checked, helperPath)
 }


### PR DESCRIPTION
## What changes

`capsule-index` checks the repository out. A consistency test refuses any job
that calls `scripts/ci/retry.sh` without doing so.

## What was found

The `v1.2.0` tag was cut and the release stopped:

```text
scripts/ci/retry.sh: No such file or directory
##[error]Process completed with exit code 127
```

`capsule-index` assembles an index out of digests the per-platform jobs pushed.
It wanted nothing from the tree and checked nothing out — correct, until #138
routed its `imagetools` calls through a helper that is a file in the tree.
Four jobs passed and the fifth could not find a shell script.

**`TestEveryRegistryCommandIsRetried` could not have caught this, and is not at
fault.** It reads the workflows for commands that reach a registry and asks
whether each goes through the helper. Whether the job *around* a command has
that helper on disk is a different question, and no amount of reading the
command answers it.

Twenty-one jobs call the helper. Twenty had a checkout for their own reasons;
this was the only one that never needed one.

## Evidence

```text
before   release.yml capsule-index: calls the helper, checks nothing out
after    21 jobs call scripts/ci/retry.sh, all with the tree
```

Mutation-verified: removing the checkout again fails the new test naming the
file and the job.

```text
--- FAIL: TestEveryJobThatCallsTheHelperHasTheTreeItLivesIn
    release.yml: job "capsule-index" calls scripts/ci/retry.sh and checks
    nothing out. The helper is a file in this repository, so the step exits
    127 naming a missing script rather than whatever it was wrapping
```

`go tool actionlint`, `go test ./... -count=1`, `gofmt`, `go vet` clean.

## What would notice this regressing

`TestEveryJobThatCallsTheHelperHasTheTreeItLivesIn` in `test/consistency`, on
every pull request. It fatals rather than passing if no job calls the helper at
all.

## Risk, compatibility and operations

One `actions/checkout` in one job, pinned to the same SHA every other checkout
in this workflow uses, with `persist-credentials: false` like the rest. The job
gains a few seconds and a working copy it does not otherwise read.

No product code. No configuration, schema, CLI, status API or deployment effect.

**The `v1.2.0` tag was cut against the broken tree and has to go before this can
be released under that version.** It published nothing — the failure is before
the index exists, so no digest was promoted, no attestation signed, no release
created. Only per-platform candidate tags reached GHCR, which are not the
release.

## Changelog

```text
NONE
```

## Notes for your reviewer

This is the shape the retry work was about, arriving from the other side: a
failure that costs a release cycle, found by the release rather than before it.
The retry helper exists because four cycles were lost to transient failures;
this one was not transient, and the cost was the same.