### PR TITLE
fix(qualification): let the weekly upstream probe run unattended

### DIFF
--- a/.github/workflows/contracts-github-actions.yml
+++ b/.github/workflows/contracts-github-actions.yml
@@ -46,7 +46,10 @@ jobs:
     runs-on: ubuntu-24.04
     # Above the suite's own 40m, plus minting two installation tokens.
     timeout-minutes: 60
-    environment: upstream-contracts
+    # Observation runs use an environment restricted to main. Qualification
+    # keeps the reviewed environment, including when dispatched from a branch.
+    environment:
+      name: ${{ inputs.qualify == true && 'upstream-contracts' || 'upstream-observation' }}
     steps:
       - name: Check out the tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -80,7 +83,7 @@ jobs:
             [ -n "$RUNNER_CMD" ] || missing="$missing RUNPOOL_CONTRACT_RUNNER_CMD"
           fi
           if [ -n "$missing" ]; then
-            echo "the upstream-contracts environment is missing:$missing"; exit 1
+            echo "the selected upstream environment is missing fixture variables:$missing"; exit 1
           fi
 
       - name: Mint the repository installation token

--- a/docs/maintainers/ci.md
+++ b/docs/maintainers/ci.md
@@ -22,7 +22,7 @@ that is what decides whether it can run on a pull request at all.
 | `integration-docker` | `outer capsule, JIT and the egress sandbox` | A real capsule, its credential channel and the egress sandbox, leaving no managed object behind | Hosted daemon |
 | `integration-docker` | `lifecycle drills` | Install, backup, restore, upgrade and uninstall, end to end | Hosted daemon |
 | `integration-docker` | `sqlite durability` | Durability on a named volume, including the disk-full case, across kills | Hosted daemon |
-| `contracts-github-actions` | `runner scale set API` | The provider adapter against the real scale-set API | Protected `upstream-contracts`; weekly, and during qualification |
+| `contracts-github-actions` | `runner scale set API` | The provider adapter against the real scale-set API | Hosted; weekly and non-qualifying runs from `main` use `upstream-observation`, while qualification and branch validation use the reviewed `upstream-contracts` |
 | `controller-e2e` | `real assignment, SIGKILL, cache and cleanup (portable)` | The exact controller and capsule candidates running real assignments, including crash adoption, on infrastructure that does not depend on the reference host | Hosted, protected `release-qualification` |
 | `controller-e2e` | `real assignment, SIGKILL, cache and cleanup (reference)` | The same workload on the exact release platform | Self-hosted, protected `release-qualification` |
 | `qualify-release` | `validate release inputs` | The ref is a protected tag, the images are digest-qualified, and the standalone candidate is the tag it claims | Hosted |
@@ -34,10 +34,14 @@ that is what decides whether it can run on a pull request at all.
 | `release` | `attest and publish qualified artifacts` | The record covers this build, the artifacts match their checksums, and the promoted digests are the qualified ones | Hosted, protected `release` |
 
 The GitHub Actions workflow also runs `github_observation` probes on its
-weekly and non-qualifying manual executions. They record upstream behavior for
-capabilities the product does not expose. They are deliberately excluded from
-release qualification; a change in an unused provider behavior must prompt
-investigation without blocking the release contract.
+weekly executions and on non-qualifying manual executions from `main`. They
+record upstream behavior for capabilities the product does not expose. They
+are deliberately excluded from release qualification; a change in an unused
+provider behavior must prompt investigation without blocking the release
+contract. A branch that needs the live contracts before merge uses
+`qualify=true` and waits for the `upstream-contracts` reviewer; a
+non-qualifying dispatch from any other branch fails closed at the observation
+environment's branch policy.
 
 `qualify-release` also calls `ci`, `contracts-github-actions` and
 `controller-e2e` rather than restating them: two definitions of one gate drift,
@@ -71,7 +75,7 @@ suite, which is why neither has a step of its own.
 
 ## Required checks
 
-Six job names are required status checks on `main`:
+Seven job names are required status checks on `main`:
 
 ```text
 the Go tree, its tests and its generated files
@@ -80,6 +84,7 @@ known vulnerabilities
 security analysis
 dependency changes
 controller image
+hermetic evidence
 ```
 
 GitHub matches a required check by its name, and the branch requires strict

--- a/docs/maintainers/repository-settings.md
+++ b/docs/maintainers/repository-settings.md
@@ -106,6 +106,26 @@ it.
   The workflow mints separate, short-lived repository and organization tokens;
   do not store a personal access token.
 
