### PR TITLE
chore(release): the changelog names v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes, newest first. Runpool follows
 a version speaks for are listed in
 [the product contract](docs/product-contract.md).
 
-## v1.2.0 — 2026-08-30
+## v1.2.0 — 2026-08-31
 
 Changes since v1.1 strengthen durable delivery, admission, qualification and
 large-backlog operation. The status document advances to `v2`, the state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes, newest first. Runpool follows
 a version speaks for are listed in
 [the product contract](docs/product-contract.md).
 
-## Unreleased
+## v1.2.0 — 2026-08-30
 
 Changes since v1.1 strengthen durable delivery, admission, qualification and
 large-backlog operation. The status document advances to `v2`, the state


### PR DESCRIPTION
## What changes

`## Unreleased` becomes `## v1.2.0 — 2026-08-31`. Two commits: the rename, and
the date following two Dependabot merges that moved the day.

## What was found

Nothing — the release-prep commit the gate requires. Every claim the existing
lead makes was verified against the tree before renaming: the three forward-only
migrations exist and are exercised against the real v1.0.0 fixture, the status
document is `v2` in code, reference and the runbook's own watching script, and
the runbook's lifecycle procedures cover install, backup, restore, upgrade and
rollback — executed by drills, not described.

Between the rename and this merge, the capsule's runner base image moved to
2.337.0 with its lock pair completed (#155) and five workflow actions bumped
(#156) — which is why the heading's date moved: the date is the release date,
and what releases now includes those.

## Evidence

The `validate` gate's whole shell, run by hand against the renamed file:

```text
gate: names v1.2.0 · lead 438 bytes · links all pinnable
delimiter clear · body 8,642 bytes of 125,000
```

`TestTheNewestChangelogSectionCouldBeReleased` green, re-run after the date
change.

## What would notice this regressing

The gate itself, on the tag.

## Risk, compatibility and operations

Documentation only. After this merges the tag is the next action.

## Changelog

```text
NONE
```