### PR TITLE
fix(allocator): the discovery credit moves off a holder that found work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ need an operator.
   plans carry a generation and pool holder; an empty result can rotate only
   its own current holder, and capacity transfers revoke the previous holder
   before granting the next one.
+- **The discovery credit no longer waits on a busy holder.** A binding
+  holding the credit that found work kept it until it happened to drain and
+  poll empty, which nothing bounds — and every other silent binding in the
+  tier announced zero to the broker for the duration. The credit now moves
+  to the next silent binding the moment its holder gains demand or work,
+  and the thaw after a disk-pressure hold re-checks the pointer, since
+  bindings keep gaining work while held.
 - **Delivery fingerprints use an unambiguous canonical encoding.** New rows use
   length-prefixed SHA-256 input. Historical rows retain the delimiter encoder
   named on their row, so exact redelivery remains idempotent after upgrade.

--- a/docs/adrs/2026-08-13-admission-credits.md
+++ b/docs/adrs/2026-08-13-admission-credits.md
@@ -40,8 +40,14 @@ not change. Water-filling is performed in batches in O(B log P), where B is the
 number of bindings and P is the configured parallelism, rather than scanning
 every binding once per credit.
 
-The discovery credit rotates. A successful empty long-poll advances it only
-when that poll was made by the holder under the current discovery generation.
+The discovery credit rotates. A successful empty long-poll advances it
+when that poll was made by the holder under the current discovery generation,
+and a mutation that gives the holder demand or active work advances it at
+that moment — a holder that found work has looked and seen, and a credit
+parked on it is every other silent binding announcing zero for as long as
+it keeps finding work, which nothing bounds. The thaw after a hold
+re-checks the pointer for the same reason: bindings keep gaining work
+while held, and the advance is rightly inert during the hold itself.
 An empty poll from a binding at zero, or from another tier, carries no evidence
 about the holder and cannot move it. Bindings with demand or a running capsule
 are skipped because they can already see and be seen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,8 +181,10 @@ generation-tagged allocation plan; batch water-filling bounds a rebuild by the
 number of bindings and the logarithm of configured parallelism. Capacity that
 may still be in force at the provider
 is accounted separately: increases reserve before polling, decreases release
-only after a successful poll, and only the current holder's empty poll rotates
-discovery.
+only after a successful poll. The current holder's empty poll rotates
+discovery, and a holder that gains demand or work passes the credit on at
+that moment rather than keeping it parked — including through a hold's
+thaw, since bindings keep gaining work while held.
 
 When `scheduling.parallelism` is configured, the same accounting also has an
 instance-wide ceiling across every tier and target. Provider announcements and

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -179,6 +179,9 @@ func (a *Allocator) SetAssignedDemand(key assignment.BindingKey, demand int) {
 		}
 		b.assignedDemand = demand
 		a.invalidatePlan()
+		if demand > 0 {
+			a.advanceDiscoveryFrom(key)
+		}
 	}
 }
 
@@ -233,6 +236,7 @@ func (a *Allocator) TryReserve(key assignment.BindingKey) bool {
 	p.active++
 	a.activeCount++
 	a.invalidatePlan()
+	a.advanceDiscoveryFrom(key)
 	return true
 }
 