+  Create `upstream-observation` for the unattended weekly probe. Copy the
+  seven non-secret variables from `upstream-contracts`, require no reviewer,
+  and allow deployments from the `main` branch only. Disable administrative
+  bypass on both environments; while the repository has one maintainer, leave
+  self-review enabled on `upstream-contracts` so its approval remains usable.
+  Scheduled runs and non-qualifying manual runs from `main` use the observation
+  environment. A non-qualifying dispatch from another branch is deliberately
+  rejected; pre-merge validation uses `qualify=true` and the reviewed
+  environment instead.
+
+  Give each environment a distinct private key for the same fixture App under
+  the `RUNPOOL_CONTRACT_APP_PRIVATE_KEY` secret name. The keys grant the same
+  installation scope but rotate and revoke independently; replacing one does
+  not interrupt the other. Only the credential owner generates or stores
+  their values. The observation key is reachable only from `main`, after the
+  branch's required checks, signature and conversation-resolution controls
+  have passed. It is not accurate to call that a required human review while
+  the repository intentionally requires zero approving reviews from its sole
+  maintainer.
+
   These contracts never run on a pull request, because they reach protected
   fixtures. So a change to `github.com/actions/scaleset` merges on hermetic
   tests alone unless somebody dispatches them: Dependabot keeps that update out


### PR DESCRIPTION
## What changes

Scheduled and non-qualifying upstream contract runs from `main` now use the unattended `upstream-observation` environment. Release qualification and pre-merge branch validation continue to use `upstream-contracts`, whose reviewer remains required.

The maintainer contract now records the exact branch policy, independent GitHub App keys, rotation boundary and dispatch matrix. Its required-check inventory is also brought back in line with the seven checks configured on `main`.

## What was found

The weekly workflow referenced `upstream-contracts`, the same environment that deliberately requires human approval during release qualification. Scheduled run 33400531229 therefore waited without executing a step until it was cancelled; a drift detector in that state could not observe upstream drift.

The first correction selected an environment by qualification mode but allowed every protected ref to reach the unattended credential and described `main` as requiring human review when it does not. The observation environment is now restricted to the exact `main` branch, so a release tag cannot fall back to it even if a future caller passes the wrong input.

Original observation: [scheduled upstream run 33400531229](https://github.com/rhobuild/runpool/actions/runs/33400531229).

## Evidence

```text
Observation                                    Result
---------------------------------------------  --------------------------------------------
Original scheduled run executed a step         NO — blocked on the reviewed environment
Observation environment deployment policy      main branch only
Observation environment required reviewers     none
Administrative bypass on both environments     disabled
Observation environment non-secret variables   7/7 present
Observation environment private key            PRESENT — name and timestamp read back
Unattended upstream contracts                  PASS (14/14)
Optional upstream observations                 PASS (6/6)
Credential-bearing evidence scan               PASS
Evidence artifact                              PASS
Qualifying route before approval               WAITING — zero steps executed
Reported pull-request checks                   PASS (8/8)
Skipped live tests                             none
Skipped reported checks                        none
```

The environment settings were read back through the GitHub API after each update. The API reports the expected observation-secret name and timestamp but cannot return its value. [Unattended run 33441144817](https://github.com/rhobuild/runpool/actions/runs/33441144817) completed in 11m47s and retained the redacted evidence artifact. Its logs contain 14 passing contracts, six passing observations, and no skipped or failed test. [Qualifying run 33442207913](https://github.com/rhobuild/runpool/actions/runs/33442207913) reached `waiting` with no steps, proving the reviewer remained in the release path; it was then cancelled deliberately. The pull-request checks are recorded by [CI run 33436605279](https://github.com/rhobuild/runpool/actions/runs/33436605279) and [CodeQL run 33436605266](https://github.com/rhobuild/runpool/actions/runs/33436605266).

## What would notice this regressing

- `actionlint` rejects an invalid environment expression or workflow structure.
- The exact `main` deployment-branch policy rejects non-qualifying feature branches and tags before their jobs receive the observation secret.
- `upstream-contracts` places qualifying jobs in `waiting` until its reviewer approves them; run 33442207913 proves that boundary with zero executed steps.
- Run 33441144817 proves the non-qualifying route from `main`, and every Monday run exercises the same path.

GitHub environment routing and protection rules are service-side state, so no hermetic repository test can execute that boundary. The two live runs are the regression evidence rather than a synthetic unit test.

## Risk, compatibility and operations

No Runpool binary, configuration, status API, schema, deployment format, network policy, ownership rule or cleanup behavior changes.

The trust boundary is narrowed rather than relaxed. `upstream-observation` can be used only from `main`; `upstream-contracts` keeps its reviewer and self-review setting for the single-maintainer repository; administrative bypass is disabled on both. A non-qualifying dispatch from another branch fails closed, while a qualifying dispatch can run there only after review.

The same fixture GitHub App supplies both environments, but each environment uses an independent private key under the same secret name. Rotation or revocation can therefore affect one path without interrupting the other. The workflow fails while minting its installation token if the observation key becomes unavailable, without exposing any fixture credential.

Rollback is a revert of this commit plus removal of `upstream-observation`. The release environment remains usable throughout because its reviewer, variables and existing secret were preserved.

This separates operational access paths without changing a product architecture decision, so it does not require an ADR.

## Changelog

```text
NONE
```

The change affects maintainer CI operations and has no user-visible runtime or configuration effect.

## Notes for your reviewer

The environment expression and exact-`main` policy form one boundary and were reviewed together. Both routes have now been measured against the merged commit: observation executed unattended, while qualification remained reviewer-gated.
