### PR TITLE
fix(qualification): the durability transcript declares its boundary

### DIFF
--- a/.github/workflows/qualify-release.yml
+++ b/.github/workflows/qualify-release.yml
@@ -197,7 +197,7 @@ jobs:
             -suite sqlite-durability -commit "$QUALIFICATION_COMMIT" -run "$QUALIFICATION_RUN_URL" \
             -started-at "$started" -completed-at "$completed" \
             -environment release-platform -runner self-hosted \
-            -platform-facts platform-facts.json -log-format mixed \
+            -platform-facts platform-facts.json -log-format go-then-cases \
             -log sqlite-contract.log > sqlite-durability.json
 
       - name: Run the lifecycle drills

--- a/internal/qualification/cmd/suite-evidence/main.go
+++ b/internal/qualification/cmd/suite-evidence/main.go
@@ -35,7 +35,7 @@ func main() {
 		controller    = flag.String("controller-image", "", "digest-qualified controller image")
 		capsule       = flag.String("capsule-image", "", "digest-qualified capsule image")
 		logPath       = flag.String("log", "", "test or drill log")
-		logFormat     = flag.String("log-format", "go", "go, drill, mixed, or cases")
+		logFormat     = flag.String("log-format", "go", "go, drill, go-then-cases, or cases")
 		explicitCases caseFlags
 	)
 	flag.Var(&explicitCases, "case", "case result as id=passed (repeatable; log-format=cases)")
@@ -112,19 +112,8 @@ func readCases(format, path string, explicit caseFlags) ([]qualification.CaseEvi
 		return qualification.ParseGoTestLog(file)
 	case "drill":
 		return qualification.ParseDrillLog(file)
-	case "mixed":
-		goCases, err := qualification.ParseGoTestLog(file)
-		if err != nil {
-			return nil, err
-		}
-		if _, err := file.Seek(0, 0); err != nil {
-			return nil, err
-		}
-		drillCases, err := qualification.ParseDrillLog(file)
-		if err != nil {
-			return nil, err
-		}
-		return append(goCases, drillCases...), nil
+	case "go-then-cases":
+		return qualification.ParseGoSuiteThenCases(file)
 	default:
 		return nil, fmt.Errorf("unknown -log-format %q", format)
 	}

