### PR TITLE
fix: what this release cycle cost, in the two places it was knowable

### DIFF
--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -110,6 +110,19 @@ jobs:
           permission-contents: read
           permission-organization-self-hosted-runners: write
 
+      # Before the suite, because the suite is eight minutes long and a
+      # fixture that is not installed is knowable in five seconds. The
+      # last release cycle was spent finding one of these from a single
+      # test, after the tag had been cut.
+      - name: Verify the installed fixtures
+        env:
+          RUNPOOL_CONTRACT_ORG_URL: ${{ vars.RUNPOOL_CONTRACT_ORG_URL }}
+          RUNPOOL_CONTRACT_ORG_TOKEN: ${{ steps.org-token.outputs.token }}
+          RUNPOOL_CONTRACT_REPO_A: ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
+          RUNPOOL_CONTRACT_REPO_B: ${{ vars.RUNPOOL_CONTRACT_REPO_B }}
+          RUNPOOL_CONTRACT_QUALIFY: ${{ inputs.qualify && '1' || '' }}
+        run: go test ./test/contract/githubactions/ -count=1 -run TestEveryFixtureThisSuiteReadsIsInstalled -v
+
       - name: Run the upstream contracts
         # The suite creates its own scale sets and removes them through
         # t.Cleanup, including on failure, so a run leaves the fixture

--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -121,7 +121,16 @@ jobs:
           RUNPOOL_CONTRACT_REPO_A: ${{ vars.RUNPOOL_CONTRACT_REPO_A }}
           RUNPOOL_CONTRACT_REPO_B: ${{ vars.RUNPOOL_CONTRACT_REPO_B }}
           RUNPOOL_CONTRACT_QUALIFY: ${{ inputs.qualify && '1' || '' }}
-        run: go test ./test/contract/githubactions/ -count=1 -run TestEveryFixtureThisSuiteReadsIsInstalled -v
+        run: |
+          check=TestEveryFixtureThisSuiteReadsIsInstalled
+          # `go test -run` that matches nothing exits 0, so a rename of
+          # the function would leave this step green and this gate gone.
+          # The name has to appear in the output, not only in the flag.
+          go test ./test/contract/githubactions/ -count=1 -run "$check" -v | tee fixture-check.log
+          grep -q "^=== RUN   $check\$" fixture-check.log || {
+            echo "$check did not run; it was renamed or removed, and this step was gating nothing" >&2
+            exit 1
+          }
 
       - name: Run the upstream contracts
         # The suite creates its own scale sets and removes them through

--- a/docs/maintainers/qualification-host.md
+++ b/docs/maintainers/qualification-host.md
@@ -118,9 +118,12 @@ su - runner -c 'cd ~/actions-runner && ./config.sh --url <repository> \
 cd /home/runner/actions-runner && ./svc.sh install runner && ./svc.sh start
 ```
 
-Put it in a runner group restricted to this repository, and never let it accept
-pull-request jobs: a pull request is code from outside, and this agent runs it
-next to a privileged daemon.
+Registered against the repository rather than the organization, which is
+what confines it: runner groups are an organization-level feature and do
+not exist for a repository-scoped runner, so there is no group to put this
+one in and nothing else can select it. Never let it accept pull-request
+jobs: a pull request is code from outside, and this agent runs it next to
+a privileged daemon.
 
 ## Capturing and freezing the reference
 

--- a/docs/maintainers/qualification-host.md
+++ b/docs/maintainers/qualification-host.md
@@ -90,11 +90,32 @@ apt-mark hold docker-ce docker-ce-cli containerd.io
 systemctl disable --now unattended-upgrades 2>/dev/null || true
 ```
 
-Then the runner agent, version 2.327.1 or newer, registered to this repository
-with the labels the qualification jobs select on:
+Then the runner agent, version 2.327.1 or newer. It refuses to configure
+as root, and this host is administered as root, so it belongs to a user of
+its own — `runner`, in the `docker` group, which is also the uid the capsule
+drops its workload to:
+
+```bash
+useradd -m -s /bin/bash -G docker runner
+su - runner -c 'mkdir -p ~/actions-runner && cd ~/actions-runner &&
+  curl -fsSL -o runner.tar.gz \
+    https://github.com/actions/runner/releases/download/v2.327.1/actions-runner-linux-x64-2.327.1.tar.gz &&
+  tar xzf runner.tar.gz && rm runner.tar.gz'
+```
+
+Register it with the labels the qualification jobs select on. `config.sh`
+supplies the first three itself and not the fourth, and a runner missing it
+takes no jobs and reports nothing wrong — the workflows simply queue for a
+runner that never answers:
 
 ```
 self-hosted, linux, x64, runpool-release-qualification
+```
+
+```bash
+su - runner -c 'cd ~/actions-runner && ./config.sh --url <repository> \
+  --token <registration token> --labels runpool-release-qualification --unattended'
+cd /home/runner/actions-runner && ./svc.sh install runner && ./svc.sh start
 ```
 
 Put it in a runner group restricted to this repository, and never let it accept