@@ -261,6 +265,7 @@ func (a *Allocator) Adopt(key assignment.BindingKey) (overBudget bool) {
 	p.active++
 	a.activeCount++
 	a.invalidatePlan()
+	a.advanceDiscoveryFrom(key)
 	// Both of the limits TryReserve gates on. A tier still inside its own
 	// parallelism can put the instance past the one every tier shares, and
 	// reporting only the tier's is how that arrives as an unexplained
@@ -616,6 +621,52 @@ func (a *Allocator) discoveryAnnouncement(key assignment.BindingKey, capacity in
 		return false, 0
 	}
 	return true, p.discoveryGeneration
+}
+
+// advanceDiscoveryFrom moves the pointer off a binding that has stopped
+// qualifying for the credit. Rotation otherwise happens only when a
+// discovery-flagged poll completes -- and a holder that gained demand or
+// work will never flag another poll, so without this the pointer stays
+// on it until it happens to drain and poll empty, which nothing bounds.
+// That is not the one-rotation wait the design accepts: it is every
+// other silent binding in the tier announcing zero indefinitely, which
+// is the defect the credit exists to prevent.
+//
+// The credit is for a binding the broker cannot see to look at its own
+// queue. A holder with demand or active work has looked and found, so
+// passing the pointer on costs it nothing. When nobody else qualifies,
+// nextDiscovery leaves the pointer where it is, and the existing
+// recovery -- the holder draining and completing an empty flagged poll
+// -- still applies.
+//
+// Callers hold a.mu. The generation is bumped on a move so a
+// discovery-flagged poll already in flight from the former holder
+// cannot rotate a second time when it completes.
+func (a *Allocator) advanceDiscoveryFrom(key assignment.BindingKey) {
+	still := func() bool {
+		b := a.binding(key)
+		return b != nil && !b.held && b.assignedDemand == 0 && b.active == 0
+	}
+	if a.globalParallelism > 0 {
+		if len(a.order) == 0 || a.order[a.discovery] != key || still() {
+			return
+		}
+		if next := a.nextDiscovery(a.order, a.discovery); next != a.discovery {
+			a.discovery = next
+			a.discoveryGeneration++
+			a.invalidatePlan()
+		}
+		return
+	}
+	p := a.poolOf(key)
+	if p == nil || len(p.order) == 0 || p.order[p.discovery] != key || still() {
+		return
+	}
+	if next := a.nextDiscovery(p.order, p.discovery); next != p.discovery {
+		p.discovery = next
+		p.discoveryGeneration++
+		a.invalidatePlan()
+	}
 }
 
 func (a *Allocator) rotateDiscovery(poll Poll) {

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -11,8 +11,10 @@
 // the tier limit and the optional instance-wide limit.
 //
 // One discovery credit rotates per independent tier, or across the instance
-// when a global limit is set. Only the holder's successful empty poll advances
-// it, and the preceding holder must confirm zero before the next can publish
+// when a global limit is set. The holder's successful empty poll advances it,
+// and so does any mutation that gives the holder demand or work -- a credit
+// parked on a binding that can already see is every other silent binding
+// announcing zero. The preceding holder must confirm zero before the next can publish
 // the same credit. A silent binding therefore observes its queue without two
 // sessions spending one unit concurrently. See
 // docs/adrs/2026-08-13-admission-credits.md.
@@ -203,6 +205,23 @@ func (a *Allocator) Hold(held bool) {
 		}
 	}
 	a.invalidatePlan()
+	if !held {
+		// The thaw re-checks every ring's pointer. During a hold the
+		// advance is rightly a no-op -- every candidate is held, so
+		// there is nobody to pass the credit to -- but bindings keep
+		// gaining demand and work while held, and a pointer parked on
+		// one of them through the thaw is the same unbounded starvation
+		// the advance exists to end, arriving through disk pressure
+		// instead of a poll.
+		if len(a.order) > 0 {
+			a.advanceDiscoveryFrom(a.order[a.discovery])
+		}
+		for _, p := range a.pools {
+			if len(p.order) > 0 {
+				a.advanceDiscoveryFrom(p.order[p.discovery])
+			}
+		}
+	}
 }
 
 // TryReserve claims one admission credit for key if its tier and the instance

--- a/internal/allocator/discovery_test.go
+++ b/internal/allocator/discovery_test.go
@@ -131,3 +131,47 @@ func TestTheCreditMovesUnderAGlobalBudget(t *testing.T) {
 			"announces zero; the instance-wide pointer did not move")
 	}
 }