--- a/internal/qualification/cmd/suite-evidence/main_test.go
+++ b/internal/qualification/cmd/suite-evidence/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/rhobuild/runpool/internal/qualification"
+)
+
+func TestReadCasesSupportsTheOrderedHarnessProtocol(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.log")
+	transcript := "--- PASS: TestOne (0.01s)\n" +
+		"RUNPOOL_PHASE go-suite-complete\n" +
+		"--- PASS: TestDiagnostic (0.01s)\n" +
+		"RUNPOOL_CASE round-1 passed\n"
+	if err := os.WriteFile(path, []byte(transcript), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases, err := readCases("go-then-cases", path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []qualification.CaseEvidence{
+		{ID: "TestOne", Outcome: qualification.CasePassed, DurationMilliseconds: 10},
+		{ID: "round-1", Outcome: qualification.CasePassed},
+	}
+	if !slices.Equal(cases, want) {
+		t.Fatalf("cases = %+v; want %+v", cases, want)
+	}
+}
+
+func TestReadCasesRejectsTheFormerAmbiguousFormat(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.log")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if cases, err := readCases("mixed", path, nil); err == nil {
+		t.Fatalf("accepted the retired mixed format: %+v", cases)
+	}
+}

--- a/internal/qualification/evidence.go
+++ b/internal/qualification/evidence.go
@@ -1,16 +1,12 @@
 package qualification
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"reflect"
-	"regexp"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/rhobuild/runpool/internal/platform"
@@ -351,83 +347,6 @@ func sameSet(name string, got, want []string) error {
 		return fmt.Errorf("%s differ: missing=%v unexpected=%v", name, missing, unexpected)
 	}
 	return nil
-}
-
-var goTestResult = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): ([^ ]+) \(([0-9.]+)s\)$`)
-
-// ParseGoTestLog extracts top-level results from Go's stable verbose test
-// protocol. A skipped or failed subtest is rejected even when its parent later
-// reports PASS, so a producer cannot flatten away an incomplete contract.
-func ParseGoTestLog(input io.Reader) ([]CaseEvidence, error) {
-	results := make(map[string]CaseEvidence)
-	order := make([]string, 0)
-	scanner := bufio.NewScanner(input)
-	for scanner.Scan() {
-		match := goTestResult.FindStringSubmatch(strings.TrimSpace(scanner.Text()))
-		if match == nil {
-			continue
-		}
-		var outcome CaseOutcome
-		switch match[1] {
-		case "PASS":
-			outcome = CasePassed
-		case "FAIL":
-			outcome = CaseFailed
-		case "SKIP":
-			outcome = CaseSkipped
-		}
-		id := match[2]
-		if strings.Contains(id, "/") {
-			if outcome != CasePassed {
-				return nil, fmt.Errorf("subtest %s %s", id, outcome)
-			}
-			continue
-		}
-		if _, exists := results[id]; exists {
-			return nil, fmt.Errorf("test %s reported more than one terminal result", id)
-		}
-		seconds, err := strconv.ParseFloat(match[3], 64)
-		if err != nil {
-			return nil, fmt.Errorf("parse duration for %s: %w", id, err)
-		}
-		results[id] = CaseEvidence{ID: id, Outcome: outcome, DurationMilliseconds: int64(seconds * 1000)}
-		order = append(order, id)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	cases := make([]CaseEvidence, 0, len(order))
-	for _, id := range order {
-		cases = append(cases, results[id])
-	}
-	return cases, nil
-}
-
-const drillMarkerPrefix = "RUNPOOL_CASE "
-
-// ParseDrillLog extracts explicit property markers from a shell harness.
-func ParseDrillLog(input io.Reader) ([]CaseEvidence, error) {
-	var cases []CaseEvidence
-	scanner := bufio.NewScanner(input)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, drillMarkerPrefix) {
-			continue
-		}
-		fields := strings.Fields(strings.TrimPrefix(line, drillMarkerPrefix))
-		if len(fields) != 2 {
-			return nil, fmt.Errorf("invalid drill marker %q", line)
-		}
-		outcome := CaseOutcome(fields[1])
-		if outcome != CasePassed && outcome != CaseFailed && outcome != CaseSkipped {
-			return nil, fmt.Errorf("invalid drill outcome %q", outcome)
-		}
-		cases = append(cases, CaseEvidence{ID: fields[0], Outcome: outcome})
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, err
-	}
-	return cases, nil
 }
 
 // EncodeSuiteEvidence writes the stable, indented artifact representation.

--- a/internal/qualification/evidence_test.go
+++ b/internal/qualification/evidence_test.go
@@ -59,6 +59,105 @@ func TestGoTestEvidenceRecordsOnlyObservedTerminalResults(t *testing.T) {
 	}
 }
 
+func TestDrillEvidenceRejectsDuplicateCaseResults(t *testing.T) {
+	transcript := strings.NewReader(
+		caseMarkerPrefix + "round-1 passed\n" +
+			caseMarkerPrefix + "round-1 failed\n",
+	)
+	if cases, err := ParseDrillLog(transcript); err == nil {
+		t.Fatalf("accepted contradictory case results: %+v", cases)
+	}
+}
+
+func TestGoSuiteThenCasesValidatesTheDurabilityInventory(t *testing.T) {
+	log, err := os.Open(filepath.Join("testdata", "sqlite-durability-transcript.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = log.Close() })
+
+	cases, err := ParseGoSuiteThenCases(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(cases))
+	for _, observed := range cases {
+		ids = append(ids, observed.ID)
+		if observed.Outcome != CasePassed {
+			t.Errorf("case %s = %s; want passed", observed.ID, observed.Outcome)
+		}
+	}
+	want, err := ExpectedCases(SuiteSQLiteDurability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(ids, want) {
+		t.Fatalf("case ids = %v; want %v", ids, want)
+	}
+	if cases[1].DurationMilliseconds != 3040 {
+		t.Errorf("crash recovery duration = %dms; want 3040ms", cases[1].DurationMilliseconds)
+	}
+
+	observed := frozenReference().Platforms[1].Platform
+	environment := ExecutionEnvironment{
+		Kind: EnvironmentReleasePlatform, Runner: "self-hosted", Facts: &observed,
+	}
+	manifest, err := NewSuiteEvidence(
+		SuiteSQLiteDurability, testBuild(), environment,
+		time.Unix(1, 0), time.Unix(2, 0), cases,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateSuiteEvidence(manifest, testBuild(), observed); err != nil {
+		t.Fatalf("complete durability evidence was refused: %v", err)
+	}
+	if manifest.Summary != (CaseSummary{Expected: 10, Executed: 10, Passed: 10}) {
+		t.Errorf("summary = %+v; want ten executed and passed cases", manifest.Summary)
+	}
+}
+
+func TestGoSuiteThenCasesRequiresAnOrderedProtocol(t *testing.T) {
+	for name, transcript := range map[string]string{
+		"missing boundary":    "--- PASS: TestOne (0.01s)\n",
+		"duplicate boundary":  goSuiteCompleteMarker + "\n" + goSuiteCompleteMarker + "\n",
+		"case before suite":   caseMarkerPrefix + "round-1 passed\n" + goSuiteCompleteMarker + "\n",
+		"unknown phase":       qualificationPhasePrefix + "another-phase\n",
+		"duplicate go result": "--- PASS: TestOne (0.01s)\n--- PASS: TestOne (0.02s)\n" + goSuiteCompleteMarker + "\n",
+		"duplicate case":      goSuiteCompleteMarker + "\n" + caseMarkerPrefix + "round-1 passed\n" + caseMarkerPrefix + "round-1 passed\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cases, err := ParseGoSuiteThenCases(strings.NewReader(transcript))
+			if err == nil {
+				t.Fatalf("parsed malformed protocol: %+v", cases)
+			}
+		})
+	}
+}
+
+func TestGoSuiteThenCasesUsesOnlyTheExplicitBoundary(t *testing.T) {
+	transcript := strings.NewReader(
+		"--- PASS: TestOne (0.01s)\n" +
+			"PASS\n" +
+			"--- PASS: TestTwo (0.02s)\n" +
+			goSuiteCompleteMarker + "\n" +
+			"--- PASS: TestVerifyExisting (0.03s)\n" +
+			caseMarkerPrefix + "round-1 passed\n",
+	)
+	cases, err := ParseGoSuiteThenCases(transcript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []CaseEvidence{
+		{ID: "TestOne", Outcome: CasePassed, DurationMilliseconds: 10},
+		{ID: "TestTwo", Outcome: CasePassed, DurationMilliseconds: 20},
+		{ID: "round-1", Outcome: CasePassed},
+	}
+	if !slices.Equal(cases, want) {
+		t.Fatalf("cases = %+v; want %+v", cases, want)
+	}
+}
+
 func TestSuiteEvidenceIsBoundToCasesBuildAndEnvironment(t *testing.T) {
 	definition, ok := definitionFor(SuiteHermetic)
 	if !ok {
@@ -201,14 +300,16 @@ func TestShellDrillInventoriesHaveOneSuccessMarkerPerCase(t *testing.T) {
 				if id == SuiteSQLiteDurability && strings.HasPrefix(expected, "container-kill-round-") {
 					continue
 				}
-				marker := drillMarkerPrefix + expected + " " + string(CasePassed)
+				marker := caseMarkerPrefix + expected + " " + string(CasePassed)
 				if count := strings.Count(string(body), marker); count != 1 {
 					t.Errorf("%s contains marker %q %d times; require exactly one", script, marker, count)
 				}
 			}
 			if id == SuiteSQLiteDurability {
 				for _, fragment := range []string{
-					"for round in 1 2 3", `echo "RUNPOOL_CASE container-kill-round-$round passed"`,
+					`echo "RUNPOOL_PHASE go-suite-complete"`,
+					"for round in 1 2 3",
+					`echo "RUNPOOL_CASE container-kill-round-$round passed"`,
 				} {
 					if !strings.Contains(string(body), fragment) {
 						t.Errorf("%s does not contain %q", script, fragment)

--- a/internal/qualification/testdata/sqlite-durability-transcript.log
+++ b/internal/qualification/testdata/sqlite-durability-transcript.log
@@ -1,0 +1,43 @@
+Run started=2026-08-31T05:58:34Z
+== filesystem under the named volume ==
+/dev/vda2            ext4       472042484  26711648 425162412   6% /state
+== full durability suite on the named volume ==
+=== RUN   TestPragmas
+    durability_test.go:28: embedded sqlite 3.53.3
+--- PASS: TestPragmas (0.00s)
+=== RUN   TestCrashRecovery
+    durability_test.go:89: recovered cleanly 12 times; 24014 entries survived
+--- PASS: TestCrashRecovery (3.04s)
+=== RUN   TestContention
+--- PASS: TestContention (0.14s)
+=== RUN   TestSingletonLock
+--- PASS: TestSingletonLock (0.50s)
+=== RUN   TestBackupRestore
+    durability_test.go:246: restorable backup verified with 100 entries while a writer was live
+--- PASS: TestBackupRestore (0.05s)
+=== RUN   TestDiskFull
+--- PASS: TestDiskFull (0.01s)
+=== RUN   TestMigrationMechanics
+--- PASS: TestMigrationMechanics (0.00s)
+PASS
+RUNPOOL_PHASE go-suite-complete
+== container-kill rounds ==
+=== RUN   TestVerifyExisting
+    contract_test.go:214: verified kill.db: 1915 entries survived a container kill
+--- PASS: TestVerifyExisting (0.00s)
+PASS
+round 1: recovered
+RUNPOOL_CASE container-kill-round-1 passed
+=== RUN   TestVerifyExisting
+    contract_test.go:214: verified kill.db: 4247 entries survived a container kill
+--- PASS: TestVerifyExisting (0.01s)
+PASS
+round 2: recovered
+RUNPOOL_CASE container-kill-round-2 passed
+=== RUN   TestVerifyExisting
+    contract_test.go:214: verified kill.db: 6578 entries survived a container kill
+--- PASS: TestVerifyExisting (0.01s)
+PASS
+round 3: recovered
+RUNPOOL_CASE container-kill-round-3 passed
+SQLite durability suite passed

--- a/internal/qualification/transcript.go
+++ b/internal/qualification/transcript.go
@@ -1,0 +1,192 @@
+package qualification
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	maxEvidenceLogLineBytes  = 1024 * 1024
+	caseMarkerPrefix         = "RUNPOOL_CASE "
+	qualificationPhasePrefix = "RUNPOOL_PHASE "
+	goSuiteCompleteMarker    = qualificationPhasePrefix + "go-suite-complete"
+)
+
+var goTestResult = regexp.MustCompile(`^--- (PASS|FAIL|SKIP): ([^ ]+) \(([0-9.]+)s\)$`)
+
+type goTestCaseCollector struct {
+	results map[string]CaseEvidence
+	order   []string
+}
+
+func newGoTestCaseCollector() *goTestCaseCollector {
+	return &goTestCaseCollector{results: make(map[string]CaseEvidence)}
+}
+
+func (collector *goTestCaseCollector) observe(line string) error {
+	match := goTestResult.FindStringSubmatch(strings.TrimSpace(line))
+	if match == nil {
+		return nil
+	}
+	var outcome CaseOutcome
+	switch match[1] {
+	case "PASS":
+		outcome = CasePassed
+	case "FAIL":
+		outcome = CaseFailed
+	case "SKIP":
+		outcome = CaseSkipped
+	}
+	id := match[2]
+	if strings.Contains(id, "/") {
+		if outcome != CasePassed {
+			return fmt.Errorf("subtest %s %s", id, outcome)
+		}
+		return nil
+	}
+	if _, exists := collector.results[id]; exists {
+		return fmt.Errorf("test %s reported more than one terminal result", id)
+	}
+	seconds, err := strconv.ParseFloat(match[3], 64)
+	if err != nil {
+		return fmt.Errorf("parse duration for %s: %w", id, err)
+	}
+	collector.results[id] = CaseEvidence{
+		ID: id, Outcome: outcome, DurationMilliseconds: int64(seconds * 1000),
+	}
+	collector.order = append(collector.order, id)
+	return nil
+}
+
+func (collector *goTestCaseCollector) cases() []CaseEvidence {
+	cases := make([]CaseEvidence, 0, len(collector.order))
+	for _, id := range collector.order {
+		cases = append(cases, collector.results[id])
+	}
+	return cases
+}
+
+type caseMarkerCollector struct {
+	cases []CaseEvidence
+	seen  map[string]struct{}
+}
+
+func newCaseMarkerCollector() *caseMarkerCollector {
+	return &caseMarkerCollector{seen: make(map[string]struct{})}
+}
+
+func (collector *caseMarkerCollector) observe(line string) (bool, error) {
+	observed, ok, err := parseCaseMarker(line)
+	if err != nil || !ok {
+		return ok, err
+	}
+	if _, exists := collector.seen[observed.ID]; exists {
+		return true, fmt.Errorf("case %s reported more than one terminal result", observed.ID)
+	}
+	collector.seen[observed.ID] = struct{}{}
+	collector.cases = append(collector.cases, observed)
+	return true, nil
+}
+
+func parseCaseMarker(line string) (CaseEvidence, bool, error) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, caseMarkerPrefix) {
+		return CaseEvidence{}, false, nil
+	}
+	fields := strings.Fields(strings.TrimPrefix(line, caseMarkerPrefix))
+	if len(fields) != 2 {
+		return CaseEvidence{}, true, fmt.Errorf("invalid case marker %q", line)
+	}
+	outcome := CaseOutcome(fields[1])
+	if outcome != CasePassed && outcome != CaseFailed && outcome != CaseSkipped {
+		return CaseEvidence{}, true, fmt.Errorf("invalid case outcome %q", outcome)
+	}
+	return CaseEvidence{ID: fields[0], Outcome: outcome}, true, nil
+}
+
+func scanEvidenceLog(input io.Reader, observe func(string) error) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Buffer(make([]byte, 64*1024), maxEvidenceLogLineBytes)
+	for scanner.Scan() {
+		if err := observe(scanner.Text()); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan qualification transcript: %w", err)
+	}
+	return nil
+}
+
+// ParseGoTestLog extracts top-level results from Go's stable verbose test
+// protocol. A skipped or failed subtest is rejected even when its parent later
+// reports PASS, so a producer cannot flatten away an incomplete contract.
+func ParseGoTestLog(input io.Reader) ([]CaseEvidence, error) {
+	collector := newGoTestCaseCollector()
+	if err := scanEvidenceLog(input, collector.observe); err != nil {
+		return nil, err
+	}
+	return collector.cases(), nil
+}
+
+// ParseDrillLog extracts explicit property markers from a shell harness.
+func ParseDrillLog(input io.Reader) ([]CaseEvidence, error) {
+	collector := newCaseMarkerCollector()
+	if err := scanEvidenceLog(input, func(line string) error {
+		_, err := collector.observe(line)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return collector.cases, nil
+}
+
+// ParseGoSuiteThenCases reads the ordered transcript protocol used when a
+// harness runs one authoritative Go suite before executing diagnostic rounds.
+// The harness must emit RUNPOOL_PHASE go-suite-complete exactly once. Go test
+// results are evidence only before that boundary; explicit RUNPOOL_CASE
+// markers are evidence only after it.
+func ParseGoSuiteThenCases(input io.Reader) ([]CaseEvidence, error) {
+	goCases := newGoTestCaseCollector()
+	explicitCases := newCaseMarkerCollector()
+	goSuiteComplete := false
+
+	err := scanEvidenceLog(input, func(line string) error {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, qualificationPhasePrefix) {
+			if trimmed != goSuiteCompleteMarker {
+				return fmt.Errorf("invalid qualification phase marker %q", trimmed)
+			}
+			if goSuiteComplete {
+				return errors.New("go suite completion marker appears more than once")
+			}
+			goSuiteComplete = true
+			return nil
+		}
+
+		if !goSuiteComplete {
+			observed, isExplicitCase, err := parseCaseMarker(trimmed)
+			if err != nil {
+				return err
+			}
+			if isExplicitCase {
+				return fmt.Errorf("case %s appears before the go suite completion marker", observed.ID)
+			}
+			return goCases.observe(trimmed)
+		}
+		_, err := explicitCases.observe(trimmed)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !goSuiteComplete {
+		return nil, errors.New("go suite completion marker is missing")
+	}
+	return append(goCases.cases(), explicitCases.cases...), nil
+}

--- a/test/contract/sqlite/testdata/remote-harness.sh
+++ b/test/contract/sqlite/testdata/remote-harness.sh
@@ -43,6 +43,7 @@ docker run --rm --memory 256m --cpus 1 \
   -e RUNPOOL_SQLITE_CONTRACT_DIR=/state -e RUNPOOL_SQLITE_SMALL_DIR=/small \
   "$img" /suite/sqlite-contract.test -test.v -test.count=1 \
   -test.run '^(TestPragmas|TestCrashRecovery|TestContention|TestSingletonLock|TestBackupRestore|TestDiskFull|TestMigrationMechanics)$'
+echo "RUNPOOL_PHASE go-suite-complete"
 
 echo "== container-kill rounds =="
 for round in 1 2 3; do


### PR DESCRIPTION
## What changes

The SQLite durability harness now declares the boundary between its authoritative Go suite and its container-kill verification rounds. The evidence composer consumes that ordered `go-then-cases` protocol with a bounded streaming parser instead of treating every Go result in the combined transcript as one suite.

Transcript parsing now lives separately from the evidence model and validator. The former `mixed` format is retired rather than retained as a compatibility alias.

## What was found

The durability properties passed in the release qualification run, including all three container-kill recovery rounds, but evidence composition failed afterward. `TestVerifyExisting` is intentionally executed once per kill round; the old `mixed` parser interpreted those diagnostic executions as duplicate terminal results from the authoritative seven-test suite.

The first proposed correction inferred the boundary from the first bare `PASS` or `FAIL`. That would have made ordinary subprocess output part of the parser grammar, accepted a transcript with no boundary, and loaded the complete log into memory. This change replaces that heuristic with one explicit `RUNPOOL_PHASE go-suite-complete` marker emitted by the harness only after the primary suite succeeds.

Original observation: [release qualification run 33361641264](https://github.com/rhobuild/runpool/actions/runs/33361641264).

## Evidence

```text
Gate                                           Result
---------------------------------------------  --------------------------------------------
SQLite durability harness on Docker Engine     PASS (29.6.1, overlay2, cgroup v2)
Composed SQLite evidence                       PASS (10 expected, 10 executed, 10 passed)
Go race + shuffled repository suite            PASS
Statement coverage                             63.5% (55.0% floor)
go vet                                         PASS
staticcheck                                    PASS
actionlint                                     PASS
shellcheck                                     PASS
sqlc diff                                      PASS
sqlc vet                                       PASS
Known Go vulnerabilities                       none
Skipped local checks                           none
```

The live Docker execution above is regression evidence for this parser and harness change; it is not presented as release-platform certification. The release qualification workflow must produce fresh evidence for the candidate commit on the selected release host.

## What would notice this regressing

- `TestGoSuiteThenCasesValidatesTheDurabilityInventory` exercises the complete seven-test plus three-round transcript through final suite validation.
- `TestGoSuiteThenCasesRequiresAnOrderedProtocol` rejects a missing or repeated boundary, an unknown phase, premature cases, and duplicate results.
- `TestGoSuiteThenCasesUsesOnlyTheExplicitBoundary` proves that bare Go summaries cannot end the authoritative section and that diagnostic Go results after the boundary do not become evidence.
- `TestReadCasesSupportsTheOrderedHarnessProtocol` binds the CLI format to the parser; its companion rejects the retired `mixed` format.
- `TestShellDrillInventoriesHaveOneSuccessMarkerPerCase` binds the harness markers to the registered SQLite inventory.
- `qualify-release.yml` composes and validates all ten expected cases before release evidence can pass.

## Risk, compatibility and operations

This changes an internal qualification transcript contract and its workflow consumer together. It does not change the Runpool CLI, runtime configuration, status API, database schema, deployment format, credentials, networking, resource ownership, or cleanup behavior.

Malformed or partially upgraded transcripts fail closed: the boundary must occur exactly once, cases before it are refused, and unknown phases or duplicate terminal results are errors. Input is processed incrementally with a one-megabyte per-line limit rather than being read without a bound.

There is intentionally no compatibility alias for `mixed`; no released consumer invokes this internal command, and accepting both grammars would preserve the ambiguity being removed. Rollback is a revert of this commit and its workflow change.

This is a correction to executable evidence plumbing, not a new architectural constraint, so it does not require an ADR.

## Changelog

```text
NONE
```

The change affects release qualification internals and has no user-visible runtime or configuration effect.

## Notes for your reviewer

Review the protocol state transition in `internal/qualification/transcript.go` first, then compare it with the marker placement in `test/contract/sqlite/testdata/remote-harness.sh`. Fresh release qualification remains required before any release decision.
