### PR TITLE
chore(deps): refresh the Docker dind index

### DIFF
--- a/build/capsule/Dockerfile
+++ b/build/capsule/Dockerfile
@@ -19,7 +19,7 @@ COPY internal/ internal/
 RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" \
       -o /out/capsule-supervisor ./cmd/capsule-supervisor
 
-FROM docker:29.7.2-dind@sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07 AS engine
+FROM docker:29.7.2-dind@sha256:360545c5305996eb06cc850c0e48f352809fc0930c66031fe46c370b70075c2b AS engine
 
 FROM ghcr.io/actions/actions-runner:2.337.0@sha256:e5496277be5d09bc968b3d64911b74e219ac4a3f2edce956a3ecf9271bea1ef4
 

--- a/build/images.lock.json
+++ b/build/images.lock.json
@@ -15,7 +15,7 @@
     "targeting one of these resolves that platform's child of the same",
     "pinned digest."
   ],
-  "resolved": "2026-08-15",
+  "resolved": "2026-08-31",
   "platforms": [
     "linux/amd64",
     "linux/arm64"
@@ -29,7 +29,7 @@
     },
     "dind": {
       "ref": "docker:29.7.2-dind",
-      "digest": "sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07",
+      "digest": "sha256:360545c5305996eb06cc850c0e48f352809fc0930c66031fe46c370b70075c2b",
       "upstream": "https://hub.docker.com/_/docker",
       "note": "Runs privileged inside the capsule; its data root is a fresh volume per job. Release qualification exercises this exact digest through the capsule candidate."
     }

--- a/internal/imagelock/images.lock.json
+++ b/internal/imagelock/images.lock.json
@@ -15,7 +15,7 @@
     "targeting one of these resolves that platform's child of the same",
     "pinned digest."
   ],
-  "resolved": "2026-08-15",
+  "resolved": "2026-08-31",
   "platforms": [
     "linux/amd64",
     "linux/arm64"
@@ -29,7 +29,7 @@
     },
     "dind": {
       "ref": "docker:29.7.2-dind",
-      "digest": "sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07",
+      "digest": "sha256:360545c5305996eb06cc850c0e48f352809fc0930c66031fe46c370b70075c2b",
       "upstream": "https://hub.docker.com/_/docker",
       "note": "Runs privileged inside the capsule; its data root is a fresh volume per job. Release qualification exercises this exact digest through the capsule candidate."
     }


### PR DESCRIPTION
## What changes

The digest-qualified `docker:29.7.2-dind` build stage and both copies of the reviewed image lock move together to the current official index digest. The selected Docker version and the two release platforms do not change.

## What was found

Docker republished the mutable `29.7.2-dind` tag. The registry now resolves it to `sha256:360545c5305996eb06cc850c0e48f352809fc0930c66031fe46c370b70075c2b`, while the lock and Dockerfile retained `sha256:12e683a161823b2a839aeea999b9d960e6e1f9a97b1679ad6b441982e2d9cf07`. The registry drift gate failed in [PR #158](https://github.com/rhobuild/runpool/pull/158), which is the intended fail-closed behavior.

Inspection of both immutable indexes shows why the index moved: Docker rebuilt only the `linux/arm/v6` child. The `linux/amd64` child remains `sha256:ab772b0eaf0b01e5843f6574e50ccdfc34a7bdcb82bbf2decafde54a0ee884a9`, and the `linux/arm64` child remains `sha256:df2316a6ed13583a9fd33b6cf2f99f43ff3b90f2766a2d97745703cd43caad8b`. Those are exactly the two platforms Runpool declares.

## Evidence

```text
Observation                                    Result
---------------------------------------------  --------------------------------------------
Mutable docker:29.7.2-dind tag                 resolved to index 360545c53059
linux/amd64 child across both indexes          unchanged (ab772b0eaf0b)
linux/arm64 child across both indexes          unchanged (df2316a6ed13)
Reported pull-request checks                   PASS (12/12)
Skipped reported checks                        none
```

The registry observations compared the old and new immutable indexes. [CI run 33435896436](https://github.com/rhobuild/runpool/actions/runs/33435896436), [Docker integration run 33435896362](https://github.com/rhobuild/runpool/actions/runs/33435896362), and [CodeQL run 33435896412](https://github.com/rhobuild/runpool/actions/runs/33435896412) record the complete passing pull-request result.

## What would notice this regressing

- `internal/qualification/cmd/image-lock` fails when either mutable tag no longer resolves to its reviewed index or a declared release platform disappears.
- `internal/imagelock` fails when the embedded and reviewed locks differ or the Dockerfile names another digest.
- `test/consistency` binds the lock, Dockerfile and release-platform declarations.
- `integration-docker` builds and exercises the capsule because this PR changes `build/capsule/**` and `build/images.lock.json`.

## Risk, compatibility and operations

The privileged dind input remains Docker 29.7.2 from the same Docker Official Images source revision. The only changed child in the upstream index is arm/v6, which Runpool neither builds nor releases; the amd64 and arm64 payload bytes remain identical.

No Runpool CLI, configuration, status API, schema, deployment format, provider behavior, ownership rule or cleanup contract changes. Rollback is a revert to the still-addressable previous immutable index, but the mutable-tag verification would continue to reject it.

This is a reviewed dependency lock refresh, not an architectural decision, so it does not require an ADR.

## Changelog

```text
NONE
```

The released Docker version and supported payload bytes are unchanged.

## Notes for your reviewer

Compare the child manifests rather than only the two index digests. Merge this PR before rebasing [PR #158](https://github.com/rhobuild/runpool/pull/158); the latter correctly cannot pass its required registry gate against the stale lock on `main`.