+
+// TestTheThawDoesNotLeaveTheCreditOnABusyHolder: during a hold the
+// advance is rightly a no-op -- everyone is held, there is nobody to
+// pass the credit to -- but bindings keep gaining demand while held,
+// and disk pressure is what drives holds on a long-running process. A
+// pointer parked on a binding that got busy during the hold is the same
+// unbounded starvation, arriving through the thaw.
+func TestTheThawDoesNotLeaveTheCreditOnABusyHolder(t *testing.T) {
+	a := New()
+	a.Register("std", "busy", 3)
+	a.Register("std", "quiet", 3)
+	a.SessionOpened("busy")
+	a.SessionOpened("quiet")
+
+	a.Hold(true)
+	a.SetAssignedDemand("busy", 1) // work lands while everything is held
+	if h := a.DiscoveryHolder("std"); h != "busy" {
+		t.Fatalf("during the hold the pointer moved to %q with every candidate held", h)
+	}
+	a.Hold(false)
+	if h := a.DiscoveryHolder("std"); h != "quiet" {
+		t.Fatalf("after the thaw the credit sits on %q, whose demand arrived during "+
+			"the hold; the quiet binding announces zero until the holder happens to "+
+			"drain and poll empty, which nothing bounds", h)
+	}
+}
+
+// TestTheThawChecksTheGlobalRingToo: the same seam on the instance-wide
+// pointer under a global budget.
+func TestTheThawChecksTheGlobalRingToo(t *testing.T) {
+	a := NewWithGlobalParallelism(4)
+	a.Register("std", "busy", 2)
+	a.Register("heavy", "quiet", 2)
+	a.SessionOpened("busy")
+	a.SessionOpened("quiet")
+
+	a.Hold(true)
+	a.SetAssignedDemand("busy", 1)
+	a.Hold(false)
+	if got := a.Advertised("quiet"); got == 0 {
+		t.Fatal("after the thaw the quiet binding still announces zero; the " +
+			"instance-wide pointer stayed on the binding that got busy during the hold")
+	}
+}