--- a/test/contract/githubactions/fixtures_test.go
+++ b/test/contract/githubactions/fixtures_test.go
@@ -1,0 +1,94 @@
+package githubcontract
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// installedFixtures maps each versioned fixture to the repositories that
+// must carry it, by the environment variable naming each.
+//
+// It is written out rather than derived because the mapping is a fact
+// about the fixture organisation, not about this tree: identity and the
+// organization cache probe both targets, and label routing dispatches
+// into the first only.
+var installedFixtures = map[string][]string{
+	"identity.yml":           {envRepoA, envRepoB},
+	"organization-cache.yml": {envRepoA, envRepoB},
+	"label-routing.yml":      {envRepoA},
+}
+
+// TestEveryFixtureThisSuiteReadsIsInstalled fails in seconds, naming
+// every fixture that is missing or has drifted, before anything
+// dispatches.
+//
+// Each test that uses a fixture already verifies its own copy — that is
+// the check that must never be removed, because it runs against the file
+// the dispatch is about to use. This one exists for when it fails: a
+// missing fixture surfaced eight minutes into a release, from one test,
+// naming one file, after the tag had been cut. The same absence is
+// knowable in five seconds and can name all of them at once.
+//
+// It is also the check a maintainer can run before cutting a tag, which
+// is the point: the fixtures live in other repositories, and nothing in
+// this one can otherwise say whether they are there.
+func TestEveryFixtureThisSuiteReadsIsInstalled(t *testing.T) {
+	_, token := target(t, envOrgURL, envOrgToken)
+	rest := newRESTClient(token)
+	ctx := testCtx(t)
+
+	files, err := filepath.Glob(filepath.Join("testdata", "*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no versioned fixtures found, so this proves nothing")
+	}
+
+	checked := 0
+	for _, path := range files {
+		name := filepath.Base(path)
+		repos, mapped := installedFixtures[name]
+		if !mapped {
+			t.Errorf("testdata/%s is versioned here and no test says which repository "+
+				"carries it. A fixture nothing installs is one a suite skips or fails "+
+				"on, and neither says so until it runs", name)
+			continue
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := sha256.Sum256(body)
+
+		for _, which := range repos {
+			repo := os.Getenv(which)
+			if repo == "" {
+				if os.Getenv(envQualify) != "" {
+					t.Fatalf("release qualification requires %s; the fixtures it names "+
+						"cannot be checked", which)
+				}
+				t.Skipf("%s not set; the fixture check is opt-in", which)
+			}
+			checked++
+			got, err := rest.installedFixtureDigest(ctx, repo, ".github/workflows/"+name)
+			if err != nil {
+				t.Errorf("%s is not installed on %s: %v\n    install testdata/%s there, "+
+					"byte for byte", name, repo, err, name)
+				continue
+			}
+			if got != hex.EncodeToString(want[:]) {
+				t.Errorf("%s on %s has drifted from testdata/%s; the suite would measure a "+
+					"workflow this repository no longer describes", name, repo, name)
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no fixture was checked against any repository, so this proves nothing")
+	}
+	t.Logf("%d installed fixtures match %s", checked, fmt.Sprintf("%d versioned files", len(files)))
+}

--- a/test/contract/githubactions/fixtures_test.go
+++ b/test/contract/githubactions/fixtures_test.go
@@ -13,11 +13,16 @@ import (
 // must carry it, by the environment variable naming each.
 //
 // It is written out rather than derived because the mapping is a fact
-// about the fixture organisation, not about this tree: identity and the
-// organization cache probe both targets, and label routing dispatches
-// into the first only.
+// about the fixture organisation, not about this tree: the organization
+// cache probe is the only one that needs both targets, because what it
+// proves is that a JIT runner is not bound to the repository that caused
+// it. Identity and label routing dispatch into the first alone.
+//
+// An entry claiming more than a test needs is worse than no check at
+// all: it fails a qualification for a fixture nothing reads, which
+// nothing keeps in sync, for a gap that does not exist.
 var installedFixtures = map[string][]string{
-	"identity.yml":           {envRepoA, envRepoB},
+	"identity.yml":           {envRepoA},
 	"organization-cache.yml": {envRepoA, envRepoB},
 	"label-routing.yml":      {envRepoA},
 }
@@ -36,10 +41,35 @@ var installedFixtures = map[string][]string{
 // It is also the check a maintainer can run before cutting a tag, which
 // is the point: the fixtures live in other repositories, and nothing in
 // this one can otherwise say whether they are there.
+//
+// Scope, said out loud because the name does not say it: this covers the
+// fixtures this package reads. The controller end-to-end suite keeps its
+// own, in a third repository under a different filename and behind
+// separate credentials, and it is not checked here. That gap is worse
+// than the one this closes -- the e2e job runs after the live contracts,
+// so a fixture missing there surfaces later than the one that cost this
+// cycle, not earlier.
 func TestEveryFixtureThisSuiteReadsIsInstalled(t *testing.T) {
 	_, token := target(t, envOrgURL, envOrgToken)
 	rest := newRESTClient(token)
 	ctx := testCtx(t)
+
+	// Resolved before the loop, and that is not tidiness: t.Skip runs
+	// Goexit, so a skip decided inside the loop abandons every fixture
+	// after it -- in a test whose whole promise is naming all of them at
+	// once.
+	repos := map[string]string{}
+	for _, which := range []string{envRepoA, envRepoB} {
+		repo := os.Getenv(which)
+		if repo == "" {
+			if os.Getenv(envQualify) != "" {
+				t.Fatalf("release qualification requires %s; the fixtures it carries "+
+					"cannot be checked", which)
+			}
+			t.Skipf("%s not set; the fixture check is opt-in", which)
+		}
+		repos[which] = repo
+	}
 
 	files, err := filepath.Glob(filepath.Join("testdata", "*.yml"))
 	if err != nil {
@@ -52,7 +82,7 @@ func TestEveryFixtureThisSuiteReadsIsInstalled(t *testing.T) {
 	checked := 0
 	for _, path := range files {
 		name := filepath.Base(path)
-		repos, mapped := installedFixtures[name]
+		carriedBy, mapped := installedFixtures[name]
 		if !mapped {
 			t.Errorf("testdata/%s is versioned here and no test says which repository "+
 				"carries it. A fixture nothing installs is one a suite skips or fails "+
@@ -65,15 +95,8 @@ func TestEveryFixtureThisSuiteReadsIsInstalled(t *testing.T) {
 		}
 		want := sha256.Sum256(body)
 
-		for _, which := range repos {
-			repo := os.Getenv(which)
-			if repo == "" {
-				if os.Getenv(envQualify) != "" {
-					t.Fatalf("release qualification requires %s; the fixtures it names "+
-						"cannot be checked", which)
-				}
-				t.Skipf("%s not set; the fixture check is opt-in", which)
-			}
+		for _, which := range carriedBy {
+			repo := repos[which]
 			checked++
 			got, err := rest.installedFixtureDigest(ctx, repo, ".github/workflows/"+name)
 			if err != nil {


### PR DESCRIPTION
## What changes

The qualification-host recipe says the two things that stop you registering a
runner. And a check names every missing or drifted fixture in five seconds,
before the suite that would otherwise find one of them in eight minutes.

## What was found

Both gaps cost a release cycle today, hours apart.

**The recipe.** `docs/maintainers/qualification-host.md` said "then the runner
agent, version 2.327.1 or newer, registered with the labels" and stopped. Two
things it left out:

- `config.sh` **refuses to run as root**, and this host is administered as root.
  A `runner` user already existed for it — in the `docker` group, the same uid
  the capsule drops its workload to — and nothing said so.
- `config.sh` supplies `self-hosted`, `linux` and `x64` itself and **not the
  fourth label**. A runner without `runpool-release-qualification` takes no jobs
  and reports nothing wrong; the workflows queue for a runner that never
  answers.

This matters more than a normal doc gap: the recipe is what remains when the
disposable host is destroyed, and it is the only thing that reproduces the
eighteen frozen facts without a fresh platform review.

**The fixtures.** They live in other repositories. Nothing here can say whether
they are installed. One was not, and it said so **eight minutes into
qualification, from one test, naming one file, after the tag had been cut** —
because `RUNPOOL_CONTRACT_QUALIFY` turns a skip into a failure, correctly.

## Evidence

The fixture check run against the real fixture organisation, and all three ways
it can be wrong:

```text
healthy            5 installed fixtures match 3 versioned files      PASS  2.1s
not installed      never-installed.yml is not installed on target-a: 404
drifted            label-routing.yml on target-a has drifted from testdata/…
unmapped           testdata/unmapped.yml is versioned here and no test says
                   which repository carries it
```

The unmapped case is the one worth having: a fixture added to `testdata/` that
nobody installs is one a suite skips or fails on, and neither says so until it
runs.

```text
go test ./... -count=1     clean
gofmt · go vet · actionlint  clean
```

## What would notice this regressing

`TestEveryFixtureThisSuiteReadsIsInstalled` in `test/contract/githubactions`,
run as its own workflow step before the suite. It fatals rather than skipping
under `RUNPOOL_CONTRACT_QUALIFY`, and fatals if it checked nothing.

**Every test keeps verifying its own copy.** That check must not be removed —
it runs against the file the dispatch is about to use, where this one runs
minutes earlier. This is the fast, complete report; that is the last line.

Nothing tests the recipe. It is prose about a machine, and the machine that
proves it is being destroyed.

## Risk, compatibility and operations

No product code. One documentation section, one new test file, one workflow
step that runs a single Go test with credentials that step's neighbours already
hold.

The new step adds a few seconds to a job that runs for eight minutes, and it
runs before any scale set is created, so a failure there leaves the fixture
organisation untouched.

## Changelog

```text
NONE
```

## Notes for your reviewer

`installedFixtures` is written out rather than derived. That is deliberate — the
mapping is a fact about the fixture organisation, not about this tree — but it
is a second place that knows something the tests know, so the unmapped-fixture
check exists to keep the two from drifting apart silently.

The third gap this cycle exposed is not here: the release path is not exercised
until a protected tag exists, so `qualify` and `publish` are unreachable from a
pull request or a dry run. That is a design change, not a fix, and putting it in
the change that unblocks a release would be the wrong place for it.