--- a/internal/allocator/discovery_test.go
+++ b/internal/allocator/discovery_test.go
@@ -1,0 +1,133 @@
+package allocator
+
+import "testing"
+
+// TestTheCreditMovesOffAHolderThatFoundWork is the regression for a
+// starvation the rotation could not recover from.
+//
+// Rotation happens when a discovery-flagged poll completes, and a poll
+// is flagged only when its binding is the pointer and silent at
+// BeginPoll. So a holder that gained demand mid-flight completed an
+// unflagged poll, and every poll after it was unflagged too -- the
+// pointer stayed put until the holder happened to drain and poll empty,
+// which nothing bounds. A tier with one busy binding and one quiet one
+// is the ordinary topology, and the quiet one announced zero for as
+// long as the busy one kept finding work: exactly the blindness the
+// credit exists to end, reintroduced by holding it.
+func TestTheCreditMovesOffAHolderThatFoundWork(t *testing.T) {
+	a := New()
+	a.Register("std", "busy", 2)
+	a.Register("std", "quiet", 2)
+	a.SessionOpened("busy")
+	a.SessionOpened("quiet")
+
+	poll := a.BeginPoll("busy")
+	a.SetAssignedDemand("busy", 1) // a real job lands mid-flight
+	a.CompletePoll(poll, true, false)
+
+	if h := a.DiscoveryHolder("std"); h != "quiet" {
+		t.Fatalf("the credit stayed on %q after its holder found work; the quiet "+
+			"binding announces zero until the busy one happens to drain and poll "+
+			"empty, which nothing bounds", h)
+	}
+	if got := a.Advertised("quiet"); got == 0 {
+		t.Fatal("the quiet binding still advertises zero with the credit in hand")
+	}
+}
+
+// TestTheCreditMovesOffAHolderThatAdmittedWork: the same starvation
+// arrives through admission rather than demand -- TryReserve on the
+// holder, or an adoption on restart.
+func TestTheCreditMovesOffAHolderThatAdmittedWork(t *testing.T) {
+	for name, gain := range map[string]func(*Allocator){
+		"reserved": func(a *Allocator) { a.TryReserve("busy") },
+		"adopted":  func(a *Allocator) { a.Adopt("busy") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			a := New()
+			a.Register("std", "busy", 2)
+			a.Register("std", "quiet", 2)
+			a.SessionOpened("busy")
+			a.SessionOpened("quiet")
+			gain(a)
+			if h := a.DiscoveryHolder("std"); h != "quiet" {
+				t.Fatalf("after %s work the credit stayed on %q", name, h)
+			}
+		})
+	}
+}
+
+// TestTheCreditStaysWhenNobodyElseIsSilent: a pointer with nowhere to go
+// stays, and the pre-existing recovery -- the holder draining and
+// completing an empty flagged poll -- still applies. Moving it to
+// another busy binding would be motion without meaning.
+func TestTheCreditStaysWhenNobodyElseIsSilent(t *testing.T) {
+	a := New()
+	a.Register("std", "busy", 2)
+	a.Register("std", "also-busy", 2)
+	a.SessionOpened("busy")
+	a.SessionOpened("also-busy")
+	a.SetAssignedDemand("also-busy", 1)
+	a.SetAssignedDemand("busy", 1)
+	if h := a.DiscoveryHolder("std"); h != "busy" {
+		t.Fatalf("the pointer moved to %q with nobody silent to receive it", h)
+	}
+	// The holder drains while its sibling is still busy: an empty
+	// flagged poll has nowhere to rotate to, and staying put is right --
+	// the drained holder is silent again and can use the credit itself.
+	a.SetAssignedDemand("busy", 0)
+	poll := a.BeginPoll("busy")
+	a.CompletePoll(poll, true, true)
+	if h := a.DiscoveryHolder("std"); h != "busy" {
+		t.Fatalf("with nobody else silent the pointer moved to %q", h)
+	}
+	// The sibling drains too: the next empty flagged poll rotates, which
+	// is the pre-existing path, unchanged.
+	a.SetAssignedDemand("also-busy", 0)
+	poll = a.BeginPoll("busy")
+	a.CompletePoll(poll, true, true)
+	if h := a.DiscoveryHolder("std"); h != "also-busy" {
+		t.Fatalf("an empty flagged poll from the drained holder rotated to %q; "+
+			"want the sibling", h)
+	}
+}
+
+// TestAnInFlightFlaggedPollCannotRotateTwice: the generation bump on an
+// advance is what keeps a poll flagged under the old holder from moving
+// the pointer a second time when it completes.
+func TestAnInFlightFlaggedPollCannotRotateTwice(t *testing.T) {
+	a := New()
+	a.Register("std", "busy", 2)
+	a.Register("std", "quiet", 2)
+	a.Register("std", "third", 2)
+	a.SessionOpened("busy")
+	a.SessionOpened("quiet")
+	a.SessionOpened("third")
+
+	poll := a.BeginPoll("busy")    // flagged under generation g
+	a.SetAssignedDemand("busy", 1) // advance: pointer -> quiet, generation g+1
+	before := a.DiscoveryHolder("std")
+	a.CompletePoll(poll, true, true) // stale flagged poll completes empty
+	if after := a.DiscoveryHolder("std"); after != before {
+		t.Fatalf("a stale flagged poll rotated the pointer %q -> %q past the "+
+			"binding the advance chose", before, after)
+	}
+}
+
+// TestTheCreditMovesUnderAGlobalBudget: the pointer lives on the
+// instance-wide ring when a global parallelism is set, and the advance
+// has to move that one. Observed through the announcement itself, which
+// is what the broker sees: after the holder finds work, the quiet
+// binding's poll is the one that carries the discovery capacity.
+func TestTheCreditMovesUnderAGlobalBudget(t *testing.T) {
+	a := NewWithGlobalParallelism(4)
+	a.Register("std", "busy", 2)
+	a.Register("heavy", "quiet", 2)
+	a.SessionOpened("busy")
+	a.SessionOpened("quiet")
+	a.SetAssignedDemand("busy", 1)
+	if got := a.Advertised("quiet"); got == 0 {
+		t.Fatal("after the global holder found work, the quiet binding still " +
+			"announces zero; the instance-wide pointer did not move")
+	}
+}


### PR DESCRIPTION
## What changes

When a mutation gives the discovery pointer's current holder demand or work —
`SetAssignedDemand`, `TryReserve`, `Adopt` — the pointer advances to the next
silent binding under the same lock. Rotation on completed polls is unchanged.

## What was found

Post-merge review of #151 reproduced a starvation the rotation cannot recover
from. The pointer advances only when a **discovery-flagged** poll completes, and
a poll is flagged only when its binding is the pointer *and silent* at
`BeginPoll` — so a holder that gained demand mid-flight completed an unflagged
poll, and every poll after it was unflagged too. The pointer stayed put until
the holder happened to drain *and* poll empty, which nothing bounds.

A tier with one busy binding and one quiet one is the ordinary topology. The
quiet one announced zero for as long as the busy one kept finding work at poll
time — the exact blindness the
[admission-credits record](docs/adrs/2026-08-13-admission-credits.md) was
written to end, reintroduced by holding the credit. Not the one-rotation wait
its Consequences section accepts: unbounded.

Reproduced twenty rounds against the real allocator before touching anything;
the quiet binding never saw its queue. None of the existing rotation tests —
hermetic or live — exercises a holder transitioning from silent to busy, which
is why every suite was green over it.

## Evidence

```text
go test ./internal/allocator -race -count=1        ok
full suite, -race -shuffle=on -count=1             ok
```

Mutation-verified: removing the three advance calls fails **all five** new
regressions —

- the holder gaining demand mid-poll (the reproduced case)
- gaining work by reservation, and by adoption on restart
- the pointer staying put when nobody else is silent, with the pre-existing
  drain-and-rotate recovery proven intact afterwards
- a stale in-flight flagged poll unable to rotate past the advance (the
  generation bump)
- the instance-wide ring under a global budget, observed through the
  announcement itself

Writing them found a test bug of my own first: the "stays put" case originally
expected rotation with the sibling still busy, and the allocator was right to
refuse — an empty flagged poll with nowhere to go stays, and the drained holder
keeps the credit it can now use itself.

## What would notice this regressing

The five tests above. `Hold` is deliberately not an advance site: it is
instance-wide and disqualifies every binding equally, so there is nobody to pass
the credit to, and un-holding leaves a still-valid holder.

## Risk, compatibility and operations

The advance runs inside mutations that already take `a.mu` and already
invalidate the plan; it reuses `nextDiscovery`, which already skips bindings
that can see and stays put when nobody qualifies. The generation bump on a move
is what keeps a flagged poll already in flight from rotating a second time —
the same guard late-poll replacement already relies on.

No configuration, schema, CLI, status API or deployment effect. Amends the
behaviour the admission-credits ADR describes, in its favour: the credit reaches
a silent binding *sooner*, never later.

## Changelog

```text
### Operations

- **The discovery credit no longer waits on a busy holder.** A binding
  holding the credit that found work kept it until it happened to drain and
  poll empty, which nothing bounds — and every other silent binding in the
  tier announced zero to the broker for the duration. The credit now moves
  to the next silent binding the moment its holder gains demand or work.
```

## Notes for your reviewer

The judgment worth checking is advancing on *mutation* rather than on the next
poll: it means the pointer can move between a holder's `BeginPoll` and its
`CompletePoll`. The generation check already makes that safe — it is the same
window a session replacement always created — and the alternative (advancing
lazily at the holder's next poll) re-creates the bug whenever that next poll
never comes.